### PR TITLE
Unique slug ui

### DIFF
--- a/lib/modules/apostrophe-doc-type-manager/index.js
+++ b/lib/modules/apostrophe-doc-type-manager/index.js
@@ -35,6 +35,7 @@ module.exports = {
     self.pushAssets();
     self.pushDefineSingleton();
     self.addSearchIndexListener();
+    self.addSlugPrefixMigration();
   },
 
   beforeConstruct: function(self, options) {

--- a/lib/modules/apostrophe-doc-type-manager/lib/api.js
+++ b/lib/modules/apostrophe-doc-type-manager/lib/api.js
@@ -301,6 +301,20 @@ module.exports = function(self, options) {
 
     self.patchAdminPermissionInSchema();
 
+    var slug = _.find(self.schema, { name: 'slug' });
+    if (slug) {
+      // always check for slug conflicts with other docs
+      slug.checkTaken = true;
+      if (self.options.slugPrefix) {
+        slug.prefix = self.options.slugPrefix;
+      }
+      if (self.apos.docs.options.deconflictSlugs === false) {
+        // Developer prefers no automatic resolution of
+        // conflicts, even during title entry
+        slug.deconflict = false;
+      }
+    }
+
   };
 
   // In the schema, `_editUsers` and `_editGroups` are
@@ -451,6 +465,28 @@ module.exports = function(self, options) {
       return;
     }
     return self.apos.migrations.addSortify(self.__meta.name, { type: self.name }, field);
+  };
+
+  self.addSlugPrefixMigration = function() {
+    if (!self.options.slugPrefix) {
+      return;
+    }
+    self.apos.migrations.add(self.__meta.name + 'SlugPrefix', function() {
+      return self.apos.migrations.eachDoc({
+        type: self.name,
+        slug: {
+          $not: new RegExp('^' + self.apos.utils.regExpQuote(self.options.slugPrefix))
+        }
+      }, function(doc) {
+        return self.apos.docs.db.update({
+          _id: doc._id
+        }, {
+          $set: {
+            slug: self.options.slugPrefix + doc.slug
+          }
+        });
+      });
+    });
   };
 
 };

--- a/lib/modules/apostrophe-docs/index.js
+++ b/lib/modules/apostrophe-docs/index.js
@@ -28,6 +28,12 @@
 // mechanism can be disabled by explicitly setting `conflictResolution`
 // to false. Doing so is *not recommended* for normal operation but has
 // valid applications in automated testing.
+//
+// **`deconflictSlugs`: by default, Apostrophe will suggest nonconflicting
+// slugs based on the title as the user types the title of a page or piece.
+// If you do not want this feature and would prefer that the user encouter
+// a clear error message every time their slug is in conflict, forcing
+// them to make a manual choice, explicitly set this option to `false`.
 
 var async = require('async');
 

--- a/lib/modules/apostrophe-docs/lib/routes.js
+++ b/lib/modules/apostrophe-docs/lib/routes.js
@@ -81,4 +81,38 @@ module.exports = function(self, options) {
     });
   });
 
+  self.route('post', 'slug-deconflict', function(req, res) {
+    if (!req.user) {
+      return res.status(404).send('notfound');
+    }
+    var _id = self.apos.launder.id(req.body._id);
+    var slug = self.apos.launder.string(req.body.slug);
+    var counter = 1;
+    var suffix;
+    return deconflict(slug).then(function(slug) {
+      return res.send({ status: 'ok', slug: slug });
+    }).catch(function(err) {
+      self.apos.utils.error(err);
+      return res.send({ status: 'error' });
+    });
+
+    function deconflict(slug) {
+      var criteria = {
+        slug: slug
+      };
+      if (_id) {
+        criteria._id = { $ne: _id };
+      }
+      return self.find(req, criteria).permission(false).trash(null).published(null).projection({ slug: 1 }).toObject().then(function(doc) {
+        if (doc) {
+          counter++;  
+          suffix = '-' + counter;
+          slug = slug.replace(/\-\d+$/, '') + suffix;
+          return deconflict(slug);
+        } else {
+          return slug;
+        }
+      });
+    }
+  });
 };

--- a/lib/modules/apostrophe-docs/lib/routes.js
+++ b/lib/modules/apostrophe-docs/lib/routes.js
@@ -54,4 +54,31 @@ module.exports = function(self, options) {
     );
   });
 
+  // Determine if a particular slug is available. Since the slug namespace
+  // is shared by all doc types, you only need to be a user to access this
+  // route. No other information about the document with that slug is returned
+  self.route('post', 'slug-taken', function(req, res) {
+    if (!req.user) {
+      return res.status(404).send('notfound');
+    }
+    var slug = self.apos.launder.string(req.body.slug);
+    var _id = self.apos.launder.id(req.body._id);
+    var criteria = {
+      slug: slug
+    };
+    if (_id) {
+      criteria._id = { $ne: _id };
+    }
+    return self.find(req, criteria).permission(false).trash(null).published(null).projection({ slug: 1 }).toObject().then(function(doc) {
+      if (doc) {
+        return res.send({ status: 'taken' });
+      } else {
+        return res.send({ status: 'ok' });
+      }
+    }).catch(function(err) {
+      self.apos.utils.error(err);
+      return res.send({ status: 'error' });
+    });
+  });
+
 };

--- a/lib/modules/apostrophe-docs/lib/routes.js
+++ b/lib/modules/apostrophe-docs/lib/routes.js
@@ -105,9 +105,9 @@ module.exports = function(self, options) {
       }
       return self.find(req, criteria).permission(false).trash(null).published(null).projection({ slug: 1 }).toObject().then(function(doc) {
         if (doc) {
-          counter++;  
+          counter++;
           suffix = '-' + counter;
-          slug = slug.replace(/\-\d+$/, '') + suffix;
+          slug = slug.replace(/-\d+$/, '') + suffix;
           return deconflict(slug);
         } else {
           return slug;

--- a/lib/modules/apostrophe-pages/public/js/editor.js
+++ b/lib/modules/apostrophe-pages/public/js/editor.js
@@ -95,7 +95,10 @@ apos.define('apostrophe-pages-editor', {
     // before that happens, the afterSave method is provided and can be overridden
     // as you see fit.
     self.saveContent = function(callback) {
-      var page = {};
+      var page = {
+        // provide _id so the slug deconfliction code knows
+        _id: self.page._id
+      };
       var data;
       return async.series({
         convert: function(callback) {

--- a/lib/modules/apostrophe-pieces/index.js
+++ b/lib/modules/apostrophe-pieces/index.js
@@ -6,6 +6,19 @@
 // into pages all over the site. To learn more, see:
 //
 // [Reusable content with pieces](../tutorials/getting-started/reusable-content-with-pieces.html)
+//
+// ## Options
+//
+// ### `slugPrefix`
+//
+// If set this string, which typically should end with `-`, will be prepended
+// to the slugs of all pieces of this type in order to prevent needless
+// conflicts with the slugs of other piece types.
+//
+// ## More Options
+//
+// See [reusable content with pieces](../tutorials/getting-started/reusable-content-with-pieces.html)
+// for many additional options.
 
 var _ = require('@sailshq/lodash');
 

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -99,6 +99,7 @@ apos.define('apostrophe-schemas', {
       }
 
       self.enableSlug($title, $slug, title, slug);
+      self.watchSlugConflicts($title, $slug, title, slug, object);
     };
 
     // Gather data from form elements and push it into properties of the data
@@ -533,10 +534,39 @@ apos.define('apostrophe-schemas', {
         prefix = $slug.data('prefix') + '-';
       }
       if ((originalTitle === '') || (currentSlugTitle === apos.utils.slugify(prefix + originalTitle))) {
-        $title.on('change keyup paste', function(e) {
+        $title.on('textchange', function(e) {
           $slug.val($slug.val().replace(/[^/]*$/, apos.utils.slugify(prefix + $title.val())));
         });
       }
+    };
+
+    self.watchSlugConflicts = function($title, $slug, title, slug, object) {
+      if (!slug.checkTaken) {
+        return;
+      }
+      if (slug.deconflict === false) {
+        return;
+      }
+      var watchSlugTimeout;
+      $title.off('textchange.watchSlugConflicts');
+      $title.on('textchange.watchSlugConflicts', function() {
+        if (watchSlugTimeout) {
+          return;
+        }
+        watchSlugTimeout = setTimeout(watchSlug, 500);
+        function watchSlug() {
+          $.jsonCall(apos.docs.options.action + '/slug-deconflict', {
+            _id: object._id,
+            slug: $slug.val()
+          }, function(result) {
+            clearTimeout(watchSlugTimeout);
+            watchSlugTimeout = null;
+            if (result.status === 'ok') {
+              $slug.val(result.slug);
+            }
+          });
+        }
+      });
     };
 
     self.enableShowFields = function(data, name, $field, $el, field) {
@@ -966,61 +996,14 @@ apos.define('apostrophe-schemas', {
 
     self.addFieldType({
       name: 'slug',
-      populate: function(data, name, $field, $el, field, callback) {
-        return populateString(data, name, $field, $el, field, function(err) {
-          if (err) {
-            return callback(err);
-          }
-          var $fieldset = self.findFieldset($el, name);
-          $field.off('textchange.schemaSlug');
-          $field.on('textchange.schemaSlug', function() {
-            // We'll debounce this with a timeout. We don't clear
-            // that variable until the API actually responds, so we
-            // are also safe against unexpected surprises in the order
-            // of the responses. -Tom
-            var ckTimeout;
-            checkConflict();
-            function checkConflict() {
-              if (ckTimeout) {
-                return;
-              }
-              ckTimeout = setTimeout(checkConflictBody, 100);
-            }
-            function checkConflictBody() {
-              var val = $field.val();
-              if (!val.length) {
-                clearError();
-                ckTimeout = null;
-                return;
-              }
-              $.jsonCall(
-                apos.docs.options.action + '/slug-taken',
-                { slug: val, _id: data._id },
-                function(data) {
-                  ckTimeout = null;
-                  if (data.status === 'ok') {
-                    clearError();
-                  } else if (data.status === 'taken') {
-                    self.showError($el, self.error(field, 'taken'));
-                  }
-                }, function(err) {
-                  ckTimeout = null;
-                  checkConflict();
-                }
-              );
-            }
-            function clearError() {
-              $fieldset.removeClass('apos-error--taken');
-              if (!$fieldset.is('[class^="apos-error--"]')) {
-                $fieldset.removeClass('apos-error');
-              }
-            }
-          });
-          return callback(null);
-        });
-      },
+      populate: populateString,
       convert: function(data, name, $field, $el, field, callback) {
         return convertString(data, name, $field, $el, field, function(err) {
+          if (!field.checkTaken) {
+            // A slug field being used for a purpose other
+            // than an apostrophe doc
+            return callback(null);
+          }
           if (err) {
             return callback(err);
           }

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -220,6 +220,9 @@ apos.define('apostrophe-schemas', {
         case 'invalid':
           error.message = 'Value is not valid';
           break;
+        case 'taken':
+          error.message = 'Already taken';
+          break;
       }
       return error;
     };
@@ -707,53 +710,6 @@ apos.define('apostrophe-schemas', {
           return callback('required');
         }
         return setImmediate(callback);
-      },
-      contextualConvert: function(data, name, $el, field) {
-        // We cannot call getWidgetData here because of recursion
-        var existingData = JSON.parse($el.attr('data') || '{}');
-        if (!existingData) {
-          return;
-        }
-        var dotPath = existingData.__dotPath;
-        var docId = existingData.__docId;
-        if (!dotPath && docId) {
-          return;
-        }
-        existingData = existingData[name];
-        if (!existingData) {
-          return;
-        }
-        // Contextually convert any areas
-        // that are fields of this array field
-        _.each(field.schema, function(sub) {
-          if ((sub.type !== 'area') && (sub.type !== 'singleton')) {
-            return;
-          }
-          var n = 0;
-          while (true) {
-            var selector = '[data-apos-area][data-doc-id="' + docId + '"][data-dot-path="' + dotPath + '.' + name + '.' + n + '.' + sub.name + '"]';
-            var $area = $el.find(selector);
-            if (!$area.length) {
-              break;
-            }
-            var editor = $area.data('editor');
-            if (editor) {
-              if (existingData[n]) {
-                existingData[n][sub.name] = {
-                  type: 'area',
-                  items: editor.serialize()
-                };
-              }
-            }
-            n++;
-          }
-        });
-        data[name] = existingData;
-      },
-      // Always returns true because it is designed to work nondestructively
-      // with fields that don't turn out to be contextual
-      contextualIsPresent: function($el, field) {
-        return true;
       }
     });
 
@@ -1010,8 +966,82 @@ apos.define('apostrophe-schemas', {
 
     self.addFieldType({
       name: 'slug',
-      populate: populateString,
-      convert: convertString
+      populate: function(data, name, $field, $el, field, callback) {
+        return populateString(data, name, $field, $el, field, function(err) {
+          if (err) {
+            return callback(err);
+          }
+          var $fieldset = self.findFieldset($el, name);
+          $field.off('textchange.schemaSlug');
+          $field.on('textchange.schemaSlug', function() {
+            // We'll debounce this with a timeout. We don't clear
+            // that variable until the API actually responds, so we
+            // are also safe against unexpected surprises in the order
+            // of the responses. -Tom
+            var ckTimeout;
+            checkConflict();
+            function checkConflict() {
+              if (ckTimeout) {
+                return;
+              }
+              ckTimeout = setTimeout(checkConflictBody, 100);
+            }
+            function checkConflictBody() {
+              var val = $field.val();
+              if (!val.length) {
+                clearError();
+                ckTimeout = null;
+                return;
+              }
+              $.jsonCall(
+                apos.docs.options.action + '/slug-taken',
+                { slug: val, _id: data._id },
+                function(data) {
+                  ckTimeout = null;
+                  if (data.status === 'ok') {
+                    clearError();
+                  } else if (data.status === 'taken') {
+                    self.showError($el, self.error(field, 'taken'));
+                  }
+                }, function(err) {
+                  ckTimeout = null;
+                  checkConflict();
+                }
+              );
+            }
+            function clearError() {
+              $fieldset.removeClass('apos-error--taken');
+              if (!$fieldset.is('[class^="apos-error--"]')) {
+                $fieldset.removeClass('apos-error');
+              }
+            }
+          });
+          return callback(null);
+        });
+      },
+      convert: function(data, name, $field, $el, field, callback) {
+        return convertString(data, name, $field, $el, field, function(err) {
+          if (err) {
+            return callback(err);
+          }
+          $.jsonCall(
+            apos.docs.options.action + '/slug-taken',
+            { slug: data[name], _id: data._id },
+            function(data) {
+              if (data.status === 'ok') {
+                return callback(null);
+              } else if (data.status === 'taken') {
+                return callback('taken');
+              } else {
+                return callback('error');
+              }
+            }, function(err) {
+              apos.utils.error(err);
+              return callback(err);
+            }
+          );
+        });
+      }
     });
 
     self.addFieldType({
@@ -1057,7 +1087,6 @@ apos.define('apostrophe-schemas', {
         for (var c in data[name]) {
           self.findSafe($fieldset, 'input[name="' + name + '"][value="' + data[name][c] + '"]', '.apos-field').prop('checked', true);
         }
-        self.enableShowFields(data, name, $field, $el, field);
         return setImmediate(callback);
       },
       convert: function(data, name, $field, $el, field, callback) {

--- a/lib/modules/apostrophe-users/index.js
+++ b/lib/modules/apostrophe-users/index.js
@@ -62,6 +62,9 @@ module.exports = {
   adminOnly: true,
   // Means not included in public sitewide search. -Tom
   searchable: false,
+  // Always prefix slugs for this type of piece to prevent conflicts
+  // with frontend pieces
+  slugPrefix: 'user-',
 
   afterConstruct: function(self, callback) {
     self.initializeCredential();
@@ -95,7 +98,6 @@ module.exports = {
         type: 'slug',
         name: 'slug',
         label: 'Slug',
-        prefix: 'user',
         required: true
       },
       {


### PR DESCRIPTION
Implemented per discussion with @carlykaras and @stuartromanek:

* If you are editing the title and Apostrophe is suggesting slugs for you, those slugs are automatically deconflicted. This is the common use case for automatically resolving this problem.

 However, the deconfliction can be turned off via `deconflictSlugs: false` as an option to the `apostrophe-docs` module, to meet the original specifications of an enterprise client interested in this change.

* If you are editing the slug directly, there is no automatic deconfliction. Instead, there is a clear error message when you attempt to save, because attempting to deconflict things interactively as the user is typing a slug or automatically adding a suffix to it so it is "an error, but not any more, not really" would be too confusing.

* In addition, all pieces modules can now accept a `slugPrefix` option. If present this becomes a prefix to all slugs of that document type, preventing conflict in most of the cases in which it used to come up.

* Finally, a migration is automatically supplied for every module that uses `slugPrefix` to check for slugs without the prefix and fix them.
