### PR TITLE
Add launder function to slug filter

### DIFF
--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -1157,6 +1157,9 @@ module.exports = {
             }
           },
           safeFor: 'manage',
+          launder: function(s) {
+            return self.apos.launder.string(s);
+          },
           choices: function(callback) {
             return self.sortedDistinct(field.name, cursor, callback);
           }


### PR DESCRIPTION
As discussed today with @boutell, the `slug` filter misses a `launder` function for filters. Here is the quick fix.