### PR TITLE
#771 made static texts translatable

### DIFF
--- a/lib/modules/apostrophe-admin-bar/views/adminBar.html
+++ b/lib/modules/apostrophe-admin-bar/views/adminBar.html
@@ -19,7 +19,7 @@
           {%- if item.options.href -%}
             <a href="{{ apos.prefix }}{{ item.options.href }}">
           {%- endif -%}
-            {{ item.label }}
+            {{ __(item.label | d('')) }}
           {%- if item.href -%}
             </a>
           {%- endif -%}
@@ -31,7 +31,7 @@
                   {%- if subItem.options.href -%}
                     <a href="{{ apos.prefix }}{{ subItem.options.href }}">
                   {%- endif -%}
-                  {{ subItem.label }}
+                  {{ __(subItem.label | d('')) }}
                   {%- if subItem.href -%}
                     </a>
                   {%- endif -%}

--- a/lib/modules/apostrophe-attachments/views/attachment.html
+++ b/lib/modules/apostrophe-attachments/views/attachment.html
@@ -7,9 +7,9 @@
     <div class="apos-attachment-preview"><img data-preview src="" alt=""></div>
     <span class="apos-attachment-name" data-name></span> 
     <div class="apos-button-group">
-      <a class="apos-button apos-button--action" href="#" data-link target="_blank">View file</a>
+      <a class="apos-button apos-button--action" href="#" data-link target="_blank">{{ __("View file") }}</a>
       {% if field.crop %}
-        <a class="apos-button apos-button--action" href="#" data-crop-attachment>Crop image</a>
+        <a class="apos-button apos-button--action" href="#" data-crop-attachment>{{ __("Crop image") }}</a>
       {% endif %}
       {% if field.trash %}
         {{ buttons.danger('Delete File', { action: 'trash' }) }}

--- a/lib/modules/apostrophe-doc-type-manager/views/chooserBase.html
+++ b/lib/modules/apostrophe-doc-type-manager/views/chooserBase.html
@@ -7,7 +7,7 @@
   {# AJAX populates me #}
 </div>
 {# Initially hidden #}
-<div class="apos-chooser-limit-reached">Limit Reached</div>
+<div class="apos-chooser-limit-reached">{{ __("Limit Reached") }}</div>
 {% if data.autocomplete %}
   <input type="text" name="autocomplete" class="apos-field-input apos-field-input-text" data-autocomplete />
 {% endif %}

--- a/lib/modules/apostrophe-doc-type-manager/views/chooserChoiceBase.html
+++ b/lib/modules/apostrophe-doc-type-manager/views/chooserChoiceBase.html
@@ -1,7 +1,7 @@
 {% import 'apostrophe-schemas:macros.html' as schemas %}
 {# choice is the object. relationship contains any relationship properties. #}
 <div class="apos-text-meta">{% block meta %}{% endblock %}</div>
-<div class="apos-text-normal">{% block title %}{{ choice.title }}{% endblock %}</div>
+<div class="apos-text-normal">{% block title %}{{ __(choice.title | d('')) }}{% endblock %}</div>
 {%- block inline -%}
   {%- set inline = apos.utils.filterNonempty(data.relationship, 'inline') -%}
   {%- if inline.length -%}

--- a/lib/modules/apostrophe-files-widgets/views/widget.html
+++ b/lib/modules/apostrophe-files-widgets/views/widget.html
@@ -1,5 +1,5 @@
 {%- for piece in data.widget._pieces -%}
   {% if piece.attachment %}
-    <a href="{{ apos.attachments.url(piece.attachment) }}">{{ piece.title }}</a>
+    <a href="{{ apos.attachments.url(piece.attachment) }}">{{ __(piece.title | d('')) }}</a>
   {% endif %}
 {%- endfor -%}

--- a/lib/modules/apostrophe-files/views/editorModal.html
+++ b/lib/modules/apostrophe-files/views/editorModal.html
@@ -1,7 +1,7 @@
 {% extends 'editorBase.html' %}
 
 {%- block label -%}
-Edit File
+{{ __("Edit File") }}
 {%- endblock -%}
 
 {%- block filters -%}

--- a/lib/modules/apostrophe-images-widgets/views/widgetEditor.html
+++ b/lib/modules/apostrophe-images-widgets/views/widgetEditor.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block label %}
-Choose Images
+{{ __("Choose Images") }}
 {% endblock %}
 
 {% block body %}

--- a/lib/modules/apostrophe-images/views/chooser.html
+++ b/lib/modules/apostrophe-images/views/chooser.html
@@ -1,11 +1,11 @@
 {%- extends "chooserBase.html" -%}
 
 {%- block label -%}
-  Image Gallery
+{{ __("Image Gallery") }}
 {%- endblock -%}
 
 {%- block instructions -%}
-  Choose images to add.
+{{ __("Choose images to add.") }}
 {%- endblock -%}
 
 

--- a/lib/modules/apostrophe-images/views/editorModal.html
+++ b/lib/modules/apostrophe-images/views/editorModal.html
@@ -1,7 +1,7 @@
 {% extends 'editorBase.html' %}
 
 {%- block label -%}
-Edit Image
+{{ __("Edit Image") }}
 {%- endblock -%}
 
 {%- block filters -%}

--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -17,6 +17,7 @@
 var Passport = require('passport').Passport;
 var LocalStrategy = require('passport-local');
 var _ = require('lodash');
+var __ = require('i18n').__;
 
 
 module.exports = {
@@ -138,11 +139,11 @@ module.exports = {
             return done(err);
           }
           if (!user){
-            return done(null, false, { message: 'Your username or password was incorrect'});
+            return done(null, false, { message: __('Your username or password was incorrect')});
           }
           return self.apos.users.verifyPassword(user, password, function(err) {
             if (err){
-              return done(null, false, { message: 'Your username or password was incorrect'});
+              return done(null, false, { message: __('Your username or password was incorrect')});
             }
             return self.apos.callAll('login', function(err) {
               return done(err, user);

--- a/lib/modules/apostrophe-login/views/loginBase.html
+++ b/lib/modules/apostrophe-login/views/loginBase.html
@@ -1,5 +1,5 @@
 {% extends data.outerLayout %}
-{% block title %}Login{% endblock %}
+{% block title %}{{ __("Login") }}{% endblock %}
 
 {% block bodyClass %}apos-login-page{% endblock %}
 

--- a/lib/modules/apostrophe-modal/views/base.html
+++ b/lib/modules/apostrophe-modal/views/base.html
@@ -3,7 +3,7 @@
 <div data-modal class="apos-ui apos-modal {% block modalClass %}{% endblock %}" {% block dataAttrs %}{% endblock %}>
   <div class="apos-modal-header">{#
     #}<span class="apos-modal-title" data-modal-title>
-      {% block label %}Give Me a Label!{% endblock %}
+      {% block label %}{{ __("Give Me a Label!") }}{% endblock %}
     </span>{#
     #}<div class="apos-modal-instructions" data-modal-instructions>
       {% block instructions %}{% endblock %}
@@ -28,7 +28,7 @@
     <div data-modal-content class="apos-modal-content apos-modal-slide-current">
 
       <div class="apos-modal-body">
-        {% block body %} I am a Modal! {% endblock %}
+        {% block body %}{{ __("I am a Modal!") }}{% endblock %}
 
       </div>
       {% block footerContainer %}

--- a/lib/modules/apostrophe-modal/views/baseView.html
+++ b/lib/modules/apostrophe-modal/views/baseView.html
@@ -3,7 +3,7 @@
 <div>
   <div class="apos-ui-view-header">
     <span class="apos-ui-view-title">
-      {% block label %}Give Me a Label!{% endblock %}
+      {% block label %}{{ __("Give Me a Label!") }}{% endblock %}
     </span>
     {# The parent modal controls the lifecycle #}
     {#{% block controls %}{% endblock %}#}
@@ -15,7 +15,7 @@
     {% block filters %}{% endblock %}
   </div>
   <div class="apos-ui-view-body">
-    {% block body %} I am a Modal! {% endblock %}
+    {% block body %}{{ __("I am a Modal!") }}{% endblock %}
 
   </div>
   <div class="apos-ui-view-footer">

--- a/lib/modules/apostrophe-modal/views/macros.html
+++ b/lib/modules/apostrophe-modal/views/macros.html
@@ -12,6 +12,6 @@
         <img src="/modules/apos/images/small-spinner.gif">
       </span>
     {%- endif -%}
-    {{ options.label }}
+    {{ __(options.label | d('')) }}
   </a>
 {%- endmacro -%}

--- a/lib/modules/apostrophe-pages/views/editor.html
+++ b/lib/modules/apostrophe-pages/views/editor.html
@@ -10,19 +10,19 @@
 
 {% block label %}
 	{% if data.verb == 'update' %}
-		Page Settings
+        {{ __('Page Settings') }}
 	{% elif data.verb == 'insert' %}
-		New Page
+        {{ __('New Page') }}
   {% elif data.verb == 'copy' %}
-    Copy Page
+        {{ __('Copy Page') }}
 	{% endif %}
 {% endblock %}
 
 {% block instructions %}
 	{% if data.verb == 'update' %}
-		Change the settings of the page you're currently on.
+        {{ __("Change the settings of the page you're currently on.") }}
 	{% elif data.verb == 'insert' %}
-		Set the options for a new page.
+        {{ __("Set the options for a new page.") }}
 	{% endif %}
 {% endblock %}
 

--- a/lib/modules/apostrophe-pages/views/menu.html
+++ b/lib/modules/apostrophe-pages/views/menu.html
@@ -1,7 +1,7 @@
 {% import 'apostrophe-ui:components/dropdowns.html' as dropdowns with context -%}
 <div class="apos-context-menu">
   {{ dropdowns.base({
-      label: __("Page Menu"),
+      label: "Page Menu",
       items: data.contextMenu
     }, 'button', { buttonType: 'global' })
   }}

--- a/lib/modules/apostrophe-pages/views/publishMenu.html
+++ b/lib/modules/apostrophe-pages/views/publishMenu.html
@@ -2,7 +2,7 @@
 {%- if not data.page.published or (data.piece and not data.piece.published) -%}
 <div class="apos-context-menu">
   {{ dropdowns.base({
-      label: __("Unpublished"),
+      label: "Unpublished",
       items: data.publishMenu
     }, 'button', { buttonType: 'global', attributes: 'apos--danger' })
   }}

--- a/lib/modules/apostrophe-pieces/views/createModal.html
+++ b/lib/modules/apostrophe-pieces/views/createModal.html
@@ -15,5 +15,5 @@
 {%- endblock -%}
 
 {%- block instructions -%}
-  Fill out the fields to add a new {{ data.options.label }}.
+  {{ __('Fill out the fields to add a new %s.', data.options.label | d(''))}}
 {%- endblock -%}

--- a/lib/modules/apostrophe-pieces/views/editorBase.html
+++ b/lib/modules/apostrophe-pieces/views/editorBase.html
@@ -11,7 +11,7 @@
 {%- endblock -%}
 
 {%- block label -%}
-  {{ __('Edit %s', data.options.label) }}
+  {{ __('Edit %s', (data.options.label | d(''))) }}
 {%- endblock -%}
 
 {%- block filters -%}
@@ -27,7 +27,7 @@
 {%- endblock -%}
 
 {%- block instructions -%}
-  Fill out the fields to edit an existing {{ data.options.label }}.
+  {{ __('Fill out the fields to edit an existing %s.', (data.options.label | d(''))) }}
 {%- endblock -%}
 
 {% block footerContainer %}

--- a/lib/modules/apostrophe-pieces/views/manageResultLabel.html
+++ b/lib/modules/apostrophe-pieces/views/manageResultLabel.html
@@ -1,9 +1,9 @@
 <div class='apos-manage-result-label'>
 	{%- if data.filters.q -%}
-		Showing {{ data.total }} results for <span>"{{ data.filters.q }}"</span>
+		{{ __('Showing %s results for ', data.total) }}<span>"{{ data.filters.q }}"</span>
 	{%- elif data.total == 0 -%}
-		No results for current filters.
+        {{ __('No results for current filters.') }}
 	{%- else -%}
-		Showing {{ data.skip + 1 }} - {{ data.skip + data.pieces.length }} of {{ data.total }} results
+		{{ __('Showing %s - %s of %s results', data.skip + 1, data.skip + data.pieces.length, data.total) }}
 	{%- endif -%}
 </div>

--- a/lib/modules/apostrophe-pieces/views/managerModalBase.html
+++ b/lib/modules/apostrophe-pieces/views/managerModalBase.html
@@ -11,7 +11,7 @@
 {%- endblock -%}
 
 {%- block instructions -%}
-  You can select content to display by entering the titles of individual {{ data.options.pluralLabel }}, or tags.
+  {{ __('You can select content to display by entering the titles of individual %s, or tags.', __(data.options.pluralLabel |  d(''))) }}
 {%- endblock -%}
 
 {%- block filters -%}
@@ -21,7 +21,7 @@
 {%- endblock -%}
 
 {%- block label -%}
-  {{ __('Manage ' + data.options.pluralLabel) }}
+  {{ __('Manage %s', __(data.options.pluralLabel | d(''))) }}
 {%- endblock -%}
 
 {%- block body -%}

--- a/lib/modules/apostrophe-pieces/views/menu.html
+++ b/lib/modules/apostrophe-pieces/views/menu.html
@@ -13,7 +13,7 @@
   <div class="apos-admin-bar-item">
     <div class="apos-admin-bar-item">
       {{ dropdowns.base({
-        label: __(data.options.pluralLabel),
+        label: data.options.pluralLabel,
         items: [
           { label: 'One of the things', link: '#', action: 'data-something' },
           { label: 'Another Stuff', link: '#', action: 'data-something' },

--- a/lib/modules/apostrophe-pieces/views/select.html
+++ b/lib/modules/apostrophe-pieces/views/select.html
@@ -9,20 +9,20 @@
 {% endblock %}
 
 {% block label %}
-{{ __('Choose ' + data.options.pluralLabel) }}
+{{ __('Choose %s', __(data.options.pluralLabel | d(''))) }}
 {% endblock %}
 
 {% block body %}
 <ul>
-  <li><a href="#">Individually</a></li>
-  <li><a href="#">Automatically</a></li>
+  <li><a href="#">{{ __('Individually') }}</a></li>
+  <li><a href="#">{{ __('Automatically') }}</a></li>
 </ul>
 
 {# Populated via js #}
 <div data-individual-view></div>
 
 <div data-automatic-view>
-  <h4>By Tag</h4>
+  <h4>{{ __("By Tag") }}</h4>
   <input type="text" />
 </div>
 {% endblock %}

--- a/lib/modules/apostrophe-schemas/views/arrayEditor.html
+++ b/lib/modules/apostrophe-schemas/views/arrayEditor.html
@@ -2,12 +2,12 @@
 {%- extends "apostrophe-modal:baseSlideable.html" -%}
 
 {%- block controls  -%}
-  <div class="apos-array-save-item apos-button apos-button--minor" data-apos-cancel>Cancel</div>{#
-#}<div class="apos-array-save-item apos-button" data-apos-save-array-items>Save Items</div>
+  <div class="apos-array-save-item apos-button apos-button--minor" data-apos-cancel>{{ __('Cancel') }}</div>{#
+#}<div class="apos-array-save-item apos-button" data-apos-save-array-items>{{ __('Save Items') }}</div>
 {%- endblock -%}
 {%- block body -%}
   <div class="apos-chooser" data-apos-array-items></div>
-  <div class="apos-array-add-item apos-button apos-button--major apos-button--square" data-apos-add-array-item>+ Add Item</div>
+  <div class="apos-array-add-item apos-button apos-button--major apos-button--square" data-apos-add-array-item>{{ __('+ Add Item') }}</div>
     <div class="apos-array-editor" data-apos-array-item></div>
   </div>
 {%- endblock -%}

--- a/lib/modules/apostrophe-schemas/views/macros.html
+++ b/lib/modules/apostrophe-schemas/views/macros.html
@@ -9,7 +9,7 @@
           {%- for group in groups -%}
             {%- if group.fields.length -%}
             <div class="apos-schema-tab{% if loop.first %} apos-active{% endif %}" data-apos-open-group="{{ group.name }}">
-              {{ group.label }}
+              {{ __(group.label | d('')) }}
             </div>
             {%- endif -%}
           {%- endfor -%}
@@ -38,7 +38,7 @@
 
 {%- macro fieldset(field, bodyMacro) %}
   <fieldset class="apos-field apos-field-{{ field.type | css }} apos-field-{{ field.name | css }} {{ field.classes }}" data-name="{{ field.name }}" {{ field.attributes }}>
-    <label for="{{ name }}" class="apos-field-label">{{ field.label }}</label>
+    <label for="{{ name }}" class="apos-field-label">{{ __(field.label | d('')) }}</label>
     {%- if field.help -%}
       <div class="apos-field-help">{{ __(field.help) }}</div>
     {%- endif -%}
@@ -105,7 +105,7 @@
     </ul>
     <input type="text" name="{{ field.name }}" data-autocomplete placeholder="{{ __('Type Here') }}" class="apos-field-input apos-field-input-text" />
     <span class="apos-limit-indicator" data-limit-indicator>{{ __('Limit Reached!') }}</span>
-    <a href="#" class="apos-tag-add" data-add><i class="fa fa-plus"></i> Add</a>
+    <a href="#" class="apos-tag-add" data-add><i class="fa fa-plus"></i> {{ __("Add") }}</a>
 
   </div>
 {%- endmacro -%}
@@ -134,7 +134,7 @@
       <label class="apos-form-checkbox-label apos-text-small">
         <input class="apos-form-checkbox-input" type="checkbox" name="{{ field.name }}" value="{{ choice.value }}">
         <span class="apos-form-checkbox-indicator"></span>
-        {{ choice.label }}
+        {{ __(choice.label | d('')) }}
       </label>
     </div>
   {%- endfor -%}
@@ -178,7 +178,7 @@
         <label for="{{ field.name }}" class="apos-field-label"></label>
         <label data-array-length></label><br>
         <a href="#" class="apos-control apos-button" data-apos-edit-array>
-          Edit {{ __(field.label) }}
+          {{ __("Edit %s", __(field.label | d(''))) }}
           <i class="fa fa-angle-right"></i>
         </a>
       </span>

--- a/lib/modules/apostrophe-schemas/views/radioTable.html
+++ b/lib/modules/apostrophe-schemas/views/radioTable.html
@@ -1,7 +1,7 @@
 {% macro radioTableHeader(choices) %}
   <td></td>
   {%- for choice in choices -%}
-    <td>{{ choice.label }}</td>
+    <td>{{ __(choice.label | d('')) }}</td>
   {%- endfor -%}
 {% endmacro %}
 
@@ -18,7 +18,7 @@
 
 
 <fieldset class="apos-fieldset apos-fieldset-radio-table apos-fieldset-{{ data.name | css }}" data-name="{{ data.name }}">
-  <label>{{ data.label }}</label>
+  <label>{{ __(data.label | d('')) }}</label>
   {# Text entry for autocompleting the next item #}
   {# { label: 'Admin', value: 'admin'}
   { name:'blog', label: 'Blog' } #}

--- a/lib/modules/apostrophe-search/views/index.html
+++ b/lib/modules/apostrophe-search/views/index.html
@@ -4,7 +4,7 @@
 {% block main %}
   <form data-apos-search-page-form method="GET" action="{{ data.url | e }}#main">
     {% if data.filters %}
-      <div class="ld-meta">Filter Results By Type</div>
+      <div class="ld-meta">{{ __('Filter Results By Type') }}</div>
       <ul>
         {% for filter in data.filters %}
           <li>
@@ -16,7 +16,7 @@
         {% endfor %}
       </ul>
     {% endif %}
-    <div class="ld-meta">New Search</div>
+    <div class="ld-meta">{{ __('New Search') }}</div>
     <input type="search" data-apos-search-field value="{{ data.query.q | e }}" name="q" />
     <input type="submit" value="Search" />
   </form>

--- a/lib/modules/apostrophe-tags/views/manager.html
+++ b/lib/modules/apostrophe-tags/views/manager.html
@@ -19,7 +19,7 @@
     {{ __('Create, edit, and remove tags.') }}
   </p>#}
   <div class="apos-manage-tag-add-wrapper">
-    <input data-apos-tag-add-field type="text" class="apos-field-input apos-field-input-text" placeholder="Find or add a tag..."/>
+    <input data-apos-tag-add-field type="text" class="apos-field-input apos-field-input-text" placeholder="{{ __('Find or add a tag...') }}"/>
     <a href="#" data-apos-tag-add class="apos-manage-tag-add fa fa-plus"></a>
   </div>
 {% endblock %}

--- a/lib/modules/apostrophe-tags/views/menu.html
+++ b/lib/modules/apostrophe-tags/views/menu.html
@@ -6,7 +6,7 @@
   <div class="apos-admin-bar-item">
     <div class="apos-admin-bar-item">
       {{ dropdowns.base({
-        label: __('Tags'),
+        label: 'Tags',
         items: []}, 'admin', { direction: 'down', listMacro: listMenu }
       ) }}
     </div>

--- a/lib/modules/apostrophe-templates/views/templateError.html
+++ b/lib/modules/apostrophe-templates/views/templateError.html
@@ -8,7 +8,7 @@
 <html lang="en-US">
 <head>
   <meta charset="utf-8">
-  <title>An error has occurred</title>
+  <title>{{ __("An error has occurred") }}</title>
   <style type="text/css">
     body {
       background-color: #ccf;
@@ -26,8 +26,8 @@
 </head>
 <body>
   <main>
-    <h1>An error has occurred</h1>
-    <p>An error has occurred. We're working on it. We apologize for the inconvenience.</p>
+    <h1>{{ __('An error has occurred') }}</h1>
+    <p>{{ __("An error has occurred. We're working on it. We apologize for the inconvenience.") }}</p>
   </main>
 </body>
 </html>

--- a/lib/modules/apostrophe-ui/views/components/buttons.html
+++ b/lib/modules/apostrophe-ui/views/components/buttons.html
@@ -1,5 +1,5 @@
 {% macro base(label, options, classes) -%}
-  <a {{ ('href=' + options.url) if options.url }} class="apos-button {{ classes }}" {{ options.attributes }} data-apos-{{ options.action | css }}{% if options.value %}='{{ options.value }}'{% endif %}><span class="apos-button-label">{{ label }}</span>{% if options.icon %}<i class="fa fa-{{ options.icon }}"></i>{% endif %}</a>
+  <a {{ ('href=' + options.url) if options.url }} class="apos-button {{ classes }}" {{ options.attributes }} data-apos-{{ options.action | css }}{% if options.value %}='{{ options.value }}'{% endif %}><span class="apos-button-label">{{ __(label | d('')) }}</span>{% if options.icon %}<i class="fa fa-{{ options.icon }}"></i>{% endif %}</a>
 {%- endmacro -%}
 
 {% macro normal(label, options) -%}

--- a/lib/modules/apostrophe-ui/views/components/dropdowns.html
+++ b/lib/modules/apostrophe-ui/views/components/dropdowns.html
@@ -2,7 +2,7 @@
 
 {% macro menuItem(content, options) -%}
   <li class="apos-dropdown-item" data-apos-{{ content.action }}{% if content.value %}="{{ content.value }}"{% endif %}>
-    {{ content.label }}
+    {{ __(content.label | d('')) }}
   </li>
 {%- endmacro %}
 
@@ -22,7 +22,7 @@
       {%- endif -%}
     {%- elif type == 'admin' -%}
       <div class="apos-admin-bar-item-inner">
-        {{ menu.label }}
+        {{ __(menu.label | d('')) }}
       </div>
     {%- endif -%}
     <ul class="apos-dropdown-items" data-apos-dropdown-items>

--- a/lib/modules/apostrophe-ui/views/components/fields.html
+++ b/lib/modules/apostrophe-ui/views/components/fields.html
@@ -1,14 +1,14 @@
 {% macro string(name, placeholder, value) -%}
-  <input name="{{ name }}" placeholder="{{placeholder}}" class="apos-field-input apos-field-input-text" type="text" value="{{value}}">
+  <input name="{{ name }}" placeholder="{{__(placeholder | d(''))}}" class="apos-field-input apos-field-input-text" type="text" value="{{__(value | d(''))}}">
 {%- endmacro %}
 
 {% macro textarea(name, placeholder) -%}
-  <textarea name="{{ name }}" placeholder="{{placeholder}}" class="apos-field-input apos-field-input-textarea"></textarea>
+  <textarea name="{{ name }}" placeholder="{{__(placeholder | d(''))}}" class="apos-field-input apos-field-input-textarea"></textarea>
 {%- endmacro %}
 
 {% macro checkbox(name, placeholder) -%}
   <label>
-    <input name="{{ name }}" placeholder="{{placeholder}}" class="apos-field-input apos-field-input-checkbox" type="checkbox">
+    <input name="{{ name }}" placeholder="{{__(placeholder | d(''))}}" class="apos-field-input apos-field-input-checkbox" type="checkbox">
     <span class="apos-field-input-checkbox-indicator"></span>
   </label>
 {%- endmacro %}
@@ -17,7 +17,7 @@
   <div class="apos-field-input-select-wrapper">
     <select name="{{ name }}" class="apos-field-input apos-field-input-select">
       {%- for option in options -%}
-        <option value="{{ option.value }}">{{ option.label }}</option>
+        <option value="{{ option.value }}">{{ __(option.label | d('')) }}</option>
       {%- endfor -%}
     </select>
   </div>

--- a/lib/modules/apostrophe-ui/views/components/links.html
+++ b/lib/modules/apostrophe-ui/views/components/links.html
@@ -1,5 +1,5 @@
 {% macro base(label, options, classes) -%}
-  <a {{ ('href=' + options.url) if options.url }} class="apos-link {{ classes }}" data-{{ options.action }}>{{ label }}</a>
+  <a {{ ('href=' + options.url) if options.url }} class="apos-link {{ classes }}" data-{{ options.action }}>{{ __(label | d('')) }}</a>
 {%- endmacro -%}
 
 {% macro major(label, options) -%}

--- a/lib/modules/apostrophe-users/views/accountMenu.html
+++ b/lib/modules/apostrophe-users/views/accountMenu.html
@@ -6,7 +6,7 @@
 {%- if data.permissions.edit -%}
   <div class="apos-admin-bar-item">
     <div class="apos-admin-bar-item">
-      {{ dropdowns.base({ label: __('Account'), items: [] },
+      {{ dropdowns.base({ label: 'Account', items: [] },
         'admin',
         { direction: 'down', listMacro: listMenu }
       ) }}

--- a/lib/modules/apostrophe-widgets/views/baseWidgetEditor.html
+++ b/lib/modules/apostrophe-widgets/views/baseWidgetEditor.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block label %}
-{{ data.label }}
+{{ __(data.label | d('')) }}
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
I added a few __(...) for translations.
The i18n library used for translation renders an error if the message key is undefined. Unfortunately in some cases this has happened and therefore I added the `| d('')` to avoid errors.