### PR TITLE
Fix styling of autocomplete item active state

### DIFF
--- a/lib/modules/apostrophe-ui/public/css/components/autocomplete.less
+++ b/lib/modules/apostrophe-ui/public/css/components/autocomplete.less
@@ -6,16 +6,19 @@
 
   .ui-menu-item
   {
-    color: @apos-white;
-    background-color: @apos-primary;
+    color: @apos-primary;
+    background-color: @apos-light;
     border: none;
     padding: @apos-padding-1;
     font-family: "Roboto", "Helvetica", sans-serif;
     font-size: 14px;
     font-weight: 500;
+    padding: 0;
   }
 
   .ui-menu-item-wrapper {
+    padding: 10px;
+    background: transparent;
     border: none;
   }
 
@@ -27,7 +30,7 @@
     border: none;
     color: @apos-white;
     background: none;
-    background-color: transparent;
+    background-color: @apos-primary;
     font-weight: 600;
     margin: 0;
   }

--- a/lib/modules/apostrophe-ui/public/css/components/autocomplete.less
+++ b/lib/modules/apostrophe-ui/public/css/components/autocomplete.less
@@ -6,6 +6,8 @@
 
   .ui-menu-item
   {
+    color: @apos-white;
+    background-color: @apos-primary;
     border: none;
     padding: @apos-padding-1;
     font-family: "Roboto", "Helvetica", sans-serif;
@@ -13,12 +15,21 @@
     font-weight: 500;
   }
 
-  .ui-menu-item:hover,
-  .ui-menu-item.ui-state-focus
+  .ui-menu-item-wrapper {
+    border: none;
+  }
+
+  .ui-state-active,
+  .ui-state-active:hover,
+  .ui-widget-content .ui-state-active,
+  .ui-widget-content .ui-state-active:hover
   {
     border: none;
-    background: none;
     color: @apos-white;
-    background-color: @apos-primary;
+    background: none;
+    background-color: transparent;
+    font-weight: 600;
+    margin: 0;
   }
+
 }

--- a/lib/modules/apostrophe-ui/public/css/components/autocomplete.less
+++ b/lib/modules/apostrophe-ui/public/css/components/autocomplete.less
@@ -6,7 +6,7 @@
 
   .ui-menu-item
   {
-    color: @apos-primary;
+    color: @apos-black;
     background-color: @apos-light;
     border: none;
     padding: @apos-padding-1;


### PR DESCRIPTION
This relates to PR #1432 which never made it in, because it was modifying the vendor file.

This overrules the basic styling of jQuery UI in a way that jQuery UI vendor can be updated without this breaking (unless there's changes to the class names or structure of the autocomplete of course).

I kept the styling pretty basic (bold font on active), but I could add more transitions if someone would point me in the direction of what you would like.