### PR TITLE
allow ending through truncate, just like nunjucks would let you do

### DIFF
--- a/lib/templates.js
+++ b/lib/templates.js
@@ -183,8 +183,8 @@ module.exports = function(self) {
       return self.cssName(data);
     });
 
-    nunjucksEnv.addFilter('truncate', function(data, limit) {
-      return self.truncatePlaintext(data, limit);
+    nunjucksEnv.addFilter('truncate', function(data, limit, end) {
+      return self.truncatePlaintext(data, limit, end);
     });
 
     nunjucksEnv.addFilter('jsonAttribute', function(data) {


### PR DESCRIPTION
Originally Nunjucks provides the following function
    truncate: function(input, length, killwords, end)
Apos also has the possibilty to add an ending 
    self.truncatePlaintext = function(str, length, pruneStr)

Then Nunjucks truncate function is overwritten by apos, but originally without the ending
    nunjucksEnv.addFilter('truncate', function(data, limit) {
      return self.truncatePlaintext(data, limit);
    });

this small fix lets it through so I can change the ending dynamically ;) 
