### PR TITLE
page settings for all pages in reorganize, must be able to commit the…

### DIFF
--- a/lib/modules/apostrophe-pages/public/js/reorganize.js
+++ b/lib/modules/apostrophe-pages/public/js/reorganize.js
@@ -90,14 +90,10 @@ apos.define('apostrophe-pages-reorganize', {
         $link = $('<a class="apos-edit" target="_blank"></a>');
         $link.attr('data-node-id', node.id);
 
-        if (node.type === 'trash') {
-
-          $link.attr('data-edit', '1');
-          $link.append('Edit Page');
-          // add published indicator
-          $li.find('.jqtree-element .apos-reorganize-controls--published').append('<span class="apos-reorganize-published apos-reorganize-published--' + node.publish + '"></span>');
-
-        }
+        $link.attr('data-edit', '1');
+        $link.append('Settings');
+        // add published indicator
+        $li.find('.jqtree-element .apos-reorganize-controls--published').append('<span class="apos-reorganize-published apos-reorganize-published--' + node.publish + '"></span>');
 
         $link.attr('href', '#');
         $li.find('.jqtree-element .apos-reorganize-controls--edit').append($link);


### PR DESCRIPTION
… trash for one thing

We used to have the ability to access "page settings" for any page, or certainly those considered trash.

Somehow we wound up with busted logic though where the only page whose settings can be accessed while in the trash is... the legacy trash can parent page... whose settings are actually not interesting. Womp womp.

Without this, it is impossible to commit the fact that a draft page is in the trash, so that it winds up in the trash in the live locale also.

I see no reason not to allow the "Settings" button for all pages in reorganize, which will teach its availability and make it more likely folks will consider using it for a page in the trash in order to get to the "Workflow" menu.

Screenshot with this solution:

https://www.dropbox.com/s/wklauivcyteocuz/huctz-ma.png?raw=1