### PR TITLE
field types may optionally supply a showError method to intercept the…

### DIFF
--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -319,6 +319,10 @@ apos.define('apostrophe-schemas', {
 
     self.showError = function($el, error) {
       var $fieldset = self.findFieldset($el, error.field.name);
+      var type = self.fieldTypes[error.field.type];
+      if (type.showError) {
+        return type.showError($fieldset, error);
+      }
       $fieldset.addClass('apos-error');
       $fieldset.addClass('apos-error--' + apos.utils.cssName(error.type));
       if (error.message) {
@@ -757,7 +761,19 @@ apos.define('apostrophe-schemas', {
           data[name] = {};
         }
         var $fieldset = self.findFieldset($el, name);
-        self.convert($fieldset, field.schema, data[name], callback);
+        self.convert($fieldset, field.schema, data[name], function(errors) {
+          var err = null;
+          if (errors) {
+            $fieldset.data('nestedErrors', errors);
+            err = 'invalid';
+          }
+          return callback(err);
+        });
+      },
+      showError: function($fieldset, err) {
+        var nestedErrors = $fieldset.data('nestedErrors');
+        $fieldset.data('nestedErrors', null);
+        self.showError($fieldset, nestedErrors[0]);
       }
     });
 


### PR DESCRIPTION
… normal error display process, providing a chance to show an error in a nested field of an object, for instance. Implementation for the object field type. Arrays do not need one because you cannot save the array modal with errors.