### PR TITLE
ability to pass cookie options for the csrf cookie, such as secure: true

### DIFF
--- a/lib/modules/apostrophe-express/index.js
+++ b/lib/modules/apostrophe-express/index.js
@@ -147,6 +147,21 @@
 // is unnecessary because the password itself is unknown to the
 // third party site; it effectively serves as an XSRF token.
 //
+// You can also pass options to the Express [`res.cookie`](https://expressjs.com/en/api.html#res.cookie) call that sets the cookie:
+//
+// ```javascript
+// csrf: {
+//   exceptions: [ '/cheesy-post-route' ],
+//   cookie: {
+//     // Send it only if the request is HTTPS
+//     secure: true
+//   }
+// }
+// ```
+//
+// Do not set the `httpOnly` flag as this will prevent legitimate same-origin
+// JavaScript from adding it to requests.
+// 
 // ### middleware
 //
 // If a `middleware` array is present, those functions are added
@@ -491,12 +506,12 @@ module.exports = {
         }
         // Reset the cookie so that if its lifetime somehow detaches from
         // that of the session cookie we're still OK
-        res.cookie(self.apos.csrfCookieName, token);
+        res.cookie(self.apos.csrfCookieName, token, (self.options.csrf && self.options.csrf.cookie) || {});
       } else {
         // All non-safe requests must be preceded by a safe request that establishes
         // the CSRF token, both as a cookie and in the session. Otherwise a user who is logged
         // in but doesn't currently have a CSRF token is still vulnerable.
-        // See options.csrfExceptions
+        // See options.csrf.exceptions
         if ((!req.cookies[self.apos.csrfCookieName]) || (req.get('X-XSRF-TOKEN') !== req.cookies[self.apos.csrfCookieName]) || (req.session['XSRF-TOKEN'] !== req.cookies[self.apos.csrfCookieName])) {
           res.statusCode = 403;
           return res.send('forbidden');


### PR DESCRIPTION
This addresses security scanner concerns about the cookie being potentially sent in response to HTTP as well as HTTPS requests.