### PR TITLE
Improve Pages admin UI

### DIFF
--- a/lib/modules/apostrophe-pages/views/reorganize.html
+++ b/lib/modules/apostrophe-pages/views/reorganize.html
@@ -6,7 +6,8 @@
 
 {% block controls %}
   <div class="apos-modal-controls">
-    {{ buttons.major('Finished', { action: 'save' }) }}
+    {{ buttons.minor('Finished', { action: 'save' }) }}
+    {{ buttons.major('New Page', { action: 'insert-page' }) }}
   </div>
 {% endblock %}
 
@@ -27,7 +28,7 @@
     <span class="apos-reorganize-controls">Edit</span>
     <span class="apos-reorganize-controls">Link</span>
     <span class="apos-reorganize-controls">Trash</span>
-  </div> 
+  </div>
   {# This gets fired up by jstree #}
   <div class="apos-table apos-reorganize-tree" data-tree>
   </div>


### PR DESCRIPTION
The current pages admin modal is not completely consistent with the rest of the admin modals in Apostrophe.

This PR introduces a new button on the upper right side of the of the modal with the label "New Page" (same as bottom menu uses), styled as a major button.

The "Finished" button was styled as a major button before, which was inconsistent for the UI as every other admin modal uses minor styling for the "Finished" button.

Hope to see this PR make it into the core as it improves usability in relation to page management and at the same time corrects inconsistencies in the Apostrophe admin UI.  I do have other concerns and improvements in mind for this area, but I will probably get back to those in another PR if this one is accepted.