### PR TITLE
Tag creation: check if value before adding tag

### DIFF
--- a/lib/modules/apostrophe-tags/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-tags/public/js/manager-modal.js
@@ -46,15 +46,19 @@ apos.define('apostrophe-tags-manager-modal', {
 
     self.add = function($el) {
       var value = $el.siblings('[data-apos-tag-add-field]').val();
-      return self.api('addTag', { tag: value }, function(response) {
-        if (response.status !== 'ok') {
-          apos.notify('An error occurred. Please try again.', { type: 'error', dismiss: true });
-          return;
-        }
-        // Reset value, since we added the tag
-        self.$search.val('');
-        self.refresh();
-      });
+      if (value) {
+        return self.api('addTag', { tag: value }, function(response) {
+          if (response.status !== 'ok') {
+            apos.notify('An error occurred. Please try again.', { type: 'error', dismiss: true });
+            return;
+          }
+          // Reset value, since we added the tag
+          self.$search.val('');
+          self.refresh();
+        });
+      } else {
+        apos.notify('Please, fill in the input before adding a tag.', { type: 'error', dismiss: true });
+      }
     };
 
     self.edit = function($el, value) {


### PR DESCRIPTION
Currently, in the tag management modal (in the admin bar category "Tags"), if the input is empty and the user clicks the "+" button to add a tag, there is an error message "An error occurred. Please try again.".

Several users complained it is not clear the problem is coming from an empty value. That is why I propose this pull request to have a clearer explanation. Also, this PR blocks the whole process of going through apostrophe-pieces and apostrophe-db `insert` method only to find out the there is no title in the new piece to add (because the title is filled with an empty tag value).