### PR TITLE
keepalive mechanism now uses a query against an empty collection rath…

### DIFF
--- a/lib/modules/apostrophe-db/index.js
+++ b/lib/modules/apostrophe-db/index.js
@@ -109,9 +109,10 @@ module.exports = {
     // a feature now. -Tom
 
     self.keepalive = function() {
+      self.keepaliveCollection = self.apos.db.collection('aposKeepalive');
       self.keepaliveInterval = setInterval(function() {
         // We don't actually care about the result.
-        return self.apos.db.admin().serverStatus(function(err, info) {
+        return self.keepaliveCollection.findOne(function(err, dummy) {
           if (err) {
             console.error(err);
           }


### PR DESCRIPTION
…er than a serverStatus command, which might not be something the mongo user has permission to do (for instance with various mongo hosting packages)