### PR TITLE
Improvements to apos.images.srcset function

### DIFF
--- a/lib/modules/apostrophe-images/lib/api.js
+++ b/lib/modules/apostrophe-images/lib/api.js
@@ -85,12 +85,21 @@ module.exports = function(self, options) {
   // of a `srcset` HTML attribute.
 
   self.srcset = function(attachment, cropRelationship) {
-    var sources = self.apos.attachments.imageSizes.map(function(imageSize) {
+    if (!self.apos.attachments.isSized(attachment)) {
+      return '';
+    }
+
+    var sources = self.apos.attachments.imageSizes.filter(function(imageSize) {
+      return imageSize.width < attachment.width;
+    }).map(function(imageSize) {
       var src = self.apos.attachments.url(attachment, { size: imageSize.name, crop: cropRelationship });
       var width = imageSize.width;
 
       return src + ' ' + width + 'w';
     });
+
+    var originalSrc = self.apos.attachments.url(attachment, { size: 'original', crop: cropRelationship });
+    sources.push(originalSrc + ' ' + attachment.width + 'w');
 
     return sources.join(', ');
   };

--- a/lib/modules/apostrophe-images/lib/api.js
+++ b/lib/modules/apostrophe-images/lib/api.js
@@ -89,17 +89,24 @@ module.exports = function(self, options) {
       return '';
     }
 
+    // Since images are never scaled up once uploaded, we only need to include a
+    // single image size that's larger than the original image (if such an image
+    // size exists) to cover as many bases as possible
+    var includedOriginalWidth = false;
+
     var sources = self.apos.attachments.imageSizes.filter(function(imageSize) {
-      return imageSize.width < attachment.width;
+      if (imageSize.width < attachment.width) {
+        return true;
+      } else if (!includedOriginalWidth) {
+        includedOriginalWidth = true;
+        return true;
+      }
     }).map(function(imageSize) {
       var src = self.apos.attachments.url(attachment, { size: imageSize.name, crop: cropRelationship });
-      var width = imageSize.width;
+      var width = Math.min(imageSize.width, attachment.width);
 
       return src + ' ' + width + 'w';
     });
-
-    var originalSrc = self.apos.attachments.url(attachment, { size: 'original', crop: cropRelationship });
-    sources.push(originalSrc + ' ' + attachment.width + 'w');
 
     return sources.join(', ');
   };

--- a/test/images.js
+++ b/test/images.js
@@ -127,12 +127,12 @@ describe('Images', function() {
       width: 1200,
       height: 800
     });
-    assert.equal(srcset, ['/uploads/attachments/test-test.full.jpg 1140w',
+    assert.equal(srcset, ['/uploads/attachments/test-test.max.jpg 1200w',
+      '/uploads/attachments/test-test.full.jpg 1140w',
       '/uploads/attachments/test-test.two-thirds.jpg 760w',
       '/uploads/attachments/test-test.one-half.jpg 570w',
       '/uploads/attachments/test-test.one-third.jpg 380w',
-      '/uploads/attachments/test-test.one-sixth.jpg 190w',
-      '/uploads/attachments/test-test.jpg 1200w'].join(', '));
+      '/uploads/attachments/test-test.one-sixth.jpg 190w'].join(', '));
   });
 
   it('should not generate a srcset string for an SVG image', function() {

--- a/test/images.js
+++ b/test/images.js
@@ -121,16 +121,28 @@ describe('Images', function() {
 
   it('should generate a srcset string for an image', function() {
     var srcset = apos.images.srcset({
-      group: 'images',
       name: 'test',
+      _id: 'test',
       extension: 'jpg',
-      _id: 'test'
+      width: 1200,
+      height: 800
     });
-    assert(srcset === ['/uploads/attachments/test-test.max.jpg 1600w',
-      '/uploads/attachments/test-test.full.jpg 1140w',
+    assert.equal(srcset, ['/uploads/attachments/test-test.full.jpg 1140w',
       '/uploads/attachments/test-test.two-thirds.jpg 760w',
       '/uploads/attachments/test-test.one-half.jpg 570w',
       '/uploads/attachments/test-test.one-third.jpg 380w',
-      '/uploads/attachments/test-test.one-sixth.jpg 190w'].join(', '));
+      '/uploads/attachments/test-test.one-sixth.jpg 190w',
+      '/uploads/attachments/test-test.jpg 1200w'].join(', '));
+  });
+
+  it('should not generate a srcset string for an SVG image', function() {
+    var srcset = apos.images.srcset({
+      name: 'test',
+      _id: 'test',
+      extension: 'svg',
+      width: 1200,
+      height: 800
+    });
+    assert.equal(srcset, '');
   });
 });


### PR DESCRIPTION
Firstly, this change makes it so that the `apos.attachments.isSized` return value is respected. If a particular attachment isn't sizes (eg. if it's an SVG), we return an empty srcset attribute. This change was prompted by #1595.

Secondly, we now never return image sizes that are larger than the original. And we also make sure to include the original image size in the srcset return value. I would just like to check if including the `original` image size in the srcset attribute seems reasonable to the core devs (@boutell, @stuartromanek etc). Does uploadsfs compress that image as well, or could it be that `original` is a huge images, whereas the other image sizes are compressed?