### PR TITLE
Fix for error message sent by attachments module

### DIFF
--- a/lib/modules/apostrophe-attachments/lib/routes.js
+++ b/lib/modules/apostrophe-attachments/lib/routes.js
@@ -14,8 +14,14 @@ module.exports = function(self, options) {
     }
     return self.accept(req, file, function(err, file) {
       if (err) {
+        var clientMsg = 'err';
+
+        if ((typeof err) === 'string') {
+          clientMsg = err;
+        }
+
         self.apos.utils.error(err);
-        return res.send({ status: err });
+        return res.send({ status: clientMsg });
       }
       if (req.query.html) {
         res.setHeader('Content-Type', 'text/html');

--- a/lib/modules/apostrophe-attachments/lib/routes.js
+++ b/lib/modules/apostrophe-attachments/lib/routes.js
@@ -15,7 +15,7 @@ module.exports = function(self, options) {
     return self.accept(req, file, function(err, file) {
       if (err) {
         self.apos.utils.error(err);
-        return res.send({ status: 'err' });
+        return res.send({ status: err });
       }
       if (req.query.html) {
         res.setHeader('Content-Type', 'text/html');


### PR DESCRIPTION
This fixes the static 'err' message when uploading unsupported file via apostrophe-attachments. The change renders a meaningful message in the frontend in case of error.