### PR TITLE
Parses date before moment processing

### DIFF
--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -409,7 +409,7 @@ module.exports = {
           return '';
         }
 
-        date = Date.parse(date);
+        date = new Date(date).toISOString();
 
         var s = moment(date).format(format);
         return s;

--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -408,6 +408,9 @@ module.exports = {
         if (!date) {
           return '';
         }
+
+        date = Date.parse(date);
+
         var s = moment(date).format(format);
         return s;
       });


### PR DESCRIPTION
In an older 2.x project we're passing a date from the Twitter API through the date filter, bypassing the normal processing in apostrophe-twitter-widgets' [`getRelativeTime`](https://github.com/apostrophecms/apostrophe-twitter-widgets/blob/master/index.js#L159) method. This caused Moment.js to kick out this warning:

> Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date(), which is not reliable across all browsers and versions. Non RFC2822/ISO date formats are discouraged and will be removed in an upcoming major release. Please refer to http://momentjs.com/guides/#/warnings/js-date/ for more info.

The change here uses the `Date.parse()` method in the date filter the same as apostrophe-twitter-widgets does to prep the data, preventing the deprecation warning.