### PR TITLE
Adds help text to html fields by default

### DIFF
--- a/lib/modules/apostrophe-html-widgets/index.js
+++ b/lib/modules/apostrophe-html-widgets/index.js
@@ -17,7 +17,8 @@ module.exports = {
         type: 'string',
         name: 'code',
         label: 'Raw HTML (Code)',
-        textarea: true
+        textarea: true,
+        help: 'Be careful when embedding third-party code, as it can break the website editing functionality. If a page becomes unusable, add "?safe_mode=1" to the URL to make it work temporarily without the problem code being rendered.'
       }
     ];
   },


### PR DESCRIPTION
When adding an HTML field for a client it seemed that help text would be valuable to head off and deal with code conflicts. I figured that might be worth including by default. Some of the text is taken from the comment at the top of that file.