### PR TITLE
apos.notify is available on the server

### DIFF
--- a/lib/modules/apostrophe-notifications/index.js
+++ b/lib/modules/apostrophe-notifications/index.js
@@ -1,28 +1,250 @@
-// This module provides a framework for triggering notifications within the Apostrophe admin UI.
+// This module provides a framework for triggering notifications
+// within the Apostrophe admin UI. Notifications may be triggered
+// either on the browser or the server side, via `apos.notice`.
+
+var _ = require('@sailshq/lodash');
+var Promise = require('bluebird');
 
 module.exports = {
   extend: 'apostrophe-module',
 
   construct: function(self, options) {
+
     self.pushAssets = function() {
       self.pushAsset('script', 'user', { when: 'user' });
       self.pushAsset('stylesheet', 'user', { when: 'user' });
     };
 
-    /**
-     * Render a notification partial with the passed message.
-     */
-    self.route('post', 'notification', function (req, res) {
+    // Call with `req`, then a message, followed by any interpolated strings
+    // which must correspond to %s placeholders in `message` (variable number
+    // of arguments), followed by an `options` object if desired.
+    //
+    // If you do not have a `req` it is acceptable to pass a user `_id` string
+    // in place of `req`. Someone must be the recipient.
+    //
+    // `options.type` styles the notification and may be set to `error`,
+    // `warn` or `success`. If not set, a "plain" default style is used.
+    //
+    // If `options.dismiss` is set to `true`, the message will auto-dismiss after 5 seconds.
+    // If it is set to a number of seconds, it will dismiss after that number of seconds.
+    // Otherwise it will not dismiss unless clicked.
+    //
+    // The message is internationalized, which is why the use of
+    // %s placeholders for any inserted titles, etc. is important.
+    //
+    // Throws an error if there is no `req.user`.
+    //
+    // This method is aliased as `apos.notify` for convenience.
+    //
+    // The method returns a promise, which you may await if you need
+    // to be absolutely certain the notification has been committed
+    // to the database, for instance before exiting a command line task.
+    // You may also pass a callback as a final argument.
+
+    self.trigger = function(req, message, options) {
+      var callback = arguments[arguments.length - 1];
+      if (typeof callback === 'function') {
+        return self.trigger.apply(self, Array.prototype.slice.call(arguments, 0, arguments.length - 1)).then(function() {
+          return callback(null);
+        }).catch(function(err) {
+          return callback(err);
+        });
+      }
+      if ((typeof req) === 'string') {
+        // String was passed, assume it is a user _id
+        req = {
+          user: {
+            _id: req
+          }
+        };
+      }
+      if (!req.user) {
+        throw 'forbidden';
+      }
+      var strings = [];
+      var i = 2;
+      var index = 0;
+      while (true) {
+        index = message.indexOf('%s', index);
+        if (index === -1) {
+          break;
+        }
+        // Don't match the same one over and over
+        index += 2;
+        if ((i >= arguments.length) || ((typeof (arguments[i]) === 'object'))) {
+          throw new Error('Bad notification call: number of %s placeholders does not match number of string arguments after message');
+        }
+        strings.push(arguments[i++]);
+      }
+      if ((i === (arguments.length - 1)) && (typeof (arguments[i]) === 'object')) {
+        options = arguments[i++];
+      } else {
+        options = {};
+      }
+
+      if (i !== arguments.length) {
+        throw new Error('Bad notification call: number of %s placeholders does not match number of string arguments after message');
+      }
+
+      var notification = {
+        _id: self.apos.utils.generateId(),
+        createdAt: new Date(),
+        userId: req.user._id,
+        message: message,
+        strings: strings
+      };
+
+      if (options.dismiss === true) {
+        options.dismiss = 5;
+      }
+
+      _.merge(notification, options);
+
+      return self.db.insert(notification);
+    };
+
+    // Send a new notification for the user.
+    self.route('post', 'trigger', function(req, res) {
+      var type = self.apos.launder.select(req.body.type, [ 'error', 'warn', 'success', 'info' ], 'info');
       var message = self.apos.launder.string(req.body.message);
       var strings = self.apos.launder.strings(req.body.strings);
-      var args = [ message ].concat(strings);
-      message = self.apos.i18n.__.apply(self.apos.i18n, args);
-      res.send(self.render(req, 'notification', { message: message }));
+      var dismiss = self.apos.launder.integer(req.body.dismiss);
+      var pulse = self.apos.launder.boolean(req.body.pulse);
+      // TODO what is this one for?
+      var id = self.apos.launder.id(req.body.id);
+      try {
+        self.trigger.apply(self, [ req, message ].concat(strings).concat([ {
+          dismiss: dismiss,
+          type: type,
+          pulse: pulse,
+          id: id
+        } ]));
+      } catch (err) {
+        self.apos.utils.error(err);
+        return res.send({ status: 'error' });
+      }
+      return res.send({ status: 'ok' });
     });
+
+    // Dismiss the notification indicated by `req.body._id`.
+    self.route('post', 'dismiss', function(req, res) {
+      var _id = self.apos.launder.id(req.body._id);
+      self.db.remove({
+        _id: _id
+      }).then(function() {
+        return res.send({ status: 'ok' });
+      }).catch(function(err) {
+        self.apos.utils.error(err);
+        return res.send({ status: 'error' });
+      });
+    });
+
+    // Poll for active notifications. Responds with:
+    //
+    // `{ status: 'ok', notifications: [ ... ], dismissed: [ id1... ] }`
+    //
+    // Each notification has an `html` property containing
+    // its rendered, localized markup, as well as `_id`, `createdAt`
+    // and `id` (if one was provided when it was triggered).
+    //
+    // The client must provide `req.body.displayingIds`,
+    // an array of notification `_id` properties it is already displaying.
+    // Without this, all notifications that have not been dismissed via the
+    // dismiss route are sent.
+    //
+    // If any of the ids in `displayingIds` have been recently dismissed,
+    // the response will include them in its `dismissed` property.
+    //
+    // This route will wait up to 10 seconds
+    // for new notifications (long polling), but then respond with an
+    // empty array to avoid proxy server timeouts.
+    //
+    // As usual POST is used to avoid unwanted caching of the response.
+
+    self.route('post', 'poll-notifications', function(req, res) {
+      if (!req.user._id) {
+        return res.send({ status: 'invalid' });
+      }
+      var start = Date.now();
+      var displayingIds = self.apos.launder.ids(req.body.displayingIds);
+      return attempt();
+
+      function attempt() {
+        if (Date.now() - start >= 10000) {
+          return res.send({
+            status: 'ok',
+            notifications: [],
+            dismissed: []
+          });
+        }
+        return Promise.try(function() {
+          return self.find(req, { displayingIds: displayingIds });
+        }).then(function(result) {
+          var notifications = result.notifications;
+          var dismissed = result.dismissed;
+          if ((!notifications.length) && (!dismissed.length)) {
+            return Promise.delay(1000).then(attempt);
+          }
+          _.each(notifications, function(notification) {
+            var args = [ notification.message ].concat(notification.strings);
+            var message = req.__.apply(req, args);
+            var params = _.clone(notification);
+            params.message = message;
+            notification.html = self.render(
+              req,
+              'notification',
+              params
+            );
+          });
+          return res.send({
+            status: 'ok',
+            notifications: notifications,
+            dismissed: dismissed
+          });
+        });
+      }
+
+    });
+
+    // Resolves with an object with `notifications` and `dismissed`
+    // properties.
+    //
+    // Returns a promise if no callback is passed.
+    //
+    // If `options.displayingIds` is set, notifications
+    // whose `_id` properties appear in it are not returned.
+
+    self.find = function(req, options, callback) {
+      if (callback) {
+        return self.find(req, options).then(function(result) {
+          return callback(null, result);
+        }).catch(callback);
+      }
+      return self.db.find({
+        userId: req.user._id
+      }).sort({ createdAt: 1 }).toArray().then(function(notifications) {
+        return {
+          notifications: _.filter(notifications,
+            function(notification) {
+              return !_.includes(options.displayingIds || [], notification._id);
+            }
+          ),
+          dismissed: _.difference(options.displayingIds || [], _.pluck(notifications, '_id'))
+        };
+      });
+    };
+
+    self.ensureCollection = function(callback) {
+      self.db = self.apos.db.collection('aposNotifications');
+      return self.db.ensureIndex({ userId: 1, createdAt: 1 }, callback);
+    };
+
   },
 
-  afterConstruct: function(self) {
+  afterConstruct: function(self, callback) {
     self.pushAssets();
     self.pushCreateSingleton();
+    self.apos.notify = self.trigger;
+    return self.ensureCollection(callback);
   }
 };

--- a/lib/modules/apostrophe-notifications/public/js/user.js
+++ b/lib/modules/apostrophe-notifications/public/js/user.js
@@ -2,10 +2,22 @@ apos.define('apostrophe-notifications', {
 
   extend: 'apostrophe-context',
 
-  construct: function(self) {
+  afterConstruct: function(self) {
+    apos.notify = self.trigger;
+
+    apos.on('modalStackPop', self.reparentContainer);
+    apos.on('modalStackPush', self.reparentContainer);
+
+    self.createContainer();
+
+    self.enable();
+  },
+
+  construct: function(self, options) {
 
     // Call with a message, followed by any interpolated strings which must correspond
-    // to %s placeholders in `message`, followed by an `options` object if desired.
+    // to %s placeholders in `message` (variable number of arguments), followed by an
+    // `options` object if desired.
     //
     // `options.type` styles the notification and may be set to `error`,
     // `warn` or `success`. If not set, a "plain" default style is used.
@@ -46,41 +58,98 @@ apos.define('apostrophe-notifications', {
         throw new Error('Bad notification call: number of %s placeholders does not match number of string arguments after message');
       }
 
-      var $notification;
-
       if (options.dismiss === true) {
         options.dismiss = 5;
       }
 
-      self.html('notification', { message: message, strings: strings }, function(data) {
-        $notification = $($.parseHTML(data));
+      // Send it to the server, which will send it back to us via
+      // the same long polling mechanism that allows it to reach
+      // other tabs, and allows server-sent notifications to
+      // reach us
 
-        if (options.type) {
-          $notification.addClass('apos-notification--' + options.type);
-        }
-
-        if (options.pulse) {
-          $notification.addClass('apos-notification--pulse');
-        }
-
-        if (options.id) {
-          $notification.attr('id', options.id);
-        }
-
-        if (options.dismiss) {
-          $notification.attr('data-apos-notification-dismiss', options.dismiss);
-
-          setTimeout(function() {
-            self.dismiss($notification);
-          }, (1000 * options.dismiss));
-        }
-
-        $notification.click(function() {
-          self.dismiss($notification);
-        });
-
-        self.addToContainer($notification);
+      self.api('trigger', {
+        message: message,
+        strings: strings,
+        type: options.type,
+        dismiss: options.dismiss,
+        pulse: options.pulse,
+        id: options.id
+      }, function() {
+        // We sent it, we're good. The server will get back to us
+        // and display it quite soon thanks to long polling
       });
+
+    };
+
+    self.enable = function() {
+      self.ids = [];
+      poll();
+      function poll() {
+        self.api('poll-notifications', {
+          displayingIds: self.ids
+        }, function(data) {
+          if (data.status !== 'ok') {
+            apos.utils.error(data.status);
+            return retryLater();
+          }
+          _.each(data.notifications, function(notification) {
+            self.display(notification);
+          });
+          self.ids = self.ids.concat(_.pluck(data.notifications, '_id'));
+          self.ids = _.uniq(self.ids);
+          _.each(data.dismissed, function(id) {
+            var $notification = $('[data-apos-notification-id="' + id + '"]');
+            self.dismiss($notification, true);
+          });
+          // Long polling loop continues
+          poll();
+        }, function(err) {
+          apos.utils.error(err);
+          return retryLater();
+        });
+      }
+      function retryLater() {
+        setTimeout(poll, 5000);
+      }
+    };
+
+    // Display a notification received from the server.
+    // You want `apos.notify`, not this method, unless you are
+    // overriding how notifications are displayed.
+
+    self.display = function(notification) {
+
+      var $notification = $($.parseHTML(notification.html));
+
+      if (notification.type) {
+        $notification.addClass('apos-notification--' + notification.type);
+      }
+
+      if (notification.pulse) {
+        $notification.addClass('apos-notification--pulse');
+      }
+
+      // This is an id assigned programmatically by the developer, it
+      // is separate from the `_id` property assigned by the server.
+      if (notification.id) {
+        $notification.attr('id', notification.id);
+      }
+
+      $notification.attr('data-apos-notification-id', notification._id);
+
+      if (notification.dismiss) {
+        $notification.attr('data-apos-notification-dismiss', notification.dismiss);
+
+        setTimeout(function() {
+          self.dismiss($notification);
+        }, (1000 * notification.dismiss));
+      }
+
+      $notification.click(function() {
+        self.dismiss($notification);
+      });
+
+      self.addToContainer($notification);
     };
 
     self.createContainer = function() {
@@ -103,7 +172,22 @@ apos.define('apostrophe-notifications', {
       }, 100);
     };
 
-    self.dismiss = function($notification) {
+    self.dismiss = function($notification, fromServer) {
+
+      var _id = $notification.attr('data-apos-notification-id');
+      self.ids = _.filter(self.ids, function(id) {
+        return id !== _id;
+      });
+
+      if (!fromServer) {
+        // We're doing it, so tell the server
+        self.api('dismiss', {
+          _id: _id
+        }, function() {
+          // Now the server knows not to send it anymore
+        });
+      }
+
       $notification.addClass('apos-notification--hidden');
 
       setTimeout(function() {
@@ -113,14 +197,6 @@ apos.define('apostrophe-notifications', {
         }
       }, 300);
     };
-  },
-
-  afterConstruct: function(self) {
-    apos.notify = self.trigger;
-
-    apos.on('modalStackPop', self.reparentContainer);
-    apos.on('modalStackPush', self.reparentContainer);
-
-    self.createContainer();
   }
+
 });


### PR DESCRIPTION
With exactly the same syntax as in the browser, except with `req` or a user `_id` as first argument and an optional callback if you really need to be sure it has landed in the database.

Also apos.notify is now persistent for that user until they dismiss the notification (dismiss: true still works and does dismiss it permanently).

Persistence applies whether the notification was born in browser or server land.

Long polling is used for a prompt response although with some compromise to avoid beating up mongodb too much.

There have been no changes to the user experience other than persistence (refreshing the page does not make all notifications "dismiss", which happened only because we did not have a real implementation of keeping them around until they were properly dismissed).

This was implemented because debugging yet another quasi-implementation of it for yet another module (in this particular case, apostrophe-favicons for our demo) did not make sense. The server needs a simple way to send the user notifications, which we can improve and revise the UX of anytime — I'm just opting the server in to what the browser already has access to.