### PR TITLE
feat(date): add locale parameter to date filter

### DIFF
--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -418,7 +418,7 @@ module.exports = {
         if (!date) {
           return '';
         }
-        var dateLocale = locale || 'en';
+        var dateLocale = locale || self.apos.templates.contextReq.locale;
         moment.locale(dateLocale);
         var s = moment(date).format(format);
         return s;

--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -419,7 +419,7 @@ module.exports = {
           return '';
         }
         moment.locale(locale);  
-        var s = moment.(date).format(format);
+        var s = moment(date).format(format);
         return s;
       });
 

--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -411,14 +411,15 @@ module.exports = {
       // Format the given date with the given momentjs
       // format string.
 
-      env.addFilter('date', function(date, format) {
+      env.addFilter('date', function(date, format, locale='en') {
         // Nunjucks is generally highly tolerant of bad
         // or missing data. Continue this tradition by not
         // crashing if date is null. -Tom
         if (!date) {
           return '';
         }
-        var s = moment(date).format(format);
+        moment.locale(locale);  
+        var s = moment.(date).format(format);
         return s;
       });
 

--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -411,14 +411,15 @@ module.exports = {
       // Format the given date with the given momentjs
       // format string.
 
-      env.addFilter('date', function(date, format, locale='en') {
+      env.addFilter('date', function(date, format, locale) {
         // Nunjucks is generally highly tolerant of bad
         // or missing data. Continue this tradition by not
         // crashing if date is null. -Tom
         if (!date) {
           return '';
         }
-        moment.locale(locale);  
+        var dateLocale = locale || 'en';
+        moment.locale(dateLocale);
         var s = moment(date).format(format);
         return s;
       });


### PR DESCRIPTION
default locale is `en`, date filter can be called as `date(format, locale)`