### PR TITLE
we need to map jpeg to jpg earlier on upload, not the fault of uploadfs

### DIFF
--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -313,6 +313,8 @@ module.exports = function(self, options) {
     if (effectiveSize) {
       path += '.' + effectiveSize;
     }
+    // Do NOT use resolveExtension because we need to link to the actual
+    // name of the file
     return path + '.' + attachment.extension;
   };
 
@@ -409,7 +411,7 @@ module.exports = function(self, options) {
         return false;
       }
       if (options.extension) {
-        if (attachment.extension !== options.extension) {
+        if (self.resolveExtension(attachment.extension) !== options.extension) {
           return false;
         }
       }
@@ -419,7 +421,7 @@ module.exports = function(self, options) {
         }
       }
       if (options.extensions) {
-        if (!_.contains(options.extensions, attachment.extension)) {
+        if (!_.contains(options.extensions, self.resolveExtension(attachment.extension))) {
           return false;
         }
       }
@@ -586,7 +588,7 @@ module.exports = function(self, options) {
   // Available as a template helper.
 
   self.isCroppable = function(attachment) {
-    return attachment && self.croppable[attachment.extension];
+    return attachment && self.croppable[self.resolveExtension(attachment.extension)];
   };
 
   // Returns true if this type of attachment is sized,
@@ -594,13 +596,27 @@ module.exports = function(self, options) {
   // size, as it does with GIF, JPEG and PNG files.
   //
   // Accepts either an entire attachment object or an extension.
+  //
+  // Can accept `jpeg` or `jpg`, because it is needed prior to the
+  // imagemagick code that resolves that difference.
 
   self.isSized = function(attachment) {
     if ((typeof attachment) === 'object') {
-      return self.sized[attachment.extension];
+      return self.sized[self.resolveExtension(attachment.extension)];
     } else {
-      return self.sized[attachment];
+      return self.sized[self.resolveExtension(attachment)];
     }
+  };
+
+  // Resolve a file extension such as jpeg to its canonical form (jpg).
+  // If no extension map is configured for this extension, return it as-is.
+
+  self.resolveExtension = function(extension) {
+    var group = self.getFileGroup(extension);
+    if (group) {
+      return group.extensionMaps[extension] || extension;
+    }
+    return extension;
   };
 
   self.middleware = {
@@ -976,7 +992,7 @@ module.exports = function(self, options) {
         return callback(null);
       }
       var sizes;
-      if (!_.contains([ 'gif', 'jpg', 'png' ], attachment.extension)) {
+      if (!_.contains([ 'gif', 'jpg', 'png' ], self.resolveExtension(attachment.extension))) {
         sizes = [ { name: 'original' } ];
       } else {
         sizes = self.imageSizes.concat([ { name: 'original' } ]);


### PR DESCRIPTION
Fix for #1653 

Please test your cropping scenario with a NEW upload initially using the .jpeg extension.

I am not sure a migration is urgently needed, it would be a significant lift and these are probably uncommon.

Thanks