### PR TITLE
Fix initial flash/jump of attachments preview

### DIFF
--- a/lib/modules/apostrophe-attachments/views/attachment.html
+++ b/lib/modules/apostrophe-attachments/views/attachment.html
@@ -3,7 +3,7 @@
 
 
 {% macro attachment(field) %}
-  <div class="apos-attachment-existing" data-existing>
+  <div class="apos-attachment-existing" style="display:none;" data-existing>
     <div class="apos-attachment-preview"><img data-preview src="" alt=""></div>
     <span class="apos-attachment-name" data-name></span>
     <div class="apos-button-group">
@@ -19,7 +19,7 @@
       {% endif %}
     </div>
   </div>
-  <input type="file" name="{{ field.name }}" style="display:none" data-uploader />
+  <input type="file" name="{{ field.name }}" style="display:none;" data-uploader />
   {% if not field.readOnly %}{{ buttons.action('Upload File', { action: 'uploader-target' }) }}{% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
This PR fixes a small design flash/jump in the design, when loading an attachment field in a schema.

Before this PR, the preview area would flash/jump due to it being hidden `with jQuery.hide()`.

`.hide()` is still in use, just to make sure, but additionally an inline style is added with `display: none;` to make sure there's the browser is not waiting for jQuery to kick in. This removes the jump/flash. When the user later adds a file and the preview becomes available, jQuery is doing `.show()` and with that removes the inline style so the preview image is shown.

It's the small things, I know... But they all count :) And yes, this could be styled in a less file, but considering that the same template has another inline style I thought I would keep it like that. This can always be moved later on.