### PR TITLE
1728 undo remove widget

### DIFF
--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -1,7 +1,6 @@
 
 @apos-translucent-opacity: 0.4;
 
-
 .apos-area, .apos-area-widgets, .apos-area-widget { position: relative; }
 
 .apos-area
@@ -316,6 +315,23 @@
     border: 2px solid @apos-secondary;
     .apos-button:hover { color: @apos-secondary; }
     .apos-button[data-apos-trash-item]:hover { color: darken(@apos-red, 20%); }
+  }
+}
+
+.apos-area-inline-undo {
+  padding: @apos-padding-1;
+  background-color: @apos-purple;
+  color: @apos-white;
+  button {
+    // Like a link
+    border: 0;
+    background-color: inherit;
+    color: inherit;
+    display: inline;
+    font-size: inherit;
+    font-family: inherit;
+    text-decoration: underline;
+    cursor: pointer;
   }
 }
 

--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -317,21 +317,31 @@
     .apos-button[data-apos-trash-item]:hover { color: darken(@apos-red, 20%); }
   }
 }
-
+.apos-area-inline-undo__label {
+  margin-right: 5px;
+}
 .apos-area-inline-undo {
+  display: flex;
+  border: 0;
+  cursor: pointer;
+  background-color: inherit;
+  color: inherit;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  .apos-rounded;
   padding: @apos-padding-1;
-  background-color: @apos-purple;
+  background-color: @apos-blue;
   color: @apos-white;
-  button {
-    // Like a link
-    border: 0;
-    background-color: inherit;
-    color: inherit;
-    display: inline;
-    font-size: inherit;
-    font-family: inherit;
+  font-size: 13px;
+  margin-bottom: 1rem;
+  transition: all 0.3s ease;
+  &:hover {
+    background-color: darken(@apos-blue, 10%)
+  }
+  .apos-area-inline-undo__undo {
     text-decoration: underline;
-    cursor: pointer;
+    margin-left: 5px;
   }
 }
 

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -197,7 +197,7 @@ apos.define('apostrophe-areas-editor', {
       $wrapper.replaceWith(
         $remover
       );
-      $remover.on('click', 'button', function() {
+      $remover.on('click', function() {
         $remover.replaceWith($wrapper);
         self.checkEmptyAreas();
         self.respectLimit();
@@ -209,7 +209,7 @@ apos.define('apostrophe-areas-editor', {
         $remover.fadeOut(function() {
           $remover.remove();
         });
-      }, 5000000);
+      }, 7000);
       apos.emit('widgetTrashed', $widget);
     };
 

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -144,7 +144,7 @@ apos.define('apostrophe-areas-editor', {
       // if the click came from such a menu
       self.dismissContextContentMenu($el);
 
-      // If there's any intial content items, remove them on selecting
+      // If there are any initial content items, remove them on selecting
       // your first widget. Right now, we're parsing the data-options through
       // self.options and using self.options.initialContent or what we think is
       // the default from aposLocals.
@@ -190,9 +190,26 @@ apos.define('apostrophe-areas-editor', {
       var $widget = $el.closest('[data-apos-widget]');
       self.stopEditingRichText();
       self.removeAreaControls($widget);
-      $widget.parent('[data-apos-widget-wrapper]').remove();
+
+      var $wrapper = $widget.parent('[data-apos-widget-wrapper]');
+      var $remover = self.fromTemplate('[data-apos-undo-remove-widget]');
+      $remover.find('[data-apos-widget-type-label]').text(apos.areas.getWidgetManager($widget.attr('data-apos-widget')).label);
+      $wrapper.replaceWith(
+        $remover        
+      );
+      $remover.on('click', 'button', function() {
+        $remover.replaceWith($wrapper);
+        self.checkEmptyAreas();
+        self.respectLimit();
+        return false;
+      });
       self.checkEmptyAreas();
       self.respectLimit();
+      setTimeout(function() {
+        $remover.fadeOut(function() {
+          $remover.remove();
+        });
+      }, 5000000);
       apos.emit('widgetTrashed', $widget);
     };
 

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -195,7 +195,7 @@ apos.define('apostrophe-areas-editor', {
       var $remover = self.fromTemplate('[data-apos-undo-remove-widget]');
       $remover.find('[data-apos-widget-type-label]').text(apos.areas.getWidgetManager($widget.attr('data-apos-widget')).label);
       $wrapper.replaceWith(
-        $remover        
+        $remover
       );
       $remover.on('click', 'button', function() {
         $remover.replaceWith($wrapper);

--- a/lib/modules/apostrophe-areas/views/editor.html
+++ b/lib/modules/apostrophe-areas/views/editor.html
@@ -2,5 +2,6 @@
   <div class="apos-templates" data-apos-area-editor-templates>
     {% include "widgetControls.html" %}
     {% include "itemSeparator.html" %}
+    {% include "undoRemove.html" %}
   </div>
 </div>

--- a/lib/modules/apostrophe-areas/views/undoRemove.html
+++ b/lib/modules/apostrophe-areas/views/undoRemove.html
@@ -1,3 +1,3 @@
-<div data-apos-undo-remove-widget class="apos-area-inline-undo">
-  <span data-apos-widget-type-label></span> widget removed. <button>Undo</button>
-</div>
+<button data-apos-undo-remove-widget class="apos-area-inline-undo">
+  <span data-apos-widget-type-label class="apos-area-inline-undo__label"></span> widget removed. <span class="apos-area-inline-undo__undo">Undo</span>
+</button>

--- a/lib/modules/apostrophe-areas/views/undoRemove.html
+++ b/lib/modules/apostrophe-areas/views/undoRemove.html
@@ -1,0 +1,3 @@
+<div data-apos-undo-remove-widget class="apos-area-inline-undo">
+  <span data-apos-widget-type-label></span> widget removed. <button>Undo</button>
+</div>


### PR DESCRIPTION
@stuartromanek I am assigning review to you because it looks good in the sandbox but I can't figure out how to use apos-text-normal (?) without getting an undefined error. Scoped it in apos-ui and still got one of those. Not sure if I'm barking up the right tree to make sure these get a reasonable font in any project context.

I went with the original @carlykaras suggestion of apos-purple and avoided the notification styles because the border on those turns out to be jarring when in context in a stream of widgets. This is more of an inline thing than an "unrelated context layered on top" thing.