### PR TITLE
Improve NaN validations for integers and floats

### DIFF
--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -1412,6 +1412,9 @@ module.exports = {
           if (field.required && (_.isUndefined(data[name]) || !data[name].toString().length)) {
             return callback('required');
           }
+          if (data[name] && isNaN(parseFloat(data[name]))) {
+            return callback('invalid');
+          }
           // This makes it possible to have a field that is not required, but min / max defined
           // This allows the form to be saved and sets the value to null if no value was given by
           // the user.
@@ -1455,6 +1458,9 @@ module.exports = {
           object[name] = self.apos.launder.float(data[name], field.def, field.min, field.max);
           if (field.required && (_.isUndefined(data[name]) || !data[name].toString().length)) {
             return callback('required');
+          }
+          if (data[name] && isNaN(parseFloat(data[name]))) {
+            return callback('invalid');
           }
           if (!data[name] && data[name] !== 0) {
             object[name] = null;

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -201,6 +201,9 @@ apos.define('apostrophe-schemas', {
         case 'max':
           error.message = 'Max. permitted value is: ' + field.max;
           break;
+        case 'invalid':
+          error.message = 'Value is not valid';
+          break;
       }
       return error;
     };
@@ -1047,6 +1050,9 @@ apos.define('apostrophe-schemas', {
         if (field.required && (!(data[name] && data[name].length))) {
           return setImmediate(_.partial(callback, 'required'));
         }
+        if (data[name] && isNaN(parseFloat(data[name]))) {
+          return setImmediate(_.partial(callback, 'invalid'));
+        }
         if (data[name] && field.max !== undefined && parseInt(data[name], 10) > field.max) {
           return setImmediate(_.partial(callback, 'max'));
         }
@@ -1067,6 +1073,9 @@ apos.define('apostrophe-schemas', {
         data[name] = $field.val();
         if (field.required && (!(data[name] && data[name].length))) {
           return setImmediate(_.partial(callback, 'required'));
+        }
+        if (data[name] && isNaN(parseFloat(data[name]))) {
+          return setImmediate(_.partial(callback, 'invalid'));
         }
         if (data[name] && field.max !== undefined && parseFloat(data[name]) > field.max) {
           return setImmediate(_.partial(callback, 'max'));

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -1014,6 +1014,236 @@ describe('Schemas', function() {
     });
   });
 
+  it('should not allow a text value to be submitted for a required integer field', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'integer',
+          name: 'price',
+          label: 'Price',
+          required: true
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: 'A'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(err);
+      done();
+    });
+  });
+
+  it('should not allow a text value to be submitted for a required float field', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'float',
+          name: 'price',
+          label: 'Price',
+          required: true
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: 'A'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(err);
+      done();
+    });
+  });
+
+  it('should not allow a text value to be submitted for a non required integer field with min and max', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'integer',
+          name: 'price',
+          label: 'Price',
+          min: 1,
+          max: 10
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: 'A'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(err);
+      done();
+    });
+  });
+
+  it('should not allow a text value to be submitted for a non required float field with min and max', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'float',
+          name: 'price',
+          label: 'Price',
+          min: 1,
+          max: 10
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: 'A'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(err);
+      done();
+    });
+  });
+
+  it('should not allow a text value to be submitted for a non required integer field with a default value set', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'integer',
+          name: 'price',
+          label: 'Price',
+          def: 2
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: 'A'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(err);
+      done();
+    });
+  });
+
+  it('should not allow a text value to be submitted for a non required float field with a default value set', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'float',
+          name: 'price',
+          label: 'Price',
+          def: 2.10
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: 'A'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(err);
+      done();
+    });
+  });
+
+  it('should not allow a text value to be submitted for a non required integer field', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'integer',
+          name: 'price',
+          label: 'Price'
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: 'A'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(err);
+      done();
+    });
+  });
+
+  it('should not allow a text value to be submitted for a non required float field', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'float',
+          name: 'price',
+          label: 'Price'
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: 'A'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(err);
+      done();
+    });
+  });
+
+  it('should allow a parsable string/integer value to be submitted for a non required integer field', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'integer',
+          name: 'price',
+          label: 'Price'
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: '22a'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(result.price === 22);
+      done();
+    });
+  });
+
+  it('should allow a parsable string/float value to be submitted for a non required float field', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'float',
+          name: 'price',
+          label: 'Price'
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      price: '11.4b'
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(result.price === 11.4);
+      done();
+    });
+  });
+
   it('should convert simple data correctly', function(done) {
     var schema = apos.schemas.compose({
       addFields: simpleFields


### PR DESCRIPTION
This PR improves earlier work I did on validation of integers and floats.

Before this PR it would be possible to submit a non numeric value and get through validations for a integer or float field.

This PR introduces a new check that validates the value (if a value is subitted) and does a callback with `invalid` as the argument, so the error can be output.

This validation is not relying on neither `required` nor `min` or `max`.

Added plenty of tests to cover this new validation, and the existing ones are still passing.