### PR TITLE
1424: fixed problems that prevented strikethrough feature from being …

### DIFF
--- a/lib/modules/apostrophe-doc-type-manager/public/js/chooser.js
+++ b/lib/modules/apostrophe-doc-type-manager/public/js/chooser.js
@@ -13,7 +13,7 @@ apos.define('apostrophe-doc-type-manager-chooser', {
     self.choices = [];
   },
   afterConstruct: function(self, callback) {
-    self.removed = self.options.removed;
+    self.removed = self.options.field.removedIdsField;
     self.enableInlineSchema();
 
     return async.series([
@@ -222,7 +222,7 @@ apos.define('apostrophe-doc-type-manager-chooser', {
         }
         self.remove(_id, false);
         var $choices = self.$el.find('[data-choices]>.apos-chooser-choice');
-        if (!$choices.length) {
+        if (self.removed || (!$choices.length)) {
           // Markup is too custom, just re-render
           return self.refresh();
         }

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -272,8 +272,8 @@ module.exports = function(self, options) {
       if (!_.isEmpty(propagateSet)) {
         commands.push({ $set: propagateSet });
       }
-        // Oh brother, must do it in two passes
-        // https://jira.mongodb.org/browse/SERVER-1050
+      // Oh brother, must do it in two passes
+      // https://jira.mongodb.org/browse/SERVER-1050
       var criteria = {
         $and: [
           {

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -260,23 +260,20 @@ module.exports = function(self, options) {
     });
 
     if ((!_.isEmpty(propagatePull)) || (!_.isEmpty(propagateAdd)) || (!_.isEmpty(propagateSet))) {
-      var command = {};
-      var pullCommand;
+      var commands = [];
+      // Use separate commands because MongoDB is increasingly intolerant
+      // of using these operators in the same update call
       if (!_.isEmpty(propagatePull)) {
-        command.$pull = operate(propagatePull, '$in');
+        commands.push({ $pull: operate(propagatePull, '$in') });
       }
       if (!_.isEmpty(propagateAdd)) {
-        command.$addToSet = operate(propagateAdd, '$each');
+        commands.push({ $addToSet: operate(propagateAdd, '$each') });
       }
       if (!_.isEmpty(propagateSet)) {
-        command.$set = propagateSet;
+        commands.push({ $set: propagateSet });
       }
-      if ((!_.isEmpty(propagatePull)) && (!_.isEmpty(propagateAdd.length))) {
         // Oh brother, must do it in two passes
         // https://jira.mongodb.org/browse/SERVER-1050
-        pullCommand = { $pull: command.$pull };
-        delete command.$pull;
-      }
       var criteria = {
         $and: [
           {
@@ -285,16 +282,8 @@ module.exports = function(self, options) {
           self.apos.permissions.criteria(req, 'edit-' + page.type)
         ]
       };
-      return async.series({
-        pull: function(callback) {
-          if (!pullCommand) {
-            return callback(null);
-          }
-          return self.apos.docs.db.update(criteria, pullCommand, { multi: true }, callback);
-        },
-        main: function(callback) {
-          return self.apos.docs.db.update(criteria, command, { multi: true }, callback);
-        }
+      return async.eachSeries(commands, function(command, callback) {
+        return self.apos.docs.db.update(criteria, command, { multi: true }, callback);
       }, callback);
     } else {
       return setImmediate(callback);


### PR DESCRIPTION
1424: fixed problems that prevented strikethrough feature from being used at all to access "apply to subpages" when disabling user permissions on a page. Also, made sure the recent UX improvements to removing other types of items from choosers quickly do not interfere.

The more backendy part of the problem has to do with mongodb 3.6 being pickier than mongodb 3.4. Hey guys, semantic versioning is a thing, try it