### PR TITLE
we cannot retry on duplicate keys forever, limit it to 20 attempts wh…

### DIFF
--- a/lib/modules/apostrophe-docs/lib/api.js
+++ b/lib/modules/apostrophe-docs/lib/api.js
@@ -543,6 +543,9 @@ module.exports = function(self, options) {
 
   self.retryUntilUnique = function(req, doc, actor, callback) {
     var done = false;
+    var maxAttempts = 20;
+    var attempt = 0;
+    var firstError;
     return async.whilst(
       function() { return !done; },
       function(callback) {
@@ -553,6 +556,19 @@ module.exports = function(self, options) {
           }
           if (!self.isUniqueError(err)) {
             return callback(err);
+          }
+          if (!firstError) {
+            firstError = err;
+          }
+          attempt++;
+          if (attempt === maxAttempts) {
+            // Odds are now 1 in 100000000000000000000 that it is really due
+            // to a duplicate path or slug; a far more likely explanation is
+            // that another docFixUniqueError handler is needed to address
+            // an additional property that has to be unique. Report the
+            // original error to avoid confusion ("ZOMG, what are all these digits!")
+            firstError.aposAddendum = 'retryUntilUnique failed, most likely you need another docFixUniqueError method to handle another property that has a unique index, reporting original error';
+            return callback(firstError);
           }
           return self.apos.callAll('docFixUniqueError', req, doc, callback);
         });


### PR DESCRIPTION
…ich makes it statistically impossible that one of the deduplicatable keys we actually know about is still at fault