### PR TITLE
implemented profiling API (with do-nothing placeholder version, so it is always safe to call)

### DIFF
--- a/lib/modules/apostrophe-utils/lib/api.js
+++ b/lib/modules/apostrophe-utils/lib/api.js
@@ -5,6 +5,7 @@ var XRegExp = require('xregexp').XRegExp;
 var crypto = require('crypto');
 var cuid = require('cuid');
 var fs = require('fs');
+var now = require('performance-now');
 
 module.exports = function(self, options) {
 
@@ -620,6 +621,54 @@ module.exports = function(self, options) {
 
   self.error = function(msg) {
     self.logger.error.apply(self.logger, arguments);
+  };
+
+  // Performance profiling method. At the start of the operation you want
+  // to profile, call with req (may be null or omitted entirely) and a
+  // dot-namespaced key. A function is returned. Call that function
+  // with no arguments at the end of your operation.
+  //
+  // Alternatively, you may pass the duration in milliseconds yourself as the
+  // third argument. In this case no function is returned. This is useful if
+  // you are already gathering timing information for other purposes.
+  //
+  // Profiler modules such as `apostrophe-profiler` override this
+  // method to provide detailed performance analysis. Note that they must
+  // support both calling syntaxes. The default implementation does nothing.
+  //
+  // If the dot-separated key looks like `callAll.pageBeforeSend.module-name`,
+  // time is tracked to `callAll`, `callAll.pageBeforeSend`, and
+  // `callAll.pageBeforeSend.module-name` as categories. Note that the
+  // most general category should come first.
+  //
+  // To avoid overhead and bloat in the core, the default implementation
+  // does nothing. Also most core modules and methods do not invoke this method.
+  // However, the `apostrophe-profiler` module extends them to invoke it,
+  // for performance reasons: the profiler itself can have
+  // a performance overhead.
+
+  self.profile = function(req, key /* , duration */) {
+    if ((typeof req) === 'string') {
+      if (arguments.length === 2) {
+        return self.profile(null, arguments[0], arguments[1]);
+      } else {
+        return self.profile(null, arguments[0]);
+      }
+    }
+    if (arguments.length === 2) {
+      // This is a do-nothing placeholder implementation
+      return function() {};
+    } else {
+      // All-in-one version with duration, there's nothing to fake
+    }
+  };
+
+  // Returns time since the start of the process in milliseconds,
+  // with high-resolution accuracy. Used by apos.utils.profile.
+  // See: https://www.npmjs.com/package/performance-now
+
+  self.now = function() {
+    return now();
   };
 
 };

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",
     "path-to-regexp": "^1.7.0",
+    "performance-now": "^2.1.0",
     "prompt": "^0.2.14",
     "qs": "^5.2.1",
     "regexp-quote": "0.0.0",

--- a/test/utils.js
+++ b/test/utils.js
@@ -217,5 +217,26 @@ describe('Utils', function() {
       assert(input[3] === 'Fred');
       assert(input[4] === 'jane');
     });
+
+    it('does not crash when apos.utils.profile is called with two arguments', function() {
+      apos.utils.profile(apos.tasks.getReq(), 'this.is.a.path')();
+      assert(true);
+    });
+
+    it('does not crash when apos.utils.profile is called with three arguments', function() {
+      apos.utils.profile(apos.tasks.getReq(), 'this.is.a.path', 100);
+      assert(true);
+    });
+
+    it('does not crash when apos.utils.profile is called with one argument (no req arg)', function() {
+      apos.utils.profile('this.is.a.path')();
+      assert(true);
+    });
+
+    it('does not crash when apos.utils.profile is called with two arguments (no req arg)', function() {
+      apos.utils.profile('this.is.a.path', 100);
+      assert(true);
+    });
+
   });
 });


### PR DESCRIPTION
See #1427 

Placeholder implementation, with tests verifying it does no harm. For now at least the version in the core intentionally does nothing, profiler modules then have an open door to implement it (and the overhead it might involve). The apostrophe-debug module now expects this API.