### PR TITLE
Add rich text styling for most common tags in Apostrophe modal rich text editor

### DIFF
--- a/lib/modules/apostrophe-rich-text-widgets/public/css/components/rich-text-widget.less
+++ b/lib/modules/apostrophe-rich-text-widgets/public/css/components/rich-text-widget.less
@@ -35,3 +35,28 @@
 }
 
 [data-apos-widget-wrapper="apostrophe-rich-text"]:hover { z-index: @apos-z-index-6; }
+
+.apos-modal-body [data-rich-text]
+{
+  p {
+    margin: 10px 0;
+  }
+  a {
+    color: inherit;
+    text-decoration: underline;
+  }
+  b, strong {
+    font-weight: bold;
+  }
+  em, i {
+    font-style: italic;
+  }
+  ul {
+    margin-left: 30px;
+    list-style-type: disc;
+  }
+  ol {
+    margin-left: 30px;
+    list-style-type: decimal;
+  }
+}


### PR DESCRIPTION
This PR adds rich text editor styling for the most common tags in the Apostrophe modal rich text editor.

It seems these were forgotten, leading to random styling depending on how the project was styled. This PR adds basic support for the most common tags.

Tags like H1, H2 is not included as they are not considered by me to be basic and those tags should be added using the `styles` option of the rich text editor.

To test use the following configuration on a field:

```javascript
options: {
  toolbar: [ 'Styles', 'Bold', 'Italic', 'Link', 'Unlink', 'BulletedList', 'NumberedList' ]
}
```

I will post a screenshot to display the various styles based on the improvements introduced in this PR.

And yes, underline is not there, because the underline tag is no included html 5, and ckeditor does not even allow adding a underline button to the editor (can be done using a custom style).

Colors of `a` tags are inherited, but could be a fixed blue (or green) if someone thinks that would be better?

Fixes #1599.