### PR TITLE
Add more upload emit events

### DIFF
--- a/lib/modules/apostrophe-attachments/public/js/user.js
+++ b/lib/modules/apostrophe-attachments/public/js/user.js
@@ -109,6 +109,10 @@ apos.define('apostrophe-attachments', {
         url: self.action + '/upload',
         start: function (e) {
           busy(true);
+          apos.emit('attachmentUploadStarted', {
+            $fieldset: $fieldset,
+            field: field
+          });
         },
         // Even on an error we should note we're not spinning anymore
         always: function (e, data) {
@@ -118,6 +122,11 @@ apos.define('apostrophe-attachments', {
           var extensions;
           if (data.result.status !== 'ok') {
             apos.notify(data.result.status);
+            apos.emit('attachmentUploadError', {
+              $fieldset: $fieldset,
+              field: field,
+              status: data.result.status
+            });
             return;
           }
           var file = data.result.file;
@@ -143,6 +152,10 @@ apos.define('apostrophe-attachments', {
               return;
             }
           }
+          apos.emit('attachmentUploadSuccess', {
+            $fieldset: $fieldset,
+            field: field
+          });
           self.updateExisting($fieldset, file, field);
         },
         add: function(e, data) {


### PR DESCRIPTION
This PR adds a few more emit events to file uploads.

Currently there's only one event that one can listen on inside a widget player.

My use case is a public user submitted form which includes a upload field for files.

Before this PR it would be hard for me to lock up the UI **while** the file(s) are being uploaded, which would result in a potential form submitted without the file actually attached.

Having more events to listen on, one can listen to various events and have the UI react accordingly. It will even be possible to discard events or differentiate depending on the field name / field schema configuration.

I'm open to renaming these of course, and I don't have a specific use case for each and every one of them now, but since I am adding the ones I need, I thought I would try to cover all situations.