### PR TITLE
Respect return values of event handlers in jQuery.fn.onSafe

### DIFF
--- a/lib/modules/apostrophe-assets/public/js/vendor/jquery.onSafe.js
+++ b/lib/modules/apostrophe-assets/public/js/vendor/jquery.onSafe.js
@@ -16,6 +16,6 @@ jQuery.fn.onSafe = function(eventType, selector, ignore, fn) {
       // Leave this event alone
       return;
     }
-    fn.call(this, event);
+    return fn.call(this, event);
   }
 };


### PR DESCRIPTION
`jQuery.fn.onSafe` would previously not pass the return value of event handlers to jQuery. That meant that even if the event handler would `return false`, event.stopPropagation and event.preventDefault would not be called.

This came up as an issue for me after the recent merging of #1638, where I now had a set of .apos-buttons inside of an area, that was wrapped in an `<a>` element. Clicking the .apos-buttons would trigger a click on the link as well, and so the browser would navigate away from the page.