### PR TITLE
fixed the lateCriteria cursor method and eliminated a nuisance warnin…

### DIFF
--- a/lib/modules/apostrophe-docs/lib/cursor.js
+++ b/lib/modules/apostrophe-docs/lib/cursor.js
@@ -1258,6 +1258,9 @@ module.exports = {
               // inside an $and. Should be used as little as possible
               _.assign(criteria, lateCriteria);
             }
+            if (self.get('log')) {
+              self.apos.utils.log(require('util').inspect(criteria, { depth: 20 }));
+            }
             var mongo = self.lowLevelMongoCursor(self.get('req'), criteria, self.get('projection'), {
               skip: self.get('skip'),
               limit: self.get('limit'),

--- a/lib/modules/apostrophe-docs/lib/cursor.js
+++ b/lib/modules/apostrophe-docs/lib/cursor.js
@@ -1254,12 +1254,11 @@ module.exports = {
             var criteria = self.get('criteria');
             var lateCriteria = self.get('lateCriteria');
             if (lateCriteria) {
+              // Support for criteria that mongodb will not accept
+              // inside an $and. Should be used as little as possible
               _.assign(criteria, lateCriteria);
             }
-            if (self.get('log')) {
-              self.apos.utils.log(require('util').inspect(criteria, { depth: 20 }));
-            }
-            var mongo = self.lowLevelMongoCursor(self.get('req'), self.get('criteria'), self.get('projection'), {
+            var mongo = self.lowLevelMongoCursor(self.get('req'), criteria, self.get('projection'), {
               skip: self.get('skip'),
               limit: self.get('limit'),
               sort: self.get('sortMongo')

--- a/lib/modules/apostrophe-module/lib/events.js
+++ b/lib/modules/apostrophe-module/lib/events.js
@@ -103,10 +103,14 @@ module.exports = function(self, options) {
     var args = [ callAllName ].concat(remainder);
     args.push(function(err) {
       if (err) {
-        return _callback(err);
+        // See: http://goo.gl/rRqMUw
+        _callback(err);
+        return null;
       }
       return self.promiseEmit.apply(self, [ eventName ].concat(remainder)).then(function() {
-        return _callback(null);
+        // See: http://goo.gl/rRqMUw
+        _callback(null);
+        return null;
       }).catch(_callback);
     });
     return self.apos.callAll.apply(self.apos, args);


### PR DESCRIPTION
…g from bluebird when we intentionally end a promise chain

This addresses two things:

1. Apostrophe has long had a "lateCriteria" method you can call on a cursor to merge in some mongo operators that are incompatible with `$and` so you can't just use our `and({whatever...})` method as we so often do. However, it was busted because we were building it and then not passing it to mongo. Fixed.
2. Latest bluebird promise module emits warnings if, in your `then()` function, you fail to return anything because it is assumed that you unintentionally dropped the ball and didn't continue the promise chain. Silence these, per their docs, by returning `null` explicitly after invoking our callback as we always did. 