### PR TITLE
Adding a page by task

### DIFF
--- a/lib/modules/apostrophe-pages/index.js
+++ b/lib/modules/apostrophe-pages/index.js
@@ -291,6 +291,76 @@ module.exports = {
       ], callback);
     };
 
+    // Task to add a page from apostrophe
+    // command line
+
+    self.apos.tasks.add('apostrophe-pages', 'add',
+      'Usage: node app apostrophe-pages:add title /slug type /parentslug\n\n' +
+      'This adds a new page .\n',
+      function(apos, argv, callback) {
+        return self.addFromTask(callback);
+      }
+    );
+
+    self.addFromTask = function(callback) {
+      var argv = self.apos.argv;
+      if(argv._.length !== 5 ){
+        return callback('Incorrect number of arguments.');
+      }
+
+      var title = argv._[1];
+      var slug = argv._[2];
+      var type = argv._[3];
+      var parentslug = argv._[4];
+      var req = self.apos.tasks.getReq();
+
+      var page = {
+          editUsersIds: [],
+          loginRequired: '',
+          orphan: '0',
+          published: '1',
+          slug: slug,
+          tags: [],
+          title: title,
+          type: type
+        };
+
+      
+      var parentPage;
+      var safePage;
+      return async.series({
+        findParent: function(cb) {
+          return self.find(req, { slug: parentslug }).permission('publish-apostrophe-page').toObject(function(err, _parentPage) {
+            if (err) {
+              return cb(err);
+            }
+            if (!_parentPage) {
+              return cb('Parent page not found');
+            }
+            parentPage = _parentPage;
+            safePage = self.newChild(parentPage);
+            return cb(null);
+          });
+        },
+        convert: function(cb) {
+          var manager = self.apos.docs.getManager(self.apos.launder.string(page.type));
+          if (!manager) {
+            return cb('Template not found');
+          }
+          var schema = manager.allowedSchema(req);
+          return self.apos.schemas.convert(req, schema, 'form', page, safePage, cb);
+        },
+        insert: function(cb) {
+          return self.insert(req, parentPage, safePage, cb);
+        }
+      }, function(err) {
+        if (err) {
+          return callback(err);
+        }
+        return callback();
+      });
+    };
+
   },
 
 };


### PR DESCRIPTION
I extended the apostrophe-pages module to propose a task to add a page. 
I think is a "developer-friendly" feature to include in apostrophe-pages, but if you prefer I can create a new module on npm for that.