### PR TITLE
promisified all of the apis for migrations, including the option of i…

### DIFF
--- a/lib/modules/apostrophe-migrations/lib/api.js
+++ b/lib/modules/apostrophe-migrations/lib/api.js
@@ -1,34 +1,42 @@
 var broadband = require('broadband');
 var async = require('async');
+var Promise = require('bluebird');
 
 module.exports = function(self, options) {
 
-  // Add a migration callback to be invoked when the apostrophe-migrations:migrate task is invoked. As an optimization,
-  // the callback MIGHT not be invoked if it has been invoked before, but your callback MUST be idempotent (it must not
-  // behave badly if the migration has been run before).
+  // Add a migration function to be invoked when the apostrophe-migrations:migrate task is invoked.
+  //
+  // The function is invoked with a callback. If it returns a promise,
+  // the promise is awaited, and the function should not also invoke the callback.
+  // However for bc this situation is tolerated.
   //
   // The options argument may be omitted. If options.safe is true, this migration will still be run when the
   // --safe option is passed to the task. ONLY SET THIS OPTION IF THE CALLBACK HAS NO NEGATIVE IMPACT ON A RUNNING,
   // LIVE SITE. But if you can mark a migration safe, do it, because it minimizes downtime when deploying.
 
-  self.add = function(name, callback, options) {
+  self.add = function(name, fn, options) {
     if (!options) {
       options = {};
     }
-    self.migrations.push({ name: name, options: options, callback: callback });
+    self.migrations.push({ name: name, options: options, callback: fn });
   };
 
   // Invoke the iterator function once for each doc in the aposDocs collection.
   // If only three arguments are given, `limit` is assumed to be 1 (only one
   // doc may be processed at a time).
   //
+  // The iterator is passed a document and a callback. If the iterator
+  // returns a promise, it is awaited, and must NOT invoke the callback.
+  //
   // This method will never visit the same doc twice in a single call, even if
   // modifications are made.
   //
-  // THIS API IS FOR MIGRATION AND TASK USE ONLY AND HAS NO SECURITY.
+  // THIS API IS FOR MIGRATION AND TASK USE ONLY AND HAS NO SECURITY
+  //
+  // This method returns a promise if no callback is supplied.
 
   self.eachDoc = function(criteria, limit, iterator, callback) {
-    if (arguments.length === 3) {
+    if ((typeof limit) === 'function') {
       callback = iterator;
       iterator = limit;
       limit = 1;
@@ -37,34 +45,57 @@ module.exports = function(self, options) {
   };
 
   // Invoke the iterator function once for each document in the given collection.
-  // If only three arguments are given, `limit` is assumed to be 1 (only one
+  // If `limit` is omitted, `limit` is assumed to be 1 (only one
   // doc may be processed at a time).
   //
   // This method will never visit the same document twice in a single call, even if
   // modifications are made.
   //
   // THIS API IS FOR MIGRATION AND TASK USE ONLY AND HAS NO SECURITY.
+  //
+  // The iterator is passed a document and a callback. If the iterator
+  // accepts only one parameter, it is assumed to return a promise,
+  // which is awaited in lieu of a callback.
 
   self.each = function(collection, criteria, limit, iterator, callback) {
-    if (arguments.length === 4) {
+    if ((typeof limit) === 'function') {
       callback = iterator;
       iterator = limit;
       limit = 1;
     }
 
-    // Sort by _id. This ensures that no document is
-    // ever visited twice, even if we modify documents as
-    // we go along.
-    //
-    // Otherwise there can be unexpected results from find()
-    // in typical migrations as the changes we make can
-    // affect the remainder of the query.
-    //
-    // https://groups.google.com/forum/#!topic/mongodb-user/AFC1ia7MHzk
+    if (callback) {
+      return body(callback);
+    } else {
+      return Promise.promisify(body)();
+    }
 
-    var cursor = collection.find(criteria);
-    cursor.sort({ _id: 1 });
-    return broadband(cursor, limit, iterator, callback);
+    function body(callback) {
+      var cursor = collection.find(criteria);
+      // Sort by _id. This ensures that no document is
+      // ever visited twice, even if we modify documents as
+      // we go along.
+      //
+      // Otherwise there can be unexpected results from find()
+      // in typical migrations as the changes we make can
+      // affect the remainder of the query.
+      //
+      // https://groups.google.com/forum/#!topic/mongodb-user/AFC1ia7MHzk
+      cursor.sort({ _id: 1 });
+      return broadband(cursor, limit, function(doc, callback) {
+        if (iterator.length === 1) {
+          return Promise.try(function() {
+            return iterator(doc);
+          }).then(function() {
+            return callback(null);
+          }).catch(function(err) {
+            return callback(err);
+          });
+        } else {
+          return iterator(doc, callback);
+        }
+      }, callback);
+    }
   };
 
   // Invoke the iterator function once for each area in each doc in
@@ -78,64 +109,105 @@ module.exports = function(self, options) {
   // This method will never visit the same doc twice in a single call, even if
   // modifications are made.
   //
+  // If `callback` is omitted, a promise is returned.
+  //
+  // If the iterator accepts only four parameters, it is assumed to
+  // return a promise. The promise is awaited, and the
+  // iterator must NOT invoke its callback.
+  //
   // THIS API IS FOR MIGRATION AND TASK USE ONLY AND HAS NO SECURITY.
   //
   // YOUR ITERATOR MUST BE ASYNCHRONOUS.
 
   self.eachArea = function(criteria, limit, iterator, callback) {
-    if (arguments.length === 3) {
+    if ((typeof limit) === 'function') {
       callback = iterator;
       iterator = limit;
       limit = 1;
     }
-    return self.eachDoc(criteria, limit, function(doc, callback) {
-      var areaInfos = [];
-      self.apos.areas.walk(doc, function(area, dotPath) {
-        areaInfos.push({ area: area, dotPath: dotPath });
-      });
-      return async.eachSeries(areaInfos, function(areaInfo, callback) {
-        return iterator(doc, areaInfo.area, areaInfo.dotPath, callback);
-      }, function(err) {
-        if (err) {
-          return callback(err);
-        }
-        // Prevent stack crash when a lot of docs have no areas to iterate
-        return setImmediate(callback);
-      });
-    }, callback);
+    if (callback) {
+      return body(callback);
+    } else {
+      return Promise.promisify(body)();
+    }
+    function body(callback) {
+      return self.eachDoc(criteria, limit, function(doc, callback) {
+        var areaInfos = [];
+        self.apos.areas.walk(doc, function(area, dotPath) {
+          areaInfos.push({ area: area, dotPath: dotPath });
+        });
+        return async.eachSeries(areaInfos, function(areaInfo, callback) {
+          if (iterator.length === 3) {
+            return Promise.try(function() {
+              return iterator(doc, areaInfo.area, areaInfo.dotPath);
+            }).then(function() {
+              return callback(null);
+            }).catch(callback);
+          }
+          return iterator(doc, areaInfo.area, areaInfo.dotPath, callback);
+        }, function(err) {
+          if (err) {
+            return callback(err);
+          }
+          // Prevent stack crash when a lot of docs have no areas to iterate
+          return setImmediate(callback);
+        });
+      }, callback);
+    }
   };
 
   // Invoke the iterator function once for each widget in each area in each doc
-  // in the aposDocs collection. The `iterator` function receives
-  // `(doc, widget, dotPath, callback)`. `criteria` may be used to limit
-  // the docs for which this is done.
+  // in the aposDocs collection.
   //
   // If only three arguments are given, `limit` is assumed to be 1 (only one
   // doc may be processed at a time).
+  //
+  // The `iterator` function receives `(doc, widget, dotPath, callback)`.
+  // `criteria` may be used to limit
+  // the docs for which this is done. If the iterator accepts exactly
+  // three arguments, it is assumed to return a promise, and the iterator
+  // must NOT invoke the callback.
   //
   // This method will never visit the same doc twice in a single call, even if
   // modifications are made.
   //
   // Widget loaders are NOT called.
   //
+  // If `callback` is omitted, a promise is returned.
+  //
   // THIS API IS FOR MIGRATION AND TASK USE ONLY AND HAS NO SECURITY.
   //
   // YOUR ITERATOR MUST BE ASYNCHRONOUS.
 
   self.eachWidget = function(criteria, limit, iterator, callback) {
-    if (arguments.length === 3) {
+    if ((typeof limit) === 'function') {
       callback = iterator;
       iterator = limit;
       limit = 1;
     }
-    return self.eachArea(criteria, limit, function(doc, area, dotPath, callback) {
-      var i = 0;
-      return async.eachSeries(area.items || [], function(item, callback) {
-        var n = i;
-        i++;
-        return iterator(doc, item, dotPath + '.items.' + n, callback);
+    if (callback) {
+      return body(callback);
+    } else {
+      return Promise.promisify(body)();
+    }
+    function body(callback) {
+      return self.eachArea(criteria, limit, function(doc, area, dotPath, callback) {
+        var i = 0;
+        return async.eachSeries(area.items || [], function(item, callback) {
+          var n = i;
+          i++;
+          if (iterator.length === 3) {
+            return Promise.try(function() {
+              return iterator(doc, item, dotPath + '.items.' + n);
+            }).then(function() {
+              return callback(null);
+            }).catch(callback);
+          } else {
+            return iterator(doc, item, dotPath + '.items.' + n, callback);
+          }
+        }, callback);
       }, callback);
-    }, callback);
+    }
   };
 
   // Most of the time, this is called automatically for you. Any

--- a/lib/modules/apostrophe-migrations/lib/implementation.js
+++ b/lib/modules/apostrophe-migrations/lib/implementation.js
@@ -1,5 +1,6 @@
 var async = require('async');
 var _ = require('@sailshq/lodash');
+var Promise = require('bluebird');
 
 module.exports = function(self, options) {
 
@@ -65,6 +66,76 @@ module.exports = function(self, options) {
     // Add our own migration at the last possible minute so we can
     // prepend before all others
     self.addCollectionMigration();
+    // Here because if we add it in apostrophe-pieces it will
+    // actually be added once per subclass which is inefficient
+    self.addDeduplicatePiecesInTrashMigration();
+    // Here for consistency with the above
+    self.addDeduplicatePagesInTrashMigration();
+  };
+
+  self.addDeduplicatePiecesInTrashMigration = function() {
+    var req = self.apos.tasks.getReq();
+    return self.apos.migrations.add('deduplicatePiecesInTrash', function() {
+      return self.apos.migrations.eachDoc({
+        trash: true,
+        $and: [
+          {
+            slug: {
+              $not: /^\//
+            }
+          }, {
+            slug: {
+              $not: /deduplicate/
+            }
+          }
+        ]
+      }, function(piece) {
+        var manager = self.apos.docs.getManager(piece.type);
+        if (!manager) {
+          return;
+        }
+        if (!self.apos.synth.instanceOf(manager, 'apostrophe-pieces')) {
+          return;
+        }
+        return Promise.promisify(manager.deduplicateTrash)(req, piece);
+      });
+    });
+  };
+
+  self.addDeduplicatePagesInTrashMigration = function() {
+    if (!self.apos.docs.trashInSchema) {
+      // This mechanism is not used for pages unless trash is an
+      // ordinary schema field rather than a place in the tree
+      return;
+    }
+    var req = self.apos.tasks.getReq();
+    return self.apos.migrations.add('deduplicatePagesInTrash', function() {
+      return self.apos.migrations.eachDoc({
+        trash: true,
+        $and: [
+          {
+            slug: /^\//
+          }, {
+            slug: {
+              $not: /deduplicate/
+            }
+          }
+        ]
+      }, function(page) {
+        if (page.slug === '/trash') {
+          // legacy trashcan does not get deduplicated
+          return;
+        }
+        var manager = self.apos.docs.getManager(page);
+        if (!manager) {
+          return;
+        }
+        if (!self.apos.synth.instanceOf(manager, 'apostrophe-custom-pages')) {
+          return;
+        }
+        return Promise.promisify(manager.deduplicateTrash)(req, page);
+      });
+    });
   };
 
   self.addSortifyMigrations = function() {
@@ -117,7 +188,17 @@ module.exports = function(self, options) {
         return callback(null);
       }
       self.apos.utils.log('Running database migration: ' + migration.name);
-      return migration.callback(function(err) {
+      var fn = migration.callback;
+      if (migration.callback.length === 0) {
+        fn = function(callback) {
+          return Promise.try(function() {
+            return migration.callback();
+          }).then(function() {
+            return callback(null);
+          }).catch(callback);
+        };
+      }
+      return fn(function(err) {
         if (err) {
           self.apos.utils.error(err);
           return callback(err);


### PR DESCRIPTION
…terators that return promises, and implemented migrations for old piece and page slugs that have not been deduplicated and thus can block new pages or pieces from taking a slug even though we have logic for this for new pages and pieces