### PR TITLE
Make it possible to pass options for pikaday for schema field type date

### DIFF
--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -1100,7 +1100,8 @@ apos.define('apostrophe-schemas', {
         // Never good here, breaks calendar UI
         $field.attr('autocomplete', 'off');
         $field.val(data[name]);
-        apos.ui.enhanceDate($field);
+        var options = field.options || {};
+        apos.ui.enhanceDate($field, options);
         if (field.legacy) {
           apos.ui.enhanceDate(self.findField($el, field.legacy));
         }


### PR DESCRIPTION
This PR makes it possible to pass on pikday configuration by adding an `options` object for the date field in the schema.

This makes it possible to tweak the client side date selector with all [pikaday configuration options](https://github.com/dbushell/Pikaday#usage).

It's possible that one or more option won't work fully, but most should. I have personally tested i18n and other basic configurations such as date formatting.

Very alternative date formatting could lead into trouble when the value is submitted, but it looks like `launder.date` takes very well care of the most common ones, so the date is converted to format Apostrophe needs to save it in the DB in.

I'm of course open for renaming `options` to `pikadayOptions` or something similar — just let me know and I will update the PR.

Fixes #1527.