### PR TITLE
Create symlink folder for scoped package ...

### DIFF
--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -575,6 +575,17 @@ module.exports = {
         var last = chain[chain.length - 1];
         var from = self.getAssetRoot() + '/public/modules/' + name;
         var to = last.dirname + '/public';
+        var scope = to.match(/@.+?(?=\/)/);
+
+        // Create symlink folder for scoped package, if it does not exist.
+        if (scope) {
+          var symlink = self.getAssetRoot() + '/public/modules/' + scope[0];
+
+          if (!fs.existsSync(symlink)) {
+            fs.mkdirSync(symlink);
+          }
+        }
+
         self.linkAssetFolder(from, to);
       });
       return callback(null);


### PR DESCRIPTION
... if it does not exist.

Tested with scoped package that is pushing assets to the browser.
Symlink will be created successfully after creating the scope folder (@scope) first.

Closes #1337.