### PR TITLE
Adds help text to indicate the alt text field

### DIFF
--- a/lib/modules/apostrophe-images/index.js
+++ b/lib/modules/apostrophe-images/index.js
@@ -1,3 +1,4 @@
+const _ = require('@sailshq/lodash');
 // A subclass of `apostrophe-pieces`, `apostrophe-images` establishes a library
 // of uploaded images in formats suitable for use on the web.
 //
@@ -76,6 +77,11 @@ module.exports = {
 
   },
   construct: function(self, options) {
+    const titleField = _.find(options.addFields, {name: 'title'});
+    if (titleField) {
+      titleField.help = 'This field used for the default image widget\'s "alternative text," read by assistive devices.';
+    }
+
     self.pushAsset('script', 'chooser', { when: 'user' });
     self.pushAsset('script', 'relationship-editor', { when: 'user' });
     self.pushAsset('script', 'manager-modal', { when: 'user' });

--- a/lib/modules/apostrophe-images/index.js
+++ b/lib/modules/apostrophe-images/index.js
@@ -79,7 +79,7 @@ module.exports = {
   construct: function(self, options) {
     const titleField = _.find(options.addFields, {name: 'title'});
     if (titleField) {
-      titleField.help = 'This field used for the default image widget\'s "alternative text," read by assistive devices.';
+      titleField.help = 'This field is used for the default image widget\'s "alternative text," read by assistive devices.';
     }
 
     self.pushAsset('script', 'chooser', { when: 'user' });


### PR DESCRIPTION
I found this confusing myself and had been thinking the description field was used for alt text. I looked and found I was wrong. Help text added to clarify this for users.

I know devs at P'unk Ave at least are overriding or replacing the core image widget, so this would be meant to help make the field use consistent across implementations. Wording suggestions welcome.