### PR TITLE
Fix modal pieces pager padding

### DIFF
--- a/lib/modules/apostrophe-pager/public/css/user.less
+++ b/lib/modules/apostrophe-pager/public/css/user.less
@@ -12,9 +12,9 @@
 
   .apos-pager-number
   {
-    padding: @apos-padding-1 4px;
     a
     {
+      padding: @apos-padding-1 4px;
       text-decoration: none;
       color: @apos-black;
     }


### PR DESCRIPTION
This PR improves "clickability" on pager numbers in the pieces modal dialog.

This is done by moving the padding from the wrapping `span` tag to the inside `a` tag.

**Observations:**
I personally don't think this pager is where it should be at this time in terms of usability and look and feel. It's very small (even with this fix), hard to click and I think long term this should be scaled up at least on larger screens. I have not intended that today, mostly because I don't fully yet understand the amount of items that can go on the left of the same footer area, so I'm not sure how much size this one can be allowed with responsive styling. I hope to get back to that in the near future but I would of course receive any feedback related to this from the core/UI team with gratitude.