### PR TITLE
we need a clean way to add the global doc to req.data from a task etc…

### DIFF
--- a/lib/modules/apostrophe-global/index.js
+++ b/lib/modules/apostrophe-global/index.js
@@ -34,6 +34,7 @@
 // `_id`: the MongoDB ID of the global doc. Available after `modulesReady`.
 
 var async = require('async');
+var Promise = require('bluebird');
 
 module.exports = {
 
@@ -139,25 +140,55 @@ module.exports = {
       self.expressMiddleware = self.addGlobalToData;
     };
 
-    // Standard middleware. Fetch the global doc and add it to `req.data` as `req.data.global`.
+    // Fetch the global doc and add it to `req.data` as `req.data.global`, if it
+    // is not already present. If it is not already present, skip the
+    // extra query.
+    //
+    // If called with three arguments, acts as middleware.
+    //
+    // If called with two arguments, the first is `req` and the second is
+    // invoked as `callback`.
+    //
+    // If called with one argument, that argument is `req` and a promise
+    // is returned.
 
     self.addGlobalToData = function(req, res, next) {
-      if (self.options.deferWidgetLoading) {
-        req.deferWidgetLoading = true;
+      if (arguments.length >= 3) {
+        // middleware
+        return body(function(err) {
+          if (err) {
+            self.apos.utils.error('ERROR loading global doc: ', err);
+            // Here in middleware we can't tell if this would have been a page,
+            // so we can't set `aposError` and wait. We have to force the issue
+            res.status(500).send('error');
+            return;
+          }
+          // Don't break other middleware or routes that might not be defer-aware.
+          // The regular page rendering route will reenable this on its own
+          req.deferWidgetLoading = false;
+          return next();
+        });
+      } else if (arguments.length === 2) {
+        // res is actually callback
+        return body(res);
+      } else {
+        // just takes req and returns promise
+        return Promise.promisify(body)();
       }
-      return async.series([ findGlobal, loadDeferredWidgets ], function(err) {
-        if (err) {
-          self.apos.utils.error('ERROR loading global doc: ', err);
-          // Here in middleware we can't tell if this would have been a page,
-          // so we can't set `aposError` and wait. We have to force the issue
-          res.status(500).send('error');
-          return;
+
+      function body(callback) {
+
+        if (req.data.body) {
+          return callback(null);
         }
-        // Don't break other middleware or routes that might not be defer-aware.
-        // The regular page rendering route will reenable this on its own
-        req.deferWidgetLoading = false;
-        return next();
-      });
+
+        if (self.options.deferWidgetLoading) {
+          req.deferWidgetLoading = true;
+        }
+
+        return async.series([ findGlobal, loadDeferredWidgets ], callback);
+
+      }
 
       function findGlobal(callback) {
         return self.findGlobal(req, function(err, result) {

--- a/lib/modules/apostrophe-global/index.js
+++ b/lib/modules/apostrophe-global/index.js
@@ -141,7 +141,7 @@ module.exports = {
     };
 
     // Fetch the global doc and add it to `req.data` as `req.data.global`, if it
-    // is not already present. If it is not already present, skip the
+    // is not already present. If it is already present, skip the
     // extra query.
     //
     // If called with three arguments, acts as middleware.

--- a/test/global.js
+++ b/test/global.js
@@ -1,0 +1,67 @@
+var t = require('../test-lib/test.js');
+var assert = require('assert');
+var Promise = require('bluebird');
+var apos;
+
+describe('Global', function() {
+
+  this.timeout(t.timeout);
+
+  it('global should exist on the apos object', function(done) {
+    apos = require('../index.js')({
+      root: module,
+      shortName: 'test',
+      modules: {
+        'apostrophe-express': {
+          secret: 'xxx',
+          port: 7900
+        }
+      },
+      afterInit: function(callback) {
+        assert(apos.global);
+        // In tests this will be the name of the test file,
+        // so override that in order to get apostrophe to
+        // listen normally and not try to run a task. -Tom
+        apos.argv._ = [];
+        return callback(null);
+      },
+      afterListen: function(err) {
+        assert(!err);
+        done();
+      }
+    });
+  });
+
+  it('should populate when global.addGlobalToData is used as middleware', function(done) {
+    var req = apos.tasks.getAnonReq();
+    req.res.status = function(n) {
+      assert(n <= 400);
+      return req.res;
+    }
+    req.res.send = function(m) {};
+    return apos.global.addGlobalToData(req, req.res, function() {
+      assert(req.data.global);
+      assert(req.data.global.type === 'apostrophe-global');
+      done();
+    });
+  });
+
+  it('should populate when global.addGlobalToData is used with a callback', function(done) {
+    var req = apos.tasks.getAnonReq();
+    return apos.global.addGlobalToData(req, function(err) {
+      assert(!err);
+      assert(req.data.global);
+      assert(req.data.global.type === 'apostrophe-global');
+      done();
+    });
+  });
+
+  it('should populate when global.addGlobalToData is used to return a promise', function() {
+    var req = apos.tasks.getAnonReq();
+    return apos.global.addGlobalToData(req).then(function() {
+      assert(req.data.global);
+      assert(req.data.global.type === 'apostrophe-global');
+    });
+  });
+
+});


### PR DESCRIPTION
we need a clean way to add the global doc to req.data from a task etc. without doing extra work if it is already there, for apostrophe-pieces-orderings