### PR TITLE
fix: change usage of momentjs to local instance instead of global

### DIFF
--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -419,8 +419,7 @@ module.exports = {
           return '';
         }
         var dateLocale = locale || self.apos.templates.contextReq.locale;
-        moment.locale(dateLocale);
-        var s = moment(date).format(format);
+        var s = moment(date).locale(dateLocale).format(format);
         return s;
       });
 


### PR DESCRIPTION
A small addition to my previous PR

This changes the momentjs usage to avoid changing the global locale with the date filter. 

As mentioned in #1709