### PR TITLE
a hovered widget control should be lower in the zindex stack than an …

### DIFF
--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -263,7 +263,7 @@
   {
     display: block;
     opacity: @apos-translucent-opacity;
-    z-index: @apos-z-index-4;
+    z-index: @apos-z-index-2;
     &:hover { opacity: 1; }
   }
 }


### PR DESCRIPTION
…open area menu
Prevents this situation

https://github.com/apostrophecms/apostrophe-demo-2018/issues/54

