### PR TITLE
Remove .apos-area-widgets, so that we get a consistent DOM structure

### DIFF
--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -2,7 +2,7 @@
 @apos-translucent-opacity: 0.4;
 
 
-.apos-area, .apos-area-widgets, .apos-area-widget { position: relative; }
+.apos-area, .apos-area-widget { position: relative; }
 
 .apos-area
 {
@@ -12,8 +12,8 @@
   &.apos-limit-reached
   {
     >.apos-ui .apos-area-controls,
-    >[data-apos-widgets]>[data-apos-widget-wrapper]>.apos-ui .apos-area-controls { display: none !important; }
-    >[data-apos-widgets]>[data-apos-widget-wrapper]>[data-apos-widget]>.apos-ui [data-apos-clone-item] { display: none !important; }
+    >[data-apos-widget-wrapper]>.apos-ui .apos-area-controls { display: none !important; }
+    >[data-apos-widget-wrapper]>[data-apos-widget]>.apos-ui [data-apos-clone-item] { display: none !important; }
   }
   // When we are dragging a widget, we want it to be at the forefront.
   .apos-area-widget.ui-draggable-dragging { z-index: @apos-z-index-9; }
@@ -37,7 +37,7 @@
         display: block;
         position: absolute;
         left: -41px;
-        top: -22px;      
+        top: -22px;
         height: 60px;
         width: 100px;
       }
@@ -255,7 +255,7 @@
 .apos-area.apos-hover
 {
   >[data-apos-area-controls-original]>.apos-area-controls,
-  >.apos-area-widgets>.apos-area-widget-wrapper:hover>.apos-ui>.apos-area-controls
+  >.apos-area-widget-wrapper:hover>.apos-ui>.apos-area-controls
   {
     display: block;
     opacity: @apos-translucent-opacity;
@@ -290,7 +290,7 @@
     position: relative;
   }
   & > .apos-ui .apos-area-controls,
-  & > .apos-area-widgets > .apos-area-widget-wrapper > .apos-ui .apos-area-controls
+  & > .apos-area-widget-wrapper > .apos-ui .apos-area-controls
   {
     top: auto;
     padding: 10px 0;
@@ -305,7 +305,7 @@
   }
 
   // color contextual controls as well
-  & > .apos-area-widgets > .apos-area-widget-wrapper > .apos-area-widget > .apos-ui .apos-buttons
+  & > .apos-area-widget-wrapper > .apos-area-widget > .apos-ui .apos-buttons
   {
     .apos-glow(@apos-secondary);
     border: 2px solid @apos-secondary;

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -61,7 +61,7 @@ apos.define('apostrophe-areas-editor', {
     };
 
     self.addEmptyClass = function() {
-      if (self.$el.find('[data-apos-widgets]').html() === "") {
+      if (self.getWidgets().length === 0) {
         self.$el.addClass('apos-empty');
       }
     };
@@ -339,7 +339,7 @@ apos.define('apostrophe-areas-editor', {
       if (self.$selected && self.$selected.length) {
         self.$selected.parent('[data-apos-widget-wrapper]').after($item);
       } else {
-        self.$el.find('[data-apos-widgets]:first').prepend($item);
+        $(self.getWidgets()[0]).prepend($item);
       }
       self.addAreaControls($item.findSafe('[data-apos-widget]', '[data-apos-area]'));
     };
@@ -352,6 +352,7 @@ apos.define('apostrophe-areas-editor', {
       $areas.each(function() {
         var $area = $(this);
         var $ancestor = $draggable.closest('[data-apos-area]');
+        var $widgets = $area.findSafe('[data-apos-widget-wrapper]', '[data-apos-area]');
         var i;
 
         atTop();
@@ -364,11 +365,11 @@ apos.define('apostrophe-areas-editor', {
           if (($area[0] === $ancestor[0]) && (!$draggable.prev().length)) {
             return;
           }
-          $area.find('[data-apos-widgets]:first').prepend(self.newSeparator());
+
+          $widgets.first().before(self.newSeparator());
         }
 
         function after() {
-          var $widgets = $area.findSafe('[data-apos-widget-wrapper]', '[data-apos-area]');
           $(window).trigger('aposDragging', [$widgets]);
           // Counter so we can peek ahead
           i = 0;

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -338,6 +338,8 @@ apos.define('apostrophe-areas-editor', {
       $item.data('areaEditor', self);
       if (self.$selected && self.$selected.length) {
         self.$selected.parent('[data-apos-widget-wrapper]').after($item);
+      } else if (self.getWidgets().length === 0) {
+        self.$el.append($item);
       } else {
         $(self.getWidgets()[0]).before($item);
       }

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -362,7 +362,7 @@ apos.define('apostrophe-areas-editor', {
           // Drop zone at the top of every area, unless we are dragging the top item
           // in that particular area
 
-          if (($area[0] === $ancestor[0]) && (!$draggable.prev().length)) {
+          if (($area[0] === $ancestor[0]) && ($area.find('[data-apos-widget-wrapper]').index($draggable) === 0)) {
             return;
           }
 

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -339,7 +339,7 @@ apos.define('apostrophe-areas-editor', {
       if (self.$selected && self.$selected.length) {
         self.$selected.parent('[data-apos-widget-wrapper]').after($item);
       } else {
-        $(self.getWidgets()[0]).prepend($item);
+        $(self.getWidgets()[0]).before($item);
       }
       self.addAreaControls($item.findSafe('[data-apos-widget]', '[data-apos-area]'));
     };

--- a/lib/modules/apostrophe-areas/views/area.html
+++ b/lib/modules/apostrophe-areas/views/area.html
@@ -13,7 +13,6 @@
     {%- else -%}
       {% include "areaControls.html" %}
     {%- endif -%}
-    <div class="apos-area-widgets" data-apos-widgets>
   {%- endif -%}
   {%- for widget in data.area.items -%}
     {%- set widgetOptions = data.options.widgets[widget.type] or {} -%}
@@ -22,5 +21,4 @@
     {%- endif -%}
     {{ apos.areas.widget(widget, widgetOptions) }}
   {%- endfor -%}
-  {%- if canEdit %}</div>{% endif -%}
 </div>


### PR DESCRIPTION
Previously, an additional wrapper element would be added to areas. That element would wrap the widgets contained in that area, but doesn't serve a very big function, and makes it a lot harder for developers to style their sites, since this particular wrapper would only appear for logged in users and not for logged out users.

The one function it had seems to have been to help with dragging and dropping, but it's not necessary for that to work.

It's possible that it's too optimistic to remove this wrapper altogether, but this is a first attempt at doing so in order to start a discussion around whether it's reasonable at all.