### PR TITLE
Improve styling on current revision

### DIFF
--- a/lib/modules/apostrophe-versions/public/css/user.less
+++ b/lib/modules/apostrophe-versions/public/css/user.less
@@ -63,6 +63,17 @@
     }
 
   }
+
+  // Current revision disabled button
+  .apos-version-current .apos-button.apos-button--disabled {
+    color: @apos-primary;
+    cursor: default;
+    font-size: 16px;
+    padding: 1em 3em;
+    opacity: 1;
+    background: transparent;
+  }
+
 }
 
 // Changes Diff Container

--- a/lib/modules/apostrophe-versions/views/versions.html
+++ b/lib/modules/apostrophe-versions/views/versions.html
@@ -19,7 +19,7 @@
 <div class="apos-versions" data-no-changes="{{ __('No changes to display.') }}">
   {# Loop over all versions and render changes in each one #}
   {% for version in data.versions %}
-    <div class="apos-version" data-version="{{ version._id }}" data-previous="{{ version._previous._id }}">
+    <div class="apos-version{% if loop.first %} apos-version-current{% endif %}" data-version="{{ version._id }}" data-previous="{{ version._previous._id }}">
       <div class="apos-author">
         <div class="apos-avatar-wrapper">
         </div>


### PR DESCRIPTION
This PR improves styling on the current revision of the version dialog.

Green color to better indicate everything is alright, better alignment and no cursor to indicate there's nothing to click here. 