### PR TITLE
first pass at RTL interface, one big file

### DIFF
--- a/lib/modules/apostrophe-ui/public/css/global/rtl.less
+++ b/lib/modules/apostrophe-ui/public/css/global/rtl.less
@@ -1,0 +1,126 @@
+.apos-rtl {
+
+  .apos-ui {
+    text-align: right;
+    direction: rtl;
+  }
+
+  a.cke_button,
+  .cke_toolgroup,
+  .cke_combo {
+    float: right;
+  }
+
+  .apos-ui .apos-chooser-manage-view-wrapper { 
+    float: left;
+  }
+
+  .apos-modal .apos-array-editor {
+    float: left;
+  }
+  .apos-modal .apos-array-add-item, .apos-modal .apos-array-limit-reached {
+    left: auto; right: 0;
+  }
+
+  .apos-ui .fa-angle-right {
+    -webkit-transform: rotateY(180deg);
+    transform: rotateY(180deg);
+  }
+
+  .apos-ui .apos-button--circular .fa-plus:before{
+    position: relative;
+    left: 10px;
+  }
+  .apos-ui .apos-dropdown.apos-dropdown--area-controls.apos-active>.apos-button>i {
+    left: 1px;
+    top: 3px;
+  }
+  .apos-modal .apos-reorganize-tree {
+    margin-left: 0;
+    margin-right: 220px;
+  }
+  .apos-ui.apos-modal .apos-manage-result-label { text-align: right; }
+  .apos-ui .apos-table table { text-align: right; }
+  .apos-ui .apos-admin-bar { left: auto; right: 20px; }
+  .apos-ui .apos-context-menu-container { left: auto; right: 20px; }
+  .apos-area-widget-controls--context { left: auto; right: 10px;}
+  .apos-area.apos-empty>.apos-ui .apos-area-controls--singleton { left: auto; right: 20px; text-align: right; }
+  .apos-ui.apos-modal .apos-modal-header .apos-modal-controls { float: left; }
+  .apos-modal .apos-schema-group { float: left; }
+  .apos-ui.apos-modal .apos-modal-header .apos-modal-filters .apos-modal-filter, .apos-ui.apos-modal .apos-modal-body .apos-modal-filters .apos-modal-filter
+  {
+    margin-right: 0; margin-left: 40px;
+  }
+  .apos-ui.apos-modal .apos-modal-header .apos-modal-title { margin-right: 0; margin-left: 2%;}
+  .apos-ui.apos-modal .apos-modal-header .apos-modal-filters .apos-modal-filter .apos-field-input-select-wrapper select, .apos-ui.apos-modal .apos-modal-body .apos-modal-filters .apos-modal-filter .apos-field-input-select-wrapper select
+  {
+    margin-left: 0;
+    margin-right: 10px;
+    padding: 10px 15px0px 10px 30px
+  }
+  .apos-ui.apos-modal .apos-modal-header .apos-modal-filters .apos-modal-filter .apos-field-input-select-wrapper::after, .apos-ui.apos-modal .apos-modal-body .apos-modal-filters .apos-modal-filter .apos-field-input-select-wrapper::after {
+    right: auto;
+    left: 1px;
+  }
+  .apos-manage-pager {
+    float: left;
+  }
+  .apos-manage-batch-operations {
+    float: right;
+  }
+  .apos-manage-batch-operations .apos-manage-batch-operations-select {
+    margin-right: 0; margin-left: 20px;
+  }
+  .apos-ui .apos-manage-batch-operation-forms .apos-field-tags .apos-tags .apos-tag-add {
+    right: 133px;
+    left: auto;
+  }
+  .apos-ui .apos-manage-batch-operation-forms .apos-field-tags .apos-field-label {
+    left: 50px;
+  }
+  .apos-ui .apos-field-tags .apos-tags .apos-tag-add {
+    left: 0; right: auto;
+  }
+  .apos-ui .apos-field-input-select-wrapper:after {
+    left: 30px; right: auto;
+  }
+  .apos-reorganize-tree .jqtree-tree .jqtree-title {
+    margin-right: 2em;
+  }
+  ul.jqtree-tree .jqtree-toggler {
+    margin-left: 0.5em;
+    margin-right: 0;
+  }
+  .apos-reorganize-tree .jqtree-tree .jqtree-title {
+    margin-left: 0;
+  }
+  .apos-reorganize-tree .jqtree-tree .apos-reorganize-controls a {
+    padding-right: 10px;
+    padding-left: 0;
+  }
+  ul.jqtree-tree .jqtree-title.jqtree-title-folder {
+    margin-right: 0;
+  }
+  .apos-reorganize-tree .jqtree-tree .jqtree-folder>ul.jqtree_common {
+    margin-right: 14px;
+    border-right: 2px dashed @apos-primary;
+    margin-left: 0;
+    border-left: 0;
+  }
+  .apos-reorganize-tree .jqtree-tree .jqtree-folder {
+    padding-right: 10px;
+  }
+  .apos-modal.apos-versions-modal .apos-versions .apos-version a[data-apos-revert] {
+    float: left;
+  }
+  .apos-modal.apos-versions-modal .apos-versions .apos-version cite {
+    margin-left: 0.2em;
+    margin-right: 0;
+  }
+
+  .apos-modal.apos-versions-modal .apos-versions .apos-version>.apos-changes {
+    padding-right: 60px;
+    padding-left: 0;
+  }
+}
+

--- a/lib/modules/apostrophe-ui/public/css/user.less
+++ b/lib/modules/apostrophe-ui/public/css/user.less
@@ -32,5 +32,6 @@
 	@import 'components/tables.less';
 }
 
+@import 'global/rtl.less';
 @import 'components/autocomplete.less';
 @import 'components/busy.less';


### PR DESCRIPTION
just drop the class `apos-rtl` into your `{% bodyClass %}` block to get rolling.

As a first pass, this is all in one giant RTL stylesheet file. These style adjustments should get integrated into the appropriate component-level stylesheets.

There is also a glitch I am investigating where certain character symbols `.` `()` don't respect the same order as the rest of the text string.

Having this kind of support is not trivial, any new interface elements will have to be double checked against the `apos-rtl` class.

Begins to address #245