### PR TITLE
Improve versions UI

### DIFF
--- a/lib/modules/apostrophe-versions/public/js/editor.js
+++ b/lib/modules/apostrophe-versions/public/js/editor.js
@@ -19,9 +19,18 @@ apos.define('apostrophe-versions-editor', {
         var $version = $toggle.closest('[data-version]');
         var currentId = $version.attr('data-version');
         var oldId = $version.attr('data-previous');
-        self.html('compare', { oldId: oldId, currentId: currentId }, function(html) {
-          $version.find('[data-changes]').html(html);
-        });
+        var $versionContent = $version.find('[data-changes]');
+        var noChanges = $('[data-no-changes]').attr('data-no-changes');
+        if ($versionContent.html() !== '') {
+          $versionContent.html('');
+        } else {
+          self.html('compare', { oldId: oldId, currentId: currentId }, function(html) {
+            if (html && html.trim() === '') {
+              html = noChanges;
+            }
+            $versionContent.html(html);
+          });
+        }
         return false;
       });
       self.$el.on('click', '[data-apos-revert]', function() {

--- a/lib/modules/apostrophe-versions/public/js/editor.js
+++ b/lib/modules/apostrophe-versions/public/js/editor.js
@@ -20,7 +20,7 @@ apos.define('apostrophe-versions-editor', {
         var currentId = $version.attr('data-version');
         var oldId = $version.attr('data-previous');
         var $versionContent = $version.find('[data-changes]');
-        var noChanges = $('[data-no-changes]').attr('data-no-changes');
+        var noChanges = self.$el.find('[data-no-changes]').attr('data-no-changes');
         if ($versionContent.html() !== '') {
           $versionContent.html('');
         } else {

--- a/lib/modules/apostrophe-versions/views/versions.html
+++ b/lib/modules/apostrophe-versions/views/versions.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block body %}
-<div class="apos-versions">
+<div class="apos-versions" data-no-changes="{{ __('No changes to display.') }}">
   {# Loop over all versions and render changes in each one #}
   {% for version in data.versions %}
     <div class="apos-version" data-version="{{ version._id }}" data-previous="{{ version._previous._id }}">


### PR DESCRIPTION
This PR improves the usability of the versions modal.

With this PR Apostrophe will now allow the user to click on the same "See Changes" link to close a version change, which is nice when comparing many and long changes.

Additionally a default message is shown if there is no changes to display. This message is added in the template and fetched in JS to make it localizable.