### PR TITLE
refactored whileBusy so it can be optionally put in place as a separa…

### DIFF
--- a/lib/modules/apostrophe-docs/lib/cursor.js
+++ b/lib/modules/apostrophe-docs/lib/cursor.js
@@ -1256,7 +1256,7 @@ module.exports = {
             if (lateCriteria) {
               _.assign(criteria, lateCriteria);
             }
-            if (self.get('log')) {
+            if (self.get('log') || process.env.APOS_LOG_ALL_QUERIES) {
               self.apos.utils.log(require('util').inspect(criteria, { depth: 20 }));
             }
             var mongo = self.lowLevelMongoCursor(self.get('req'), self.get('criteria'), self.get('projection'), {

--- a/lib/modules/apostrophe-global/index.js
+++ b/lib/modules/apostrophe-global/index.js
@@ -141,10 +141,121 @@ module.exports = {
       });
     };
 
-    // Add the `addGlobalToData` middleware.
+    // Add the `addGlobalToData` middleware. And if requested,
+    // the separate middleware for checking the global busy flag
+    // when addGlobalToData has been overridden in a way that might
+    // involve caching or otherwise not be up to date at all times.
 
     self.enableMiddleware = function() {
-      self.expressMiddleware = self.addGlobalToData;
+      self.expressMiddleware = (self.options.separateWhileBusyMiddleware ? [
+        self.whileBusyMiddleware
+      ] : []).concat([ self.addGlobalToData ]);
+    };
+
+    self.whileBusyMiddleware = function(req, res, next) {
+      var _global;
+      return async.series([
+        find,
+        check
+      ], function(err) {
+        if (err) {
+          self.apos.utils.error(err);
+          return res.status(500).send('error');
+        }
+        return next();
+      });
+
+      function find(callback) {
+        return self.find(req, { slug: self.slug })
+          .permission(false)
+          .areas(false)
+          .joins(false)
+          .toObject(function(err, __global) {
+            if (err) {
+              return res.status(500).send('error');
+            }
+            _global = __global;
+            return callback(null);
+          });
+      }
+
+      function check(callback) {
+        return self.checkWhileBusy(req, _global, callback);
+      }
+    };
+
+    self.checkWhileBusy = function(req, _global, callback) {
+      var lockName = 'apostrophe-global-busy';
+      var localeLockName;
+      var propName = 'globalBusy';
+      var localePropName;
+      if (req.locale) {
+        localeLockName = lockName + '-' + req.locale;
+        localePropName = propName + req.locale;
+      }
+      return async.series([
+        considerGlobal,
+        considerLocale
+      ], callback);
+
+      function considerGlobal(callback) {
+        return considerLock(propName, lockName, callback);
+      }
+
+      function considerLocale(callback) {
+        if (!localePropName) {
+          return callback(null);
+        }
+        return considerLock(localePropName, localeLockName, callback);
+      }
+
+      function considerLock(propName, lockName, callback) {
+        if (_global[propName]) {
+          return self.apos.locks.lock(lockName, {
+            wait: (req.res && req.res.send) ? self.options.whileBusyRequestDelay * 1000 : Number.MAX_VALUE,
+            waitForSelf: true
+          }, function(err) {
+            if (!err) {
+              // We got in after a period of the system being busy,
+              // or the process with the lock went away. Either way,
+              // we should clear globalBusy and give up our lock,
+              // then continue normal operation.
+              return async.series([ unmark, unlock, refind ], callback);
+            }
+            // An error occurred. If it is because the lock is still
+            // present after waiting as long as we could for this req,
+            // send a try-again response to the user.
+            if ((err === 'locked') && req.res && req.res.send) {
+              return self.busyTryAgainSoon(req);
+            } else {
+              // All other errors propagate normally
+              return callback(err);
+            }
+          });
+        }
+        return callback(null);
+        function unmark(callback) {
+          var $set = {};
+          $set[propName] = false;
+          return self.apos.docs.db.update({
+            _id: _global._id
+          }, {
+            $set: $set
+          }, callback);
+        }
+        function unlock(callback) {
+          return self.apos.locks.unlock(lockName, callback);
+        }
+        function refind(callback) {
+          return self.findGlobal(req, function(err, result) {
+            if (err) {
+              return callback(err);
+            }
+            req.data.global = result;
+            return callback(null);
+          });
+        }
+      }
     };
 
     // Fetch the global doc and add it to `req.data` as `req.data.global`, if it
@@ -193,91 +304,24 @@ module.exports = {
           req.deferWidgetLoading = true;
         }
 
-        return async.series([ findGlobal, loadDeferredWidgets ], callback);
+        return async.series([ findGlobal, check, loadDeferredWidgets ], callback);
 
       }
 
       function findGlobal(callback) {
         return self.findGlobal(req, function(err, result) {
-          var lockName = 'apostrophe-global-busy';
-          var localeLockName;
-          var propName = 'globalBusy';
-          var localePropName;
           if (err) {
             return callback(err);
           }
 
           req.data.global = result;
 
-          if (req.locale) {
-            localeLockName = lockName + '-' + req.locale;
-            localePropName = propName + req.locale;
-          }
-
-          return async.series([
-            considerGlobal,
-            considerLocale
-          ], callback);
-
-          function considerGlobal(callback) {
-            return considerLock(propName, lockName, callback);
-          }
-
-          function considerLocale(callback) {
-            if (!localePropName) {
-              return callback(null);
-            }
-            return considerLock(localePropName, localeLockName, callback);
-          }
-
-          function considerLock(propName, lockName, callback) {
-            if (req.data.global[propName]) {
-              return self.apos.locks.lock(lockName, {
-                wait: (req.res && req.res.send) ? self.options.whileBusyRequestDelay * 1000 : Number.MAX_VALUE,
-                waitForSelf: true
-              }, function(err) {
-                if (!err) {
-                  // We got in after a period of the system being busy,
-                  // or the process with the lock went away. Either way,
-                  // we should clear globalBusy and give up our lock,
-                  // then continue normal operation.
-                  return async.series([ unmark, unlock, refind ], callback);
-                }
-                // An error occurred. If it is because the lock is still
-                // present after waiting as long as we could for this req,
-                // send a try-again response to the user.
-                if ((err === 'locked') && req.res && req.res.send) {
-                  return self.busyTryAgainSoon(req);
-                } else {
-                  // All other errors propagate normally
-                  return callback(err);
-                }
-              });
-            }
-            return callback(null);
-            function unmark(callback) {
-              var $set = {};
-              $set[propName] = false;
-              return self.apos.docs.db.update({
-                _id: req.data.global._id
-              }, {
-                $set: $set
-              }, callback);
-            }
-            function unlock(callback) {
-              return self.apos.locks.unlock(lockName, callback);
-            }
-            function refind(callback) {
-              return self.findGlobal(req, function(err, result) {
-                if (err) {
-                  return callback(err);
-                }
-                req.data.global = result;
-                return callback(null);
-              });
-            }
-          }
+          return callback(null);
         });
+      }
+
+      function check(callback) {
+        return self.checkWhileBusy(req, req.data.global, callback);
       }
 
       function loadDeferredWidgets(callback) {

--- a/test/global.js
+++ b/test/global.js
@@ -297,3 +297,132 @@ describe('Global', function() {
     });
   });
 });
+
+describe('Global with separateWhileBusyMiddleware', function() {
+
+  this.timeout(t.timeout);
+
+  after(function(done) {
+    return t.destroy(apos, done);
+  });
+
+  it('global should exist on the apos object', function(done) {
+    apos = require('../index.js')({
+      root: module,
+      shortName: 'test',
+      modules: {
+        'apostrophe-express': {
+          secret: 'xxx',
+          port: 7900
+        },
+        'apostrophe-global': {
+          separateWhileBusyMiddleware: true,
+          whileBusyDelay: 0.5,
+          construct: function(self, options) {
+            var superAddGlobalToData = self.addGlobalToData;
+            // For test purposes, use a simplified global middleware
+            // that does not implement the locking, to verify that
+            // the separateWhileBusyMiddleware successfully takes over
+            // this role
+            self.addGlobalToData = function(req, res, next) {
+              if (arguments.length === 3) {
+                return self.findGlobal(req, function(err, _global) {
+                  assert(!err);
+                  req.data.global = _global;
+                  return next();
+                });
+              }
+              return superAddGlobalToData.apply(self, arguments);
+            };
+          }
+        }
+      },
+      afterInit: function(callback) {
+        assert(apos.global);
+        // In tests this will be the name of the test file,
+        // so override that in order to get apostrophe to
+        // listen normally and not try to run a task. -Tom
+        apos.argv._ = [];
+        return callback(null);
+      },
+      afterListen: function(err) {
+        assert(!err);
+        done();
+      }
+    });
+  });
+
+  it('give global doc a workflowLocale property to simulate use with workflow', function() {
+    return apos.docs.db.update({
+      type: 'apostrophe-global'
+    }, {
+      $set: {
+        workflowLocale: 'en'
+      }
+    });
+  });
+
+  it('busy mechanism (global)', function() {
+    this.timeout(50000);
+    var retrieved = false;
+    return apos.global.whileBusy(function() {
+      // Intentional parallelism: start a request while
+      // we're busy, so we can verify it waits
+      request('http://localhost:7900/').then(function(content) {
+        // fn should complete before this is retrieved
+        assert(content.indexOf('counts: 10') !== -1);
+        retrieved = true;
+      });
+      return apos.docs.db.findOne({
+        type: 'apostrophe-global'
+      }).then(function(global) {
+        assert(global.globalBusy);
+      }).then(function() {
+        return Promise.mapSeries(_.range(0, 10), function(i) {
+          return apos.docs.db.update({
+            type: 'apostrophe-global'
+          }, {
+            $inc: {
+              counts: 1
+            }
+          }).then(function() {
+            return Promise.delay(50);
+          });
+        }).then(function() {
+          return apos.docs.db.findOne({
+            type: 'apostrophe-global'
+          });
+        }).then(function(doc) {
+          assert(doc.counts === 10);
+        });
+      }).then(function() {
+        assert(!retrieved);
+      });
+    }).then(function() {
+      // Wait up to 1 second more for the delayed request to succeed
+      var start = Date.now();
+      return check();
+      function check() {
+        if (retrieved) {
+          return;
+        }
+        if (Date.now() - start > 1000) {
+          assert(false);
+        }
+        return Promise.delay(50).then(check);
+      }
+    }).then(function() {
+      // Now that we are no longer busy a new request should take less than a second
+      return request('http://localhost:7900/').then(function(content) {
+        assert(content.indexOf('counts: 10') !== -1);
+      });
+    }).then(function() {
+      return apos.docs.db.findOne({
+        type: 'apostrophe-global'
+      });
+    }).then(function(global) {
+      assert(!global.globalBusy);
+    });
+  });
+
+});


### PR DESCRIPTION
…te middleware function if heavy-duty full loading of the global doc is being cached or otherwise not 100% real and up to date. DGAD needs this because they load req.data.global from a cache, so it might be stale and not contain the very latest value of the `globalBusy` property. The alternative middleware still fetches the global doc but does so without any areas or joins so it's lightweight.