### PR TITLE
Update class of widget wrapper in self.replaceWidget

### DIFF
--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -330,6 +330,7 @@ apos.define('apostrophe-areas-editor', {
       var data = apos.areas.getWidgetData($widget);
       apos.areas.setWidgetData($widget, data);
       $old.replaceWith($widget);
+      $widget.parent('[data-apos-widget-wrapper]').attr('class', $wrapper.attr('class'));
       self.fixInsertedWidgetDotPaths($widget);
       apos.emit('enhance', $widget);
     };


### PR DESCRIPTION
When widgets are rerendered, this change makes it so that we also account for the possibility of the classes having changes on the widget wrapper.

Basically, if the module has a `getWidgetWrapperClasses` method that changes its output when the properties of the widget change, this change makes it so that we pick that up without having to reload the page.