### PR TITLE
Read options.addLabel in areaControls

### DIFF
--- a/lib/modules/apostrophe-areas/views/areaControls.html
+++ b/lib/modules/apostrophe-areas/views/areaControls.html
@@ -8,7 +8,7 @@
         {%- for name, options in data.options.widgets -%}
           {%- if data.widgetManagers[name] -%}
             {%- if not options.readOnly -%}
-              <li class="apos-dropdown-item" data-apos-add-item="{{ name }}">{{ __(data.widgetManagers[name].label) }}</li>
+              <li class="apos-dropdown-item" data-apos-add-item="{{ name }}">{{ options.addLabel or __(data.widgetManagers[name].label) }}</li>
             {% endif %}
           {%- else -%}
             {{ apos.log("Your area contains a widget of type " + name + " but there is no manager for that type. Maybe you forgot to configure the " + name + "-widgets module?") }}


### PR DESCRIPTION
This lets developers customise the label for a particular widget in the `apos.area` dropdown menu for adding widgets. It simply mimics the behavior of `apos.singleton` (aside from the fact that developers shouldn't include "Add " in the addLabel here).

Note to self: should probably submit a PR to the docs if this is merged to note that both `apos.singleton` and `apos.area` support this option.