### PR TITLE
Versions compare: Fix crash when oldText or currentText is undefined

### DIFF
--- a/lib/modules/apostrophe-versions/lib/api.js
+++ b/lib/modules/apostrophe-versions/lib/api.js
@@ -270,6 +270,9 @@ module.exports = function(self, options) {
       });
 
       var manager = self.apos.docs.getManager(docType);
+      if (!manager) {
+        return callback(null);
+      }
       return manager.find(req, { _id: { $in: ids } }).published(null).toArray(function(err, docs) {
         if (err) {
           return callback(err);

--- a/lib/modules/apostrophe-versions/lib/api.js
+++ b/lib/modules/apostrophe-versions/lib/api.js
@@ -394,7 +394,10 @@ module.exports = function(self, options) {
             }
           }
 
-          var diff = jsDiff.diffSentences(oldText, currentText, { ignoreWhitespace: true });
+          var diff = [];
+          if (oldText !== undefined && currentText !== undefined) {
+            diff = jsDiff.diffSentences(oldText, currentText, { ignoreWhitespace: true });
+          }
 
           var changes = _.map(_.filter(diff, function(diffChange) {
             return diffChange.added || diffChange.removed;

--- a/lib/modules/apostrophe-versions/lib/api.js
+++ b/lib/modules/apostrophe-versions/lib/api.js
@@ -508,7 +508,7 @@ module.exports = function(self, options) {
       // but the areas are still different, look to see if a
       // widget changed position. The first one that changed position
       // is worth reporting as "moved"
-      if ((version1.items.length === version2.items.length) && (!importantChanges)) {
+      if ((version1.items && version2.items && version1.items.length === version2.items.length) && (!importantChanges)) {
         var ranksById = {};
         var i;
         var oldRank;


### PR DESCRIPTION
This PR fixes a crash that happens when `oldText` or `currentText` is for some reason undefined.

The diff library is trying to split on a string value that's undefined and that chokes, resulting in a server crash for me.

Corrected by skipping the diff if either is undefined. There may be a better way, let me know and I will update the PR.

**Stacktrace:**

```javascript
/path/to/apostrophe/node_modules/diff/lib/diff/sentence.js:16
  return value.split(/(\S.+?[.!?])(?=\s+|$)/);
               ^

TypeError: Cannot read property 'split' of undefined
    at Diff.sentenceDiff.tokenize (/path/to/apostrophe/node_modules/diff/lib/diff/sentence.js:16:16)
    at Diff.diff (/path/to/apostrophe/node_modules/diff/lib/diff/base.js:35:39)
    at Object.diffSentences (/path/to/apostrophe/node_modules/diff/lib/diff/sentence.js:20:23)
    at compareField (/path/to/apostrophe/lib/modules/apostrophe-versions/lib/api.js:399:29)
    at /path/to/apostrophe/lib/modules/apostrophe-versions/lib/api.js:335:28
    at /path/to/apostrophe/node_modules/@sailshq/lodash/lib/index.js:3253:15
    at baseForOwn (/path/to/apostrophe/node_modules/@sailshq/lodash/lib/index.js:2223:14)
    at /path/to/apostrophe/node_modules/@sailshq/lodash/lib/index.js:3223:18
    at Function.<anonymous> (/path/to/apostrophe/node_modules/@sailshq/lodash/lib/index.js:3526:13)
    at compareObjects (/path/to/apostrophe/lib/modules/apostrophe-versions/lib/api.js:326:9)
    at compareWidgets (/path/to/apostrophe/lib/modules/apostrophe-versions/lib/api.js:541:16)
    at /path/to/apostrophe/lib/modules/apostrophe-versions/lib/api.js:498:22
    at arrayEach (/path/to/apostrophe/node_modules/@sailshq/lodash/lib/index.js:1463:13)
    at Function.<anonymous> (/path/to/apostrophe/node_modules/@sailshq/lodash/lib/index.js:3525:13)
    at compareAreas (/path/to/apostrophe/lib/modules/apostrophe-versions/lib/api.js:485:9)
    at compareField (/path/to/apostrophe/lib/modules/apostrophe-versions/lib/api.js:356:18)
    at /path/to/apostrophe/lib/modules/apostrophe-versions/lib/api.js:335:28
    at /path/to/apostrophe/node_modules/@sailshq/lodash/lib/index.js:3253:15
    at baseForOwn (/path/to/apostrophe/node_modules/@sailshq/lodash/lib/index.js:2223:14)
    at /path/to/apostrophe/node_modules/@sailshq/lodash/lib/index.js:3223:18
    at Function.<anonymous> (/path/to/apostrophe/node_modules/@sailshq/lodash/lib/index.js:3526:13)
    at compareObjects (/path/to/apostrophe/lib/modules/apostrophe-versions/lib/api.js:326:9)
```