### PR TITLE
Added apos.global.whileBusy(fn) method

### DIFF
--- a/lib/modules/apostrophe-global/index.js
+++ b/lib/modules/apostrophe-global/index.js
@@ -199,57 +199,84 @@ module.exports = {
 
       function findGlobal(callback) {
         return self.findGlobal(req, function(err, result) {
+          var lockName = 'apostrophe-global-busy';
+          var localeLockName;
+          var propName = 'globalBusy';
+          var localePropName;
           if (err) {
             return callback(err);
           }
+
           req.data.global = result;
 
-          if (req.data.global.globalBusy) {
-            return self.apos.locks.lock('apostrophe-global-busy', {
-              wait: (req.res && req.res.send) ? self.options.whileBusyRequestDelay * 1000 : Number.MAX_VALUE,
-              waitForSelf: true
-            }, function(err) {
-              if (!err) {
-                // We got in after a period of the system being busy,
-                // or the process with the lock went away. Either way,
-                // we should clear globalBusy and give up our lock,
-                // then continue normal operation.
-                return async.series([ unmark, unlock, refind ], callback);
-                function unmark(callback) {
-                  return self.apos.docs.db.update({
-                    _id: req.data.global._id,
-                    globalBusy: true
-                  }, {
-                    $set: {
-                      globalBusy: false
-                    }
-                  }, callback);
-                }
-                function unlock(callback) {
-                  return self.apos.locks.unlock('apostrophe-global-busy', callback);
-                }
-                function refind(callback) {
-                  return self.findGlobal(req, function(err, result) {
-                    if (err) {
-                      return callback(err);
-                    }
-                    req.data.global = result;
-                    return callback(null);
-                  });
-                }
-              }
-              // An error occurred. If it is because the lock is still
-              // present after waiting as long as we could for this req,
-              // send a try-again response to the user.
-              if ((err === 'locked') && req.res && req.res.send) {
-                return self.busyTryAgainSoon(req);
-              } else {
-                // All other errors propagate normally
-                return callback(err);
-              }
-            });
+          if (req.locale) {
+            localeLockName = lockName + '-' + req.locale;
+            localePropName = propName + req.locale;
           }
-          return callback(null);
+
+          return async.series([
+            considerGlobal,
+            considerLocale
+          ], callback);
+
+          function considerGlobal(callback) {
+            return considerLock(propName, lockName, callback);
+          }
+
+          function considerLocale(callback) {
+            if (!localePropName) {
+              return callback(null);
+            }
+            return considerLock(localePropName, localeLockName, callback);
+          }
+
+          function considerLock(propName, lockName, callback) {
+            if (req.data.global[propName]) {
+              return self.apos.locks.lock(lockName, {
+                wait: (req.res && req.res.send) ? self.options.whileBusyRequestDelay * 1000 : Number.MAX_VALUE,
+                waitForSelf: true
+              }, function(err) {
+                if (!err) {
+                  // We got in after a period of the system being busy,
+                  // or the process with the lock went away. Either way,
+                  // we should clear globalBusy and give up our lock,
+                  // then continue normal operation.
+                  return async.series([ unmark, unlock, refind ], callback);
+                  function unmark(callback) {
+                    var $set = {};
+                    $set[propName] = false;
+                    return self.apos.docs.db.update({
+                      _id: req.data.global._id
+                    }, {
+                      $set: $set
+                    }, callback);
+                  }
+                  function unlock(callback) {
+                    return self.apos.locks.unlock(lockName, callback);
+                  }
+                  function refind(callback) {
+                    return self.findGlobal(req, function(err, result) {
+                      if (err) {
+                        return callback(err);
+                      }
+                      req.data.global = result;
+                      return callback(null);
+                    });
+                  }
+                }
+                // An error occurred. If it is because the lock is still
+                // present after waiting as long as we could for this req,
+                // send a try-again response to the user.
+                if ((err === 'locked') && req.res && req.res.send) {
+                  return self.busyTryAgainSoon(req);
+                } else {
+                  // All other errors propagate normally
+                  return callback(err);
+                }
+              });
+            }
+            return callback(null);
+          }
         });
       }
 
@@ -287,22 +314,41 @@ module.exports = {
     // that deploys an entirely new set of content to the site. Use of
     // this method for anything more routine would have a crippling
     // performance impact.
+    //
+    // **Use with workflow**: if `options.locale` argument is present, only
+    // the given locale name is marked busy. If `req` has any other
+    // `req.locale` it proceeds normally. This option works only with
+    // 'apostrophe-workflow' (the global docs must have `workflowLocale`
+    // properties).
 
-    self.whileBusy = function(fn, criteria) {
+    self.whileBusy = function(fn, options) {
       var locked = false;
       var marked = false;
+      var lockName = 'apostrophe-global-busy';
+      var propName = 'globalBusy';
+      var locale = options && options.locale;
+      if (locale) {
+        lockName += '-' + locale;
+        propName += locale;
+      }
+      var criteria = {
+        type: self.name
+      }
+      if (locale) {
+        criteria.workflowLocale = locale;
+      }
       return Promise.try(function() {
-        return self.apos.locks.lock('apostrophe-global-busy');
+        return self.apos.locks.lock(lockName);
       }).then(function() {
         locked = true;
-        return self.apos.docs.db.update({
-          type: self.name
-        }, {
-          $set: {
-            globalBusy: true
-          }
-        }, {
-          // workflow-aware
+        var $set = {};
+        $set[propName] = true;
+        var args = {
+          $set: $set
+        };
+        return self.apos.docs.db.update(criteria, args, {
+          // so that if we really want to lock across all locales
+          // (locale not passed and workflow present), we can
           multi: true
         });
       }).then(function() {
@@ -312,21 +358,21 @@ module.exports = {
         return fn();
       }).finally(function() {
         return Promise.try(function() {
+          var $set = {};
+          $set[propName] = false;
+          var args = {
+            $set: $set
+          };
           if (marked) {
-            return self.apos.docs.db.update({
-              type: self.name
-            }, {
-              $set: {
-                globalBusy: false
-              }
-            }, {
-              // workflow-aware
+            return self.apos.docs.db.update(criteria, args, {
+              // workflow-aware for cases where we really do want
+              // to lock across all locales
               multi: true
             });
           }
         }).then(function() {
           if (locked) {
-            return self.apos.locks.unlock('apostrophe-global-busy');
+            return self.apos.locks.unlock(lockName);
           }
         });
       });

--- a/lib/modules/apostrophe-global/index.js
+++ b/lib/modules/apostrophe-global/index.js
@@ -288,7 +288,7 @@ module.exports = {
     // this method for anything more routine would have a crippling
     // performance impact.
 
-    self.whileBusy = function(fn) {
+    self.whileBusy = function(fn, criteria) {
       var locked = false;
       var marked = false;
       return Promise.try(function() {
@@ -301,6 +301,9 @@ module.exports = {
           $set: {
             globalBusy: true
           }
+        }, {
+          // workflow-aware
+          multi: true
         });
       }).then(function() {
         marked = true;
@@ -316,6 +319,9 @@ module.exports = {
               $set: {
                 globalBusy: false
               }
+            }, {
+              // workflow-aware
+              multi: true
             });
           }
         }).then(function() {

--- a/lib/modules/apostrophe-global/index.js
+++ b/lib/modules/apostrophe-global/index.js
@@ -49,6 +49,12 @@ module.exports = {
 
   pluralLabel: 'Global',
 
+  whileBusyDelay: 60,
+
+  whileBusyRetryAfter: 5,
+
+  whileBusyRequestDelay: 10,
+
   searchable: false,
 
   beforeConstruct: function(self, options) {
@@ -197,6 +203,43 @@ module.exports = {
             return callback(err);
           }
           req.data.global = result;
+
+          if (req.data.global.globalBusy) {
+            return self.apos.locks.lock('apostrophe-global-busy', {
+              wait: (req.res && req.res.send) ? self.options.whileBusyRequestDelay * 1000 : Number.MAX_VALUE,
+              waitForSelf: true
+            }, function(err) {
+              if (!err) {
+                // We got in after a period of the system being busy,
+                // or the process with the lock went away. Either way,
+                // we should clear globalBusy and give up our lock,
+                // then continue normal operation.
+                return async.series(unmark, unlock, callback);
+                function unmark(callback) {
+                  return self.apos.docs.db.update({
+                    _id: req.data.global._id,
+                    globalBusy: true
+                  }, {
+                    $set: {
+                      globalBusy: false
+                    }
+                  }, callback);
+                }
+                function unlock(callback) {
+                  return self.apos.unlock('apostrophe-global-busy', callback);
+                }
+              }
+              // An error occurred. If it is because the lock is still
+              // present after waiting as long as we could for this req,
+              // send a try-again response to the user.
+              if ((err === 'locked') && res.res && req.res.send) {
+                return self.busyTryAgainSoon(req);
+              } else {
+                // All other errors propagate normally
+                return callback(err);
+              }
+            });
+          }
           return callback(null);
         });
       }
@@ -207,6 +250,77 @@ module.exports = {
         }
         return self.apos.areas.loadDeferredWidgets(req, callback);
       }
+    };
+
+    self.busyTryAgainSoon = function(req) {
+      if (!_.includes([ 'GET', 'HEAD' ], req.method)) {
+        // Typically an API will receive this sad news
+        return req.res.status(503).send({ status: 'busy' });
+      }
+      return req.res.status(503).set('Refresh', self.options.whileBusyRetryAfter).send(self.render('busy.html'));
+    };
+
+    // Run the given function while the entire site is marked as busy.
+    //
+    // This is a promise-based method. `fn` may return a promise, which will
+    // be awaited. This method will return a promise, which must be awaited.
+    //
+    // While the site is busy new requests are delayed as much as possible,
+    // then GET requests receive a simple "busy" page that retries
+    // after an interval, etc. To address the issue of requests already
+    // in progress, this method marks the site busy, then waits for
+    // `options.whileBusyDelay` seconds before invoking `fn`.
+    // That option defaults to 60 (one minute). Explicitly tracking
+    // all requests in flight would have too much performance impact
+    // on normal operation.
+    //
+    // This method should be used very rarely, for instance for a procedure
+    // that deploys an entirely new set of content to the site. Use of
+    // this method for anything more routine would have a crippling
+    // performance impact.
+
+    self.whileBusy = function(fn) {
+      var locked = false;
+      var marked = false;
+      return Promise.try(function() {
+        console.log('locking');
+        return self.apos.locks.lock('apostrophe-global-busy');
+      }).then(function() {
+        console.log('marking');
+        locked = true;
+        return self.apos.docs.db.update({
+          type: self.name
+        }, {
+          $set: {
+            globalBusy: true
+          }
+        });
+      }).then(function() {
+        console.log('delaying');
+        marked = true;
+        return Promise.delay(self.options.whileBusyDelay * 1000);
+      }).then(function() {
+        console.log('invoking');
+        return fn();
+      }).finally(function() {
+        return Promise.try(function() {
+          if (marked) {
+            console.log('unmarking');
+            return self.apos.docs.db.update({
+              type: self.name
+            }, {
+              $set: {
+                globalBusy: false
+              }
+            });
+          }
+        }).then(function() {
+          if (locked) {
+            console.log('unlocking');
+            return self.apos.locks.unlock('apostrophe-global-busy');
+          }
+        });
+      });
     };
 
     var superGetCreateSingletonOptions = self.getCreateSingletonOptions;

--- a/lib/modules/apostrophe-global/index.js
+++ b/lib/modules/apostrophe-global/index.js
@@ -242,27 +242,6 @@ module.exports = {
                   // we should clear globalBusy and give up our lock,
                   // then continue normal operation.
                   return async.series([ unmark, unlock, refind ], callback);
-                  function unmark(callback) {
-                    var $set = {};
-                    $set[propName] = false;
-                    return self.apos.docs.db.update({
-                      _id: req.data.global._id
-                    }, {
-                      $set: $set
-                    }, callback);
-                  }
-                  function unlock(callback) {
-                    return self.apos.locks.unlock(lockName, callback);
-                  }
-                  function refind(callback) {
-                    return self.findGlobal(req, function(err, result) {
-                      if (err) {
-                        return callback(err);
-                      }
-                      req.data.global = result;
-                      return callback(null);
-                    });
-                  }
                 }
                 // An error occurred. If it is because the lock is still
                 // present after waiting as long as we could for this req,
@@ -276,6 +255,27 @@ module.exports = {
               });
             }
             return callback(null);
+            function unmark(callback) {
+              var $set = {};
+              $set[propName] = false;
+              return self.apos.docs.db.update({
+                _id: req.data.global._id
+              }, {
+                $set: $set
+              }, callback);
+            }
+            function unlock(callback) {
+              return self.apos.locks.unlock(lockName, callback);
+            }
+            function refind(callback) {
+              return self.findGlobal(req, function(err, result) {
+                if (err) {
+                  return callback(err);
+                }
+                req.data.global = result;
+                return callback(null);
+              });
+            }
           }
         });
       }
@@ -333,7 +333,7 @@ module.exports = {
       }
       var criteria = {
         type: self.name
-      }
+      };
       if (locale) {
         criteria.workflowLocale = locale;
       }

--- a/lib/modules/apostrophe-global/index.js
+++ b/lib/modules/apostrophe-global/index.js
@@ -214,7 +214,7 @@ module.exports = {
                 // or the process with the lock went away. Either way,
                 // we should clear globalBusy and give up our lock,
                 // then continue normal operation.
-                return async.series(unmark, unlock, callback);
+                return async.series([ unmark, unlock, refind ], callback);
                 function unmark(callback) {
                   return self.apos.docs.db.update({
                     _id: req.data.global._id,
@@ -226,13 +226,22 @@ module.exports = {
                   }, callback);
                 }
                 function unlock(callback) {
-                  return self.apos.unlock('apostrophe-global-busy', callback);
+                  return self.apos.locks.unlock('apostrophe-global-busy', callback);
+                }
+                function refind(callback) {
+                  return self.findGlobal(req, function(err, result) {
+                    if (err) {
+                      return callback(err);
+                    }
+                    req.data.global = result;
+                    return callback(null);
+                  });
                 }
               }
               // An error occurred. If it is because the lock is still
               // present after waiting as long as we could for this req,
               // send a try-again response to the user.
-              if ((err === 'locked') && res.res && req.res.send) {
+              if ((err === 'locked') && req.res && req.res.send) {
                 return self.busyTryAgainSoon(req);
               } else {
                 // All other errors propagate normally
@@ -257,7 +266,7 @@ module.exports = {
         // Typically an API will receive this sad news
         return req.res.status(503).send({ status: 'busy' });
       }
-      return req.res.status(503).set('Refresh', self.options.whileBusyRetryAfter).send(self.render('busy.html'));
+      return req.res.status(503).set('Refresh', self.options.whileBusyRetryAfter).send(self.render(req, 'busy.html'));
     };
 
     // Run the given function while the entire site is marked as busy.
@@ -283,10 +292,8 @@ module.exports = {
       var locked = false;
       var marked = false;
       return Promise.try(function() {
-        console.log('locking');
         return self.apos.locks.lock('apostrophe-global-busy');
       }).then(function() {
-        console.log('marking');
         locked = true;
         return self.apos.docs.db.update({
           type: self.name
@@ -296,16 +303,13 @@ module.exports = {
           }
         });
       }).then(function() {
-        console.log('delaying');
         marked = true;
         return Promise.delay(self.options.whileBusyDelay * 1000);
       }).then(function() {
-        console.log('invoking');
         return fn();
       }).finally(function() {
         return Promise.try(function() {
           if (marked) {
-            console.log('unmarking');
             return self.apos.docs.db.update({
               type: self.name
             }, {
@@ -316,7 +320,6 @@ module.exports = {
           }
         }).then(function() {
           if (locked) {
-            console.log('unlocking');
             return self.apos.locks.unlock('apostrophe-global-busy');
           }
         });

--- a/lib/modules/apostrophe-global/views/busy.html
+++ b/lib/modules/apostrophe-global/views/busy.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+
+<html lang="en-US">
+<head>
+  <meta charset="utf-8">
+  <title>{{ __("One moment please...") }}</title>
+  <style type="text/css">
+    body {
+      background-color: #ccf;
+    }
+    main {
+      margin: auto;
+      margin-top: 100px;
+      width: 600px;
+      border-radius: 12px;
+      background-color: #eef;
+      padding: 20px;
+      font-family: Helvetica;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>{{ __('One moment please...') }}</h1>
+    <p>{{ __("We're in the process of updating the site for you. This page will refresh in a few seconds.") }}</p>
+  </main>
+</body>
+</html>

--- a/lib/modules/apostrophe-locks/index.js
+++ b/lib/modules/apostrophe-locks/index.js
@@ -17,10 +17,17 @@ module.exports = {
     //
     // We MUST release the lock later by calling `unlock` with the same name.
     //
+    // If the lock is in use by another party, this method will wait until it is 
+    // no longer in use, unless `options.wait` is present. If `options.wait`
+    // is explicitly `false`, the method will not wait at all, and 
+    // the error reported will be the string `'locked'`. If `options.wait`
+    // is a number, the method will wait that many milliseconds before
+    // reporting the `locked` error.
+    //
     // The `options` argument can be omitted completely.
     //
     // Calling this method when you already have the specified lock will
-    // yield an error.
+    // yield an error unless the `waitForSelf` option is true.
     //
     // If you call without a callback, a promise is returned instead.
     //
@@ -42,10 +49,18 @@ module.exports = {
       // older than the `idleTimeout`.
 
       var retryDelay = 10;
+      var start = Date.now();
 
       if (typeof (options) !== 'object') {
         callback = options;
         options = {};
+      }
+      var wait = Number.MAX_VALUE;
+      if (_.isNumber(options.wait)) {
+        wait = options.wait;
+      }
+      if (options.wait === false) {
+        wait = 0;
       }
 
       if (callback) {
@@ -58,6 +73,9 @@ module.exports = {
 
         self.intervals = self.intervals || {};
         if (self.intervals[name]) {
+          if (options.waitForSelf) {
+            return retry();
+          }
           return setImmediate(function() {
             return callback(new Error("Attempted to lock " + name + " which we have already locked."));
           });
@@ -123,6 +141,13 @@ module.exports = {
           // Only duplicate keys should be retried
           if (err.code !== 11000) {
             return callback(err);
+          }
+          return retry();
+        }
+
+        function retry() {
+          if (start + wait > Date.now()) {
+            return callback('locked');
           }
           // Try try again
           setTimeout(function() {

--- a/lib/modules/apostrophe-locks/index.js
+++ b/lib/modules/apostrophe-locks/index.js
@@ -17,9 +17,9 @@ module.exports = {
     //
     // We MUST release the lock later by calling `unlock` with the same name.
     //
-    // If the lock is in use by another party, this method will wait until it is 
+    // If the lock is in use by another party, this method will wait until it is
     // no longer in use, unless `options.wait` is present. If `options.wait`
-    // is explicitly `false`, the method will not wait at all, and 
+    // is explicitly `false`, the method will not wait at all, and
     // the error reported will be the string `'locked'`. If `options.wait`
     // is a number, the method will wait that many milliseconds before
     // reporting the `locked` error.

--- a/lib/modules/apostrophe-locks/index.js
+++ b/lib/modules/apostrophe-locks/index.js
@@ -62,7 +62,6 @@ module.exports = {
       if (options.wait === false) {
         wait = 0;
       }
-
       if (callback) {
         return body(callback);
       } else {
@@ -146,7 +145,7 @@ module.exports = {
         }
 
         function retry() {
-          if (start + wait > Date.now()) {
+          if (start + wait < Date.now()) {
             return callback('locked');
           }
           // Try try again

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "qs": "^5.2.1",
     "regexp-quote": "0.0.0",
     "request": "^2.85.0",
+    "request-promise": "^4.2.2",
     "resolve": "^1.8.1",
     "rimraf": "^2.6.2",
     "sanitize-html": "^1.18.3",

--- a/test/caches.js
+++ b/test/caches.js
@@ -23,6 +23,7 @@ describe('Caches', function() {
       },
 
       afterListen: function(err) {
+        console.error(err);
         assert(!err);
         return done();
       }

--- a/test/global.js
+++ b/test/global.js
@@ -1,6 +1,9 @@
 var t = require('../test-lib/test.js');
 var assert = require('assert');
 var apos;
+var request = require('request-promise');
+var _ = require('lodash');
+var Promise = require('bluebird');
 
 describe('Global', function() {
 
@@ -18,6 +21,9 @@ describe('Global', function() {
         'apostrophe-express': {
           secret: 'xxx',
           port: 7900
+        },
+        'apostrophe-global': {
+          whileBusyDelay: 0.5
         }
       },
       afterInit: function(callback) {
@@ -66,5 +72,60 @@ describe('Global', function() {
       assert(req.data.global.type === 'apostrophe-global');
     });
   });
+
+  it('busy mechanism', function() {
+    this.timeout(50000);
+    var retrieved = false;
+    console.log('invoking whileBusy');
+    return apos.global.whileBusy(function() {
+      console.log('sending request');
+      // Intentional parallelism: start a request while
+      // we're busy, so we can verify it waits
+      request('http://localhost:7900/').then(function(content) {
+        console.log(content);
+        // fn should complete before this is retrieved
+        assert(content.indexOf('counts: 10') !== -1);
+        retrieved = true;
+      });
+      return apos.docs.db.findOne({
+        type: 'apostrophe-global'
+      }).then(function(global) {
+        assert(global.globalBusy);
+      }).then(function() {
+        return Promise.mapSeries(_.range(0, 10), function() {
+          return apos.docs.db.update({
+            type: 'apostrophe-global'
+          }, {
+            $inc: {
+              counts: 1
+            }
+          }).then(function() {
+            return Promise.delay(50);
+          });
+        });
+      }).then(function() {
+        assert(!retrieved);
+      });
+    }).then(function() {
+      // Wait up to 1 second more for the delayed request to succeed
+      var start = Date.now();
+      return check();
+      function check() {
+        if (retrieved) {
+          return;
+        }
+        if (Date.now() - start > 1000) {
+          assert(false);
+        }
+        return Promise.delay(50).then(check);
+      }
+    }).then(function() {
+      // Now that we are no longer busy a new request should take less than a second
+      return request('http://localhost:7900/').then(function(content) {
+        assert(Date.now() - start < 1000);
+        assert(content.indexOf('counts: 10') !== -1);
+      });
+    });
+  })
 
 });

--- a/test/global.js
+++ b/test/global.js
@@ -2,7 +2,7 @@ var t = require('../test-lib/test.js');
 var assert = require('assert');
 var apos;
 var request = require('request-promise');
-var _ = require('lodash');
+var _ = require('@sailshq/lodash');
 var Promise = require('bluebird');
 
 describe('Global', function() {

--- a/test/global.js
+++ b/test/global.js
@@ -73,7 +73,17 @@ describe('Global', function() {
     });
   });
 
-  it('busy mechanism', function() {
+  it('give global doc a workflowLocale property to simulate use with workflow', function() {
+    return apos.docs.db.update({
+      type: 'apostrophe-global'
+    }, {
+      $set: {
+        workflowLocale: 'en'
+      }
+    });
+  });
+
+  it('busy mechanism (global)', function() {
     this.timeout(50000);
     var retrieved = false;
     return apos.global.whileBusy(function() {
@@ -134,6 +144,156 @@ describe('Global', function() {
     }).then(function(global) {
       assert(!global.globalBusy);
     });
-  })
+  });
 
+  it('reset counts', function() {
+    return apos.docs.db.update({
+      type: 'apostrophe-global'
+    }, {
+      $set: {
+        counts: 0
+      }
+    });
+  });
+
+  it('busy mechanism (default locale)', function() {
+    this.timeout(50000);
+    var retrieved = false;
+    return apos.global.whileBusy(function() {
+      // Intentional parallelism: start a request while
+      // we're busy, so we can verify it waits
+      request('http://localhost:7900/').then(function(content) {
+        // fn should complete before this is retrieved
+        assert(content.indexOf('counts: 10') !== -1);
+        retrieved = true;
+      });
+      return apos.docs.db.findOne({
+        type: 'apostrophe-global'
+      }).then(function(global) {
+        assert(global.globalBusyen);
+      }).then(function() {
+        return Promise.mapSeries(_.range(0, 10), function(i) {
+          return apos.docs.db.update({
+            type: 'apostrophe-global'
+          }, {
+            $inc: {
+              counts: 1
+            }
+          }).then(function() {
+            return Promise.delay(50);
+          });
+        }).then(function() {
+          return apos.docs.db.findOne({
+            type: 'apostrophe-global'
+          });
+        }).then(function(doc) {
+          assert(doc.counts === 10);
+        });
+      }).then(function() {
+        assert(!retrieved);
+      });
+    }, { locale: 'en' }).then(function() {
+      // Wait up to 1 second more for the delayed request to succeed
+      var start = Date.now();
+      return check();
+      function check() {
+        if (retrieved) {
+          return;
+        }
+        if (Date.now() - start > 1000) {
+          assert(false);
+        }
+        return Promise.delay(50).then(check);
+      }
+    }).then(function() {
+      // Now that we are no longer busy a new request should take less than a second
+      return request('http://localhost:7900/').then(function(content) {
+        assert(content.indexOf('counts: 10') !== -1);
+      });
+    }).then(function() {
+      return apos.docs.db.findOne({
+        type: 'apostrophe-global'
+      });
+    }).then(function(global) {
+      assert(!global.globalBusyen);
+    });
+  });
+
+  it('reset counts', function() {
+    return apos.docs.db.update({
+      type: 'apostrophe-global'
+    }, {
+      $set: {
+        counts: 0
+      }
+    });
+  });
+
+  it('busy mechanism (some other locale)', function() {
+    this.timeout(50000);
+    var retrieved = false;
+    return apos.global.whileBusy(function() {
+      // Intentional parallelism: start a request while
+      // we're busy, so we can verify it doesn't wait
+      request('http://localhost:7900/').then(function(content) {
+        // Should not wait for all 10 additions because it is a request
+        // for the en locale and we locked fr
+        assert(content.indexOf('counts: 10') === -1);
+        retrieved = true;
+      });
+      return apos.docs.db.findOne({
+        type: 'apostrophe-global'
+      }).then(function(global) {
+        // This property would only appear on the global doc
+        // for the fr locale, if there were one, and we are simulating
+        // from the perspective of en
+        assert(!global.globalBusyfr);
+      }).then(function() {
+        return Promise.mapSeries(_.range(0, 10), function(i) {
+          return apos.docs.db.update({
+            type: 'apostrophe-global'
+          }, {
+            $inc: {
+              counts: 1
+            }
+          }).then(function() {
+            return Promise.delay(50);
+          });
+        }).then(function() {
+          return apos.docs.db.findOne({
+            type: 'apostrophe-global'
+          });
+        }).then(function(doc) {
+          assert(doc.counts === 10);
+        });
+      }).then(function() {
+        // we locked fr, not en, so this should have got through already
+        assert(retrieved);
+      });
+    }, { locale: 'fr' }).then(function() {
+      // Wait up to 1 second more for the delayed request to succeed
+      var start = Date.now();
+      return check();
+      function check() {
+        if (retrieved) {
+          return;
+        }
+        if (Date.now() - start > 1000) {
+          assert(false);
+        }
+        return Promise.delay(50).then(check);
+      }
+    }).then(function() {
+      // Now that we are no longer busy a new request should take less than a second
+      return request('http://localhost:7900/').then(function(content) {
+        assert(content.indexOf('counts: 10') !== -1);
+      });
+    }).then(function() {
+      return apos.docs.db.findOne({
+        type: 'apostrophe-global'
+      });
+    }).then(function(global) {
+      assert(!global.globalBusyfr);
+    });
+  });
 });

--- a/test/lib/modules/apostrophe-pages/views/pages/home.html
+++ b/test/lib/modules/apostrophe-pages/views/pages/home.html
@@ -5,3 +5,5 @@
 {% else %}
   <a href="/login">Log In</a>
 {% endif %}
+{# Necessary to the apostrophe-global tests. #}
+counts: {{ data.global.counts }}

--- a/test/locales/en.json
+++ b/test/locales/en.json
@@ -10,5 +10,9 @@
 	"Log In": "Log In",
 	"Your username or password was incorrect": "Your username or password was incorrect",
 	"That document may be being edited by %s (%s). Their last edit was %s minutes ago.\nIf you take control, they could lose unsaved work.\nDo you want to take control?": "That document may be being edited by %s (%s). Their last edit was %s minutes ago.\nIf you take control, they could lose unsaved work.\nDo you want to take control?",
-	"your username or password was incorrect": "your username or password was incorrect"
+	"your username or password was incorrect": "your username or password was incorrect",
+	"One moment please...": "One moment please...",
+	"We're in the process of updating the site for you. This page will refresh in a few seconds.": "We're in the process of updating the site for you. This page will refresh in a few seconds.",
+	"An error has occurred": "An error has occurred",
+	"An error has occurred. We're working on it. We apologize for the inconvenience.": "An error has occurred. We're working on it. We apologize for the inconvenience."
 }


### PR DESCRIPTION
This method allows you to run a function to completion while the entire site is paused. Obviously this should be super rare, used for things like deploying entirely new content to the site, and would have a hideous performance impact if used routinely. But it's very useful for a big operation like replacing all the content without a period of inconsistent results (as requested in DGAD-449).

HOW YOUR FUNCTION GETS RUN

A lock is obtained, the `global` doc is marked busy, and then requests in progress are waited out with a simple timer rather than trying to actually track them because the performance cost of tracking them across load-balanced cores and servers would be too high.

Next your function runs. If it returns a promise the promise is awaited. This is a new API and supporting both can be complicated, so callbacks are not an option.

After your function runs, the global doc is marked not busy, and the lock is released.

MEANWHILE

When any request comes in, we check to see if the global doc (which we always fetch anyway) is marked busy.

If it is, we wait until we can get the lock. If we get it, this means the function passed to `whileBusy` has simply finished, or the lock expired due to that function crashing. Just in case of the latter, we clear the busy flag in the global doc, which we can do because we hold the lock at this point. Then we release the lock and go on with our lives.

If we can't get the lock after several seconds, i.e. we're in danger of hitting the proxy server's time limit, and it's a GET/HEAD request, we send the user a simple 503 page with a "Refresh" header, lather rinse repeat until they get the page they were hoping for. Other request methods get a simple 503.

See unit tests in `test/global.js`.
