### PR TITLE
cleaning up asset bundles can now be done without any access to the p…

### DIFF
--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -269,13 +269,12 @@ module.exports = {
     };
 
     // Initialize services required for asset bundles. Obtains the
-    // self.generations mongodb collection, extracts a bundle if appropriate,
-    // and initializes cleanup of old bundles in uploadfs if appropriate.
+    // self.generations mongodb collection and extracts a bundle if
+    // appropriate.
 
     self.enableBundles = function() {
       self.generations = self.apos.db.collection('apostropheGenerations');
       self.extractBundleIfAppropriate();
-      self.uploadfsBundleCleanup();
     };
 
     // Extract an asset bundle if appropriate. The default implementation
@@ -294,20 +293,16 @@ module.exports = {
     // shut down old instances that might be using them
 
     self.uploadfsBundleCleanup = function() {
-
-      if (!process.env.APOS_BUNDLE_IN_UPLOADFS) {
-        return;
-      }
-
       var locked = false;
       var generations;
 
-      setTimeout(cleanup, 5 * 1000 * 60);
+      setTimeout(cleanup, process.env.APOS_BUNDLE_CLEANUP_DELAY ? parseInt(process.env.APOS_BUNDLE_CLEANUP_DELAY) : 5 * 1000 * 60);
 
       function cleanup() {
         return async.series([
           lock,
           find,
+          insert,
           remove
         ], function(err) {
           if (locked) {
@@ -339,6 +334,18 @@ module.exports = {
             generations = _generations;
             return callback(err);
           });
+        }
+
+        function insert(callback) {
+          if (_.find(generations, { _id: self.generation })) {
+            return callback(null);
+          }
+          // Enumerate the copies the same way they were enumerated when
+          // this bundle was copied into uploadfs. Note that the bundle
+          // exists both locally and in uploadfs so we can do that here too
+          var current = { _id: self.generation, copies: self.enumerateCopies(self.apos.rootDir + '/' + process.env.APOS_BUNDLE + '/public', '/assets/' + self.generation), when: new Date() };
+          generations.push(current);
+          return self.generations.insert(current, callback);
         }
 
         function remove(callback) {
@@ -499,6 +506,9 @@ module.exports = {
       self.tooLateToPushAssets = true;
 
       if (self.fromBundle) {
+        if (process.env.APOS_BUNDLE_IN_UPLOADFS) {
+          self.uploadfsBundleCleanup();
+        }
         // We extracted an asset bundle that already contains everything
         return setImmediate(callback);
       }
@@ -721,12 +731,28 @@ module.exports = {
 
       var copies = [];
 
-      enumerateDir(from, to);
+      copies = self.enumerateCopies(from, to);
 
-      return async.series([
-        performCopies,
-        storeGeneration
-      ], callback);
+      return performCopies(callback);
+
+      function performCopies(callback) {
+        return async.eachLimit(copies, 5, function(copy, callback) {
+          return self.apos.attachments.uploadfs.copyIn(copy.from, copy.to, callback);
+        }, callback);
+      }
+
+    };
+
+    // Given a local folder (the public/ subdir of an asset bundle)
+    // and an uploadfs path (where it will later be web-accessible),
+    // return an array of copies that must be performed, with `from`
+    // and `to` properties
+
+    self.enumerateCopies = function(from, to) {
+
+      var copies = [];
+      enumerateDir(from, to);
+      return copies;
 
       function enumerateDir(from, to) {
         var files = fs.readdirSync(from);
@@ -748,17 +774,6 @@ module.exports = {
           to: toFile
         });
       }
-
-      function performCopies(callback) {
-        return async.eachLimit(copies, 5, function(copy, callback) {
-          return self.apos.attachments.uploadfs.copyIn(copy.from, copy.to, callback);
-        }, callback);
-      }
-
-      function storeGeneration(callback) {
-        return self.generations.insert({ _id: self.generation, copies: copies, when: new Date() }, callback);
-      }
-
     };
 
     self.buildLessMasters = function(callback) {


### PR DESCRIPTION
…roduction database on the part of the asset generation task. If a bundle is copied to uploadfs and never used even once, it cannot be cleaned up except manually. That is an acceptable price to separate asset generation from db access (a priority for DGAD).