### PR TITLE
Fix condition that use potential undefined variable and crash the application 

### DIFF
--- a/lib/modules/apostrophe-pieces-widgets/index.js
+++ b/lib/modules/apostrophe-pieces-widgets/index.js
@@ -294,7 +294,7 @@ module.exports = {
     // whether the join has relationship properties or not.
 
     self.pushPieceForWidget = function(widget, piece) {
-      if (self.joinById.relationship && (widget.by === 'id')) {
+      if (self.joinById && self.joinById.relationship && (widget.by === 'id')) {
         widget._pieces.push({
           item: piece,
           relationship: (widget[self.joinById.relationshipsField] || {})[piece._id]


### PR DESCRIPTION
## Bug

It's possible to define pieces selected through the property `by` in custom pieces widget.
However set `by` to `['all']` crashs the application, which try to read a property of an undefined value in an if condition.

## How to reproduce

Create a custom pieces widget extending `apostrophe-pieces-widgets` with the following `by` restriction:

```
module.exports = {
  extend: 'apostrophe-pieces-widgets',
  by: ['all'],
  ...
}
```

Try to run the application, which will crash with the following error

```
TypeError: Cannot read property 'relationship' of undefined
    at Object.self.pushPieceForWidget (/Users/seao/Travail/Stage/Michelin/bicycle/node_modules/apostrophe/lib/modules/apostrophe-pieces-widgets/index.js:297:24)
    at ...
```

## Fix

Change

`if (self.joinById.relationship && (widget.by === 'id'))`

to

`if (self.joinById && self.joinById.relationship && (widget.by === 'id'))`

as `self.joinById` can be undefined