### PR TITLE
Add box-sizing and zero out margin

### DIFF
--- a/lib/modules/apostrophe-ui/public/css/global/reset.less
+++ b/lib/modules/apostrophe-ui/public/css/global/reset.less
@@ -47,3 +47,10 @@ table {
 	border-collapse: collapse;
 	border-spacing: 0;
 }
+
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+  margin: 0;
+}


### PR DESCRIPTION
Close #886. 

Box-sizing is set on `*` in the client boilerplate reset.

If you install Apostrophe without the client boilerplate or aren't managing box sizing at project level inputs are noticeably offset throughout the UI.

Can anyone think of any side effects? 