### PR TITLE
Strengthen broken infinite scroll in some browsers and site configurations

### DIFF
--- a/lib/modules/apostrophe-ui/public/css/global/infinitescroll.less
+++ b/lib/modules/apostrophe-ui/public/css/global/infinitescroll.less
@@ -1,4 +1,8 @@
 [data-apos-ajax-infinite-scroll] {
   display: block;
   visibility: hidden;
+  height: 0;
+  border: 0;
+  margin: 0;
+  padding: 0;
 }

--- a/lib/modules/apostrophe-ui/public/css/global/infinitescroll.less
+++ b/lib/modules/apostrophe-ui/public/css/global/infinitescroll.less
@@ -1,3 +1,4 @@
 [data-apos-ajax-infinite-scroll] {
-  display: none
+  display: block;
+  visibility: hidden;
 }

--- a/lib/modules/apostrophe-ui/public/js/ui.js
+++ b/lib/modules/apostrophe-ui/public/js/ui.js
@@ -432,15 +432,12 @@ apos.define('apostrophe-ui', {
       });
 
       $(function() {
-        var $infiniteScroll = $('[data-apos-ajax-infinite-scroll]');
-        if ($infiniteScroll.length > 0) {
+        self.ajaxInfiniteScrollHandler();
+        $(window).on('scroll', _.throttle(function() {
           self.ajaxInfiniteScrollHandler();
-          $(window).on('scroll', _.throttle(function() {
-            self.ajaxInfiniteScrollHandler();
-          }, 200));
-        }
+        }, 200));
       });
-    }
+    };
 
     self.ajaxInfiniteScrollHandler = function() {
       var $infiniteScroll = $('[data-apos-ajax-infinite-scroll]');

--- a/lib/modules/apostrophe-ui/public/js/ui.js
+++ b/lib/modules/apostrophe-ui/public/js/ui.js
@@ -432,13 +432,15 @@ apos.define('apostrophe-ui', {
       });
 
       $(function() {
-        self.ajaxInfiniteScrollHandler();
+        var $infiniteScroll = $('[data-apos-ajax-infinite-scroll]');
+        if ($infiniteScroll.length > 0) {
+          self.ajaxInfiniteScrollHandler();
+          $(window).on('scroll', _.throttle(function() {
+            self.ajaxInfiniteScrollHandler();
+          }, 200));
+        }
       });
-
-      $(window).on('scroll', function(event) {
-        self.ajaxInfiniteScrollHandler();
-      });
-    };
+    }
 
     self.ajaxInfiniteScrollHandler = function() {
       var $infiniteScroll = $('[data-apos-ajax-infinite-scroll]');
@@ -450,7 +452,8 @@ apos.define('apostrophe-ui', {
         if ($el.data('aposSeen')) {
           return;
         }
-        var scrollBottom = $('html, body').scrollTop() + $(window).height();
+        var scrollElement = document.scrollingElement || document.documentElement;
+        var scrollBottom = scrollElement.scrollTop + $(window).height();
         var top = $el.offset().top;
         if (top - self.infiniteScrollOffset <= scrollBottom) {
           $el.data('aposSeen', 1);
@@ -597,7 +600,8 @@ apos.define('apostrophe-ui', {
             // the replacement algorithm changes the scrolling position,
             // which is good for pagination but bad for appending, so make
             // a note of the old scrolling position
-            oldTop = $('html, body').scrollTop();
+            var scrollElement = document.scrollingElement || document.documentElement;
+            oldTop = scrollElement.scrollTop;
             $appending = $new.find('[data-apos-ajax-append]');
             $appending.prepend($appendTo.contents());
           }


### PR DESCRIPTION
**Problem 1:**
Some browsers (among them Safari) fails to find the scroll position from html / body using jQuery. This is potentially related to the site having `overflow-x: hidden;` on the `html`tag.

This PR strengthens the browser lookup for the scroll position in all browsers (that I was able to test).

**Problem 2:**
Additionally jQuery fails to find the `offset.top` of the hidden "load more" button, due the button being `display: none;` in CSS/LESS. According to the jQuery documentation an element being styled with `display: none;` is excluded from the rendering tree and thus has a position that is undefined. This has been changed to `display:block;` and `visibility:hidden` This can affect the invisible space on existing sites below the AJAX content, but there's no other way and site devs can work around this by decreasing the height of the element and/or its parent. The button and it's parent(s) is removed after all content has been added to the page (nothing changed here).

**Additional improvements:**

* The on scroll event was always attached, even on pages which did not have any AJAX features. This PR does a check for the `data-apos-ajax-infinite-scroll` and only attaches the event watcher in case there is such an element in the DOM.

* The aforementioned scroll event watcher was firing on every scroll and this can lead to significant slugginess on scroll, especially on devices with less power, such as mobile. I have wrapped the event in a lodash throttle function which ensures a scroll event is only sent every 200ms. This should be plenty, as the code operates with a decent offset (500px default). In my testing I did not notice any delays in fetching data.

There's more improvements to be done here, but small steps (new around here). At least this is now fully working for me (it was broken out of the box in all browsers due to both main problems).