### PR TITLE
Fix nested error messages

### DIFF
--- a/lib/modules/apostrophe-schemas/public/css/user.less
+++ b/lib/modules/apostrophe-schemas/public/css/user.less
@@ -3,7 +3,7 @@
 @import 'components/help.less';
 
 .apos-required {
-  label::after {
+  label:first-of-type::after {
     content: ' *';
     color: @apos-base;
   }
@@ -14,10 +14,16 @@
 /////////////////////////////
 .apos-error
 {
-  input { .apos-glow(@apos-red); }
+  input {
+    &:first-of-type:not(.apos-field-input-radio) {
+      .apos-glow(@apos-red);
+    }
+  }
   label {
-    color: @apos-red;
-    &::after {
+    &:first-of-type {
+      color: @apos-red;
+    }
+    &:first-of-type::after {
       margin-left: 10px;
       content: "(" attr(data-apos-error-message) ")";
       color: inherit;
@@ -37,7 +43,7 @@
 
 .apos-error--required
 {
-  label:after
+  label:first-of-type::after
   {
     color: @apos-red;
   }

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -302,7 +302,7 @@ apos.define('apostrophe-schemas', {
       $fieldset.addClass('apos-error');
       $fieldset.addClass('apos-error--' + apos.utils.cssName(error.type));
       if (error.message) {
-        $fieldset.find('label').attr('data-apos-error-message', error.message);
+        $fieldset.find('label:first').attr('data-apos-error-message', error.message);
       }
       // makes it easy to do more with particular types of errors
       apos.emit('schemaError', $fieldset, error);


### PR DESCRIPTION
This PR fixes nested error messages.

Consider a checkbox field with a fieldset containing a label for the main label, and checkboxes with a label for each checkbox.

Before this PR, all labels would get the "required" error and become styled accordingly.

This PR fixes that behavior and ensures the error and styling is only applied to the first label within the fieldset.