### PR TITLE
npmRootDir and localesDir options that override apos.rootDir, allowin…

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = function(options) {
     // Determine root module and root directory
     self.root = options.root || getRoot();
     self.rootDir = options.rootDir || path.dirname(self.root.filename);
+    self.npmRootDir = options.npmRootDir || self.rootDir;
 
     testModule();
 
@@ -257,7 +258,7 @@ module.exports = function(options) {
   }
 
   function getNpmPath(name) {
-    var parentPath = path.resolve(self.rootDir);
+    var parentPath = path.resolve(self.npmRootDir);
     try {
       return npmResolve.sync(name, { basedir: parentPath });
     } catch (e) {

--- a/lib/modules/apostrophe-i18n/index.js
+++ b/lib/modules/apostrophe-i18n/index.js
@@ -3,6 +3,11 @@
 // usual `__()` helper function. Any options passed to this module are passed on to `i18n`.
 //
 // By default i18n locale files are generated in the `locales` subdirectory of the project.
+//
+// ## Options
+//
+// `localesDir`: if specified, the locale `.json` files are stored here, otherwise they
+// are stored in the `locales` subdirectory of the project root.
 
 var _ = require('lodash');
 var i18n = require('i18n');
@@ -14,7 +19,7 @@ module.exports = {
     _.defaults(i18nOptions, {
       locales: ['en'],
       cookie: 'apos_language',
-      directory: self.apos.rootDir + '/locales'
+      directory: self.options.localesDir || (self.apos.rootDir + '/locales')
     });
     i18n.configure(i18nOptions);
 


### PR DESCRIPTION
…g rootDir to be used to point all asset-ish, data-ish things painlessly to an alternate location