### PR TITLE
Fix label for finished button in tags

### DIFF
--- a/lib/modules/apostrophe-tags/views/manager.html
+++ b/lib/modules/apostrophe-tags/views/manager.html
@@ -7,7 +7,7 @@
 {%- endblock -%}
 
 {%- block controls -%}
-  {{ buttons.minor('Finish', { action: 'cancel' }) }}
+  {{ buttons.minor('Finished', { action: 'cancel' }) }}
 {%- endblock -%}
 
 {%- block label -%}


### PR DESCRIPTION
This PR corrects the label for the tags modal.

This modal is the only modal using the label "Finish", where all the other modals use "Finished".