### PR TITLE
push what we know about the true docId and dotPath all the way to wid…

### DIFF
--- a/lib/modules/apostrophe-areas/lib/cursor.js
+++ b/lib/modules/apostrophe-areas/lib/cursor.js
@@ -55,18 +55,23 @@ module.exports = {
               if (doc._edit) {
                 area._edit = true;
               }
+
               area._docId = doc._id;
               area._dotPath = dotPath;
+              var i = 0;
               _.each(area.items, function(item) {
                 if (area._edit) {
                   // Keep propagating ._edit so a widget can be passed
                   // like a doc to aposArea if it contains nested areas. -Tom
                   item._edit = true;
                 }
+                item.__docId = doc._id;
+                item.__dotPath = dotPath + '.' + i;
                 if (!widgetsByType[item.type]) {
                   widgetsByType[item.type] = [];
                 }
                 widgetsByType[item.type].push(item);
+                i++;
               });
             });
           }

--- a/lib/modules/apostrophe-areas/lib/helpers.js
+++ b/lib/modules/apostrophe-areas/lib/helpers.js
@@ -49,8 +49,9 @@ module.exports = function(self, options) {
           area = doc[name];
         } else {
           area = {
-            _docId: doc._id,
-            _dotPath: name,
+            // If the "doc" is actually a widget, continue the path
+            _docId: doc.__docId || doc._id,
+            _dotPath: (doc.__dotPath ? (doc.__dotPath + '.') : '') + name,
             _edit: doc._edit
           };
         }
@@ -127,8 +128,9 @@ module.exports = function(self, options) {
           area = doc[name];
         } else {
           area = {
-            _docId: doc._id,
-            _dotPath: name,
+            // If the "doc" is actually a widget, continue the path
+            _docId: doc.__docId || doc._id,
+            _dotPath: (doc.__dotPath ? (doc.__dotPath + '.') : '') + name,
             _edit: doc._edit
           };
         }


### PR DESCRIPTION
…gets, which ensures that new singletons and areas brought into existence with apos.singleton and apos.area always work, even if areas are added dynamically in beforeInsert