### PR TITLE
implement ability to display a count for each distinct choice in piec…

### DIFF
--- a/lib/modules/apostrophe-docs/lib/cursor.js
+++ b/lib/modules/apostrophe-docs/lib/cursor.js
@@ -1049,9 +1049,7 @@ module.exports = {
         return Promise.promisify(body)(property, options);
       }
       function body(property, options, callback) {
-        var countsWas;
         if (options.counts) {
-          countsWas = self.get('distinctCounts');
           self.distinctCounts(true);
         }
         var choicesFn;

--- a/lib/modules/apostrophe-docs/lib/cursor.js
+++ b/lib/modules/apostrophe-docs/lib/cursor.js
@@ -287,6 +287,20 @@ module.exports = {
       }
     });
 
+    // Filter. If set to `true`, it is possible to obtain
+    // counts for each distinct value after a call to
+    // `toCount()` is resolved by calling
+    // `cursor.get('distinctCounts')`. These
+    // are returned as an object in which the keys are
+    // the distinct values of the field, and the values
+    // are the number of occurrences for each value.
+    //
+    // This has a performance impact.
+
+    self.addFilter('distinctCounts', {
+      def: false
+    });
+
     // Given the name of a computed field (a field other than _id that
     // begins with `_`), pushes the names of the necessary physical fields
     // to compute it onto `add` and returns `true` if able to do so.
@@ -922,9 +936,15 @@ module.exports = {
     // for the given `property`. Not chainable. Wraps
     // MongoDB's `distinct` and does not understand
     // join fields directly. However, see also
-    // `toChoices`.
+    // `toChoices`, which is built upon it.
     //
     // Returns a promise if invoked without a callback.
+    //
+    // If `cursor.set('distinctCounts', true)` has been
+    // invoked, a count of docs matching each value
+    // of `property` is available after this method
+    // resolves, via `cursor.get('distinctCounts')`.
+    // This has a performance impact.
 
     self.toDistinct = function(property, callback) {
       if (callback) {
@@ -937,8 +957,52 @@ module.exports = {
           if (err) {
             return callback(err);
           }
-          return self.db.distinct(property, self.get('criteria'), callback);
+          if (!self.get('distinctCounts')) {
+            return self.db.distinct(property, self.get('criteria'), callback);
+          } else {
+            return distinctCounts({ unwind: true }, function(err, results) {
+              if (!err) {
+                return callback(null, results);
+              }
+              // Try again without $unwind for mongodb < 3.2,
+              // which doesn't like $unwind for non-array
+              // properties. Newer will treat them like
+              // single-value arrays and make only one query
+              return distinctCounts({ unwind: false }, callback);
+            });
+          }
         });
+        function distinctCounts(options, callback) {
+          var pipeline = [
+            {
+              $match: self.get('criteria')
+            }
+          ].concat(options.unwind ? [
+            {
+              $unwind: '$' + property
+            }
+          ] : []).concat([
+            {
+              $group: {
+                _id: '$' + property,
+                count: {
+                  $sum: 1
+                }
+              }
+            }
+          ]);
+          return self.db.aggregate(pipeline, function(err, results) {
+            if (err) {
+              return callback(err);
+            }
+            var counts = {};
+            _.each(results, function(doc) {
+              counts[doc._id] = doc.count;
+            });
+            self.set('distinctCounts', counts);
+            return callback(null, _.pluck(results, '_id'));
+          });
+        }
       }
     };
 
@@ -949,6 +1013,10 @@ module.exports = {
     // autocomplete API response. Most field types
     // support this well, including `joinByOne` and
     // `joinByArray`.
+    //
+    // If `options.counts` is truthy, then each result
+    // in the array will also have a `count` property,
+    // wherever this is supported.
     //
     // the `options` object can be omitted completely.
     //
@@ -981,6 +1049,11 @@ module.exports = {
         return Promise.promisify(body)(property, options);
       }
       function body(property, options, callback) {
+        var countsWas;
+        if (options.counts) {
+          countsWas = self.get('distinctCounts');
+          self.distinctCounts(true);
+        }
         var choicesFn;
         var filter = self.filters[property];
         if (filter) {
@@ -1004,15 +1077,24 @@ module.exports = {
           if (!results.length) {
             return callback(null, results);
           }
+
           if (typeof (results[0]) !== 'object') {
             // Some choices methods just deliver an array of values
-            return callback(null, _.map(results, function(result) {
+            results = _.map(results, function(result) {
               return {
                 label: result,
                 value: result
               };
-            }));
+            });
           }
+
+          if (options.counts) {
+            var counts = self.get('distinctCounts');
+            _.each(results, function(result) {
+              result.count = counts[result.value];
+            });
+          }
+
           return callback(null, results);
         });
       }

--- a/lib/modules/apostrophe-pieces-pages/index.js
+++ b/lib/modules/apostrophe-pieces-pages/index.js
@@ -18,6 +18,10 @@
 // marked as `safeFor: "public"` if they exist, and an array of choices for each is populated
 // in `req.data.piecesFilters.tags` (if the field in question is `tags`), etc. The choices in the
 // array are objects with `label` and `value` properties.
+//
+// If a filter configuration has a `counts` property set to `true`, then the array provided for
+// that filter will also have a `count` property for each value. This has a performance
+// impact.
 
 var _ = require('@sailshq/lodash');
 var async = require('async');

--- a/lib/modules/apostrophe-pieces-pages/index.js
+++ b/lib/modules/apostrophe-pieces-pages/index.js
@@ -468,6 +468,10 @@ module.exports = {
     // corresponding cursor filter method). Each filter's choices are
     // reduced by the other filters; for instance, "tags" might only reveal
     // choices not ruled out by the current "topic" filter setting.
+    //
+    // If a filter in the array has its `counts` property set to true,
+    // Apostrophe will supply a `count` property for each distinct value,
+    // whenever possible. This has a performance impact.
 
     self.populatePiecesFilters = function(cursor, callback) {
       var req = cursor.get('req');
@@ -478,7 +482,7 @@ module.exports = {
         // vice versa)
         var _cursor = cursor.clone();
         _cursor[filter.name](undefined);
-        return _cursor.toChoices(filter.name, function(err, choices) {
+        return _cursor.toChoices(filter.name, _.pick(filter, 'counts'), function(err, choices) {
           if (err) {
             return callback(err);
           }

--- a/test/docs.js
+++ b/test/docs.js
@@ -307,7 +307,7 @@ describe('Docs', function() {
       slug: 'one',
       published: true,
       type: 'test-person',
-      firstName: 'Gary',
+      firstName: 'Lori',
       lastName: 'Ferber',
       age: 15,
       alive: true
@@ -450,16 +450,25 @@ describe('Docs', function() {
       });
   });
 
-  it('should be able to fetch all unique firstNames with toDistinct', function(done) {
-    apos.docs.find(apos.tasks.getReq(), { type: 'test-person' }).toDistinct('firstName')
+  it('should be able to fetch all unique firstNames with toDistinct', function() {
+    return apos.docs.find(apos.tasks.getReq(), { type: 'test-person' }).toDistinct('firstName')
       .then(function(firstNames) {
         assert(Array.isArray(firstNames));
-        assert(firstNames.length === 6);
+        assert(firstNames.length === 5);
         assert(_.contains(firstNames, 'Larry'));
-        done();
-      })
-      .catch(function(err) {
-        assert(!err);
+      });
+  });
+
+  it('should be able to fetch all unique firstNames and their counts with toDistinct and distinctCounts', function() {
+    var cursor = apos.docs.find(apos.tasks.getReq(), { type: 'test-person' }).distinctCounts(true);
+    return cursor.toDistinct('firstName')
+      .then(function(firstNames) {
+        assert(Array.isArray(firstNames));
+        assert(firstNames.length === 5);
+        assert(_.contains(firstNames, 'Larry'));
+        var counts = cursor.get('distinctCounts');
+        assert(counts['Larry'] === 1);
+        assert(counts['Lori'] === 2);
       });
   });
 


### PR DESCRIPTION
…esFilters. The new distinctCounts filter alters the behavior of toDistinct to use an aggregation pipeline. toDistinct replies normally but you can then call cursor.get("distinctCounts") to get an object with the counts. This sidesteps a ton of bc breaks to existing "choices" methods for every type of filter that would otherwise be needed for them to gather more data, skipping ahead to the insight that everybody relies on toDistinct in the end.

In `piecesFilters` all you have to do is add `counts: true` to a filter to get this behavior.

Of course it is not as fast as plain distinct.