### PR TITLE
now the mechanism to temporarily point apos.argv at the arguments for…

### DIFF
--- a/lib/modules/apostrophe-tasks/index.js
+++ b/lib/modules/apostrophe-tasks/index.js
@@ -85,8 +85,8 @@ module.exports = {
         const argv = {
           _: args
         };
-        self.apos.argv = aposArgv;
         Object.assign(argv, options || {});
+        self.apos.argv = argv;
         var promise = task.callback(self.apos, argv, after);
         if (promise && promise.then) {
           return promise.then(function() {


### PR DESCRIPTION
… a nested task really works.

The point of this is to ensure that tasks still see the arguments passed to apos.tasks.invoke() even if they look at `self.apos.argv`, which would normally come from the command line of the original app. The temporary argv is popped off and replaced with the original after the task completes. This was implemented in 2.60.0 but I goofed on this one line.