### PR TITLE
added missing eachSeries callback to asset bundle cleanup

### DIFF
--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -343,7 +343,7 @@ module.exports = {
         function lock(callback) {
           return self.apos.locks.lock(self.__meta.name, function(err) {
             locked = !err;
-            return callback(null);
+            return callback(err);
           });
         }
 
@@ -373,7 +373,7 @@ module.exports = {
               return setImmediate(callback);
             }
             return removeGeneration(generation, callback);
-          });
+          }, callback);
         }
 
         function removeGeneration(generation, callback) {


### PR DESCRIPTION
That prevents the cleanup routine from holding a lock forever. Very simple and common async module bug reported by enterprise client.

Also added missing provision to stop if the lock method fails completely.

TEST PROCEDURE FOLLOWED (I do not think you need to duplicate this to review this simple fix):

Background: 

https://apostrophecms.org/docs/tutorials/howtos/deploying-apostrophe-in-the-cloud-with-heroku.html#efficient-asset-delivery

I manually tested this via several runs of:

```
APOS_MINIFY=1 node app apostrophe:generation --create-bundle=prod-bundle --sync-to-uploadfs
```

Followed by:

```
APOS_MINIFY=1 APOS_BUNDLE=prod-bundle APOS_BUNDLE_IN_UPLOADFS=1 APOS_BUNDLE_CLEANUP_DELAY=1000 node app
```

This yielded just one folder in `public/uploads/assets` that actually had any files. (There is an unrelated issue with the local uploadfs backend that means you sometimes have empty directories lying about depending on when the app is terminated. Not a concern here because in practice you'd be using S3, although local is OK for testing this code which is in a separate layer.) And in addition temporarily added console.log statements showed that the eachSeries call now terminates properly, returning control and allowing the lock to be released.
