### PR TITLE
Fixes pieces-page type change when types have distinct 'chooser' fields

### DIFF
--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -486,7 +486,7 @@ apos.define('apostrophe-schemas', {
       // instead there is a wrapper div inside that does. This code
       // works when enableTags is passed either the fieldset or
       // the inner wrapper div. -Tom
-      if (!$el[0].hasAttribute('data-selective')) {
+      if ($el[0] && !$el[0].hasAttribute('data-selective')) {
         $el = $el.find('[data-selective]:first');
       }
       $el.on('click', '[data-list]', function() {
@@ -914,6 +914,7 @@ apos.define('apostrophe-schemas', {
       convert: function(data, name, $field, $el, field, callback) {
         var $fieldset = self.findFieldset($el, name);
         var chooser = $fieldset.data('aposChooser');
+        if (!chooser) return callback(null);
         return chooser.getFinal(function(err, choices) {
           if (err) {
             return callback(err);
@@ -999,6 +1000,7 @@ apos.define('apostrophe-schemas', {
       convert: function(data, name, $field, $el, field, callback) {
         var $fieldset = self.findFieldset($el, name);
         var chooser = $fieldset.data('aposChooser');
+        if (!chooser) return callback(null);
         return chooser.getFinal(function(err, choices) {
           if (err) {
             return callback(err);


### PR DESCRIPTION
When I tried to change the type of classic Home page from "Home Page" to my custom page type that extends `apostrophe-pieces-pages` and has several additional `joinByArray` fields, I got JavaScript errors like `'undefined' has no property 'someProperty'`.

@boutell As you can see, in all three places in the code those caused this trouble the value was not checked for being `undefined` before accessing its property/method. So this fix does not hurt anything, but makes the code more stable.

I guess the problem is deeper than this (I suppose the custom fields are not initialized properly in this situation), but at least this fix makes it possible to change the page type, hit Save Draft and then re-enter Page Settings which are initialized properly then.