### PR TITLE
remove some default active states from jquery ui 3s css

### DIFF
--- a/lib/modules/apostrophe-assets/public/css/vendor/jquery-ui-3.less
+++ b/lib/modules/apostrophe-assets/public/css/vendor/jquery-ui-3.less
@@ -507,17 +507,7 @@ a.ui-button:focus {
 .ui-visual-focus {
 	box-shadow: 0 0 3px 1px rgb(94, 158, 214);
 }
-.ui-state-active,
-.ui-widget-content .ui-state-active,
-.ui-widget-header .ui-state-active,
-a.ui-button:active,
-.ui-button:active,
-.ui-button.ui-state-active:hover {
-	border: 1px solid #fbd850;
-	background: #ffffff url("/modules/apostrophe-assets/css/vendor/images/ui-bg_glass_65_ffffff_1x400.png") 50% 50% repeat-x;
-	font-weight: bold;
-	color: #eb8f00;
-}
+
 .ui-icon-background,
 .ui-state-active .ui-icon-background {
 	border: #fbd850;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1889830/41499755-0445fb2e-7154-11e8-9cdb-bd89825bdb3d.png)

Conflicting with our own active states. I didn't rip out all the active states from jquery ui's css because they should at least be in there in case we don't have our own but should be quieted down when conflicts come up 