### PR TITLE
nunjucksLoader.getSource function not properly handling Windows paths

### DIFF
--- a/lib/nunjucksLoader.js
+++ b/lib/nunjucksLoader.js
@@ -55,7 +55,7 @@ module.exports = function(searchPaths, noWatch, apos) {
     var fullpath = null;
 
     // Access to templates in other modules
-    var matches = name.match(/^([\w\-]+)\:(.+)$/);
+    var matches = name.match(/^([\w\-]{2,})\:(.+)$/);
     if (matches) {
       var moduleName = matches[1];
       var modulePath = matches[2];


### PR DESCRIPTION
Windows paths were matching the Regex on line 58, so I've fixed this to require a module to have 2 or more characters. This fixed the windows issue and it also still resolves all modules (albeit 2+ characters).
