### PR TITLE
Adds jpeg to list of editable file extensions

### DIFF
--- a/lib/modules/apostrophe-attachments/index.js
+++ b/lib/modules/apostrophe-attachments/index.js
@@ -170,6 +170,7 @@ module.exports = {
     self.croppable = {
       gif: true,
       jpg: true,
+      jpeg: true,
       png: true
     };
 
@@ -177,6 +178,7 @@ module.exports = {
     self.sized = {
       gif: true,
       jpg: true,
+      jpeg: true,
       png: true
     };
 


### PR DESCRIPTION
An image was missing the crop icon because it had the `.jpeg` file extension, via https://github.com/apostrophecms/apostrophe/blob/master/lib/modules/apostrophe-attachments/lib/api.js#L586