### PR TITLE
option to suppress area loader recursion warnings on a per request ba…

### DIFF
--- a/lib/modules/apostrophe-areas/lib/cursor.js
+++ b/lib/modules/apostrophe-areas/lib/cursor.js
@@ -40,7 +40,10 @@ module.exports = {
               req.areasLoadedFor[doc._id] = 0;
             }
             if (req.areasLoadedFor[doc._id] >= 5) {
-              self.apos.utils.warn('WARNING: reached maximum area loader recursion level. Doc _id is ' + doc._id + '. Are you using projections for all joins?');
+              if (!req.suppressAreaLoaderRecursionWarnings) {
+                self.apos.utils.warn('WARNING: reached maximum area loader recursion level. Doc _id is ' + doc._id + '. Are you using projections for all joins?');
+              }
+              // In any case, we can't recurse infinitely
               return;
             }
             req.areasLoadedFor[doc._id]++;


### PR DESCRIPTION
…sis. This would never be a good idea for normal page rendering, however it can make sense when iterating over many pages in a task, fetching all committable pages in workflow or other situations likely to legitimately fetch the same document many times as a join from 5+ other documents. However we still stop actually fetching them because infinite recursion cannot be permitted.