### PR TITLE
dgad 417: query optimizations

### DIFF
--- a/lib/modules/apostrophe-docs/lib/api.js
+++ b/lib/modules/apostrophe-docs/lib/api.js
@@ -23,9 +23,13 @@ module.exports = function(self, options) {
     return { slug: 1 };
   };
 
+  self.getPathLevelIndexParams = function() {
+    return { path: 1, level: 1 };
+  };
+
   self.ensureIndexes = function(callback) {
 
-    async.series([ indexType, self.ensureSlugIndex, indexTitleSortified, indexUpdatedAt, indexTags, indexPublished, indexText, indexParkedId, indexAdvisoryLockId ], callback);
+    async.series([ indexType, self.ensureSlugIndex, indexTitleSortified, indexUpdatedAt, indexTags, indexPublished, indexText, indexParkedId, indexAdvisoryLockId, self.ensurePathLevelIndex ], callback);
 
     function indexType(callback) {
       self.db.ensureIndex({ type: 1 }, {}, callback);
@@ -68,6 +72,11 @@ module.exports = function(self, options) {
 
   self.ensureTextIndex = function(callback) {
     return self.db.ensureIndex({ highSearchText: 'text', lowSearchText: 'text', title: 'text', searchBoost: 'text' }, { default_language: self.options.searchLanguage || 'none', weights: { title: 100, searchBoost: 150, highSearchText: 10, lowSearchText: 2 } }, callback);
+  };
+
+  self.ensurePathLevelIndex = function(callback) {
+    var params = self.getPathLevelIndexParams();
+    return self.db.ensureIndex(params, {}, callback);
   };
 
   // Returns a query cursor based on the permissions

--- a/lib/modules/apostrophe-docs/lib/cursor.js
+++ b/lib/modules/apostrophe-docs/lib/cursor.js
@@ -758,7 +758,7 @@ module.exports = {
         var property = self.get('explicitOrderProperty');
         if (!values.length) {
           // MongoDB gets mad if you have an empty $in
-          criteria[property] = { _iNeverMatch: true };
+          criteria[property] = { _id: '__iNeverMatch' };
           self.and(criteria);
           return;
         }

--- a/lib/modules/apostrophe-pages/lib/pagesCursor.js
+++ b/lib/modules/apostrophe-pages/lib/pagesCursor.js
@@ -83,6 +83,11 @@ module.exports = {
             paths = paths.slice(-parameters.depth);
           }
 
+          if (!paths.length) {
+            page._ancestors = [];
+            return callback(null);
+          }
+
           aCursor.and({
             path: { $in: paths }
           });
@@ -131,7 +136,7 @@ module.exports = {
       def: false,
       after: function(results, callback) {
         var value = self.get('children');
-        if (!value) {
+        if ((!value) || (!results.length)) {
           return setImmediate(callback);
         }
 

--- a/lib/modules/apostrophe-pages/lib/pagesCursor.js
+++ b/lib/modules/apostrophe-pages/lib/pagesCursor.js
@@ -166,13 +166,7 @@ module.exports = {
           });
         });
 
-        // Because mongo is incredibly stubborn in
-        // that awful mysql way now
-        if (clauses.length) {
-          cCursor.and({ $or: clauses });
-        } else {
-          cCursor.and({ ___neverEverDefined: true });
-        }
+        cCursor.and({ $or: clauses });
 
         cCursor.sort({ level: 1, rank: 1 });
 

--- a/lib/modules/apostrophe-permissions/lib/api.js
+++ b/lib/modules/apostrophe-permissions/lib/api.js
@@ -43,7 +43,7 @@ module.exports = function(self, options) {
   // specified action.
 
   self.criteria = function(req, action) {
-    var result = self._check(req, action, 'criteria', {}, { _iNeverMatch: true }, undefined, undefined, function(req, permissions, verb, type, object, newObject, strategy) {
+    var result = self._check(req, action, 'criteria', {}, { _id: '__iNeverMatch' }, undefined, undefined, function(req, permissions, verb, type, object, newObject, strategy) {
       return strategy.criteria(req, permissions, verb, type);
     });
     return result;

--- a/lib/modules/apostrophe-permissions/lib/strategiesApi.js
+++ b/lib/modules/apostrophe-permissions/lib/strategiesApi.js
@@ -118,7 +118,7 @@ module.exports = function(self, options) {
 
           if (!req.user) {
             // We want to never match
-            return { _iNeverMatch: true };
+            return { _id: '__iNeverMatch' };
           }
           // Case #4: we are only interested in people with a
           // specific permission.


### PR DESCRIPTION
* Filters like `children` and `ancestors` should not make any query at all if there are no docs returned by the original request. Formerly this was handled by making a query that never matches. To make matters worse, it was an extremely inefficient, unindexed query that never matches. 😢 
* In cases where we really do need to add a clause that never matches, at least for now, in order to avoid a major refactoring of code that is trying to stick to good separation of concerns and not try to cancel or even touch the larger query it is becoming a part of, we should write `{ _id: '__iNeverMatch' }` instead of `{ iNeverMatch: true }`, because `_id` queries are always indexed. In most of these cases, there are other clauses making the query efficient anyway, but the `explicitOrder` filter could have been very slow due to this in cases where there are no ids to order upon and nothing should be returned.