### PR TITLE
Improve batch operations UI

### DIFF
--- a/lib/modules/apostrophe-modal/public/css/components/modal-batch-operations.less
+++ b/lib/modules/apostrophe-modal/public/css/components/modal-batch-operations.less
@@ -8,9 +8,11 @@
 	.apos-manage-batch-operations-select {
 		display: inline-block;
 		width: auto;
+    min-width: 180px;
 		margin-right: @apos-margin-2;
 		font-size: 14px;
 		line-height: 21px;
+    .apos-rounded
 	}
 
   .apos-field-input,

--- a/lib/modules/apostrophe-pieces/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/manager-modal.js
@@ -348,66 +348,78 @@ apos.define('apostrophe-pieces-manager-modal', {
     // asking for user confirmation.
 
     self.batchTrash = function() {
-      return self.batchSimple(
-        'trash',
-        "Are you sure you want to trash " + self.choices.length + " item(s)?",
-        {}
-      );
+      if (self.choices.length > 0) {
+        return self.batchSimple(
+          'trash',
+          'Are you sure you want to trash ' + self.choices.length + ' item' + (self.choices.length !== 1 ? 's' : '') + '?',
+          {}
+        );
+      }
     };
 
     // Rescues all selected items (`self.choices`) from the trash, after
     // asking for user confirmation.
 
     self.batchRescue = function() {
-      return self.batchSimple(
-        'rescue',
-        "Are you sure you want to rescue " + self.choices.length + " item(s) from the trash?",
-        {}
-      );
+      if (self.choices.length > 0) {
+        return self.batchSimple(
+          'rescue',
+          'Are you sure you want to rescue ' + self.choices.length + ' item' + (self.choices.length !== 1 ? 's' : '') + ' from the trash?',
+          {}
+        );
+      }
     };
 
     // Publishes all selected items (`self.choices`), after asking for
     // user confirmation.
 
     self.batchPublish = function() {
-      return self.batchSimple(
-        'publish',
-        "Are you sure you want to publish " + self.choices.length + " items?",
-        {}
-      );
+      if (self.choices.length > 0) {
+        return self.batchSimple(
+          'publish',
+          'Are you sure you want to publish ' + self.choices.length + ' item' + (self.choices.length !== 1 ? 's' : '') + '?',
+          {}
+        );
+      }
     };
 
     // Unpublishes all selected items (`self.choices`), after asking for
     // user confirmation.
 
     self.batchUnpublish = function() {
-      return self.batchSimple(
-        'unpublish',
-        "Are you sure you want to unpublish " + self.choices.length + " items?",
-        {}
-      );
+      if (self.choices.length > 0) {
+        return self.batchSimple(
+          'unpublish',
+          'Are you sure you want to unpublish ' + self.choices.length + ' item' + (self.choices.length !== 1 ? 's' : '') + '?',
+          {}
+        );
+      }
     };
 
     // Tags all selected items (`self.choices`), after asking for
     // user confirmation.
 
     self.batchTag = function() {
-      return self.batchSimple(
-        'tag',
-        "Are you sure you want to tag " + self.choices.length + " items?",
-        {}
-      );
+      if (self.choices.length > 0) {
+        return self.batchSimple(
+          'tag',
+          'Are you sure you want to tag ' + self.choices.length + ' item' + (self.choices.length !== 1 ? 's' : '') + '?',
+          {}
+        );
+      }
     };
 
     // Untags all selected items (`self.choices`), after asking for
     // user confirmation.
 
     self.batchUntag = function() {
-      return self.batchSimple(
-        'untag',
-        "Are you sure you want to untag " + self.choices.length + " items?",
-        {}
-      );
+      if (self.choices.length > 0) {
+        return self.batchSimple(
+          'untag',
+          'Are you sure you want to untag ' + self.choices.length + ' item' + (self.choices.length !== 1 ? 's' : '') + '?',
+          {}
+        );
+      }
     };
 
     // Carry out a named batch operation, such as `trash`, displaying the

--- a/lib/modules/apostrophe-pieces/views/managerModalBase.html
+++ b/lib/modules/apostrophe-pieces/views/managerModalBase.html
@@ -44,11 +44,6 @@
             {% endfor %}
           </select>
         </div>
-        <div class="apos-manage-batch-operations-buttons">
-          {% for operation in data.options.batchOperations %}
-            {{ buttons.danger(__('Batch %s', operation.buttonLabel or operation.label), { action: 'batch-operation', value: operation.name }) }}
-          {% endfor %}
-        </div>
         {% if apos.utils.filterNonempty(data.options.batchOperations, 'schema') %}
           <div class="apos-manage-batch-operation-forms">
         {% endif %}
@@ -64,6 +59,11 @@
         {% if apos.utils.filterNonempty(data.options.batchOperations, 'schema') %}
           </div>
         {% endif %}
+        <div class="apos-manage-batch-operations-buttons">
+          {% for operation in data.options.batchOperations %}
+            {{ buttons.danger(__('Batch %s', operation.buttonLabel or operation.label), { action: 'batch-operation', value: operation.name }) }}
+          {% endfor %}
+        </div>
       </div>
     {%- endblock -%}
     <div class="apos-manage-pager" data-pager></div>

--- a/lib/modules/apostrophe-ui/public/css/components/fields.less
+++ b/lib/modules/apostrophe-ui/public/css/components/fields.less
@@ -51,8 +51,6 @@
 }
 
 .apos-field-input-select-wrapper--small:after {
-  top: 12px;
-  right: 36px;
 }
 
 .apos-field-input-select


### PR DESCRIPTION
This PR improves batch operations in the editor modal.

Due to missing disabled attributes on the button, the button is clickable even if no items has been selected for a batch operation. This is now corrected with a check in JavaScript.

At the same time the text for the confirmation has also been made "plural aware".

The UI is improved by rounding the dropdown, fixing the arrow position, by removing specific styling for the dropdown, and relying on the recent flexbox additions to arrows in general.

For tags, the field to add tags has been moved to the left, so it appears between the batch operation dropdown and the button to perform the action. It was appearing to the right of button before this PR, which could be confusing.