### PR TITLE
Added class to h4 image title

### DIFF
--- a/lib/modules/apostrophe-images-widgets/views/widgetBase.html
+++ b/lib/modules/apostrophe-images-widgets/views/widgetBase.html
@@ -14,7 +14,7 @@
               ; background-position: {{ apos.attachments.focalPointToBackgroundPosition(relationship) }}
             {%- endif -%}
           ">
-          {%- block title -%}<h4 class="image-title">{{ image.title }}</h4>{%- endblock -%}
+          {%- block title -%}<h4 class="apos-image-widget-image-title">{{ image.title }}</h4>{%- endblock -%}
           <img alt="{% block imgAlt %}{{ image.title }}{% endblock %}" data-image src="{% block imgSrc %}{{ apos.attachments.url(image.attachment, { size: data.options.size, crop: relationship }) }}{% endblock %}" />
           {%- block credit -%}
             {%- if image.credit -%}

--- a/lib/modules/apostrophe-images-widgets/views/widgetBase.html
+++ b/lib/modules/apostrophe-images-widgets/views/widgetBase.html
@@ -14,7 +14,7 @@
               ; background-position: {{ apos.attachments.focalPointToBackgroundPosition(relationship) }}
             {%- endif -%}
           ">
-          {%- block title -%}<h4>{{ image.title }}</h4>{%- endblock -%}
+          {%- block title -%}<h4 class="image-title">{{ image.title }}</h4>{%- endblock -%}
           <img alt="{% block imgAlt %}{{ image.title }}{% endblock %}" data-image src="{% block imgSrc %}{{ apos.attachments.url(image.attachment, { size: data.options.size, crop: relationship }) }}{% endblock %}" />
           {%- block credit -%}
             {%- if image.credit -%}


### PR DESCRIPTION
Allows the title to be hidden using CSS when not required. 

It's not always pretty to show the image title when the widget is used, and especially when it's embedded in other widgets. Adding a class to the h4 image title allows it to be easily hidden using CSS only when it's not required.