### PR TITLE
Update versions modal "Revert" labels to "Revert to"

### DIFF
--- a/lib/modules/apostrophe-versions/public/css/user.less
+++ b/lib/modules/apostrophe-versions/public/css/user.less
@@ -25,7 +25,7 @@
     }
     .apos-changes-meta
     {
-      width: ~'calc(100% - 220px)';
+      width: ~'calc(100% - 225px)';
       .apos-inline-block(top);
     }
 

--- a/lib/modules/apostrophe-versions/views/versions.html
+++ b/lib/modules/apostrophe-versions/views/versions.html
@@ -7,7 +7,7 @@
 
 {% block controls %}
   <div class="apos-modal-controls">
-    {{ buttons.minor('Finished', { action: 'cancel' }) }}
+    {{ buttons.minor(__('Finished'), { action: 'cancel' }) }}
   </div>
 {% endblock %}
 
@@ -25,16 +25,16 @@
         </div>
       </div>{#
       #}<div class="apos-changes-meta">
-          <cite>{{ version.author }}</cite><span>made changes on </span>
+          <cite>{{ version.author }}</cite><span>{{ __('made changes on') }}</span>
           <h4>{{ version.createdAt | date(__('MM/DD/YY[ at ]h:mma')) }}</h4><br>
           {%- if version._previous -%}
-            <h5 data-open-changes>See Changes</h5>
+            <h5 data-open-changes>{{ __('See Changes') }}</h5>
           {%- endif -%}
       </div>
         {%- if loop.first -%}
-          {{ buttons.disabled('Current', { action: 'none', value: version._id }) }}
+          {{ buttons.disabled(__('Current'), { action: 'none', value: version._id }) }}
         {%- else -%}
-          {{ buttons.major('Revert', { action: 'revert', value: version._id })}}
+          {{ buttons.major(__('Revert to'), { action: 'revert', value: version._id })}}
         {%- endif -%}
         <div class="apos-changes">
         {% if version._previous -%}


### PR DESCRIPTION
As discussed in #1515, "Revert" is somewhat ambigous compared to "Revert to" - does it mean "undo this change" or "go back to this change"? Well it does mean the latter, and labelling it "Revert to" clarifies that.

Also, I took the chance to run some more labels in there through the i18n `__` function.

Lastly, I added some additional pixels to the subtracted width of `.apos-changes-meta`, because in viewports wider than 1450px, `.apos-button--major` receives an increase in font-weight. This adds 1 additional pixel to the width of "Revert to" now that we have more characters in there, so we need to counteract that.