### PR TITLE
the purpose of the _originalWidgets property is just to preserve widg…

### DIFF
--- a/lib/modules/apostrophe-docs/lib/api.js
+++ b/lib/modules/apostrophe-docs/lib/api.js
@@ -473,6 +473,11 @@ module.exports = function(self, options) {
   // invoking a callback for each one. Optionally
   // deletes properties.
   //
+  // The `_originalWidgets` property and its subproperties
+  // are not walked because they are temporary information
+  // present only to preserve widgets during save operations
+  // performed by users without permissions for those widgets.
+  //
   // The second argument must be a function that takes
   // an object, a key, a value, a "dot path" and an
   // array containing the ancestors of this property
@@ -515,6 +520,10 @@ module.exports = function(self, options) {
     var remove = [];
     for (key in doc) {
       __dotPath = _dotPath + key.toString();
+      var ow = '_originalWidgets';
+      if ((__dotPath === ow) || (__dotPath.substring(0, ow.length) === (ow + '.'))) {
+        continue;
+      }
       if (callback(doc, key, doc[key], __dotPath, _ancestors) === false) {
         remove.push(key);
       } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "2.65.0",
+  "version": "2.66.0",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
…ets the user lacks permissions to edit, so they can be popped back in right before save. But it was getting walked by apos.areas.walk and apos.docs.walk and thus being discovered by apos.areas.richText, producing doubled rich text and doubled plaintext on sites. Do not walk this property in apos.docs.walk; that fixes all the cases.