### PR TITLE
UTF-8 fix for truncatePlaintext

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,8 +40,9 @@ module.exports = function(self) {
   /**
    * Truncate a plaintext string at the specified number of
    * characters without breaking words if possible, see
-   * underscore.string's prune function, which
-   * we have since aliased it to
+   * underscore.string's prune function, of which this is
+   * a copy of (only replacing RegExp with XRegExp for
+   * better UTF-8 support)
    */
   self.truncatePlaintext = function(str, length, pruneStr){
     if (str == null) return '';


### PR DESCRIPTION
truncatePlaintext completely failed on UTF-8 content, so I changed it slightly.

This is the issue about it:
https://github.com/punkave/apostrophe/issues/85
