### PR TITLE
Make apostrophe-ui button macro render a <button>

### DIFF
--- a/lib/modules/apostrophe-ui/public/css/components/buttons.less
+++ b/lib/modules/apostrophe-ui/public/css/components/buttons.less
@@ -20,6 +20,8 @@
 
 .apos-button
 {
+  -moz-appearance: none;
+  -webkit-appearance: none;
   position: relative;
   .apos-inline-block;
   padding: @apos-padding-1 @apos-padding-2;
@@ -27,6 +29,7 @@
   .apos-button-border;
   // .apos-text-small;
   font-size: 14px;
+  line-height: inherit;
   letter-spacing: 1px;
   @media @apos-breakpoint-desktop-xl { .apos-text-small; }
   background-color: @apos-white;
@@ -54,7 +57,12 @@
     .apos-glow;
     cursor: pointer;
   }
-  &:active
+  &:focus
+  {
+    outline: none;
+  }
+  &:active,
+  &:focus
   {
     .apos-drop-shadow(0px, 0px, 13px, 4px, fade(@apos-base, 30%));
   }
@@ -62,7 +70,7 @@
   {
     border-radius: 0px;
   }
-  
+
   &.ui-draggable-handle
   {
     cursor: move;
@@ -253,7 +261,7 @@
   box-shadow: none;
   border: none;
   padding: 0;
-  
+
   .apos-button {
     color: @apos-dark;
     padding: 4px 5px;

--- a/lib/modules/apostrophe-ui/views/components/buttons.html
+++ b/lib/modules/apostrophe-ui/views/components/buttons.html
@@ -1,5 +1,5 @@
 {% macro base(label, options, classes) -%}
-  <a {{ ('href=' + options.url) if options.url }} class="apos-button {{ classes }}" {{ options.attributes }} data-apos-{{ options.action | css }}{% if options.value %}='{{ options.value }}'{% endif %}><span class="apos-button-label">{{ __(label | d('')) }}</span>{% if options.icon %}<i class="fa fa-{{ options.icon }}"></i>{% endif %}</a>
+  <button {{ ('href=' + options.url) if options.url }} class="apos-button {{ classes }}" type="button" {{ options.attributes }} data-apos-{{ options.action | css }}{% if options.value %}='{{ options.value }}'{% endif %}><span class="apos-button-label">{{ __(label | d('')) }}</span>{% if options.icon %}<i class="fa fa-{{ options.icon }}"></i>{% endif %}</button>
 {%- endmacro -%}
 
 {% macro normal(label, options) -%}

--- a/lib/modules/apostrophe-ui/views/components/buttons.html
+++ b/lib/modules/apostrophe-ui/views/components/buttons.html
@@ -1,14 +1,18 @@
 {% macro base(label, options, classes) -%}
-  <button {{ ('href=' + options.url) if options.url }} class="apos-button {{ classes }}" type="button" {{ options.attributes }} data-apos-{{ options.action | css }}{% if options.value %}='{{ options.value }}'{% endif %}><span class="apos-button-label">{{ __(label | d('')) }}</span>{% if options.icon %}<i class="fa fa-{{ options.icon }}"></i>{% endif %}</button>
-{%- endmacro -%}
+  {%- if options.url -%}
+    <a href="{{ options.url }}" class="apos-button {{ classes }}" {{ options.attributes }} data-apos-{{ options.action | css }}{% if options.value %}='{{ options.value }}'{% endif %}><span class="apos-button-label">{{ __(label | d('')) }}</span>{% if options.icon %}<i class="fa fa-{{ options.icon }}"></i>{% endif %}</a>
+  {%- else -%}
+    <button class="apos-button {{ classes }}" type="button" {{ options.attributes }} data-apos-{{ options.action | css }}{% if options.value %}='{{ options.value }}'{% endif %}><span class="apos-button-label">{{ __(label | d('')) }}</span>{% if options.icon %}<i class="fa fa-{{ options.icon }}"></i>{% endif %}</button>
+  {%- endif -%}
+{%- endmacro %}
 
 {% macro normal(label, options) -%}
   {{ base(label, options, '') }}
-{%- endmacro -%}
+{%- endmacro %}
 
 {% macro disabled(label, options) -%}
   {{ base(label, options, 'apos-button--disabled') }}
-{%- endmacro -%}
+{%- endmacro %}
 
 {% macro inContext(label, options) -%}
   {{ base(label, options, 'apos-button--in-context') }}


### PR DESCRIPTION
As discussed in #1111.

Previously it would render an `<a>`. `<button>`s are generally better suited for this purpose, but above all it solves the problem where `<a>` elements can't be nested.

@stuartromanek, if there are other places that need updating – I'm happy to address those as well!