### PR TITLE
Fix file upload busy state check

### DIFF
--- a/lib/modules/apostrophe-attachments/public/js/user.js
+++ b/lib/modules/apostrophe-attachments/public/js/user.js
@@ -161,7 +161,8 @@ apos.define('apostrophe-attachments', {
 
     self.convert = function(data, name, $field, $el, field, callback) {
       var $fieldset = apos.schemas.findFieldset($el, name);
-      if ($fieldset.attr('data-busy') === '1') {
+      var $uploaderButton = $fieldset.find('[data-apos-uploader-target]');
+      if ($uploaderButton.attr('data-busy') === '1') {
         // If upload is in progress stay busy until this upload
         // completes. Other file attachment fields may be doing
         // the same dance.


### PR DESCRIPTION
This PR fixes the file upload busy state check.

The busy check was done on the fieldset, when it should be done on the "uploader button" which holds the busy state.

Tested that with this fix, the form will not finish converting and subsequently submitting, until the file has finished uploading.

As a bonus for fixing this one, I hope that #1509 will also be accepted, as making use of that one let's me do UI stuff while the upload is in progress. This one will be more of a safe guard to make sure the form is not submitted until the file has finished uploading.