### PR TITLE
Transform username / email to lowercase before verifying logins

### DIFF
--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -194,10 +194,11 @@ module.exports = {
 
     self.verifyLogin = function(username, password, callback) {
       var req = self.apos.tasks.getReq();
+      var userLowerCase = username.toLowerCase();
       return self.apos.users.find(req, {
         $or: [
-          { username: username },
-          { email: username }
+          { username: userLowerCase },
+          { email: userLowerCase }
         ],
         disabled: { $ne: true }
       }).toObject(function(err, user) {


### PR DESCRIPTION
The idea is that ideally we should be storing usernames and emails as lowercase values, but allowing users to login with their username / email in any format they like. A perspective (attributed to About.com) on this found on StackExchange:

---
But Case Typically Does Not Matter

Since the case sensitivity of email addresses can create a lot of confusion, interoperability problems and widespread headaches, it would be foolish to require email addresses to be typed with the correct case. Hardly any email service or ISP does enforce case sensitive email addresses, returning messages whose recipient's email address was not typed correctly (in all upper case, for example).

This means that

it does not typically matter what case you type an email address in when you send a message (If the recipient did give you an email address with distinct case, preserve it, however.)
and you should always only use lower case characters when creating a new email address to rule out any confusion.

---

Source: https://ux.stackexchange.com/questions/16848/if-your-login-is-an-email-should-you-canonicalize-lower-case-it