### PR TITLE
Slow down brute force attacks

### DIFF
--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -204,11 +204,17 @@ module.exports = {
           return callback(err);
         }
         if (!user) {
-          return callback(null, false);
+          // Slow down and keep 'em hanging to make brute force attacks less easy
+          return setTimeout(function () {
+            return callback(null, false);
+          }, 1000);
         }
         return self.apos.users.verifyPassword(user, password, function(err) {
           if (err) {
-            return callback(null, false);
+            // Slow down and keep 'em hanging to make brute force attacks less easy
+            return setTimeout(function () {
+              return callback(null, false);
+            }, 1000);
           }
           return callback(err, user);
         });


### PR DESCRIPTION
This PR adds a **one second** delay in the response on a brute force attack or incorrect login.

This is a common technique to make it harder make many (automated) login attempts to "guess" a users password.

I would like to implement a more sophisticated method for this, which would gradually slow down the possibility of trying a login, for example after x attempts in n minutes, Apostrophe would reject any login route from that IP. That will be a more complex implementation though, which would require the use of a database collection to to keep track of failed logins.

Before starting the more advanced one, if there's interest for such an improvement, I would like to have a discussion about the goals for such an implementation. I'm thinking that there could be some sensible default values and it would be possible per site to configure more aggressive or loose rules for whatever one wants.

Until then, I think this one is a simple good addition. For a legit user that by mistake types a wrong username and/or password, we steal one second before telling them, but that should really not be a big deal. 