### PR TITLE
Enable showFields on checkboxes

### DIFF
--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -242,7 +242,7 @@ module.exports = {
 
         // Extra validation for select fields, TODO move this into the field type definition
 
-        if (field.type === 'select') {
+        if (field.type === 'select' || field.type === 'checkboxes') {
           _.each(field.choices, function(choice) {
             if (choice.showFields) {
               if (!_.isArray(choice.showFields)) {

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -583,6 +583,12 @@ apos.define('apostrophe-schemas', {
                 show = true;
               }
             }
+          } else if (field.type === 'checkboxes') {
+            _.each($field || [], function(checkbox) {
+              if (checkbox.checked && checkbox.value === choice.value && choice.showFields) {
+                show = true;
+              }
+            });
           } else {
             // type select
             if (val === choice.value) {


### PR DESCRIPTION
In a schema, allow checkboxes to have a `showFields` property:
```
{
  name: 'awesomeCheckboxes',
  label: 'Awesome Checkboxes',
  type: 'checkboxes',
  choices: [{
    label: 'Choice 1',
    value: 'choice1',
  }, {
    label: 'Choice 2',
    value: 'choice2',
    showFields: ['choice2Options']
  }],
}, {
  name: 'choice2Options',
  label: 'Options for choice 2',
  type: 'string',
  required: true
}
```

The `choice2Options` field will be displayed only if `choice2` is checked in `awesomeCheckboxes`, and it will be required only if displayed (as in this example the field is required).