### PR TITLE
Option to set cursor limit for pieces

### DIFF
--- a/lib/modules/apostrophe-pieces-widgets/index.js
+++ b/lib/modules/apostrophe-pieces-widgets/index.js
@@ -24,6 +24,9 @@ module.exports = {
   extend: 'apostrophe-widgets',
 
   loadManyById: true,
+  limitByAll: null,
+  limitByTag: null,
+  limitById: null,
 
   // cursor filters to apply when loading pieces for this widget type. A common
   // case is to restrict the `projection` filter to improve performance
@@ -95,7 +98,6 @@ module.exports = {
       choices: byChoices,
       contextual: byChoices.length <= 1
     });
-
     if (_.contains(by, 'all')) {
       addFields.push({
         type: 'integer',
@@ -106,13 +108,17 @@ module.exports = {
     }
 
     if (_.contains(by, 'id')) {
-      addFields.push({
+      var piecesField = {
         type: 'joinByArray',
         name: '_pieces',
         label: (byChoices.length > 1) ? 'Individually' : 'Select...',
         idsField: 'pieceIds',
         withType: self.pieces.name
-      });
+      };
+      if (options.limitById) {
+        piecesField.limit = options.limitById;
+      }
+      addFields.push(piecesField);
     }
 
     if (_.contains(by, 'tag')) {
@@ -248,10 +254,10 @@ module.exports = {
       var cursor = self.widgetCursor(req, {});
       if (widget.by === 'tag') {
         cursor.and({ tags: { $in: widget.tags } });
-        cursor.limit(widget.limitByTag || 5);
+        cursor.limit(self.options.limitById || widget.limitByTag || 5);
       } else if (widget.by === 'all') {
         // We are interested in everything
-        cursor.limit(widget.limitByAll || 5);
+        cursor.limit(self.options.limitById || widget.limitByAll || 5);
       } else if (widget.by === 'id') {
         // By default, "by id" goes through a separate path, but support it here
         // so that the loadOne method can be used directly and naively to load

--- a/lib/modules/apostrophe-pieces-widgets/index.js
+++ b/lib/modules/apostrophe-pieces-widgets/index.js
@@ -15,6 +15,23 @@
 // If `true` (the default), Apostrophe will take all the widgets passed to the `load` method for which pieces
 // were chosen "by id", i.e. manually in a join, and do a single query to fetch them. This is usually more efficient,
 // however if you have customized the `loadOne` method you may not wish to use it.
+//
+// ### `limitByAll`
+//
+// Integer that sets the widget cursor limit when all pieces are fetched.
+// If this option is not set, editors will be presented with the usual
+// `Maximum Displayed` schema field to set this number manually
+//
+// ### `limitByTag`
+//
+// Integer that sets the widget cursor limit when pieces are fetched by tag.
+// If this option is not set, editors will be presented with the usual
+// `Maximum Displayed` schema field to set this number manually
+//
+// ### `limitById`
+//
+// Integer that sets the widget cursor limit for fetching
+// pieces individually
 
 var _ = require('@sailshq/lodash');
 var async = require('async');
@@ -98,7 +115,8 @@ module.exports = {
       choices: byChoices,
       contextual: byChoices.length <= 1
     });
-    if (_.contains(by, 'all')) {
+
+    if (_.contains(by, 'all') && !options.limitByAll) {
       addFields.push({
         type: 'integer',
         name: 'limitByAll',
@@ -127,12 +145,15 @@ module.exports = {
         name: 'tags',
         label: 'By Tag'
       });
-      addFields.push({
-        type: 'integer',
-        name: 'limitByTag',
-        label: 'Maximum displayed',
-        def: 5
-      });
+
+      if (!options.limitByTag) {
+        addFields.push({
+          type: 'integer',
+          name: 'limitByTag',
+          label: 'Maximum displayed',
+          def: 5
+        });
+      }
     }
 
     options.addFields = addFields.concat(options.addFields || []);

--- a/lib/modules/apostrophe-pieces-widgets/index.js
+++ b/lib/modules/apostrophe-pieces-widgets/index.js
@@ -254,10 +254,10 @@ module.exports = {
       var cursor = self.widgetCursor(req, {});
       if (widget.by === 'tag') {
         cursor.and({ tags: { $in: widget.tags } });
-        cursor.limit(self.options.limitById || widget.limitByTag || 5);
+        cursor.limit(self.options.limitByTag || widget.limitByTag || 5);
       } else if (widget.by === 'all') {
         // We are interested in everything
-        cursor.limit(self.options.limitById || widget.limitByAll || 5);
+        cursor.limit(self.options.limitByAll || widget.limitByAll || 5);
       } else if (widget.by === 'id') {
         // By default, "by id" goes through a separate path, but support it here
         // so that the loadOne method can be used directly and naively to load


### PR DESCRIPTION
closes #1073 

Could be improved further by removing the `limitByAll` and `limitByTag` integer fields if these options are set. 