### PR TITLE
Apostrophe schema fields, including arrays with nested fields, can now return the user to the scene of a server-determined error for further editing

### DIFF
--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -423,22 +423,18 @@ apos.define('apostrophe-areas-editor', {
       return $separator;
     };
 
-    // Open the widget for editing, optionally passing on `path`, which
-    // is a dot path to a field already known to be in an error state,
-    // ending in the name of the error itself.
-    self.editWidget = function($widget, errorPath) {
-      console.log('EDIT WIDGET PATH:');
-      console.log(errorPath);
+    self.editWidget = function($widget) {
       self.stopEditingRichText();
       self.$selected = $widget;
       var type = self.$selected.attr('data-apos-widget');
       var data = apos.areas.getWidgetData($widget);
+      data._errorPath = $widget.data('errorPath');
+      data._error = $widget.data('error');
       var originalData = _.clone(data);
       var options = self.options.widgets[type] || {};
-      options.errorPath = errorPath;
 
       apos.areas.getWidgetManager(type).edit(
-        apos.areas.getWidgetData($widget),
+        data,
         options,
         function(data, callback) {
           $.jsonCall(self.action + '/render-widget',
@@ -729,6 +725,7 @@ apos.define('apostrophe-areas-editor', {
                 var $lastWidget;
                 var failing = false;
                 var unconsumed = [];
+
                 // Last element is the error name, not part of the path.
                 var errorName = path.pop();
 
@@ -744,12 +741,14 @@ apos.define('apostrophe-areas-editor', {
                       if ($el.length) {
                         $lastWidget = $el;
                       } else {
+                        unconsumed.push(c);
                         failing = true;
                       }
                     } else {
                       // console.log('within ', $el[0], ' looking for: ' + '[data-apos-area][data-dot-path$=".' + c + '"]');
                       $el = $el.findSafe('[data-apos-area][data-dot-path$=".' + c + '"]', '[data-apos-widget]');
                       if (!$el[0]) {
+                        unconsumed.push(c);
                         failing = true;
                       }
                     }
@@ -760,7 +759,9 @@ apos.define('apostrophe-areas-editor', {
                   // console.log('trying to edit:');
                   // console.log($area[0]);
                   // console.log($lastWidget[0]);
-                  $area.data('editor').editWidget($lastWidget, unconsumed);
+                  $lastWidget.data('errorPath', unconsumed);
+                  $lastWidget.data('error', errorName);
+                  $area.data('editor').editWidget($lastWidget);
                   apos.notify('Incomplete or incorrect information was provided. Please review.');
                 } else {
                   apos.notify('An error occurred saving the document.', { type: 'error' });

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -423,13 +423,19 @@ apos.define('apostrophe-areas-editor', {
       return $separator;
     };
 
-    self.editWidget = function($widget) {
+    // Open the widget for editing, optionally passing on `path`, which
+    // is a dot path to a field already known to be in an error state,
+    // ending in the name of the error itself.
+    self.editWidget = function($widget, errorPath) {
+      console.log('EDIT WIDGET PATH:');
+      console.log(errorPath);
       self.stopEditingRichText();
       self.$selected = $widget;
       var type = self.$selected.attr('data-apos-widget');
       var data = apos.areas.getWidgetData($widget);
       var originalData = _.clone(data);
       var options = self.options.widgets[type] || {};
+      options.errorPath = errorPath;
 
       apos.areas.getWidgetManager(type).edit(
         apos.areas.getWidgetData($widget),
@@ -721,19 +727,40 @@ apos.define('apostrophe-areas-editor', {
                 var path = result.status.split(/\./);
                 var $el = self.$el;
                 var $lastWidget;
+                var failing = false;
+                var unconsumed = [];
+                // Last element is the error name, not part of the path.
+                var errorName = path.pop();
+
                 _.each(path, function(c) {
-                  if (c.match(/^\d+$/)) {
-                    $el = $el.findSafe('[data-apos-widget]', '[data-apos-widget]').eq(parseInt(c));
-                    if ($el.length) {
-                      $lastWidget = $el;
-                    }
+                  if (failing) {
+                    // Once we've found the widget that needs fixing, push the
+                    // rest of the path into `unconsumed`,
+                    // e.g., field name, array item number
+                    unconsumed.push(c);
                   } else {
-                    $el = $el.findSafe('[data-apos-area][data-apos-dot-path$="' + c + '"]');
+                    if (c.match(/^\d+$/)) {
+                      $el = $el.findSafe('[data-apos-widget]', '[data-apos-widget]').eq(parseInt(c));
+                      if ($el.length) {
+                        $lastWidget = $el;
+                      } else {
+                        failing = true;
+                      }
+                    } else {
+                      // console.log('within ', $el[0], ' looking for: ' + '[data-apos-area][data-dot-path$=".' + c + '"]');
+                      $el = $el.findSafe('[data-apos-area][data-dot-path$=".' + c + '"]', '[data-apos-widget]');
+                      if (!$el[0]) {
+                        failing = true;
+                      }
+                    }
                   }
                 });
                 if ($lastWidget.length) {
                   var $area = $lastWidget.closest('[data-apos-area]');
-                  $area.data('editor').editWidget($lastWidget);
+                  // console.log('trying to edit:');
+                  // console.log($area[0]);
+                  // console.log($lastWidget[0]);
+                  $area.data('editor').editWidget($lastWidget, unconsumed);
                   apos.notify('Incomplete or incorrect information was provided. Please review.');
                 } else {
                   apos.notify('An error occurred saving the document.', { type: 'error' });

--- a/lib/modules/apostrophe-schemas/public/js/array-modal.js
+++ b/lib/modules/apostrophe-schemas/public/js/array-modal.js
@@ -5,6 +5,9 @@ apos.define('apostrophe-array-editor-modal', {
   chooser: true,
   construct: function(self, options) {
 
+    self.error = options.error;
+    self.errorPath = options.errorPath;
+
     // This method initializes the array editor and triggers either the creation
     // or the editing of the first item. In the latter case the list of items
     // is also implicitly loaded after first generating the item titles for the
@@ -16,8 +19,11 @@ apos.define('apostrophe-array-editor-modal', {
       self.$arrayItem = self.$el.find('[data-apos-array-item]');
       self.field = options.field;
       self.arrayItems = options.arrayItems || [];
-      self.active = 0;
-
+      if (self.errorPath && self.errorPath[0]) {
+        self.active = parseInt(self.errorPath[0]);
+      } else {
+        self.active = 0;
+      }
       if (!self.arrayItems.length) {
         return self.createItem();
       } else {
@@ -145,11 +151,19 @@ apos.define('apostrophe-array-editor-modal', {
     // The list view is also refreshed.
 
     self.populateItem = function() {
-      apos.schemas.populate(self.$arrayItem.find('[data-apos-form]'), self.field.schema, self.arrayItems[self.active], function(err) {
+      var $form = self.$arrayItem.find('[data-apos-form]');
+      apos.schemas.populate($form, self.field.schema, self.arrayItems[self.active], function(err) {
         if (err) {
           apos.utils.error(err);
         }
         self.refresh();
+        if (self.errorPath && (self.errorPath.length > 1)) {
+          apos.schemas.returnToError($form, self.field.schema, self.errorPath.slice(1), self.error, function(err) {
+            if (err) {
+              apos.utils.error(err);
+            }
+          });
+        }
       });
     };
 

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -181,6 +181,24 @@ apos.define('apostrophe-schemas', {
       });
     };
 
+    self.returnToError = function($el, schema, errorPath, error, callback) {
+      var first = errorPath.shift();
+      var $fieldset = self.findFieldset($el, first);
+      var $field = self.findField($el, first);
+      var field = _.find(schema, { name: first });
+      if (!field) {
+        return setImmediate(callback);
+      }
+      var fieldType = self.fieldTypes[field.type];
+      if (fieldType.returnToError) {
+        return fieldType.returnToError(first, $field, $el, field, errorPath, error, callback);
+      } else {
+        self.showError($el, self.error(field, error));
+      }
+      return callback(null);
+    };
+
+
     // Create a valid error object to be reported from a converter.
     // You can also report a string in which case self.convert creates
     // one of these for you. The object is nice if you want to extend it
@@ -658,14 +676,29 @@ apos.define('apostrophe-schemas', {
         setArray(data[name]);
 
         $button.on('click', function() {
+          var $fieldset = self.findFieldset($el, name);
           // Mimicking .getTool from docs . . .
-          apos.create('apostrophe-array-editor-modal', {field: field, arrayItems: $field.data('apos-array'), action: options.action, save: setArray}, function(err) {
+          apos.create('apostrophe-array-editor-modal', {
+            field: field,
+            arrayItems: $field.data('apos-array'),
+            action: options.action,
+            save: setArray,
+            error: $fieldset.data('error'),
+            errorPath: $fieldset.data('errorPath')
+          }, function(err) {
             if (err) {
               apos.utils.error(err);
             }
           });
         });
         return setImmediate(callback);
+      },
+      returnToError: function(name, $field, $el, field, errorPath, error, callback) {
+        var $fieldset = self.findFieldset($el, name);
+        $fieldset.data('error', error);
+        $fieldset.data('errorPath', errorPath);
+        var $button = self.findSafeInFieldset($el, name, '[data-apos-edit-array]');
+        $button.click();
       },
       convert: function(data, name, $field, $el, field, callback) {
         if ($field.data('apos-array')) {

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -671,7 +671,8 @@ apos.define('apostrophe-schemas', {
         if ($field.data('apos-array')) {
           data[name] = $field.data('apos-array');
         }
-        if ((field.required) && (!data[name])) {
+        // Confirm that the widget is truly empty.
+        if ((field.required) && (!data[name]) && (!data[name][0])) {
           return callback('required');
         }
         return setImmediate(callback);

--- a/lib/modules/apostrophe-widgets/public/js/editor.js
+++ b/lib/modules/apostrophe-widgets/public/js/editor.js
@@ -5,6 +5,8 @@ apos.define('apostrophe-widgets-editor', {
   construct: function(self, options) {
     self.schema = self.options.schema;
     self.data = options.data || {};
+    self.errorPath = options.data._errorPath;
+    self.error = options.data._error;
     if (!self.data._id) {
       self.data._id = apos.utils.generateId();
     }
@@ -49,6 +51,24 @@ apos.define('apostrophe-widgets-editor', {
       return async.series({
         populate: function(callback) {
           return apos.schemas.populate(self.$el, self.schema, self.data, callback);
+        }
+      }, callback);
+    };
+
+    // Wait for afterShow to do things that might pop more modals
+    self.afterShow = function(callback) {
+      return async.series({
+        errorPath: function(callback) {
+          if (self.errorPath && self.errorPath.length) {
+            return apos.schemas.returnToError(self.$el, self.schema, self.errorPath, self.error, callback);
+          } else {
+            return callback(null);
+          }
+        },
+        clearError: function(callback) {
+          self.error = null;
+          self.errorPath = null;
+          return callback(null);
         }
       }, callback);
     };

--- a/lib/modules/apostrophe-widgets/public/js/user.js
+++ b/lib/modules/apostrophe-widgets/public/js/user.js
@@ -12,7 +12,8 @@ apos.define('apostrophe-widgets', {
     // edit modal but binds future editing interactions
 
     self.edit = function(data, options, save) {
-
+      // TODO: Get unconsumed errorPath from options and tell the widget to open
+      // the modal to that field.
       if (!data) {
         data = {};
       }

--- a/lib/modules/apostrophe-widgets/public/js/user.js
+++ b/lib/modules/apostrophe-widgets/public/js/user.js
@@ -12,8 +12,6 @@ apos.define('apostrophe-widgets', {
     // edit modal but binds future editing interactions
 
     self.edit = function(data, options, save) {
-      // TODO: Get unconsumed errorPath from options and tell the widget to open
-      // the modal to that field.
       if (!data) {
         data = {};
       }


### PR DESCRIPTION
This fixes common problems when "required" is added to the schema later, or when the site formerly ran a version of Apostrophe that didn't enforce all constraints browser- or server-side.