### PR TITLE
password reset tokens are hashed with the same ceremony as passwords …

### DIFF
--- a/lib/modules/apostrophe-email/index.js
+++ b/lib/modules/apostrophe-email/index.js
@@ -41,12 +41,15 @@ module.exports = {
           }
         }
       });
-      return transport.sendMail(_.assign({
+      var args = _.assign({
         html: html,
         text: text,
         from: (module.options.email && module.options.email.from) || self.options.from
-      }, options), callback);
-
+      }, options);
+      if (process.env.APOS_LOG_EMAIL) {
+        self.apos.utils.debug(args);
+      }
+      return transport.sendMail(args, callback);
     };
 
     // Fetch the nodemailer-compatible transport object. The default

--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -40,6 +40,7 @@ var Passport = require('passport').Passport;
 var LocalStrategy = require('passport-local');
 var _ = require('@sailshq/lodash');
 var qs = require('qs');
+var Promise = require('bluebird');
 
 module.exports = {
 
@@ -279,22 +280,16 @@ module.exports = {
           var clauses = [];
           clauses.push({ username: username });
           clauses.push({ email: username });
-          var adminReq = self.apos.tasks.getReq();
-          return self.apos.users.find(adminReq, {
+          return self.apos.users.find(req, {
             $or: clauses
-          }).toObject().then(function(user) {
+          }).permission(false).toObject().then(function(user) {
             if (!user) {
               throw 'notfound';
             }
             reset = self.apos.utils.generateId();
-            return self.apos.docs.db.update({
-              _id: user._id
-            }, {
-              $set: {
-                passwordReset: reset,
-                passwordResetAt: new Date()
-              }
-            }).then(function() {
+            user.passwordReset = reset;
+            user.passwordResetAt = new Date();
+            return self.apos.users.update(req, user, { permissions: false }).then(function() {
               return user;
             });
           }).then(function(user) {
@@ -303,7 +298,7 @@ module.exports = {
             }
             var parsed = require('url').parse(req.absoluteUrl);
             parsed.pathname = '/password-reset';
-            parsed.query = { reset: reset };
+            parsed.query = { reset: reset, email: user.email };
             delete parsed.search;
             url = require('url').format(parsed);
             return self.email(req, 'passwordResetEmail', { user: user, url: url, site: site }, {
@@ -320,13 +315,14 @@ module.exports = {
 
         self.apos.app.get('/password-reset', function(req, res) {
           var reset = self.apos.launder.string(req.query.reset);
+          var email = self.apos.launder.string(req.query.email);
           if (!reset.length) {
             return res.redirect('/password-reset-request?error=missing');
           }
           req.scene = 'user';
           var adminReq = self.apos.tasks.getReq();
           return self.apos.users.find(adminReq, {
-            passwordReset: reset,
+            email: email,
             passwordResetAt: { $gte: new Date(Date.now() - self.getPasswordResetLifetimeInMilliseconds()) }
           }).toObject().then(function(user) {
             if (!user) {
@@ -335,7 +331,7 @@ module.exports = {
             // Gets i18n'd in the template, also bc with what templates that tried to work
             // before certain fixes would expect (this is why we still pass a string and not
             // a flag, and why we call it `message`)
-            return self.sendPage(req, 'passwordReset', { reset: reset });
+            return self.sendPage(req, 'passwordReset', { reset: reset, email: email });
           }).catch(function(err) {
             self.apos.utils.error(err);
             return res.redirect('/login?message=' + req.__('That reset code was not found. It may have expired. Try resetting again.'));
@@ -344,22 +340,30 @@ module.exports = {
 
         self.apos.app.post('/password-reset', function(req, res) {
           var reset = self.apos.launder.string(req.body.reset);
+          var email = self.apos.launder.string(req.body.email);
           var password = self.apos.launder.string(req.body.password);
           if ((!reset.length) || (!password.length)) {
             return res.redirect('/password-reset-request?error=missing');
           }
           var adminReq = self.apos.tasks.getReq();
-          return self.apos.users.find(adminReq, {
-            passwordReset: reset,
-            passwordResetAt: { $gte: new Date(Date.now() - self.getPasswordResetLifetimeInMilliseconds()) }
-          }).toObject().then(function(user) {
+          return Promise.try(function() {
+            return self.apos.users.find(adminReq, {
+              email: email,
+              passwordResetAt: { $gte: new Date(Date.now() - self.getPasswordResetLifetimeInMilliseconds()) }
+            }).toObject();
+          }).then(function(user) {
             if (!user) {
               throw new Error('notfound');
             }
+            return self.apos.users.verifySecret(user, 'passwordReset', reset).then(function() {
+              return user;
+            });
+          }).then(function(user) {
             user.password = password;
-            delete user.passwordReset;
             delete user.passwordResetAt;
             return self.apos.users.update(adminReq, user);
+          }).then(function(user) {
+            return self.apos.users.forgetSecret(user, 'passwordReset');
           }).then(function(user) {
             return res.redirect('/login?message=' + req.__('Password has been reset. Please log in.'));
           }).catch(function(err) {
@@ -426,6 +430,12 @@ module.exports = {
         req.redirect = req.redirect || '/';
         return res.redirect(req.redirect);
       });
+    };
+
+    self.modulesReady = function() {
+      // So this property is hashed and the hash kept in the safe,
+      // rather than ever being stored literally
+      self.apos.users.addSecret('passwordReset');
     };
 
   }

--- a/lib/modules/apostrophe-login/views/passwordReset.html
+++ b/lib/modules/apostrophe-login/views/passwordReset.html
@@ -18,6 +18,7 @@
               </div>
             {% endblock %}
             <input type="hidden" name="reset" value="{{ data.reset }}" />
+            <input type="hidden" name="email" value="{{ data.email }}" />
             <div class="apos-login-submit">
               <input type="submit" class="apos-button apos-button--major" value="{% block buttonLabel %}{{ __('Reset Password') }}{% endblock %}" />
             </div>

--- a/lib/modules/apostrophe-users/index.js
+++ b/lib/modules/apostrophe-users/index.js
@@ -39,7 +39,7 @@
 // `secrets` option to an array of property names, those properties
 // are never stored directly to the database. Instead, only their
 // hashes are stored, and only in `aposUsersSafe`.
-// 
+//
 // You may also call `apos.users.addSecret('name')` to add a new
 // secret property. This is convenient when implementing a module
 // such as `apostrophe-signup`.
@@ -180,7 +180,7 @@ module.exports = {
 
     // See `options.secrets` and also the `addSecret` method. `enableSecrets`
     // is part of the implementation and should not be called directly.
- 
+
     self.enableSecrets = function() {
       self.secrets = self.options.secrets || [];
     };
@@ -308,7 +308,7 @@ module.exports = {
     };
 
     // Similar to `hashPassword`, this method hashes all of the properties
-    // enumerated in `options.secrets` and via `addSecrets`, then deletes them 
+    // enumerated in `options.secrets` and via `addSecrets`, then deletes them
     // and updates the corresponding properties of `safeUser`. If
     // a secret is named `signup`, the corresponding property in
     // `safeUser` will be named `signupHash`.
@@ -325,7 +325,7 @@ module.exports = {
     // Add the property specified by `name` to a list of
     // secret properties. These are never stored directly
     // to the user's doc in mongodb. Instead, if any of
-    // them have non-falsy values at the time a user is saved, 
+    // them have non-falsy values at the time a user is saved,
     // those values are hashed and the hash is recorded
     // in a separate mongodb collection used only for this purpose.
     // You may then call `verifySecret` later to verify that
@@ -345,13 +345,13 @@ module.exports = {
     // If `secret` is the string `'password'`, then the `password`
     // property will be deleted from `doc` and the `passwordHash`
     // property of `safeUser` will be set.
-    // 
+    //
     // If the secret property is falsy (i.e. the user left the
     // password field blank, requesting no change), it is left
     // alone and `safeUser` is not updated.
     //
     // Called automatically by `hashSecrets`, above.
-    
+
     self.hashSecret = function(doc, safeUser, secret, callback) {
       if (!doc[secret]) {
         return callback(null);
@@ -377,7 +377,7 @@ module.exports = {
     // the hash of the secret property `secret`. For security
     // the user's password and other property names specified
     // in `options.secrets` when configuring this module or via
-    // `addSecrets` are not stored as plaintext and are not kept in the 
+    // `addSecrets` are not stored as plaintext and are not kept in the
     // aposDocs collection. Instead, they are hashed and salted using the
     // `credential` module and the resulting hash is stored
     // in a separate `aposUsersSafe` collection. This method
@@ -387,7 +387,7 @@ module.exports = {
     //
     // If no callback is passed, a promise is returned.
     // If the verification fails the promise is rejected.
- 
+
     self.verifySecret = function(user, secret, attempt, callback) {
       if (callback) {
         return body(callback);
@@ -444,11 +444,11 @@ module.exports = {
           $unset: {}
         };
         changes.$unset[secret + 'Hash'] = 1;
-        return self.safe.update({ 
-          _id: user._id 
+        return self.safe.update({
+          _id: user._id
         }, changes, callback);
       }
-    }; 
+    };
 
     var superDeduplicateTrash = self.deduplicateTrash;
     // Reflect email and username changes in the safe after deduplicating in the piece

--- a/lib/modules/apostrophe-users/index.js
+++ b/lib/modules/apostrophe-users/index.js
@@ -18,7 +18,7 @@
 //
 // ### Public "staff directories" vs. users
 //
-// In our experience, combing the concept of a "user" who can log in and do things
+// In our experience, combining the concept of a "user" who can log in and do things
 // with the concept of a "staff member" who appears in a staff directory is more
 // trouble than it is worth. That's why the `published` field is not present in
 // `apostrophe-users`. You can add it back in, but then you have to deal with
@@ -27,11 +27,28 @@
 // So for a staff directory, we suggest you create a separate `employee` module
 // or similar, extending `apostrophe-pieces`, unless it's true that basically
 // everyone should be allowed to log in.
+//
+// ### `secrets` option
+//
+// For security the `password` property is not stored as plaintext and
+// is not kept in the aposDocs collection. Instead, it is hashed and salted
+// using the `credential` module and the resulting hash is stored
+// in a separate `aposUsersSafe` collection.
+//
+// Additional secrets may be hashed in this way. If you set the
+// `secrets` option to an array of property names, those properties
+// are never stored directly to the database. Instead, only their
+// hashes are stored, and only in `aposUsersSafe`.
+// 
+// You may also call `apos.users.addSecret('name')` to add a new
+// secret property. This is convenient when implementing a module
+// such as `apostrophe-signup`.
 
 var async = require('async');
 var _ = require('@sailshq/lodash');
 var credential = require('credential');
 var prompt = require('prompt');
+var Promise = require('bluebird');
 
 module.exports = {
 
@@ -49,6 +66,7 @@ module.exports = {
   afterConstruct: function(self, callback) {
     self.initializeCredential();
     self.addOurTrashPrefixFields();
+    self.enableSecrets();
     return async.series([
       self.ensureGroups,
       self.ensureSafe
@@ -160,6 +178,13 @@ module.exports = {
       self.addTrashPrefixFields([ 'username', 'email' ]);
     };
 
+    // See `options.secrets` and also the `addSecret` method. `enableSecrets`
+    // is part of the implementation and should not be called directly.
+ 
+    self.enableSecrets = function() {
+      self.secrets = self.options.secrets || [];
+    };
+
     // Index and obtain access to the `aposUsersSafe` MongoDB collection as `self.safe`.
 
     self.ensureSafe = function(callback) {
@@ -225,7 +250,7 @@ module.exports = {
     // password hash completely outside of the `aposDocs` collection.
     // First checks to be sure this is an `apostrophe-user` and invokes
     // its callback immediately if not. Invoked by `docBeforeInsert`
-    // and `docBeforeSave`.
+    // and `docBeforeUpdate`.
 
     self.insertOrUpdateSafe = function(req, doc, action, callback) {
       if (doc.type !== self.name) {
@@ -250,6 +275,9 @@ module.exports = {
         passwordHash: function(callback) {
           return self.hashPassword(doc, safeUser, callback);
         },
+        secrets: function(callback) {
+          return self.hashSecrets(doc, safeUser, callback);
+        },
         safe: function(callback) {
           if (action === 'insert') {
             return self.safe.insert(safeUser, callback);
@@ -270,18 +298,70 @@ module.exports = {
 
     // Hash the `password` property of `doc`, then delete that property
     // and update the `passwordHash` property of `safeUser`. This method is
-    // called by the `docBeforeSave` handler of this module.
+    // called by the `docBeforeInsert` and `docBeforeSave handlers of this
+    // module. If `password` is falsy (i.e. the user left it blank,
+    // requesting no change), it is left alone and `safeUser` is
+    // not updated.
 
     self.hashPassword = function(doc, safeUser, callback) {
-      if (!doc.password) {
-        return setImmediate(callback);
+      return self.hashSecret(doc, safeUser, 'password', callback);
+    };
+
+    // Similar to `hashPassword`, this method hashes all of the properties
+    // enumerated in `options.secrets` and via `addSecrets`, then deletes them 
+    // and updates the corresponding properties of `safeUser`. If
+    // a secret is named `signup`, the corresponding property in
+    // `safeUser` will be named `signupHash`.
+    //
+    // This method is called by the `docBeforeInsert` and `docBeforeSave`
+    // handlers of this module.
+
+    self.hashSecrets = function(doc, safeUser, callback) {
+      return async.eachSeries(self.secrets, function(secret, callback) {
+        return self.hashSecret(doc, safeUser, secret, callback);
+      }, callback);
+    };
+
+    // Add the property specified by `name` to a list of
+    // secret properties. These are never stored directly
+    // to the user's doc in mongodb. Instead, if any of
+    // them have non-falsy values at the time a user is saved, 
+    // those values are hashed and the hash is recorded
+    // in a separate mongodb collection used only for this purpose.
+    // You may then call `verifySecret` later to verify that
+    // a newly entered value matches the previously hashed
+    // value. This is useful to verify password reset codes,
+    // signup verification codes and the like with security
+    // just as good as that used for the password.
+
+    self.addSecret = function(name) {
+      self.secrets.push(name);
+    };
+
+    // Hashes a secret property of `doc`, deletes the property,
+    // and stores only the hash in `safeUser`. `secret` is
+    // the name of the property of `doc`, not the secret itself.
+    //
+    // If `secret` is the string `'password'`, then the `password`
+    // property will be deleted from `doc` and the `passwordHash`
+    // property of `safeUser` will be set.
+    // 
+    // If the secret property is falsy (i.e. the user left the
+    // password field blank, requesting no change), it is left
+    // alone and `safeUser` is not updated.
+    //
+    // Called automatically by `hashSecrets`, above.
+    
+    self.hashSecret = function(doc, safeUser, secret, callback) {
+      if (!doc[secret]) {
+        return callback(null);
       }
-      return self.pw.hash(doc.password, function(err, hash) {
+      return self.pw.hash(doc[secret], function(err, hash) {
         if (err) {
           return callback(err);
         }
-        delete doc.password;
-        safeUser.passwordHash = hash;
+        delete doc[secret];
+        safeUser[secret + 'Hash'] = hash;
         return callback(null);
       });
     };
@@ -290,33 +370,85 @@ module.exports = {
     // hash in the safe. `user` is an `apostrophe-user` doc.
 
     self.verifyPassword = function(user, password, callback) {
-      var safeUser;
-      return async.series({
-        getSafeUser: function(callback) {
-          return self.safe.findOne({ _id: user._id }, function(err, _safeUser) {
-            if (err) {
-              return callback(err);
-            }
-            safeUser = _safeUser;
-            return callback(null);
-          });
-        },
-        verifyHash: function(callback) {
-          if (!safeUser) {
-            return callback(new Error('No such user in the safe.'));
-          }
-          return self.pw.verify(safeUser.passwordHash, password, function(err, isValid) {
-            if (err) {
-              return callback(err);
-            }
-            if (!isValid) {
-              return callback(new Error('Incorrect password'));
-            }
-            return callback(null);
-          });
-        }
-      }, callback);
+      return self.verifySecret(user, 'password', password, callback);
     };
+
+    // Check whether the provided value `attempt` matches
+    // the hash of the secret property `secret`. For security
+    // the user's password and other property names specified
+    // in `options.secrets` when configuring this module or via
+    // `addSecrets` are not stored as plaintext and are not kept in the 
+    // aposDocs collection. Instead, they are hashed and salted using the
+    // `credential` module and the resulting hash is stored
+    // in a separate `aposUsersSafe` collection. This method
+    // can be used to verify that `attempt` matches the
+    // previously hashed value for the property named `secret`,
+    // without ever storing the actual value of the secret.
+    //
+    // If no callback is passed, a promise is returned.
+    // If the verification fails the promise is rejected.
+ 
+    self.verifySecret = function(user, secret, attempt, callback) {
+      if (callback) {
+        return body(callback);
+      } else {
+        return Promise.promisify(body)();
+      }
+      function body(callback) {
+        var safeUser;
+        return async.series({
+          getSafeUser: function(callback) {
+            return self.safe.findOne({ _id: user._id }, function(err, _safeUser) {
+              if (err) {
+                return callback(err);
+              }
+              safeUser = _safeUser;
+              return callback(null);
+            });
+          },
+          verifyHash: function(callback) {
+            if (!safeUser) {
+              return callback(new Error('No such user in the safe.'));
+            }
+            return self.pw.verify(safeUser[secret + 'Hash'], attempt, function(err, isValid) {
+              if (err) {
+                return callback(err);
+              }
+              if (!isValid) {
+                return callback(new Error('Incorrect ' + secret));
+              }
+              return callback(null);
+            });
+          }
+        }, callback);
+      }
+    };
+
+    // Forget the secret associated with the property name
+    // passed in `secret`. If `secret` is `'passwordReset'`,
+    // then the `passwordResetHash` property is deleted from
+    // the appropriate record in the `aposUsersSafe`
+    // collection. Note that the plaintext of the secret
+    // was never stored in the database in the first place.
+    //
+    // If no callback is passed, a promise is returned.
+
+    self.forgetSecret = function(user, secret, callback) {
+      if (callback) {
+        return body(callback);
+      } else {
+        return Promise.promisify(body)();
+      }
+      function body(callback) {
+        var changes = {
+          $unset: {}
+        };
+        changes.$unset[secret + 'Hash'] = 1;
+        return self.safe.update({ 
+          _id: user._id 
+        }, changes, callback);
+      }
+    }; 
 
     var superDeduplicateTrash = self.deduplicateTrash;
     // Reflect email and username changes in the safe after deduplicating in the piece


### PR DESCRIPTION
…themselves, are not stored; apostrophe now has a "secrets" mechanism that can be used for other similar cases, such as account signup tokens"

@austinstarin I've requested a review from you because this branch is a prerequisite for the new apostrophe-signup module to land.