### PR TITLE
Avoid adding UI drop zones to non-movable widgets

### DIFF
--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -407,7 +407,10 @@ apos.define('apostrophe-areas-editor', {
       return $('[data-apos-area]').filter(function() {
         var editor = $(this).data('editor');
         if ((editor && !editor.limitReached()) || ($widget.data('areaEditor') === editor)) {
-          if (_.has(editor.options.widgets, $widget.attr('data-apos-widget'))) {
+          var movableOptionKey = [$widget.attr('data-apos-widget'), 'controls', 'movable'];
+          var hasWidget = _.has(editor.options.widgets, $widget.attr('data-apos-widget'));
+
+          if (hasWidget && (_.has(editor.options.widgets, movableOptionKey) ? _.get(editor.options.widgets, movableOptionKey) : true)) {
             return true;
           }
         }
@@ -566,10 +569,12 @@ apos.define('apostrophe-areas-editor', {
         // Get rid of the hardcoded position provided by jquery UI draggable,
         // but don't remove the position: relative without which we can't see the
         // element move when we try to drag it again later
-        $item.css('top', '0');
-        $item.css('left', '0');
-        $item.css('width', 'auto');
-        $item.css('height', 'auto');
+        $item.css({
+          'height': '',
+          'left': '',
+          'top': '',
+          'width': ''
+        });
         $(event.target).after($item);
         self.disableDroppables();
         self.reRenderWidget($item);


### PR DESCRIPTION
This is a very minor fix, but I ran into it when looking into the drag and drop functionality. If you have multiple areas on the same page where the same type of widget can be added – the drag and drop functionality supports moving a particular widget between these different areas. 

It is however possible that another area has marked this widget as being "non-movable" – ie `options.controls.movable` is false. This PR makes it so that drop zones aren't added to those areas.

There is a second change in here that fixes another issue I ran into. The drag and drop functinality resets certain CSS styles after a widget has been dropped. It seems to assume very optimistically what these styles should be though (both `height` and `width` are simply set to `auto`). This 2nd change makes it so that the styles are actually removed from the DOM, and not just reset to the default browser value for each CSS rule.