### PR TITLE
Fix broken publish context menu for pages

### DIFF
--- a/lib/modules/apostrophe-pages/index.js
+++ b/lib/modules/apostrophe-pages/index.js
@@ -75,7 +75,7 @@
 // ```javascript
 // publishMenu: [
 //   {
-//     action: 'publish-apostrophe-page',
+//     action: 'publish-page',
 //     label: 'Publish Page'
 //   }
 // ]
@@ -244,7 +244,7 @@ module.exports = {
 
   publishMenu: [
     {
-      action: 'publish-apostrophe-page',
+      action: 'publish-page',
       label: 'Publish Page'
     }
   ],

--- a/lib/modules/apostrophe-templates/views/outerLayoutBase.html
+++ b/lib/modules/apostrophe-templates/views/outerLayoutBase.html
@@ -20,8 +20,8 @@
       {% if data.user %}
         <div class="apos-ui">
           <div class="apos-context-menu-container">
-            {{ apos.pages.publishMenu({ publishMenu: data.publishMenu, page: data.page, piece: data.piece, bottom: true }) }}
             {{ apos.pages.menu({ contextMenu: data.contextMenu, page: data.page, bottom: true })}}
+            {{ apos.pages.publishMenu({ publishMenu: data.publishMenu, page: data.page, piece: data.piece, bottom: true }) }}
             {{ apos.pages.afterContextMenu() }}
           </div>
         </div>


### PR DESCRIPTION
This PR fixes a bad route on the "red" context menu to publish a page. It seems that the "route" was renamed at some point and this created inconsistency from the data attribute to the JS resposible for kicking off the request to publish the page.

I also moved this publish menu to the right of the normal context menu to avoid the main context menu "jumping around" when moving to and from pages which are unpublished. I don't think it's good UX practice to have a consistent menu move around rather "randomly" unless the user herself decides to by interacting with the UI.