### PR TITLE
fix(apostrophe-pages): change page._ancestors.length check on copy to…

### DIFF
--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -1172,12 +1172,6 @@ module.exports = function(self, options) {
     }
 
     if (args.page) {
-      if (args.page.level === 0) {
-        // Snip out copy page if we are on the homepage
-        args.contextMenu = _.filter(args.contextMenu, function(item) {
-          return item.action !== 'copy-page';
-        });
-      }
       if (!self.allowedChildTypes(args.page).length) {
         // Snip out add page if no
         // child page types are allowed

--- a/lib/modules/apostrophe-pages/lib/routes.js
+++ b/lib/modules/apostrophe-pages/lib/routes.js
@@ -44,6 +44,10 @@ module.exports = function(self, options) {
           return fail('notfound');
         }
         parentPage = peerPage._ancestors && peerPage._ancestors[0] && peerPage._ancestors[peerPage._ancestors.length - 1];
+        if (!parentPage) {
+          // set root as parent if parentPage has no ancestors -> root page
+          parentPage = peerPage;
+        }
         var child = self.newChild(parentPage);
         if (!child) {
           return fail('invalid');

--- a/lib/modules/apostrophe-pages/lib/routes.js
+++ b/lib/modules/apostrophe-pages/lib/routes.js
@@ -302,10 +302,12 @@ module.exports = function(self, options) {
             return callback('notfound');
           }
           if (!currentPage._ancestors.length) {
-            return callback('notfound');
+            // currentPage is the root page, append the copied page as child
+            parentPage = currentPage;
+          } else {
+            siblingPage = currentPage;
+            parentPage = currentPage._ancestors[currentPage._ancestors.length - 1];
           }
-          siblingPage = currentPage;
-          parentPage = currentPage._ancestors[currentPage._ancestors.length - 1];
           if (!parentPage._publish) {
             return callback('notfound');
           }


### PR DESCRIPTION
… enable root-page copying

If the currentPage is the root object of the page tree, the copied page will be a child of the root
page, every other logic remains unchanged

closes #1176