### PR TITLE
build a complete picture of docIds and trashDocIds in the migration, …

### DIFF
--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -627,12 +627,12 @@ module.exports = function(self, options) {
   };
 
   self.addDocReferencesMigration = function() {
-    
     self.apos.migrations.add(self.__meta.name + '.docReferences', function(callback) {
-
       var needed;
+      var attachmentUpdates = {};
+      var parsed = 0;
 
-      return async.series([ needed, docs, attachments ], callback);
+      return async.series([ needed, docs, attachments, self.updatePermissions ], callback);
 
       function needed(callback) {
         return self.db.findOne({ docIds: { $exists: 0 } }, function(err, found) {
@@ -648,14 +648,45 @@ module.exports = function(self, options) {
         if (!needed) {
           return setImmediate(callback);
         }
-        return self.apos.migrations.eachDoc({}, 5, self.updateDocReferences, callback);
+        return self.apos.migrations.eachDoc({}, 5, addAttachmentUpdates, callback);
+      }
+
+      function addAttachmentUpdates(doc, callback) {
+        var attachments = self.all(doc);
+        var ids = _.uniq(_.pluck(attachments, '_id'));
+        _.each(ids, function(id) {
+          attachmentUpdates[id] = attachmentUpdates[id] || {
+            $set: {
+              docIds: [],
+              trashDocIds: []
+            }
+          };
+          if (doc.trash) {
+            attachmentUpdates[id].$set.trashDocIds.push(doc._id);
+          } else {
+            attachmentUpdates[id].$set.docIds.push(doc._id);
+          }
+          attachmentUpdates[id].$set.utilized = true;
+        });
+        return setImmediate(callback);
       }
 
       function attachments(callback) {
         if (!needed) {
           return setImmediate(callback);
         }
-        return async.series([ docIds, trashDocIds ], callback);
+        return async.series([ applyAttachmentUpdates, docIds, trashDocIds ], callback);
+        function applyAttachmentUpdates(callback) {
+          return async.eachLimit(_.keys(attachmentUpdates).slice(), 5, function(id, callback) {
+            return self.db.update(
+              {
+                _id: id
+              },
+              attachmentUpdates[id],
+              callback
+            );
+          }, callback);
+        }
         function docIds(callback) {
           return self.db.update({
             docIds: { $exists: 0 }
@@ -783,8 +814,7 @@ module.exports = function(self, options) {
 
     return async.series([
       updateCounts,
-      hide,
-      show
+      self.updatePermissions
     ], callback);
 
     function updateCounts(callback) {
@@ -792,6 +822,29 @@ module.exports = function(self, options) {
         return self.db.update(command[0], command[1], callback);
       }, callback);
     }
+      
+  };
+
+  // Update the permissions in uploadfs of all attachments
+  // based on whether the documents containing them
+  // are in the trash or not. Specifically, if an attachment
+  // has been utilized at least once but no longer has
+  // any entries in `docIds` and `trash` is not yet true,
+  // it becomes web-inaccessible, `utilized` is set to false
+  // and `trash` is set to true. Similarly, if an attachment
+  // has entries in `docIds` but `trash` is true,
+  // it becomes web-accessible and trash becomes false.
+  //
+  // This method is invoked at the end of `updateDocReferences`
+  // and also at the end of the migration that adds `docIds`
+  // to legacy sites. You should not need to invoke it yourself.
+
+  self.updatePermissions = function(callback) {
+
+    return async.series([
+      hide,
+      show
+    ], callback);
 
     function hide(callback) {
       return self.db.find({
@@ -906,7 +959,6 @@ module.exports = function(self, options) {
         }, callback);
       }
     }
-      
   };
 
 }


### PR DESCRIPTION
…rather than iterating the method for single docs

The use of mongodb bulkWrite operations was also considered, however it did not yield a significant performance improvement. So I reconsidered the approach and built a complete map of the docIds and trashDocIds appropriate to each attachment and then popped that into the database by iterating over the attachments, only once per attachment that actually has any docIds or trashDocIds. This is much faster. 

The initial construction of the map might be a bit quicker if it wasn't stuck with a setImmediate call for each doc, but in practice it completes in just a few minutes for close to 900,000 docs, so I'm going to stop here rather than over-optimizing.