### PR TITLE
avoid unnecessary work when fetching pages during parking. Big speedu…

### DIFF
--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -1535,7 +1535,7 @@ module.exports = function(self, options) {
         } else {
           parentSlug = item.parent;
         }
-        return self.find(req, { slug: parentSlug }).published(null).permission(false).trash(null).toObject(function(err, _parent) {
+        return self.find(req, { slug: parentSlug }).joins(false).areas(false).published(null).permission(false).trash(null).toObject(function(err, _parent) {
           if (err) {
             return callback(err);
           }
@@ -1560,7 +1560,7 @@ module.exports = function(self, options) {
         } else {
           criteria.slug = slugWithOrWithoutSlash;
         }
-        return self.find(req, criteria).published(null).permission(false).trash(null).toObject(function(err, _existing) {
+        return self.find(req, criteria).joins(false).areas(false).published(null).permission(false).trash(null).toObject(function(err, _existing) {
           if (err) {
             return callback(err);
           }
@@ -1576,7 +1576,7 @@ module.exports = function(self, options) {
         var criteria = {};
         var slugWithOrWithoutSlash = new RegExp('^' + self.apos.utils.regExpQuote(item.slug.replace(/\/$/, '')) + '/?$');
         criteria.slug = slugWithOrWithoutSlash;
-        return self.find(req, criteria).published(null).permission(false).trash(null).toObject(function(err, _existing) {
+        return self.find(req, criteria).joins(false).areas(false).published(null).permission(false).trash(null).toObject(function(err, _existing) {
           if (err) {
             return callback(err);
           }


### PR DESCRIPTION
…p with workflow and dozens of locales times several parked pages. Also stops unnecessary warnings about recursive joins