### PR TITLE
Cleanup HTML output

### DIFF
--- a/lib/modules/apostrophe-areas/views/widgetControls.html
+++ b/lib/modules/apostrophe-areas/views/widgetControls.html
@@ -12,7 +12,7 @@
             {% if control.type == 'select' %}
               <select class="apos-button apos-button--in-group apos-select" name="{{ control.name }}">
                 {% for choice in control.choices %}
-                  <option value="{{ choice.value }}" {% if data.widget[control.name] == choice.value %}selected{% endif %}>{{ choice.label }}</option>
+                  <option value="{{ choice.value }}"{% if data.widget[control.name] == choice.value %} selected{% endif %}>{{ choice.label }}</option>
                 {% endfor %}
               </select>
             {% else %}

--- a/lib/modules/apostrophe-images/views/manageViewChoices.html
+++ b/lib/modules/apostrophe-images/views/manageViewChoices.html
@@ -1,7 +1,7 @@
 {%- if data.options.manageViews and data.options.manageViews.length > 1 -%}
   <div class="apos-choose-manage-views" data-manage-views>
     {%- for view in data.options.manageViews -%}
-      <a href="#" data-apos-choose-manage-view="{{ view }}" {% if view == data.options.currentView %}class="apos-active"{% endif %}><i class="fa fa-th-{% if view == 'grid' %}large{% elif view == 'list' %}list{% else %}{{view}}{% endif %}"></i></a>
+      <a href="#" data-apos-choose-manage-view="{{ view }}"{% if view == data.options.currentView %} class="apos-active"{% endif %}><i class="fa fa-th-{% if view == 'grid' %}large{% elif view == 'list' %}list{% else %}{{view}}{% endif %}"></i></a>
     {%- endfor -%}
   </div>
 {%- endif -%}

--- a/lib/modules/apostrophe-modal/views/macros.html
+++ b/lib/modules/apostrophe-modal/views/macros.html
@@ -1,6 +1,6 @@
 {%- macro button(options) -%}
-  <a href="{% if options.url %}{{options.url }}{% else %}#{% endif %}" {% if options.dataAttrs %}{{ options.dataAttrs }} {% endif %}{#
-    #}class="apos-progress-btn{#
+  <a href="{% if options.url %}{{options.url }}{% else %}#{% endif %}"{% if options.dataAttrs %} {{ options.dataAttrs }}{% endif %}{#
+    #} class="apos-progress-btn{#
     #}{% if options.float %} apos-progress-btn--float-{{options.float}}{% endif %}{#
     #}{% if options.color %} apos-progress-btn--{{options.color}}{% endif %}{#
     #}{% if options.arrow %} apos-progress-btn--arrow-{{options.arrow}}{% endif %}{#

--- a/lib/modules/apostrophe-pieces/views/manageViewChoices.html
+++ b/lib/modules/apostrophe-pieces/views/manageViewChoices.html
@@ -13,7 +13,7 @@
 {%- if data.options.manageViews and data.options.manageViews.length > 1 -%}
   <div class="apos-choose-manage-views" data-manage-views>
     {%- for view in data.options.manageViews -%}
-      <a href="#" data-apos-choose-manage-view="{{ view }}" {% if loop.first %}class="apos-active"{% endif %}>{{view}}</a>
+      <a href="#" data-apos-choose-manage-view="{{ view }}"{% if loop.first %} class="apos-active"{% endif %}>{{view}}</a>
     {%- endfor -%}
   </div>
 {%- endif -%}

--- a/lib/modules/apostrophe-schemas/views/macros.html
+++ b/lib/modules/apostrophe-schemas/views/macros.html
@@ -136,7 +136,7 @@
   {%- for choice in field.choices -%}
     <div class="apos-form-checkbox">
       <label class="apos-form-checkbox-label apos-text-small">
-        <input class="apos-form-checkbox-input" type="checkbox" name="{{ field.name }}" value="{{ choice.value }}" {% if field.readOnly %}disabled{% endif %}>
+        <input class="apos-form-checkbox-input" type="checkbox" name="{{ field.name }}" value="{{ choice.value }}"{% if field.readOnly %} disabled{% endif %}>
         <span class="apos-form-checkbox-indicator"></span>
         {{ __(choice.label | d('')) }}
       </label>

--- a/lib/modules/apostrophe-versions/views/macros.html
+++ b/lib/modules/apostrophe-versions/views/macros.html
@@ -1,6 +1,6 @@
 {% macro renderChanges(changes) %}
   {% if changes and changes.length %}
-    <div class="apos-changes {% if change.changes.length > 1 %}apos-multiple-changes{% endif %}">
+    <div class="apos-changes{% if change.changes.length > 1 %} apos-multiple-changes{% endif %}">
       {% for change in changes %}
         {{ renderChange(change) }}
       {% endfor %}
@@ -26,4 +26,3 @@
     {{ renderChanges(change.changes) }}
   </div>
 {% endmacro %}
-


### PR DESCRIPTION
This PR corrects unnecessary spacing inside HTML tags in various places.

Instead of adding a space, then doing a condition which may add an attribute or class, this PR corrects that, so that the space is only added if the condition is true.

This is minor nitpicking, but Apostrophe should of course, try to output HTML as clean as possible. This is one tiny step in that direction.