### PR TITLE
when apostrophe cannot fix a unique key error, it is helpful to be ab…

### DIFF
--- a/lib/modules/apostrophe-docs/lib/api.js
+++ b/lib/modules/apostrophe-docs/lib/api.js
@@ -576,7 +576,8 @@ module.exports = function(self, options) {
             // that another docFixUniqueError handler is needed to address
             // an additional property that has to be unique. Report the
             // original error to avoid confusion ("ZOMG, what are all these digits!")
-            firstError.aposAddendum = 'retryUntilUnique failed, most likely you need another docFixUniqueError method to handle another property that has a unique index, reporting original error';
+            firstError.aposAddendum = 'retryUntilUnique failed, most likely you need another docFixUniqueError method to handle another property that has a unique index, reporting original error, see also aposLatestError property';
+            firstError.aposLatestError = err;
             return callback(firstError);
           }
           return self.callAllAndEmit('docFixUniqueError', 'fixUniqueError', req, doc, callback);


### PR DESCRIPTION
…le to see the last error, as well as the original one. This helps you figure it out if both a unique slug error and an unrelated unique key error are part of the puzzle