### PR TITLE
fixed the issue (see #1370) and added a migration to address it retroactively

### DIFF
--- a/lib/modules/apostrophe-attachments/index.js
+++ b/lib/modules/apostrophe-attachments/index.js
@@ -92,6 +92,7 @@ module.exports = {
       self.enableHelpers();
       self.addTypeMigration();
       self.addDocReferencesMigration();
+      self.addFixPermissionsMigration();
       self.addPermissions();
       self.apos.tasks.add('apostrophe-attachments', 'rescale',
         'Usage: node app apostrophe-attachments:rescale\n\n' +

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -842,7 +842,7 @@ module.exports = function(self, options) {
 
   // Update the permissions in uploadfs of all attachments
   // based on whether the documents containing them
-  // are in the trash or not. Specifically, if an atstachment
+  // are in the trash or not. Specifically, if an attachment
   // has been utilized at least once but no longer has
   // any entries in `docIds` and `trash` is not yet true,
   // it becomes web-inaccessible, `utilized` is set to false

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -716,6 +716,22 @@ module.exports = function(self, options) {
 
   };
 
+  self.addFixPermissionsMigration = function() {
+    self.apos.migrations.add(self.__meta.name + '.fixPermissions', function(callback) {
+      return self.apos.migrations.each(self.db, { group: 'images', trash: true }, 5, function(attachment, callback) {
+        return self.applyPermissions(attachment, true, callback);
+      }, function(err) {
+        if (err) {
+          return callback(err);
+        }
+        self.apos.utils.warn('^^^ WARNINGS ABOVE ARE OK. This migration fixes a scenario in which SOME permissions were not set.');
+        return callback(null);
+      });
+    }, {
+      safe: true
+    });
+  };
+
   self.docAfterSave = function(req, doc, options, callback) {
     return self.updateDocReferences(doc, callback);
   };
@@ -826,7 +842,7 @@ module.exports = function(self, options) {
 
   // Update the permissions in uploadfs of all attachments
   // based on whether the documents containing them
-  // are in the trash or not. Specifically, if an attachment
+  // are in the trash or not. Specifically, if an atstachment
   // has been utilized at least once but no longer has
   // any entries in `docIds` and `trash` is not yet true,
   // it becomes web-inaccessible, `utilized` is set to false
@@ -880,74 +896,12 @@ module.exports = function(self, options) {
     }
 
     function permissionsOne(attachment, trash, callback) {
-
-      var method = trash ? self.uploadfs.disable : self.uploadfs.enable;
-      return async.series([
-        original,
-        crops,
-        update
-      ], callback);
-
-      // Handle the original image and its scaled versions
-      // here ("original" means "not cropped")
-      function original(callback) {
-        if ((!trash) && (attachment.trash === undefined)) {
-          // Trash status not set at all yet means
-          // it'll be a live file as of this point,
-          // skip extra API calls
-          return callback(null);
+      return self.applyPermissions(attachment, trash, function(err) {
+        if (err) {
+          return callback(err);
         }
-        var sizes;
-        if (!_.contains([ 'gif', 'jpg', 'png' ], attachment.extension)) {
-          sizes = [ 'original' ];
-        } else {
-          sizes = self.imageSizes.concat([ 'original' ]);
-        }
-        return async.eachSeries(sizes, function(size) {
-          if (size.name === self.sizeAvailableInTrash) {
-            // This size is always kept accessible for preview
-            // in the media library
-            method = self.uploadfs.enable;
-          }
-          var path = self.url(attachment, { uploadfsPath: true, size: size.name });
-          return method(path, function(err) {
-            if (err) {
-              // afterSave is not a good place for fatal errors
-              self.apos.utils.warn('Unable to set permissions on ' + path + ', possibly it does not exist');
-            }
-            return callback(null);
-          });
-        }, callback);
-      }
-
-      function crops(callback) {
-        if ((!trash) && (attachment.trash === undefined)) {
-          // Trash status not set at all yet means
-          // it'll be a live file as of this point,
-          // skip extra API calls
-          return callback(null);
-        }
-        return async.eachSeries(attachment.crops || [], cropOne, callback);
-      }
-
-      function cropOne(crop, callback) {
-        return async.eachSeries(self.imageSizes.concat([ 'original' ]), function(size) {
-          if (size.name === self.sizeAvailableInTrash) {
-            // This size is always kept accessible for preview
-            // in the media library
-            method = self.uploadfs.enable;
-          }
-          var path = self.url(attachment, { crop: crop, uploadfsPath: true, size: size.name });
-          return method(path, function(err) {
-            if (err) {
-              // afterSave is not a good place for fatal errors
-              self.apos.utils.warn('Unable to set permissions on ' + path + ', possibly it does not exist');
-            }
-            return callback(null);
-          });
-        }, callback);
-      }
-
+        return update(callback);
+      });
       function update(callback) {
         return self.db.update({
           _id: attachment._id
@@ -957,6 +911,81 @@ module.exports = function(self, options) {
           }
         }, callback);
       }
+    }
+
+  };
+
+  // Enable or disable access to the given attachment via uploadfs, based on whether
+  // trash is true or false. If the attachment is an image, access
+  // to the size indicated by the `sizeAvailableInTrash` option
+  // (usually `one-sixth`) remains available. This operation is carried
+  // out across all sizes and crops.
+
+  self.applyPermissions = function(attachment, trash, callback) {
+    var method = trash ? self.uploadfs.disable : self.uploadfs.enable;
+    return async.series([
+      original,
+      crops
+    ], callback);
+
+    // Handle the original image and its scaled versions
+    // here ("original" means "not cropped")
+    function original(callback) {
+      if ((!trash) && (attachment.trash === undefined)) {
+        // Trash status not set at all yet means
+        // it'll be a live file as of this point,
+        // skip extra API calls
+        return callback(null);
+      }
+      var sizes;
+      if (!_.contains([ 'gif', 'jpg', 'png' ], attachment.extension)) {
+        sizes = [ { name: 'original' } ];
+      } else {
+        sizes = self.imageSizes.concat([ { name: 'original' } ]);
+      }
+      return async.eachSeries(sizes, function(size, callback) {
+        if (size.name === self.sizeAvailableInTrash) {
+          // This size is always kept accessible for preview
+          // in the media library
+          return callback(null);
+        }
+        var path = self.url(attachment, { uploadfsPath: true, size: size.name });
+        return method(path, function(err) {
+          if (err) {
+            // afterSave is not a good place for fatal errors
+            self.apos.utils.warn('Unable to set permissions on ' + path + ', most likely already done');
+          }
+          return callback(null);
+        });
+      }, callback);
+    }
+
+    function crops(callback) {
+      if ((!trash) && (attachment.trash === undefined)) {
+        // Trash status not set at all yet means
+        // it'll be a live file as of this point,
+        // skip extra API calls
+        return callback(null);
+      }
+      return async.eachSeries(attachment.crops || [], cropOne, callback);
+    }
+
+    function cropOne(crop, callback) {
+      return async.eachSeries(self.imageSizes.concat([ { name: 'original' } ]), function(size) {
+        if (size.name === self.sizeAvailableInTrash) {
+          // This size is always kept accessible for preview
+          // in the media library
+          return callback(null);
+        }
+        var path = self.url(attachment, { crop: crop, uploadfsPath: true, size: size.name });
+        return method(path, function(err) {
+          if (err) {
+            // afterSave is not a good place for fatal errors
+            self.apos.utils.warn('Unable to set permissions on ' + path + ', possibly it does not exist');
+          }
+          return callback(null);
+        });
+      }, callback);
     }
   };
 

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -971,7 +971,7 @@ module.exports = function(self, options) {
     }
 
     function cropOne(crop, callback) {
-      return async.eachSeries(self.imageSizes.concat([ { name: 'original' } ]), function(size) {
+      return async.eachSeries(self.imageSizes.concat([ { name: 'original' } ]), function(size, callback) {
         if (size.name === self.sizeAvailableInTrash) {
           // This size is always kept accessible for preview
           // in the media library

--- a/lib/modules/apostrophe-images/views/manageGridPage.html
+++ b/lib/modules/apostrophe-images/views/manageGridPage.html
@@ -3,7 +3,9 @@
 {% for piece in data.pieces -%}
   <div class="apos-manage-grid-piece" data-focus-{{ piece.type }} data-edit-dbl-{{ data.options.name | css }}="{{ piece._id }}" data-piece="{{ piece._id }}">
     <div class="apos-manage-grid-image">
-      <img src="{{ apos.attachments.url(piece.attachment, { size: 'one-third' } ) }}" alt="">
+      {# Trash only has access to very low fi version of image, by design.
+        Other sizes will 404. Might not seem so due to your cache at first. -Tom #}
+      <img src="{{ apos.attachments.url(piece.attachment, { size: (piece.trash and 'one-sixth') or 'one-third' } ) }}" alt="">
       <div class="apos-image-screen"></div>
       <div class="apos-manage-grid-piece-controls">
         {% set verb = 'rescue' if (piece.trash and not (data.canEditTrash)) else 'edit' %}

--- a/test/attachments.js
+++ b/test/attachments.js
@@ -266,10 +266,10 @@ describe('Attachment', function() {
           assert(attachment.trashDocIds.length === 1);
           try {
             fs.openSync(apos.rootDir + '/public' + apos.attachments.url(attachment, { size: 'original' }), 'r');
-            throw new Error('should not have been accessible');
           } catch (e) {
             return true;
           }
+          throw new Error('should not have been accessible');
         })
         .then(function() {
           return apos.images.rescue(req, image._id);


### PR DESCRIPTION
#1370 