### PR TITLE
do not send X-XSRF-TOKEN headers in an OPTIONS request. And on the se…

### DIFF
--- a/lib/modules/apostrophe-assets/public/js/always.js
+++ b/lib/modules/apostrophe-assets/public/js/always.js
@@ -136,7 +136,7 @@ _.extend(apos, {
 
   csrf: function() {
     $.ajaxPrefilter(function(options, originalOptions, jqXHR) {
-      if (!options.crossDomain) {
+      if ((options.type !== 'OPTIONS') && (!options.crossDomain)) {
         var csrfToken = $.cookie(apos.csrfCookieName);
         jqXHR.setRequestHeader('X-XSRF-TOKEN', csrfToken);
       }

--- a/lib/modules/apostrophe-assets/public/js/user.js
+++ b/lib/modules/apostrophe-assets/public/js/user.js
@@ -2,7 +2,7 @@ _.extend(apos, {
   enableHtmlPageId: function() {
     if (apos.htmlPageId) {
       $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
-        if (!options.crossDomain) {
+        if ((options.type !== 'OPTIONS') && (!options.crossDomain)) {
           jqXHR.setRequestHeader('Apostrophe-Html-Page-Id', apos.htmlPageId);
         }
       });

--- a/lib/modules/apostrophe-express/index.js
+++ b/lib/modules/apostrophe-express/index.js
@@ -461,8 +461,13 @@ module.exports = {
 
     self.csrfWithoutExceptions = function(req, res, next) {
       var token;
-      // All non-safe methods are subject to CSRF by default
-      if ((req.method === 'GET') || (req.method === 'HEAD') || (req.method === 'OPTIONS') || (req.method === 'TRACE')) {
+      // OPTIONS request cannot set a cookie, so manipulating the session here
+      // is not helpful. Do not attempt to set XSRF-TOKEN for OPTIONS
+      if (req.method === 'OPTIONS') {
+        return next();
+      }
+      // Safe request establishes XSRF-TOKEN in session if not set already
+      if ((req.method === 'GET') || (req.method === 'HEAD') || (req.method === 'TRACE')) {
         token = req.session && req.session['XSRF-TOKEN'];
         if (!token) {
           token = self.apos.utils.generateId();


### PR DESCRIPTION
…rver side, do not attempt to create a CSRF cookie in response to one, since cookies cannot be set for OPTIONS anyway. This fixes incompatibilities that come up when DGAD bakes their own APIs into apostrophe sites.