### PR TITLE
Fix active state of array items

### DIFF
--- a/lib/modules/apostrophe-schemas/lib/routes.js
+++ b/lib/modules/apostrophe-schemas/lib/routes.js
@@ -25,6 +25,7 @@ module.exports = function(self, options) {
     var receptacle = {};
     var source = {};
     var name = req.body.field.name;
+    var active = self.apos.launder.integer(req.body.active);
     source[name] = req.body.arrayItems;
     var field = req.body.field;
     return async.series([ convert, join ], function(err) {
@@ -44,7 +45,7 @@ module.exports = function(self, options) {
           item._title = '#' + item._ordinal;
         }
       });
-      return res.send(self.render(req, 'arrayItems', { arrayItems: receptacle[name], field: req.body.field }));
+      return res.send(self.render(req, 'arrayItems', { active: active, arrayItems: receptacle[name], field: req.body.field }));
     });
     function convert(callback) {
       return self.fieldTypes['array'].converters.form(req, source, name, receptacle, req.body.field, callback);

--- a/lib/modules/apostrophe-schemas/public/js/array-modal.js
+++ b/lib/modules/apostrophe-schemas/public/js/array-modal.js
@@ -314,7 +314,7 @@ apos.define('apostrophe-array-editor-modal', {
       }
       self.refreshing++;
       self.$arrayItems.html('');
-      return self.html('arrayItems', { arrayItems: self.arrayItems, field: self.field }, function(html) {
+      return self.html('arrayItems', { active: self.active, arrayItems: self.arrayItems, field: self.field }, function(html) {
         // If calls are nested make sure only the last one actually updates the
         // markup, as a visual optimization
         if (self.refreshing === 1) {


### PR DESCRIPTION
This PR fixes the left sidebar state for an array item. Before this PR there would be no indicator of which array item is currently active.

With this fix, the background of the active clicked item goes light to clearly indicate which item you are currently editing.

This seems to be a forgotten implementation or a regression, because the template did have a check for active item, but the browser side JS never sends the current active/clicked item, so the route cannot pass it on to the template when rendering.

This PR potentially conflicts with the fairly important tolerant-arrays branch/fix, but if that branch is merged, I will update this one to merge cleanly with master thereafter.

Not so super related note: Doing this one I got a bit better insight in the UI issue with required fields and I am considering options to try to prevent the user from moving away from required fields that are still empty. I may give a decent fix for that one a shot soonish. Open for suggestions on that one before starting :)