### PR TITLE
release resources better between tests, export a library that modules…

### DIFF
--- a/lib/modules/apostrophe-attachments/index.js
+++ b/lib/modules/apostrophe-attachments/index.js
@@ -210,6 +210,14 @@ module.exports = {
       }
     };
 
+    self.apostropheDestroy = function(callback) {
+      if (!self.uploadfs.destroy) {
+        self.apos.utils.warn('uploadfs dependency is old, cannot clean up resources i.e. timers that will prevent exit');
+        return callback(null);
+      }
+      return self.uploadfs.destroy(callback);
+    };
+
     self.enableCollection = function(callback) {
       return async.series([ collection, indexDocIds, indexTrashDocIds ], callback);
       function collection(callback) {

--- a/test-lib/test.js
+++ b/test-lib/test.js
@@ -1,51 +1,8 @@
 var fs = require('fs');
-var async = require('async');
 
 if (!fs.existsSync(__dirname + '/../test/node_modules')) {
   fs.mkdirSync(__dirname + '/../test/node_modules');
   fs.symlinkSync(__dirname + '/..', __dirname + '/../test/node_modules/apostrophe', 'dir');
 }
 
-// Global function to properly clean up an apostrophe instance and drop its
-// database to create a sane environment for the next test
-
-function destroy(apos, done) {
-  if (!apos) {
-    done();
-    return;
-  }
-  return async.series([
-    drop,
-    destroy
-  ], function(err) {
-    if (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
-      process.exit(1);
-    }
-    return done();
-  });
-  function drop(callback) {
-    return apos.db.collections(function(err, collections) {
-      if (err) {
-        return callback(err);
-      }
-
-      // drop the collections
-      return async.eachSeries(collections, function(collection, callback) {
-        if (!collection.collectionName.match(/^system\./)) {
-          return collection.drop(callback);
-        }
-        return setImmediate(callback);
-      }, callback);
-    });
-  }
-  function destroy(callback) {
-    return apos.destroy(callback);
-  }
-};
-
-module.exports = {
-  destroy: destroy,
-  timeout: (process.env.TEST_TIMEOUT && parseInt(process.env.TEST_TIMEOUT)) || 5000
-};
+module.exports = require('./util.js');

--- a/test-lib/util.js
+++ b/test-lib/util.js
@@ -1,0 +1,48 @@
+var async = require('async');
+
+// Properly clean up an apostrophe instance and drop its
+// database collections to create a sane environment for the next test.
+// Drops the collections, not the entire database, to avoid problems
+// when testing something like a mongodb hosting environment with
+// credentials per database.
+
+function destroy(apos, done) {
+  if (!apos) {
+    done();
+    return;
+  }
+  return async.series([
+    drop,
+    destroy
+  ], function(err) {
+    if (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
+      process.exit(1);
+    }
+    return done();
+  });
+  function drop(callback) {
+    return apos.db.collections(function(err, collections) {
+      if (err) {
+        return callback(err);
+      }
+
+      // drop the collections
+      return async.eachSeries(collections, function(collection, callback) {
+        if (!collection.collectionName.match(/^system\./)) {
+          return collection.drop(callback);
+        }
+        return setImmediate(callback);
+      }, callback);
+    });
+  }
+  function destroy(callback) {
+    return apos.destroy(callback);
+  }
+};
+
+module.exports = {
+  destroy: destroy,
+  timeout: (process.env.TEST_TIMEOUT && parseInt(process.env.TEST_TIMEOUT)) || 5000
+};


### PR DESCRIPTION
… like apostrophe-site-map can use to do cleanup of apostrophe between tests