### PR TITLE
Bless relationship nested objects

### DIFF
--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -2014,6 +2014,11 @@ module.exports = {
       },
       bless: function(req, field) {
         self.apos.utils.bless(req, field, 'join');
+        _.each(field.relationship, function (elem) {
+          if (elem.schema) {
+            self.bless(req, elem.schema);
+          }
+        });
       },
       join: function(req, field, objects, options, callback) {
         return self.joinDriver(req, joinr.byArray, false, objects, field.idsField, field.relationshipsField, field.name, options, callback);


### PR DESCRIPTION
In a `joinByArray` field, a "relationship" property cannot have a nested object. 

For example, this field will trigger the warning ("unblessed array") and will not save the "relationship" data:
```
{
  name: '_whatever-join',
  type: 'joinByArray',
  filters: {
    projection: {
      title: 1,
      slug: 1
    }
  },
  relationship: [
    {
      name: 'nestedStructure',
      label: 'Nested Structure',
      type: 'array',
      schema: [
        {
          name: 'nestedField1',
          label: 'Nested Field 1',
          type: 'string',
          required: true
        },
        {
          name: 'nestedField2',
          label: 'Nested Field 2',
          type: 'string',
          required: true
        }
      ]
    }
  ]
}
```

This is because the `nestedStructure` array has not been blessed. To overcome this problem, I propose the following solution: bless every nested property in the `joinByArray` definition in `apostrophe-schemas`.