### PR TITLE
Button element breaks jQuery UI Draggable's drag handles

### DIFF
--- a/lib/modules/apostrophe-areas/lib/api.js
+++ b/lib/modules/apostrophe-areas/lib/api.js
@@ -479,7 +479,8 @@ module.exports = function(self, options) {
         controls: [
           {
             icon: 'arrows',
-            action: 'drag-item'
+            action: 'drag-item',
+            url: '#'
           },
           {
             icon: 'arrow-up',


### PR DESCRIPTION
Anchor elements can still be created by the button macros by passing a `url` parameter through their options. `<button>` elements don't seem to be compatible drag handles for jQuery UI so fake in an `<a>` element with a `url` of `#`. Addresses #1680 