### PR TITLE
Added block to the context menu

### DIFF
--- a/lib/modules/apostrophe-templates/views/outerLayoutBase.html
+++ b/lib/modules/apostrophe-templates/views/outerLayoutBase.html
@@ -16,14 +16,16 @@
       {{ apos.adminBar.output() }}
     {% endblock %}
 
-    {% if data.user %}
-      <div class="apos-ui">
-        <div class="apos-context-menu-container">
-          {{ apos.pages.publishMenu({ publishMenu: data.publishMenu, page: data.page, piece: data.piece, bottom: true }) }}
-          {{ apos.pages.menu({ contextMenu: data.contextMenu, page: data.page, bottom: true })}}
-          {{ apos.pages.afterContextMenu() }}
+    {% block apostropheContextMenu %}
+      {% if data.user %}
+        <div class="apos-ui">
+          <div class="apos-context-menu-container">
+            {{ apos.pages.publishMenu({ publishMenu: data.publishMenu, page: data.page, piece: data.piece, bottom: true }) }}
+            {{ apos.pages.menu({ contextMenu: data.contextMenu, page: data.page, bottom: true })}}
+            {{ apos.pages.afterContextMenu() }}
+          </div>
         </div>
-      </div>
+      {% endif %}
     {% endif %}
     <div class="apos-refreshable" data-apos-refreshable>
       {% block beforeMain %}{% endblock %}


### PR DESCRIPTION
Added a block surrounding the context menu code. This will allow developers to control access to this menu by simply overriding the block inside of their local "lib/modules/apostrophe-templates/views/outerLayout.html"