### PR TITLE
i18n compatability for the tags autocomplete

### DIFF
--- a/public/js/user.js
+++ b/public/js/user.js
@@ -407,7 +407,7 @@ apos.moveYoungerSiblings = function(node, target) {
 // assigned to this item.
 apos.enableTags = function($el, tags) {
   tags = tags || [];
-  $el.selective({ preventDuplicates: true, add: true, data: tags, source: '/apos/autocomplete-tag', addKeyCodes: [ 13, 188] });
+  $el.selective({ preventDuplicates: true, add: true, data: tags, source: '/apos/autocomplete-tag', addKeyCodes: [ 13, 'U+002C'] });
 };
 
 // Set things up to instantiate the media library when the button is clicked. This is set up

--- a/public/js/vendor/jquery.selective.js
+++ b/public/js/vendor/jquery.selective.js
@@ -78,7 +78,10 @@
       self.$itemTemplate.remove();
       if (options.add) {
         self.$autocomplete.on('keydown.selective', function(e) {
-          if ($.inArray(e.which, addKeyCodes) !== -1)
+          if (
+            $.inArray(e.which, addKeyCodes) !== -1 || // for key code
+            $.inArray(e.originalEvent.keyIdentifier, addKeyCodes) !== -1 // for a key identifier
+          )
           {
             var val = self.$autocomplete.val();
             self.add({ label: val, value: val });


### PR DESCRIPTION
Keycodes are unreliable for i18n keyboards (keys are physically rearranged). For instance, on a Hebrew keyboard, a normal alphabet letter is in place of comma.

Therefore I added use of key identifiers - which refer to the unique character, rather than a physical key.
