### PR TITLE
modulesReady for groups was overriding a universal modulesReady for a…

### DIFF
--- a/lib/modules/apostrophe-groups/index.js
+++ b/lib/modules/apostrophe-groups/index.js
@@ -65,6 +65,7 @@ module.exports = {
   construct: function(self, options) {
 
     self.modulesReady = function() {
+      self.composeBatchOperations();
       self.setPermissionsChoices();
       self.addToAdminBarIfSuitable();
     };


### PR DESCRIPTION
…ll pieces that was introduced later, grr, this is one of the reasons why we will use async events exclusively for this kind of thing in 3.x