### PR TITLE
Make it possible to configure if admin bar loads on page load

### DIFF
--- a/lib/modules/apostrophe-admin-bar/index.js
+++ b/lib/modules/apostrophe-admin-bar/index.js
@@ -207,6 +207,11 @@ module.exports = {
     self.pushAssets = function() {
       self.pushAsset('script', 'user', { when: 'user' });
       options.browser = options.browser || {};
+      var stayOpenTimeout = self.apos.launder.integer(self.options.stayOpenTimeout);
+      _.extend(options.browser, {
+        openOnLoad: (!!(typeof self.options.openOnLoad === 'undefined' || self.options.openOnLoad)),
+        stayOpenTimeout: stayOpenTimeout > 0 ? stayOpenTimeout : 3000
+      });
       self.apos.push.browserCall('user', 'apos.create(?, ?)', self.__meta.name, options.browser);
     };
 

--- a/lib/modules/apostrophe-admin-bar/public/js/user.js
+++ b/lib/modules/apostrophe-admin-bar/public/js/user.js
@@ -19,8 +19,14 @@ apos.define('apostrophe-admin-bar', {
 
     self.enhance = function() {
       var $bar = $('[data-apos-admin-bar]');
+      if (!options.openOnLoad) {
+        $bar.css('overflow', 'hidden');
+      } else {
+        $bar.css('overflow', 'visible');
+        $bar.addClass('apos-active');
+      }
+
       var $dropdowns = $bar.find('[data-apos-dropdown]');
-      $bar.css('overflow', 'visible');
 
       // on transitionend, turn overflow on so we can see dropdowns!
       $bar.on('transitionend webkitTransitionEnd oTransitionEnd', function() {
@@ -60,7 +66,7 @@ apos.define('apostrophe-admin-bar', {
           $bar.css('overflow', '');
           $bar.removeClass('apos-active');
         }
-      }, 3000);
+      }, options.stayOpenTimeout);
     };
 
     apos.adminBar = self;

--- a/lib/modules/apostrophe-admin-bar/views/adminBar.html
+++ b/lib/modules/apostrophe-admin-bar/views/adminBar.html
@@ -1,7 +1,7 @@
 {% import 'apostrophe-ui:components/dropdowns.html' as dropdowns with context -%}
 
 <div class="apos-ui">
-  <div class="apos-admin-bar apos-active apos-text-meta" data-apos-admin-bar>
+  <div class="apos-admin-bar apos-text-meta" data-apos-admin-bar>
     <div class="apos-admin-bar-inner">
       <div class="apos-admin-bar-logo" data-apos-admin-bar-logo data-apos-actionable="data-apos-admin-bar">
         {% include 'logo.html' %}

--- a/lib/modules/apostrophe-attachments/public/js/cropEditor.js
+++ b/lib/modules/apostrophe-attachments/public/js/cropEditor.js
@@ -32,7 +32,7 @@ apos.define('apostrophe-attachments-crop-editor', {
           viewMode: 1,
           // This is a bad idea, it prevents starting a new crop
           dragMode: 'crop',
-          autoCrop: false,
+          autoCrop: true,
           cropmove: function(e) {
             self.testMinimumSize(e);
           },

--- a/lib/modules/apostrophe-images/public/css/editor.less
+++ b/lib/modules/apostrophe-images/public/css/editor.less
@@ -102,4 +102,4 @@
 
 .apos-crop-editor .jcrop-holder { margin: 0 auto; }
 .apos-crop-editor .jcrop-keymgr { top: -20px; }
-.apos-crop-editor .apos-modal-body { overflow: hidden; }
+.apos-crop-editor .apos-modal-body { overflow: hidden; padding: @apos-padding-2; }

--- a/lib/modules/apostrophe-modal/public/css/components/modal-filters.less
+++ b/lib/modules/apostrophe-modal/public/css/components/modal-filters.less
@@ -16,12 +16,12 @@
   .apos-modal-filter {
   font-size: 14px;
   margin-right: 40px;
-  
+
     .apos-field-input-select-wrapper
     {
       display: inline-block;
       border-radius: 4px;
-      
+
       select
       {
         margin-left: 10px;
@@ -31,7 +31,6 @@
       &::after
       {
         right: 7px;
-        top: 14px;
       }
     }
     label.apos-modal-filter-selection
@@ -45,7 +44,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-		
+
 		.apos-pill
 		{
 			margin-right: @apos-margin-2;

--- a/lib/modules/apostrophe-ui/public/css/global/infinitescroll.less
+++ b/lib/modules/apostrophe-ui/public/css/global/infinitescroll.less
@@ -1,3 +1,8 @@
 [data-apos-ajax-infinite-scroll] {
-  display: none
+  display: block;
+  visibility: hidden;
+  height: 0;
+  border: 0;
+  margin: 0;
+  padding: 0;
 }

--- a/lib/modules/apostrophe-ui/public/js/ui.js
+++ b/lib/modules/apostrophe-ui/public/js/ui.js
@@ -432,13 +432,15 @@ apos.define('apostrophe-ui', {
       });
 
       $(function() {
-        self.ajaxInfiniteScrollHandler();
+        var $infiniteScroll = $('[data-apos-ajax-infinite-scroll]');
+        if ($infiniteScroll.length > 0) {
+          self.ajaxInfiniteScrollHandler();
+          $(window).on('scroll', _.throttle(function() {
+            self.ajaxInfiniteScrollHandler();
+          }, 200));
+        }
       });
-
-      $(window).on('scroll', function(event) {
-        self.ajaxInfiniteScrollHandler();
-      });
-    };
+    }
 
     self.ajaxInfiniteScrollHandler = function() {
       var $infiniteScroll = $('[data-apos-ajax-infinite-scroll]');
@@ -450,7 +452,8 @@ apos.define('apostrophe-ui', {
         if ($el.data('aposSeen')) {
           return;
         }
-        var scrollBottom = $('html, body').scrollTop() + $(window).height();
+        var scrollElement = document.scrollingElement || document.documentElement;
+        var scrollBottom = scrollElement.scrollTop + $(window).height();
         var top = $el.offset().top;
         if (top - self.infiniteScrollOffset <= scrollBottom) {
           $el.data('aposSeen', 1);
@@ -597,7 +600,8 @@ apos.define('apostrophe-ui', {
             // the replacement algorithm changes the scrolling position,
             // which is good for pagination but bad for appending, so make
             // a note of the old scrolling position
-            oldTop = $('html, body').scrollTop();
+            var scrollElement = document.scrollingElement || document.documentElement;
+            oldTop = scrollElement.scrollTop;
             $appending = $new.find('[data-apos-ajax-append]');
             $appending.prepend($appendTo.contents());
           }

--- a/lib/modules/apostrophe-widgets/public/js/user.js
+++ b/lib/modules/apostrophe-widgets/public/js/user.js
@@ -13,6 +13,13 @@ apos.define('apostrophe-widgets', {
 
     self.edit = function(data, options, save) {
 
+      if (!data) {
+        data = {};
+      }
+      if (!data._id) {
+        _.assign(data, apos.schemas.newInstance(self.schema));
+      }
+
       // Only create a modal editor if the schema is not contextual only
       if (self.options.contextualOnly) {
 
@@ -21,7 +28,6 @@ apos.define('apostrophe-widgets', {
       } else {
 
         if (self.options.skipInitialModal && (!data || !data._id)) {
-
           return save(checkOrGenerateId(data), function() {});
 
         }


### PR DESCRIPTION
This PR introduces two new configuration options in app.js:

```bash
modules: {
  'apostrophe-admin-bar': {
    openOnLoad: true,
    stayOpenTimeout: 5000
  },
    ......
};
```

**Features:**

* It's possible to set `openOnLoad` to false, making the admin bar stay closed on page loads. If not set defaults to true, opening the admin bar on every page load.
* It's possible to configure the timeout until the admin bar closes after load if `openOnLoad` is `true` or `undefined` / not set. `stayOpenTimeout` configures the time in milliseconds before the admin bar closes. If **not set** or set to 0, it will default back to 3000.

**Thoughts:**

I thought about making it possible to set `stayOpenTimeout` to 0 and make it stay open infinite or until the user clicks the Apostrophe logo, but decided to not complicate the code further unless there's a want from core devs for this. In that case, let me know and I will update this PR.

This needs a bit of documentation, but I am not sure how that works, I hope the above text helps adding it for whoever has access/knowledge.