### PR TITLE
Make it possible to set field classes and attributes on form fields

### DIFF
--- a/lib/modules/apostrophe-schemas/views/fieldset.html
+++ b/lib/modules/apostrophe-schemas/views/fieldset.html
@@ -1,7 +1,7 @@
 {% macro render(field, bodyMacro) %}
   {# WARNING: if you remove apos-field as a class you will have problems with nested schemas reusing #}
   {# field names. We use this class with our $.findSafe plugin. #}
-  {% set options = { 'id': apos.utils.generateId() } %}
+  {% set options = { 'id': apos.utils.generateId(), fieldClasses: field.fieldClasses, fieldAttributes: field.fieldAttributes } %}
   <fieldset class="apos-field apos-field-{{ field.type | css }} apos-field-{{ field.name | css }} {{ field.classes }}" data-name="{{ field.name }}" {{ field.attributes }}>
     <label for="{{ options.id }}" class="apos-field-label">{{ __(field.label | d('')) }}</label>
     {%- if field.help -%}

--- a/lib/modules/apostrophe-schemas/views/macros.html
+++ b/lib/modules/apostrophe-schemas/views/macros.html
@@ -83,7 +83,7 @@
 {%- endmacro -%}
 
 {%- macro passwordBody(field, options) -%}
-  <input id="{{ options.id }}" class="apos-field-input apos-field-input-text" name="{{ field.name }}" type="password" {% if field.readOnly %}disabled{% endif %}>
+  <input id="{{ options.id }}" class="apos-field-input apos-field-input-text{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}" name="{{ field.name }}" type="password"{% if field.readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
 {%- endmacro -%}
 
 {%- macro tags(field) -%}

--- a/lib/modules/apostrophe-ui/views/components/fields.html
+++ b/lib/modules/apostrophe-ui/views/components/fields.html
@@ -1,14 +1,14 @@
 {% macro string(name, placeholder, value, readOnly, options) -%}
-  <input id="{{ options.id }}" name="{{ name }}" placeholder="{{__(placeholder | d(''))}}" class="apos-field-input apos-field-input-text" type="text" value="{{__(value | d(''))}}" {% if readOnly %}disabled{% endif %}>
+  <input id="{{ options.id }}" name="{{ name }}" placeholder="{{__(placeholder | d(''))}}" class="apos-field-input apos-field-input-text{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}" type="text" value="{{__(value | d(''))}}"{% if readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
 {%- endmacro %}
 
 {% macro textarea(name, placeholder, readOnly, options) -%}
-  <textarea id="{{ options.id }}" name="{{ name }}" placeholder="{{__(placeholder | d(''))}}" class="apos-field-input apos-field-input-textarea" {% if readOnly %}disabled{% endif %}></textarea>
+  <textarea id="{{ options.id }}" name="{{ name }}" placeholder="{{__(placeholder | d(''))}}" class="apos-field-input apos-field-input-textarea{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}"{% if readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}></textarea>
 {%- endmacro %}
 
 {% macro checkbox(name, placeholder, readOnly) -%}
   <label>
-    <input name="{{ name }}" placeholder="{{__(placeholder | d(''))}}" class="apos-field-input apos-field-input-checkbox" type="checkbox" {% if readOnly %}disabled{% endif %}>
+    <input name="{{ name }}" placeholder="{{__(placeholder | d(''))}}" class="apos-field-input apos-field-input-checkbox{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}" type="checkbox"{% if readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
     <span class="apos-field-input-checkbox-indicator"></span>
   </label>
 {%- endmacro %}
@@ -20,7 +20,7 @@
 
 {% macro select(name, options, selected, readOnly) -%}
   <div class="apos-field-input-select-wrapper">
-    <select name="{{ name }}" class="apos-field-input apos-field-input-select" {% if readOnly %}disabled{% endif %}>
+    <select name="{{ name }}" class="apos-field-input apos-field-input-select{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}"{% if readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
       {%- for option in options -%}
         <option {{ "selected" if option.value == selected }} value="{{ option.value }}">{{ __(option.label | d('')) }}</option>
       {%- endfor -%}
@@ -31,13 +31,13 @@
 {% macro color(name, placeholder, value, readOnly, options) -%}
   <label>
     <div class="apos-field-input-color-preview" data-apos-color-preview></div>
-    <input id="{{ options.id }}" name="{{ name }}" data-apos-color-empty-label="{{ __("None selected") }}" class="apos-field-input apos-field-input-color" data-apos-color type="text" value="{{__(value | d(''))}}" {% if readOnly %}disabled{% endif %}>
+    <input id="{{ options.id }}" name="{{ name }}" data-apos-color-empty-label="{{ __("None selected") }}" class="apos-field-input apos-field-input-color{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}" data-apos-color type="text" value="{{__(value | d(''))}}"{% if readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
   </label>
 {%- endmacro %}
 
 {% macro range(name, min, max, step, placeholder, value, readOnly, options) -%}
   <label>
     <span class="apos-field-input-range-value" data-apos-range-value></span>
-    <input id="{{ options.id }}" name="{{ name }}" min="{{ min }}" max="{{ max }}" step="{{ step or 'any' }}" class="apos-field-input apos-field-input-range" type="range" value="{{__(value | d(''))}}" {% if readOnly %}disabled{% endif %}>
+    <input id="{{ options.id }}" name="{{ name }}" min="{{ min }}" max="{{ max }}" step="{{ step or 'any' }}" class="apos-field-input apos-field-input-range{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}" type="range" value="{{__(value | d(''))}}"{% if readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
   </label>
 {%- endmacro %}


### PR DESCRIPTION
This PR adds the possibity of setting a schema field with the following configuration:

```
name: 'name',
type: 'string',
label: 'Name',
...
fieldClasses: 'custom-class',
fieldAttributes: 'data-custom-attribute'
```

Currently Apostrophe supports adding both `classes` and `attributes` in the same way, but those are added to the `fieldset` which wraps the form field. Some CSS frameworks requires a class put on the field itself (this is related to a submit piece where schema fields are used for a frontend submit).

**Note:**
There's a slight annoynce here in naming, as `classes` and `attributes` are already in use for the`fieldset` but for bc compatibility, it's not really possible to use the existing ones for the field and create new ones for the `fieldset` so this is the only way, even if it's not 100% obvious that this is a bit opposite of what one would expect. Maybe this can be "swapped" For 3.0, as this seems to be an undocumented feature, it's maybe not much in use yet.