### PR TITLE
a better error message for mongodb+srv URLs, including telling people…

### DIFF
--- a/lib/modules/apostrophe-db/index.js
+++ b/lib/modules/apostrophe-db/index.js
@@ -106,6 +106,14 @@ module.exports = {
         }
         uri += options.host + ':' + options.port + '/' + options.name;
       }
+      if (uri.match(/mongodb\+srv/)) {
+        return callback(new Error('You are attempting to use a mongodb+srv URI, which is only\n' +
+          'supported by the MongoDB 3.6+ driver. Apostrophe 2.x core\n' +
+          'ships with the MongoDB 2.x driver. You have two choices:\n\n' +
+          '1. Use the older type of URI to connect to your replica set.\n' +
+          'MongoDB Atlas provides both URIs.\n\n' +
+          '2. Install the apostrophe-db-mongo-3-driver module which supports the new URI.\n'));
+      }
       return mongo.MongoClient.connect(uri, connectOptions, function (err, dbArg) {
         self.apos.db = dbArg;
         if (err) {


### PR DESCRIPTION
… about the apostrophe-db-mongo-3-driver module

See:

https://stackoverflow.com/questions/51790851/apostrophe-mongo-db-user-not-authorized-to-execute-command/52026609#52026609

This is coming up in multiples so let's get a better error message out there