### PR TITLE
Fix notification colors

### DIFF
--- a/lib/modules/apostrophe-notifications/public/css/user.less
+++ b/lib/modules/apostrophe-notifications/public/css/user.less
@@ -15,7 +15,8 @@
 // With and without scoping so these styles
 // beat out the defaults inside modals too. -Tom
 
-.apos-notification, .apos-ui .apos-notification {
+.apos-notification,
+.apos-ui .apos-notification {
   background-color: @apos-white;
   color: @apos-dark;
   .apos-button-border(@apos-dark);
@@ -25,31 +26,31 @@
   margin-bottom: @apos-padding-2;
   position: relative;
   .apos-transition;
-    
+
   &-message {
     font-size: 16px;
     margin-right: 32px;
     padding: @apos-padding-1 @apos-padding-2 !important;
   }
-  
+
   &--hidden {
     opacity: 0;
   }
 }
 
-.apos-notification--error {
+.apos-notification.apos-notification--error {
   .apos-button-border(@apos-white);
   background-color: @apos-red;
   color: @apos-white;
 }
 
-.apos-notification--warn {
+.apos-notification.apos-notification--warn {
   .apos-button-border(@apos-white);
   background-color: @apos-gold;
   color: @apos-white;
 }
 
-.apos-notification--success {
+.apos-notification.apos-notification--success {
   .apos-button-border(@apos-white);
   background-color: @apos-green;
   color: @apos-white;


### PR DESCRIPTION
This PR fixes notification colors, also when the modal overlay is not present.

Before this PR notifications of type success, warning and error would sometimes display with a white background. Both on top of a modal and when there was no modal.

This PR takes a simple approach to make those notifications get a higher priority so that the background colors will always display.

Fixes #1491.