### PR TITLE
oops: moving a page beneath a parent that is not in the trash was for…

### DIFF
--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -568,11 +568,15 @@ module.exports = function(self, options) {
         }
         moved.level = level;
         moved.rank = rank;
-        // Are we in the trashcan? Our new parent reveals that
-        if (parent.trash) {
-          moved.trash = true;
-        } else {
-          delete moved.trash;
+        // Are we in the trashcan? Our new parent reveals that,
+        // but only if trash is a place in the tree rather than a
+        // simple schema field
+        if (!self.apos.docs.trashInSchema) {
+          if (parent.trash) {
+            moved.trash = true;
+          } else {
+            delete moved.trash;
+          }
         }
         return self.update(req, moved, callback);
       }

--- a/test/pages-trash-in-schema.js
+++ b/test/pages-trash-in-schema.js
@@ -1,10 +1,7 @@
 var t = require('../test-lib/test.js');
 var assert = require('assert');
-var _ = require('@sailshq/lodash');
-var request = require('request');
 
 var apos;
-var homeId;
 
 describe('Pages', function() {
 
@@ -59,7 +56,6 @@ describe('Pages', function() {
     return apos.pages.find(apos.tasks.getAnonReq(), { level: 0 }).toObject(function(err, home) {
       assert(!err);
       assert(home);
-      homeId = home._id;
       assert(home.slug === '/');
       assert(home.path === '/');
       assert(home.type === 'home');

--- a/test/pages-trash-in-schema.js
+++ b/test/pages-trash-in-schema.js
@@ -1,0 +1,121 @@
+var t = require('../test-lib/test.js');
+var assert = require('assert');
+var _ = require('@sailshq/lodash');
+var request = require('request');
+
+var apos;
+var homeId;
+
+describe('Pages', function() {
+
+  this.timeout(t.timeout);
+
+  after(function(done) {
+    return t.destroy(apos, done);
+  });
+
+  // EXISTENCE
+
+  it('should be a property of the apos object', function(done) {
+    apos = require('../index.js')({
+      root: module,
+      shortName: 'test',
+
+      modules: {
+        'apostrophe-express': {
+          secret: 'xxx',
+          port: 7900
+        },
+        'apostrophe-docs': {
+          trashInSchema: true
+        },
+        'apostrophe-pages': {
+          park: [],
+          types: [
+            {
+              name: 'home',
+              label: 'Home'
+            },
+            {
+              name: 'testPage',
+              label: 'Test Page'
+            }
+          ]
+        }
+      },
+      afterInit: function(callback) {
+        assert(apos.pages);
+        apos.argv._ = [];
+        return callback(null);
+      },
+      afterListen: function(err) {
+        assert(!err);
+        done();
+      }
+    });
+  });
+
+  it('parked homepage exists', function(done) {
+    return apos.pages.find(apos.tasks.getAnonReq(), { level: 0 }).toObject(function(err, home) {
+      assert(!err);
+      assert(home);
+      homeId = home._id;
+      assert(home.slug === '/');
+      assert(home.path === '/');
+      assert(home.type === 'home');
+      assert(home.parked);
+      assert(home.published);
+      done();
+    });
+  });
+
+  it('should be able to use db to insert documents (one is trash)', function(done) {
+    var testItems = [
+      { _id: 'one',
+        type: 'testPage',
+        slug: '/one',
+        published: true,
+        path: '/one',
+        level: 1,
+        rank: 0
+      },
+      {
+        _id: 'two',
+        type: 'testPage',
+        slug: '/two',
+        published: true,
+        path: '/two',
+        level: 1,
+        rank: 1,
+        trash: true
+      }
+    ];
+
+    apos.docs.db.insert(testItems, function(err) {
+      assert(!err);
+      done();
+    });
+
+  });
+
+  it('should be able to move second page above first page in tree without changing its trash status', function(done) {
+    apos.pages.move(apos.tasks.getReq(), 'two', 'one', 'before', function(err) {
+      if (err) {
+        console.log(err);
+      }
+      assert(!err);
+      var cursor = apos.pages.find(apos.tasks.getAnonReq(), { _id: 'two' }).trash(true);
+      cursor.toObject(function(err, page) {
+        if (err) {
+          console.log(err);
+        }
+        assert(!err);
+        assert(page.rank === 0);
+        assert(page.trash);
+        done();
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
…cing it out of the trash even when workflow is active and trash-ness is just another schema field that is not supposed to be based on location in the tree, this prematurely made pages live across many locales when moved via reorganize. Tests included