### PR TITLE
fixed bug in eachWidget method of migrations module which set the dot…

### DIFF
--- a/lib/modules/apostrophe-migrations/lib/api.js
+++ b/lib/modules/apostrophe-migrations/lib/api.js
@@ -127,7 +127,7 @@ module.exports = function(self, options) {
       return async.eachSeries(area.items || [], function(item, callback) {
         var n = i;
         i++;
-        return iterator(doc, item, dotPath + '.' + n, callback);
+        return iterator(doc, item, dotPath + '.items.' + n, callback);
       }, callback);
     }, callback);
   };


### PR DESCRIPTION
…Path parameter to the iterator incorrectly.

This method is used to iterate over literally every widget in apostropheland, for purposes of modifying them all. Obviously not done every day.

A good example of usage is in this `apostrophe-personas` PR which I just assigned to you.

Looks like we haven't used this method's `dotPath` feature in migrations written so far, I did check. (Hopefully, if we had, we would have stopped to fix it...)
