### PR TITLE
decription, credit, and creditUrl returned as part of apos.images.all…

### DIFF
--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -441,6 +441,15 @@ module.exports = function(self, options) {
             value = _.clone(value);
             value._crop = _.pick(ancestor.relationships[o._id], 'top', 'left', 'width', 'height');
             value._focalPoint = _.pick(ancestor.relationships[o._id], 'x', 'y');
+            if (o.credit) {
+              value._credit = o.credit;
+            }
+            if (o.creditUrl) {
+              value._creditUrl = o.creditUrl;
+            }
+            if (o.description) {
+              value._description = o.description;
+            }
             break;
           }
         }


### PR DESCRIPTION
… and apos.images.first

in reference to #980 