### PR TITLE
Revert "Parses date before moment processing"

### DIFF
--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -408,9 +408,6 @@ module.exports = {
         if (!date) {
           return '';
         }
-
-        date = new Date(date).toISOString();
-
         var s = moment(date).format(format);
         return s;
       });


### PR DESCRIPTION
Reverts apostrophecms/apostrophe#1362

The ISO conversion removes consideration of the time zone. The issue with MomentJS requiring strict ISO or RFC formats in a future release does need to be dealt with, but there's not an obvious solution and this is causing problems now.