### PR TITLE
concats rather than replaces html-widget fields

### DIFF
--- a/lib/modules/apostrophe-html-widgets/index.js
+++ b/lib/modules/apostrophe-html-widgets/index.js
@@ -12,7 +12,7 @@ module.exports = {
   label: 'Raw HTML',
 
   beforeConstruct: function(self, options) {
-    options.addFields = options.addFields || [
+    var addFields = [
       {
         type: 'string',
         name: 'code',
@@ -21,6 +21,8 @@ module.exports = {
         help: 'Be careful when embedding third-party code, as it can break the website editing functionality. If a page becomes unusable, add "?safe_mode=1" to the URL to make it work temporarily without the problem code being rendered.'
       }
     ];
+
+    options.addFields = addFields.concat(options.addFields || []);
   },
   afterConstruct: function(self) {
     self.addHelper();


### PR DESCRIPTION
I realize this risks a BC break, but it seems like an oversight. Was there a reason that the HTML widget doesn't concat its `addFields` with the `options.addFields` now?

I think this might only be a BC break if someone has an HTML widget extension that intentionally leaves out the `code` field for the embed code. Which would be odd.