### PR TITLE
Redirect after deleting piece

### DIFF
--- a/lib/modules/apostrophe-pieces/public/js/editor-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/editor-modal.js
@@ -221,6 +221,9 @@ apos.define('apostrophe-pieces-editor-modal', {
           return next(null);
         }
 
+        // Redirect to list view
+        window.location.href = apos.pages.page._url;
+
       }, function(err) {
         self.trashing = false;
         $el.removeClass('apos-busy');

--- a/lib/modules/apostrophe-pieces/public/js/editor-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/editor-modal.js
@@ -221,8 +221,11 @@ apos.define('apostrophe-pieces-editor-modal', {
           return next(null);
         }
 
-        // Redirect to list view
-        window.location.href = apos.pages.page._url;
+        // Redirect to list view if we don't have a manager modal
+        // (because then we are editing multiple pieces)
+        if ($('.apos-manager').length < 1) {
+          window.location.href = apos.pages.page._url;
+        }
 
       }, function(err) {
         self.trashing = false;


### PR DESCRIPTION
This PR fixes a missing redirect of the user after deleting a piece within the modal editor of the piece.

When deleting a piece in the context menu, Apostrophe would redirect correctly, but when doing it in the modal, it would stick around on the new delete piece creating confusion.