### PR TITLE
Vertically center dropdown arrows for select fields

### DIFF
--- a/lib/modules/apostrophe-ui/public/css/components/fields.less
+++ b/lib/modules/apostrophe-ui/public/css/components/fields.less
@@ -42,7 +42,8 @@
   {
     content: "\f0d7";
     position: absolute;
-    top: @apos-padding-3;
+    top: 50%;
+    transform: translateY(-50%);
     right: @apos-padding-3;
     .fa;
     pointer-events: none;


### PR DESCRIPTION
This ensures that these arrows are vertically centered – no matter what height the field has in different browsers.

![capto_capture 2018-06-23_02-22-21_pm](https://user-images.githubusercontent.com/34842497/41809623-00883572-76f1-11e8-8b0d-de6a8db1e3f4.png)

I could imagine a mix-in like

```less
.apos-center-vertical-abs() {
  top: 50%;
  transformY: (-50%);
}
```

to enable consistent styles across Apostrophe and project level changes.

And how about using `::` instead of `:` for pseudo-elements, since that is the current spec?