### PR TITLE
introduced the findWithProjection wrapper method and changed all inst…

### DIFF
--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -493,7 +493,7 @@ module.exports = function(self, options) {
     var bucketSize = 100;
     return async.series({
       getIds: function(callback) {
-        return self.db.find(criteria, { _id: 1 }).toArray(function(err, infos) {
+        return self.db.findWithProjection(criteria, { _id: 1 }).toArray(function(err, infos) {
           if (err) {
             return callback(err);
           }
@@ -508,7 +508,7 @@ module.exports = function(self, options) {
         }, function(callback) {
           var bucket = ids.slice(i, i + bucketSize);
           i += bucketSize;
-          return self.db.find({ _id: { $in: bucket } }).toArray(function(err, files) {
+          return self.db.findWithProjection({ _id: { $in: bucket } }).toArray(function(err, files) {
             if (err) {
               return callback(err);
             }
@@ -862,7 +862,7 @@ module.exports = function(self, options) {
     ], callback);
 
     function hide(callback) {
-      return self.db.find({
+      return self.db.findWithProjection({
         utilized: true,
         'docIds.0': { $exists: 0 },
         trash: { $ne: true }
@@ -875,7 +875,7 @@ module.exports = function(self, options) {
     }
 
     function show(callback) {
-      return self.db.find({
+      return self.db.findWithProjection({
         utilized: true,
         'docIds.0': { $exists: 1 },
         trash: { $ne: false }

--- a/lib/modules/apostrophe-db/index.js
+++ b/lib/modules/apostrophe-db/index.js
@@ -47,6 +47,7 @@ var async = require('async');
 
 module.exports = {
   afterConstruct: function(self, callback) {
+    self.bcPatch();
     return async.series([
       self.connectToMongo,
       self.earlyResetTask
@@ -150,8 +151,21 @@ module.exports = {
       return setImmediate(callback);
     };
 
+    // Makes a `findWithProjection` method available on all collections,
+    // which is just an alias for `find` because the MongoDB 2.x driver
+    // already allows a projection as the second argument. This is useful
+    // because the `apostrophe-db-mongo-3-driver` module provides the
+    // same method while allowing you to use the newer MongoDB 3.x driver.
+    // All existing Apostrophe code that directly calls MongoDB's `find()`
+    // is being migrated to use `findWithProjection` for forwards and
+    // backwards compatibility.
+
+    self.bcPatch = function() {
+      mongo.Collection.prototype.findWithProjection = mongo.Collection.prototype.find;
+    };
+
     self.apos.tasks.add('apostrophe-db', 'reset',
-      'Usage: node app apostrophe-db:reset \n\n' +
+      'Usage: node app apostrophe-db:reset\n\n' +
      'This destroys ALL of your content. EVERYTHING in your database.\n',
       function(apos, argv, callback) {
         return self.resetFromTask(callback);

--- a/lib/modules/apostrophe-docs/lib/cursor.js
+++ b/lib/modules/apostrophe-docs/lib/cursor.js
@@ -1281,7 +1281,7 @@ module.exports = {
     // so it must be provided
 
     self.lowLevelMongoCursor = function(req, criteria, projection, options) {
-      var mongo = self.db.find(criteria, projection);
+      var mongo = self.db.findWithProjection(criteria, projection);
       if (_.isNumber(options.skip)) {
         mongo.skip(options.skip);
       }

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -65,7 +65,7 @@ module.exports = function(self, options) {
           });
         },
         determineNextRank: function(callback) {
-          return self.apos.docs.db.find({
+          return self.apos.docs.db.findWithProjection({
             path: self.matchDescendants(parent),
             level: parent.level + 1
           }, {
@@ -1437,7 +1437,7 @@ module.exports = function(self, options) {
     var matchParentPathPrefix = new RegExp('^' + self.apos.utils.regExpQuote(originalPath + '/'));
     var matchParentSlugPrefix = new RegExp('^' + self.apos.utils.regExpQuote(originalSlug + '/'));
     var done = false;
-    var cursor = self.apos.docs.db.find(mergeCriteria({ path: matchParentPathPrefix }), { slug: 1, path: 1, level: 1 });
+    var cursor = self.apos.docs.db.findWithProjection(mergeCriteria({ path: matchParentPathPrefix }), { slug: 1, path: 1, level: 1 });
     return async.whilst(function() { return !done; }, function(callback) {
       return cursor.nextObject(function(err, desc) {
         if (err) {

--- a/lib/modules/apostrophe-versions/lib/api.js
+++ b/lib/modules/apostrophe-versions/lib/api.js
@@ -65,7 +65,7 @@ module.exports = function(self, options) {
     var now = new Date();
 
     var last = null;
-    var cursor = self.db.find({ createdAt: { $lt: now }, docId: doc._id }, { createdAt: 1, _id: 1, author: 1 }).sort({ createdAt: -1 });
+    var cursor = self.db.findWithProjection({ createdAt: { $lt: now }, docId: doc._id }, { createdAt: 1, _id: 1, author: 1 }).sort({ createdAt: -1 });
     return cursor.nextObject(iterator);
 
     function iterator(err, version) {
@@ -143,7 +143,7 @@ module.exports = function(self, options) {
   // The ._doc property of each version is set to the document.
 
   self.find = function(req, criteria, options, callback) {
-    var cursor = self.db.find(criteria);
+    var cursor = self.db.findWithProjection(criteria);
     cursor.sort({ createdAt: -1 });
     if (options.limit) {
       cursor.limit(options.limit);

--- a/test/docs.js
+++ b/test/docs.js
@@ -86,7 +86,7 @@ describe('Docs', function() {
     apos.docs.db.remove({}, function(err) {
       assert(!err);
       // Make sure it went away
-      apos.docs.db.find({ slug: 'larry' }).toArray(function(err, docs) {
+      apos.docs.db.findWithProjection({ slug: 'larry' }).toArray(function(err, docs) {
         assert(!err);
         assert(docs.length === 0);
         done();

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -123,7 +123,7 @@ describe('Pieces', function() {
     apos.docs.db.remove({}, function(err) {
       assert(!err);
       // Make sure it went away
-      apos.docs.db.find({ _id: 'testThing' }).toArray(function(err, docs) {
+      apos.docs.db.findWithProjection({ _id: 'testThing' }).toArray(function(err, docs) {
         assert(!err);
         assert(docs.length === 0);
         done();

--- a/test/versions.js
+++ b/test/versions.js
@@ -135,7 +135,7 @@ describe('Versions', function() {
       assert(object._id);
       var docId = object._id;
       // did the versions module kick-in?
-      apos.versions.db.find({ docId: docId }).toArray(function(err, versions) {
+      apos.versions.db.findWithProjection({ docId: docId }).toArray(function(err, versions) {
         assert(!err);
         // we should have a document
         assert(versions);
@@ -168,7 +168,7 @@ describe('Versions', function() {
         assert(object.alive === false);
 
         // did the versions module kick-in?
-        apos.versions.db.find({ docId: object._id }).sort({createdAt: -1}).toArray(function(err, versions) {
+        apos.versions.db.findWithProjection({ docId: object._id }).sort({createdAt: -1}).toArray(function(err, versions) {
           assert(!err);
           // we should have a document
           assert(versions);


### PR DESCRIPTION
…ances of regular mongodb find() to invoke it, allowing use of apostrophe with the forthcoming apostrophe-mongodb-3-driver module, which cannot roll back the bc break in find() itself