### PR TITLE
Hotfix/forbidden type

### DIFF
--- a/lib/modules/apostrophe-custom-pages/lib/api.js
+++ b/lib/modules/apostrophe-custom-pages/lib/api.js
@@ -52,7 +52,7 @@ module.exports = function(self, options) {
 
   self.composeSchema = function() {
     superComposeSchema();
-    const forbiddenFields = [ 'path', 'rank', 'level' ];
+    const forbiddenFields = [ 'path', 'rank', 'level', 'type' ];
     _.each(self.schema, function(field) {
       if (_.contains(forbiddenFields, field.name)) {
         throw new Error('Page type ' + self.name + ': the field name ' + field.name + ' is forbidden');

--- a/lib/modules/apostrophe-custom-pages/lib/api.js
+++ b/lib/modules/apostrophe-custom-pages/lib/api.js
@@ -52,7 +52,7 @@ module.exports = function(self, options) {
 
   self.composeSchema = function() {
     superComposeSchema();
-    const forbiddenFields = [ 'path', 'rank', 'level', 'type' ];
+    const forbiddenFields = [ 'path', 'rank', 'level' ];
     _.each(self.schema, function(field) {
       if (_.contains(forbiddenFields, field.name)) {
         throw new Error('Page type ' + self.name + ': the field name ' + field.name + ' is forbidden');

--- a/lib/modules/apostrophe-doc-type-manager/lib/api.js
+++ b/lib/modules/apostrophe-doc-type-manager/lib/api.js
@@ -157,7 +157,7 @@ module.exports = function(self, options) {
     // properties that will be overwritten by non-schema-driven
     // logic, such as `_id` or `docPermissions`
 
-    const forbiddenFields = [ '_id', 'docPermissions', 'titleSortified', 'highSearchText', 'highSearchWords', 'lowSearchText', 'searchSummary' ];
+    const forbiddenFields = [ '_id', 'docPermissions', 'type', 'titleSortified', 'highSearchText', 'highSearchWords', 'lowSearchText', 'searchSummary' ];
     _.each(self.schema, function(field) {
       if (_.contains(forbiddenFields, field.name)) {
         throw new Error('Doc type ' + self.name + ': the field name ' + field.name + ' is forbidden');


### PR DESCRIPTION
I just ran into a project that tried to add a field named `type` to indicate the type of role the person serves at the organization. This was then being overwritten by Apostrophe (rightfully), but there was no indication of that happening.

This adds this as a forbidden field for docs and pages.