### PR TITLE
Fix preview of crop image in Cross-Domain scenario

### DIFF
--- a/lib/modules/apostrophe-attachments/public/js/cropEditor.js
+++ b/lib/modules/apostrophe-attachments/public/js/cropEditor.js
@@ -21,7 +21,7 @@ apos.define('apostrophe-attachments-crop-editor', {
     };
 
     self.initCropper = function() {
-      var cropperOpts = { viewMode: 1, autoCropArea: 1 };
+      var cropperOpts = { viewMode: 1, autoCropArea: 1, checkCrossOrigin: false };
       if (options.aspectRatio) {
         cropperOpts.aspectRatio = options.aspectRatio[0] / options.aspectRatio[1];
       }


### PR DESCRIPTION
Closes #1217 

Disable Cross Origin Check of copper.js plugin by passing relevant option, as per discussion here https://github.com/apostrophecms/apostrophe/issues/1217
