### PR TITLE
Decouple min/max validations from required for integer, float and string fields

### DIFF
--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -1401,7 +1401,7 @@ module.exports = {
       name: 'integer',
       converters: {
         string: function(req, data, name, object, field, callback) {
-          object[name] = self.apos.launder.float(data[name], field.def, field.min, field.max);
+          object[name] = self.apos.launder.integer(data[name], field.def, field.min, field.max);
           // This makes it possible to have a field that is not required, but min / max defined
           // This allows the form to be saved and sets the value to null if no value was given by
           // the user.

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -977,12 +977,13 @@ module.exports = {
       converters: {
         string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.launder.string(data[name], field.def);
-          if (field.required && field.min && (object[name].length < field.min)) {
+          if (object[name] && field.min && (object[name].length < field.min)) {
             // Would be unpleasant, but shouldn't happen since the browser
             // also implements this. We're just checking for naughty scripts
             return callback('min');
           }
-          if (field.max && (object[name].length > field.max)) {
+          // If max is longer than allowed, trim the value down to the max length
+          if (object[name] && field.max && (object[name].length > field.max)) {
             object[name] = object[name].substr(0, field.max);
           }
           return setImmediate(callback);

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -989,7 +989,7 @@ module.exports = {
           // If field is required but empty (and client side didn't catch that)
           // This is new and until now if JS client side failed, then it would
           // allow the save with empty values -Lars
-          if (field.required && _.isEmpty(data[name])) {
+          if (field.required && !data[name]) {
             return callback('required');
           }
           return setImmediate(callback);
@@ -1409,13 +1409,13 @@ module.exports = {
       converters: {
         string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.launder.integer(data[name], field.def, field.min, field.max);
-          if (field.required && _.isEmpty(data[name])) {
+          if (field.required && !data[name]) {
             return callback('required');
           }
           // This makes it possible to have a field that is not required, but min / max defined
           // This allows the form to be saved and sets the value to null if no value was given by
           // the user.
-          if (_.isEmpty(data[name])) {
+          if (!data[name] && data[name] !== 0) {
             object[name] = null;
           }
           return setImmediate(callback);
@@ -1453,10 +1453,10 @@ module.exports = {
       converters: {
         string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.launder.float(data[name], field.def, field.min, field.max);
-          if (field.required && _.isEmpty(data[name])) {
+          if (field.required && !data[name]) {
             return callback('required');
           }
-          if (_.isEmpty(data[name])) {
+          if (!data[name] && data[name] !== 0) {
             object[name] = null;
           }
           return setImmediate(callback);

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -1409,6 +1409,9 @@ module.exports = {
       converters: {
         string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.launder.integer(data[name], field.def, field.min, field.max);
+          if (field.required && _.isEmpty(object[name])) {
+            return callback('required');
+          }
           // This makes it possible to have a field that is not required, but min / max defined
           // This allows the form to be saved and sets the value to null if no value was given by
           // the user.

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -986,6 +986,12 @@ module.exports = {
           if (object[name] && field.max && (object[name].length > field.max)) {
             object[name] = object[name].substr(0, field.max);
           }
+          // If field is required but empty (and client side didn't catch that)
+          // This is new and until now if JS client side failed, then it would
+          // allow the save with empty values -Lars
+          if (field.required && _.isEmpty(object[name])) {
+            return callback('required');
+          }
           return setImmediate(callback);
         },
         form: 'string'
@@ -1444,6 +1450,9 @@ module.exports = {
       converters: {
         string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.launder.float(data[name], field.def, field.min, field.max);
+          if (field.required && _.isEmpty(object[name])) {
+            return callback('required');
+          }
           if (_.isEmpty(data[name])) {
             object[name] = null;
           }

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -989,7 +989,7 @@ module.exports = {
           // If field is required but empty (and client side didn't catch that)
           // This is new and until now if JS client side failed, then it would
           // allow the save with empty values -Lars
-          if (field.required && !data[name]) {
+          if (field.required && (_.isUndefined(data[name]) || !data[name].toString().length)) {
             return callback('required');
           }
           return setImmediate(callback);
@@ -1409,7 +1409,7 @@ module.exports = {
       converters: {
         string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.launder.integer(data[name], field.def, field.min, field.max);
-          if (field.required && !data[name]) {
+          if (field.required && (_.isUndefined(data[name]) || !data[name].toString().length)) {
             return callback('required');
           }
           // This makes it possible to have a field that is not required, but min / max defined
@@ -1453,7 +1453,7 @@ module.exports = {
       converters: {
         string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.launder.float(data[name], field.def, field.min, field.max);
-          if (field.required && !data[name]) {
+          if (field.required && (_.isUndefined(data[name]) || !data[name].toString().length)) {
             return callback('required');
           }
           if (!data[name] && data[name] !== 0) {

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -1408,6 +1408,7 @@ module.exports = {
           if (_.isEmpty(data[name])) {
             object[name] = null;
           }
+          return setImmediate(callback);
         },
         form: 'string'
       },

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -977,7 +977,7 @@ module.exports = {
       converters: {
         string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.launder.string(data[name], field.def);
-          if (field.min && (object[name].length < field.min)) {
+          if (field.required && field.min && (object[name].length < field.min)) {
             // Would be unpleasant, but shouldn't happen since the browser
             // also implements this. We're just checking for naughty scripts
             return callback('min');
@@ -1401,8 +1401,13 @@ module.exports = {
       name: 'integer',
       converters: {
         string: function(req, data, name, object, field, callback) {
-          object[name] = self.apos.launder.integer(data[name], field.def, field.min, field.max);
-          return setImmediate(callback);
+          object[name] = self.apos.launder.float(data[name], field.def, field.min, field.max);
+          // This makes it possible to have a field that is not required, but min / max defined
+          // This allows the form to be saved and sets the value to null if no value was given by
+          // the user.
+          if (_.isEmpty(data[name])) {
+            object[name] = null;
+          }
         },
         form: 'string'
       },
@@ -1437,6 +1442,9 @@ module.exports = {
       converters: {
         string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.launder.float(data[name], field.def, field.min, field.max);
+          if (_.isEmpty(data[name])) {
+            object[name] = null;
+          }
           return setImmediate(callback);
         },
         form: 'string'

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -989,7 +989,7 @@ module.exports = {
           // If field is required but empty (and client side didn't catch that)
           // This is new and until now if JS client side failed, then it would
           // allow the save with empty values -Lars
-          if (field.required && _.isEmpty(object[name])) {
+          if (field.required && _.isEmpty(data[name])) {
             return callback('required');
           }
           return setImmediate(callback);
@@ -1409,7 +1409,7 @@ module.exports = {
       converters: {
         string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.launder.integer(data[name], field.def, field.min, field.max);
-          if (field.required && _.isEmpty(object[name])) {
+          if (field.required && _.isEmpty(data[name])) {
             return callback('required');
           }
           // This makes it possible to have a field that is not required, but min / max defined
@@ -1453,7 +1453,7 @@ module.exports = {
       converters: {
         string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.launder.float(data[name], field.def, field.min, field.max);
-          if (field.required && _.isEmpty(object[name])) {
+          if (field.required && _.isEmpty(data[name])) {
             return callback('required');
           }
           if (_.isEmpty(data[name])) {

--- a/lib/modules/apostrophe-schemas/public/css/user.less
+++ b/lib/modules/apostrophe-schemas/public/css/user.less
@@ -20,6 +20,7 @@
     &::after {
       margin-left: 10px;
       content: "(" attr(data-apos-error-message) ")";
+      color: inherit;
     }
   }
 }

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -191,8 +191,16 @@ apos.define('apostrophe-schemas', {
         field: field,
         type: type
       };
-      if (type === 'required') {
-        error.message = 'Required';
+      switch (type) {
+        case 'required':
+          error.message = 'Required';
+          break;
+        case 'min':
+          error.message = 'Min. permitted value is: ' + field.min;
+          break;
+        case 'max':
+          error.message = 'Max. permitted value is: ' + field.max;
+          break;
       }
       return error;
     };
@@ -864,12 +872,12 @@ apos.define('apostrophe-schemas', {
         err = self.error(field, 'required');
         return setImmediate(_.partial(callback, err));
       }
-      if (field.max && (data[name].length > field.max)) {
+      if (data[name] && field.max && (data[name].length > field.max)) {
         err = self.error(field, 'max');
         err.message = 'Maximum of ' + field.max + ' characters';
         return setImmediate(_.partial(callback, err));
       }
-      if (field.min && (data[name].length < field.min)) {
+      if (data[name] && field.min && (data[name].length < field.min)) {
         err = self.error(field, 'min');
         err.message = 'Minimum of ' + field.min + ' characters';
         return setImmediate(_.partial(callback, err));
@@ -1039,10 +1047,10 @@ apos.define('apostrophe-schemas', {
         if (field.required && (!(data[name] && data[name].length))) {
           return setImmediate(_.partial(callback, 'required'));
         }
-        if ((field.max !== undefined) && (data[name] > field.max)) {
+        if (data[name] && field.max !== undefined && data[name] > field.max) {
           return setImmediate(_.partial(callback, 'max'));
         }
-        if ((field.min !== undefined) && (data[name] < field.min)) {
+        if (data[name] && field.min !== undefined && data[name] < field.min) {
           return setImmediate(_.partial(callback, 'min'));
         }
         return setImmediate(callback);
@@ -1060,10 +1068,10 @@ apos.define('apostrophe-schemas', {
         if (field.required && (!(data[name] && data[name].length))) {
           return setImmediate(_.partial(callback, 'required'));
         }
-        if ((field.max !== undefined) && (data[name] > field.max)) {
+        if (data[name] && field.max !== undefined && data[name] > field.max) {
           return setImmediate(_.partial(callback, 'max'));
         }
-        if ((field.min !== undefined) && (data[name] < field.min)) {
+        if (data[name] && field.min !== undefined && data[name] < field.min) {
           return setImmediate(_.partial(callback, 'min'));
         }
         return setImmediate(callback);

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -1047,10 +1047,10 @@ apos.define('apostrophe-schemas', {
         if (field.required && (!(data[name] && data[name].length))) {
           return setImmediate(_.partial(callback, 'required'));
         }
-        if (data[name] && field.max !== undefined && data[name] > field.max) {
+        if (data[name] && field.max !== undefined && parseInt(data[name], 10) > field.max) {
           return setImmediate(_.partial(callback, 'max'));
         }
-        if (data[name] && field.min !== undefined && data[name] < field.min) {
+        if (data[name] && field.min !== undefined && parseInt(data[name], 10) < field.min) {
           return setImmediate(_.partial(callback, 'min'));
         }
         return setImmediate(callback);
@@ -1068,10 +1068,10 @@ apos.define('apostrophe-schemas', {
         if (field.required && (!(data[name] && data[name].length))) {
           return setImmediate(_.partial(callback, 'required'));
         }
-        if (data[name] && field.max !== undefined && data[name] > field.max) {
+        if (data[name] && field.max !== undefined && parseFloat(data[name]) > field.max) {
           return setImmediate(_.partial(callback, 'max'));
         }
-        if (data[name] && field.min !== undefined && data[name] < field.min) {
+        if (data[name] && field.min !== undefined && parseFloat(data[name]) < field.min) {
           return setImmediate(_.partial(callback, 'min'));
         }
         return setImmediate(callback);

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -339,7 +339,7 @@ describe('Schemas', function() {
     });
   });
 
-  it('should keep an empty submitted field value null when there is a min / max configuration for a integer field type', function(done) {
+  it('should keep an empty submitted field value null when there is a min / max configuration for an integer field type', function(done) {
     var schema = apos.schemas.compose({
       addFields: [
         {
@@ -418,7 +418,61 @@ describe('Schemas', function() {
     });
   });
 
-  it('should override the saved value if min and max value has been set and the submitted value is out of range for a integer field type', function(done) {
+  it('should allow saving of a 0 value if there is no min value set for an integer type field', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'integer',
+          name: 'price',
+          label: 'Price'
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: '0'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    // var result = { password: 'serious' };
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      // hashing is not the business of schemas, see the
+      // apostrophe-users module
+      assert(result.price === 0);
+      done();
+    });
+  });
+
+  it('should allow saving of a 0 value if there is no min value set for a float type field', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'float',
+          name: 'price',
+          label: 'Price'
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: '0'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    // var result = { password: 'serious' };
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      // hashing is not the business of schemas, see the
+      // apostrophe-users module
+      assert(result.price === 0);
+      done();
+    });
+  });
+
+  it('should override the saved value if min and max value has been set and the submitted value is out of range for an integer field type', function(done) {
     var schema = apos.schemas.compose({
       addFields: [
         {
@@ -476,7 +530,7 @@ describe('Schemas', function() {
     });
   });
 
-  it('should ensure a min value is being set to the configured min value if a lower value is submitted for a integer field type', function(done) {
+  it('should ensure a min value is being set to the configured min value if a lower value is submitted for an integer field type', function(done) {
     var schema = apos.schemas.compose({
       addFields: [
         {
@@ -526,7 +580,7 @@ describe('Schemas', function() {
     });
   });
 
-  it('should ensure a max value is being set to the max if a higher value is submitted for a integer field type', function(done) {
+  it('should ensure a max value is being set to the max if a higher value is submitted for an integer field type', function(done) {
     var schema = apos.schemas.compose({
       addFields: [
         {
@@ -576,7 +630,7 @@ describe('Schemas', function() {
     });
   });
 
-  it('should not modify a value if the submitted value is within min and max for a integer field type', function(done) {
+  it('should not modify a value if the submitted value is within min and max for an integer field type', function(done) {
     var schema = apos.schemas.compose({
       addFields: [
         {

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -357,7 +357,6 @@ describe('Schemas', function() {
     };
     var req = apos.tasks.getReq();
     var result = {};
-    // var result = { password: 'serious' };
     return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
       assert(!err);
       assert(_.keys(result).length === 1);
@@ -384,7 +383,6 @@ describe('Schemas', function() {
     };
     var req = apos.tasks.getReq();
     var result = {};
-    // var result = { password: 'serious' };
     return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
       assert(!err);
       assert(_.keys(result).length === 1);
@@ -434,12 +432,9 @@ describe('Schemas', function() {
     };
     var req = apos.tasks.getReq();
     var result = {};
-    // var result = { password: 'serious' };
     return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
       assert(!err);
       assert(_.keys(result).length === 1);
-      // hashing is not the business of schemas, see the
-      // apostrophe-users module
       assert(result.price === 0);
       done();
     });
@@ -461,12 +456,9 @@ describe('Schemas', function() {
     };
     var req = apos.tasks.getReq();
     var result = {};
-    // var result = { password: 'serious' };
     return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
       assert(!err);
       assert(_.keys(result).length === 1);
-      // hashing is not the business of schemas, see the
-      // apostrophe-users module
       assert(result.price === 0);
       done();
     });
@@ -490,12 +482,9 @@ describe('Schemas', function() {
     };
     var req = apos.tasks.getReq();
     var result = {};
-    // var result = { password: 'serious' };
     return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
       assert(!err);
       assert(_.keys(result).length === 1);
-      // hashing is not the business of schemas, see the
-      // apostrophe-users module
       assert(result.price === 5);
       done();
     });
@@ -519,12 +508,9 @@ describe('Schemas', function() {
     };
     var req = apos.tasks.getReq();
     var result = {};
-    // var result = { password: 'serious' };
     return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
       assert(!err);
       assert(_.keys(result).length === 1);
-      // hashing is not the business of schemas, see the
-      // apostrophe-users module
       assert(result.price === 5.1);
       done();
     });
@@ -819,8 +805,6 @@ describe('Schemas', function() {
     return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
       assert(!err);
       assert(_.keys(result).length === 1);
-      // hashing is not the business of schemas, see the
-      // apostrophe-users module
       assert(Array.isArray(result.addresses));
       assert(result.addresses.length === 2);
       assert(result.addresses[0].id);

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -293,6 +293,341 @@ describe('Schemas', function() {
     assert(_newPage.group.name === 'info');
   });
 
+  it('should error if a field is required and an empty value is submitted', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'string',
+          name: 'name',
+          label: 'Name',
+          required: true
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      name: ''
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(err === 'required');
+      done();
+    });
+  });
+
+  it('should error if the value submitted is less than min length for a string field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'string',
+          name: 'name',
+          label: 'Name',
+          min: 5
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      name: 'Cow'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(err === 'min');
+      done();
+    });
+  });
+
+  it('should keep an empty submitted field value null when there is a min / max configuration for a integer field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'integer',
+          name: 'price',
+          label: 'Price',
+          min: 1,
+          max: 10
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: ''
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    // var result = { password: 'serious' };
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === null);
+      done();
+    });
+  });
+
+  it('should keep an empty submitted field value null when there is a min / max configuration for a float field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'float',
+          name: 'price',
+          label: 'Price',
+          min: 1,
+          max: 10
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: ''
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    // var result = { password: 'serious' };
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === null);
+      done();
+    });
+  });
+
+  it('should ensure a max value is being trimmed to the max length for a string field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'string',
+          name: 'name',
+          label: 'Name',
+          max: 5
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      name: 'Apostrophe'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.name === 'Apost');
+      done();
+    });
+  });
+
+  it('should override the saved value if min and max value has been set and the submitted value is out of range for a integer field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'integer',
+          name: 'price',
+          label: 'Price',
+          min: 5,
+          max: 6
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: '3'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    // var result = { password: 'serious' };
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      // hashing is not the business of schemas, see the
+      // apostrophe-users module
+      assert(result.price === 5);
+      done();
+    });
+  });
+
+  it('should override the saved value if min and max value has been set and the submitted value is out of range for a float field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'float',
+          name: 'price',
+          label: 'Price',
+          min: 5.1,
+          max: 6
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: '3.2'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    // var result = { password: 'serious' };
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      // hashing is not the business of schemas, see the
+      // apostrophe-users module
+      assert(result.price === 5.1);
+      done();
+    });
+  });
+
+  it('should ensure a min value is being set to the configured min value if a lower value is submitted for a integer field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'integer',
+          name: 'price',
+          label: 'Price',
+          min: 5
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: '1'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === 5);
+      done();
+    });
+  });
+
+  it('should ensure a min value is being set to the configured min value if a lower value is submitted for a float field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'float',
+          name: 'price',
+          label: 'Price',
+          min: 5.3
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: '1.2'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === 5.3);
+      done();
+    });
+  });
+
+  it('should ensure a max value is being set to the max if a higher value is submitted for a integer field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'integer',
+          name: 'price',
+          label: 'Price',
+          max: 5
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: '8'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === 5);
+      done();
+    });
+  });
+
+  it('should ensure a max value is being set to the max if a higher value is submitted for a float field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'float',
+          name: 'price',
+          label: 'Price',
+          max: 5.9
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: '8'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === 5.9);
+      done();
+    });
+  });
+
+  it('should not modify a value if the submitted value is within min and max for a integer field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'integer',
+          name: 'price',
+          label: 'Price',
+          min: 4,
+          max: 6
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: '5'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === 5);
+      done();
+    });
+  });
+
+  it('should not modify a value if the submitted value is within min and max for a float field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'float',
+          name: 'price',
+          label: 'Price',
+          min: 4,
+          max: 5
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: '4.3'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === 4.3);
+      done();
+    });
+  });
+
   it('should convert simple data correctly', function(done) {
     var schema = apos.schemas.compose({
       addFields: simpleFields

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -293,7 +293,7 @@ describe('Schemas', function() {
     assert(_newPage.group.name === 'info');
   });
 
-  it('should error if a field is required and an empty value is submitted', function(done) {
+  it('should error if a field is required and an empty value is submitted for a string field type', function(done) {
     var schema = apos.schemas.compose({
       addFields: [
         {
@@ -335,6 +335,30 @@ describe('Schemas', function() {
     var result = {};
     return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
       assert(err === 'min');
+      done();
+    });
+  });
+
+  it('should convert and keep the correct value for a field which is required for a string field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'string',
+          name: 'name',
+          label: 'Name',
+          required: true
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      name: 'Apostrophe^CMS'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(result.name === 'Apostrophe^CMS');
       done();
     });
   });
@@ -416,7 +440,182 @@ describe('Schemas', function() {
     });
   });
 
-  it('should allow saving of a 0 value if there is no min value set for an integer type field', function(done) {
+  it('should allow saving a 0 value provided as a number if a field is required for an integer field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'integer',
+          name: 'price',
+          label: 'Price',
+          required: true
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: 0
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === 0);
+      done();
+    });
+  });
+
+  it('should allow saving a 0 value provided as a float if a field is required for an float field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'float',
+          name: 'price',
+          label: 'Price',
+          required: true
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: 0.00
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === 0.00);
+      done();
+    });
+  });
+
+  it('should allow saving a 0 value provided as a number if a field is required for an float field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'float',
+          name: 'price',
+          label: 'Price',
+          required: true
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: 0
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === 0);
+      done();
+    });
+  });
+
+  it('should allow saving a 0 value provided as a number if a field is required for an string field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'string',
+          name: 'price',
+          label: 'Price',
+          required: true
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: 0
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === '0');
+      done();
+    });
+  });
+
+  it('should allow saving a 0 value provided as a string if a field is required for an integer field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'integer',
+          name: 'price',
+          label: 'Price',
+          required: true
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: '0'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === 0);
+      done();
+    });
+  });
+
+  it('should allow saving a 0 value provided as a string if a field is required for an string field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'string',
+          name: 'price',
+          label: 'Price',
+          required: true
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: '0'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === '0');
+      done();
+    });
+  });
+
+  it('should allow saving a 0 value provided as a string if a field is required for an float field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'float',
+          name: 'price',
+          label: 'Price',
+          required: true
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: '0'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === 0);
+      done();
+    });
+  });
+
+  it('should allow saving a 0 value provided as a string if there is no min value set for an integer field type', function(done) {
     var schema = apos.schemas.compose({
       addFields: [
         {
@@ -440,7 +639,7 @@ describe('Schemas', function() {
     });
   });
 
-  it('should allow saving of a 0 value if there is no min value set for a float type field', function(done) {
+  it('should allow saving a 0 value provided as a string if there is no min value set for a float field type', function(done) {
     var schema = apos.schemas.compose({
       addFields: [
         {
@@ -460,6 +659,153 @@ describe('Schemas', function() {
       assert(!err);
       assert(_.keys(result).length === 1);
       assert(result.price === 0);
+      done();
+    });
+  });
+
+  it('should allow saving a negative value provided as a number for an integer field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'integer',
+          name: 'price',
+          label: 'Price'
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: -1
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === -1);
+      done();
+    });
+  });
+
+  it('should allow saving a negative value provided as a float for an float field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'float',
+          name: 'price',
+          label: 'Price'
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: -1.3
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === -1.3);
+      done();
+    });
+  });
+
+  it('should allow saving a negative value provided as a float for an string field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'string',
+          name: 'price',
+          label: 'Price'
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: -1.3
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === '-1.3');
+      done();
+    });
+  });
+
+  it('should allow saving a negative value provided as a number if a field is required for an integer field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'integer',
+          name: 'price',
+          label: 'Price',
+          required: true
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: -1
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === -1);
+      done();
+    });
+  });
+
+  it('should allow saving a negative value provided as a number if a field is required for an float field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'float',
+          name: 'price',
+          label: 'Price',
+          required: true
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: -1.3
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === -1.3);
+      done();
+    });
+  });
+
+  it('should allow saving a negative value provided as a string if a field is required for an float field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'float',
+          name: 'price',
+          label: 'Price',
+          required: true
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: '-1.3'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.price === -1.3);
       done();
     });
   });


### PR DESCRIPTION
This PR aims to decouple the `required` field configuration with `min` and `max` values for fields (pieces, pages etc).

Currently, if a field is not required, then it will become required by a `min` or `max` value configuration. This means it's not possible to validate the user input without also requiring the field.

With this PR, if a field additionally has `required: true` then it will both be required and the value has to be in the range of `min` / `max` or either of them if only one is set.

This gives the maximum flexibility in relation to ensuring that a value is properly filtered / checked without also geting 0 values into the field value for example for floats. Currently if a `min` value was set to 1 and `max` was set to 10, then it would not be possible to save the field which means you would have to remove the min / max and set `required` which is not always what you would want.

#### Use case of improved and decoupled filtering / validations:

A product has a secondary price which is not mandatory and is only sometimes needed. We want to make sure somone does not put a very low or high price by mistake, so we configure `min` and `max`. This has the unwanted side effect, that the field now becomes required because it's not possible to save the field unless it has a value within `min` and `max`.

In summary; `min` and `max` only validates if the field actually has a value and combined with `required` and `def` (which can be useful to set to `null` in some cases) this enables the developer to configure the field exactly as needed.

Additionally I corrected error messages in the UI for `min` and `max` as they came out empty and the color of the error label was also black in some situations, which is now the correct `@apos-red;` inherited for less color duplication.