### PR TITLE
Fix background color on notification on uploads when file extension is not accepted

### DIFF
--- a/lib/modules/apostrophe-attachments/public/js/user.js
+++ b/lib/modules/apostrophe-attachments/public/js/user.js
@@ -121,7 +121,7 @@ apos.define('apostrophe-attachments', {
         done: function (e, data) {
           var extensions;
           if (data.result.status !== 'ok') {
-            apos.notify(data.result.status);
+            apos.notify(data.result.status, { type: 'error' });
             apos.emit('attachmentUploadError', {
               $fieldset: $fieldset,
               field: field,


### PR DESCRIPTION
This PR sets the type error of the notification, when a file upload extension is not allowed by configuration.

Before this PR it would be white (no background) — after this PR it will be red.