### PR TITLE
clonePermanent 

### DIFF
--- a/lib/modules/apostrophe-browser-utils/public/js/always.js
+++ b/lib/modules/apostrophe-browser-utils/public/js/always.js
@@ -177,8 +177,7 @@ apos.define('apostrophe-browser-utils', {
     //
     // This removes the output of joins and
     // other dynamic loaders, so that dynamically available
-    // related content is not considered when comparing the
-    // equality of two objects with _.isEq later.
+    // content is not stored redundantly in MongoDB.
     //
     // If the object is an array, the clone is also an array.
     //
@@ -186,16 +185,27 @@ apos.define('apostrophe-browser-utils', {
     // objects are cloned as plain JSON objects.
     //
     // If `keepScalars` is true, properties beginning with `_`
-    // are kept as long as they are not objects.
+    // are kept as long as they are not objects. This is useful
+    // when using `clonePermanent` to limit JSON inserted into
+    // browser attributes, rather than filtering for the database.
+    // Preserving simple string properties like `._url` is usually
+    // a good thing in the former case.
+    //
+    // Arrays are cloned as such only if they are true arrays
+    // (Array.isArray returns true). Otherwise all objects with
+    // a length property would be treated as arrays, which is
+    // an unrealistic restriction on apostrophe doc schemas.
 
     self.clonePermanent = function(o, keepScalars) {
       var c;
-      if (Array.isArray(o)) {
+      var isArray = Array.isArray(o);
+      if (isArray) {
         c = [];
       } else {
         c = {};
       }
-      _.each(o, function(val, key) {
+
+      function iterator(val, key) {
         // careful, don't crash on numeric keys
         if (typeof key === 'string') {
           if ((key.charAt(0) === '_') && (key !== '_id')) {
@@ -204,7 +214,7 @@ apos.define('apostrophe-browser-utils', {
             }
           }
         }
-        if (val === null) {
+        if ((val === null) || (val === undefined)) {
           // typeof(null) is object, sigh
           c[key] = null;
         } else if (typeof (val) !== 'object') {
@@ -214,7 +224,13 @@ apos.define('apostrophe-browser-utils', {
         } else {
           c[key] = self.clonePermanent(val, keepScalars);
         }
-      });
+      }
+
+      if (isArray) {
+        _.each(o, iterator);
+      } else {
+        _.forOwn(o, iterator);
+      }
       return c;
     };
 


### PR DESCRIPTION
`clonePermanent` was updated on server but not browser to treat only true arrays as arrays. Now this is consistent, fixing a problem with attachments in schemas seen on CP.