### PR TITLE
Missing values for join relationships relating to permissions should be fixed by a one-time migration in apostrophe, not redundantly in workflow

### DIFF
--- a/lib/modules/apostrophe-docs/lib/api.js
+++ b/lib/modules/apostrophe-docs/lib/api.js
@@ -289,6 +289,9 @@ module.exports = function(self, options) {
   //
   // The `options` object is for future extension and is passed on
   // to this method by `insert` and `update`.
+  //
+  // This method also repairs any properties related to these which are null
+  // rather than a properly empty array or object.
 
   self.denormalizePermissions = function(req, doc, options, callback) {
     var fields = {
@@ -297,8 +300,17 @@ module.exports = function(self, options) {
       editGroupsIds: 'edit',
       editUsersIds: 'edit'
     };
+    _.each([
+      'viewUsersRelationships',
+      'viewGroupsRelationships',
+      'editUsersRelationships',
+      'editGroupsRelationships'
+    ], function(name) {
+      doc[name] = doc[name] || {};
+    });
     var docPermissions = [];
     _.each(fields, function(prefix, name) {
+      doc[name] = doc[name] || [];
       docPermissions = docPermissions.concat(
         _.map(doc[name] || [], function(id) {
           return prefix + '-' + id;

--- a/lib/modules/apostrophe-migrations/lib/implementation.js
+++ b/lib/modules/apostrophe-migrations/lib/implementation.js
@@ -194,8 +194,8 @@ module.exports = function(self, options) {
           return Promise.try(function() {
             return migration.callback();
           }).then(function() {
-            return callback(null);
-          }).catch(callback);
+            return done(null);
+          }).catch(done);
         };
       }
       return fn(function(err) {
@@ -203,8 +203,16 @@ module.exports = function(self, options) {
           self.apos.utils.error(err);
           return callback(err);
         }
-        return self.db.insert({ _id: migration.name, at: new Date() }, callback);
+        return self.db.insert({ _id: migration.name, at: new Date() }, done);
       });
+      function done(err) {
+        if (err) {
+          return callback(err);
+        } else {
+          self.apos.utils.log('Completed database migration: ' + migration.name);
+          return callback(null);
+        }
+      }
     });
   };
 };

--- a/lib/modules/apostrophe-users/index.js
+++ b/lib/modules/apostrophe-users/index.js
@@ -702,11 +702,10 @@ module.exports = {
           'editGroupsRelationships': {}
         };
         return Promise.mapSeries(_.keys(fields), function(name) {
-          self.apos.utils.info('nnj migration for ' + name);
           var criteria = {};
-          criteria[field] = { $type: 10 };
+          criteria[name] = { $type: 10 };
           var $set = {};
-          $set[field] = fields[name];
+          $set[name] = fields[name];
           return self.apos.docs.db.update(criteria, {
             $set: $set
           }, {

--- a/lib/modules/apostrophe-users/index.js
+++ b/lib/modules/apostrophe-users/index.js
@@ -70,6 +70,7 @@ module.exports = {
     self.initializeCredential();
     self.addOurTrashPrefixFields();
     self.enableSecrets();
+    self.addNonNullJoinMigration();
     return async.series([
       self.ensureGroups,
       self.ensureSafe
@@ -688,5 +689,31 @@ module.exports = {
       });
     });
 
+    self.addNonNullJoinMigration = function() {
+      self.apos.migrations.add(self.__meta.name + ':non-null-joins', function() {
+        var fields = {
+          'viewUsersIds': [],
+          'viewGroupsIds': [],
+          'editUsersIds': [],
+          'editGroupsIds': [],
+          'viewUsersRelationships': {},
+          'viewGroupsRelationships': {},
+          'editUsersRelationships': {},
+          'editGroupsRelationships': {}
+        };
+        return Promise.mapSeries(_.keys(fields), function(name) {
+          self.apos.utils.info('nnj migration for ' + name);
+          var criteria = {};
+          criteria[field] = { $type: 10 };
+          var $set = {};
+          $set[field] = fields[name];
+          return self.apos.docs.db.update(criteria, {
+            $set: $set
+          }, {
+            multi: true
+          });
+        });
+      });
+    };
   }
 };


### PR DESCRIPTION
This migration code was loose in the add-missing-locales task of workflow which meant it happened more than once. It's quite slow because it requires an unindexed query. That's OK once but not every time somebody adds a locale.