### PR TITLE
Fix late population of default values

### DIFF
--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -889,7 +889,9 @@ apos.define('apostrophe-schemas', {
     }
 
     function populateString(data, name, $field, $el, field, callback) {
-      $field.val(data[name]);
+      if (data[name] !== undefined) {
+        $field.val(data[name]);
+      }
       if (field.max) {
         if (field.textarea) {
           if (field.max) {
@@ -1043,7 +1045,9 @@ apos.define('apostrophe-schemas', {
     self.addFieldType({
       name: 'integer',
       populate: function(data, name, $field, $el, field, callback) {
-        $field.val(data[name]);
+        if (data[name] !== undefined) {
+          $field.val(data[name]);
+        }
         return setImmediate(callback);
       },
       convert: function(data, name, $field, $el, field, callback) {
@@ -1067,7 +1071,9 @@ apos.define('apostrophe-schemas', {
     self.addFieldType({
       name: 'float',
       populate: function(data, name, $field, $el, field, callback) {
-        $field.val(data[name]);
+        if (data[name] !== undefined) {
+          $field.val(data[name]);
+        }
         return setImmediate(callback);
       },
       convert: function(data, name, $field, $el, field, callback) {
@@ -1099,7 +1105,9 @@ apos.define('apostrophe-schemas', {
       populate: function(data, name, $field, $el, field, callback) {
         // Never good here, breaks calendar UI
         $field.attr('autocomplete', 'off');
-        $field.val(data[name]);
+        if (data[name] !== undefined) {
+          $field.val(data[name]);
+        }
         apos.ui.enhanceDate($field);
         if (field.legacy) {
           apos.ui.enhanceDate(self.findField($el, field.legacy));
@@ -1124,7 +1132,9 @@ apos.define('apostrophe-schemas', {
     self.addFieldType({
       name: 'color',
       populate: function (data, name, $field, $el, field, callback) {
-        $field.val(data[name]);
+        if (data[name] !== undefined) {
+          $field.val(data[name]);
+        }
         apos.ui.enhanceColorpicker($field);
         return setImmediate(callback);
       },
@@ -1145,7 +1155,9 @@ apos.define('apostrophe-schemas', {
     self.addFieldType({
       name: 'range',
       populate: function (data, name, $field, $el, field, callback) {
-        $field.val(data[name]);
+        if (data[name] !== undefined) {
+          $field.val(data[name]);
+        }
         var $valueIndicator = $field.prev();
         $valueIndicator.text($field.val());
         $field.on('input', function() {


### PR DESCRIPTION
This PR fixes late population of default values which results in an overwrite of a user input value.

Before this PR a schema field value would **always** be set on populate. Depending on latency of the user JS and how early in a custom module the `newInstance` would be called, this could affect user input values. A user may have started applying values in a field, and once the populate finally ran, that value would be overwritten to "" (effectively emptying the field).

This fix makes populate only apply a value if not `undefined` meaning `null` values are still applied (date type field uses that).