### PR TITLE
Quick fix to avoid instant crash on Windows

### DIFF
--- a/lib/templates.js
+++ b/lib/templates.js
@@ -1,4 +1,3 @@
-
 var nunjucks = require('nunjucks');
 var moment = require('moment');
 var qs = require('qs');
@@ -53,6 +52,8 @@ module.exports = function(self) {
     if (!finalName.match(/\.\w+$/)) {
       finalName += '.html';
     }
+
+    finalName = finalName.replace(/\\/g, '/').replace(/c:/, '');
 
     return self.getNunjucksEnv(dirs).getTemplate(finalName).render(data);
 


### PR DESCRIPTION
apostrophe-sandbox crashes instantly on page load on Windows because Nunjucks can't find the home.html template as it is supplied a Windows-style path. This is a rather crude fix that at least ensures Apostrophe can be used on Windows.

I couldn't quite tell if the real issue is in Apostrphe or Nunjucks yet as I'm not that familiar with them yet, I'll keep looking though. I'd appreciate if this gets merged anyways unless the deeper issue can be found quickly as this completely breaks Windows support.
