### PR TITLE
bless relationship in joinByArray

### DIFF
--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -2029,6 +2029,9 @@ module.exports = {
             self.bless(req, elem.schema);
           }
         });
+        if (field.relationship) {
+          self.bless(req, field.relationship);
+        }
       },
       join: function(req, field, objects, options, callback) {
         return self.joinDriver(req, joinr.byArray, false, objects, field.idsField, field.relationshipsField, field.name, options, callback);


### PR DESCRIPTION
In https://github.com/apostrophecms/apostrophe/pull/1712, I intended to solve the problem of a nested structure not blessed. But I forgot one part in `joinByArray` bless function.

Here is the fix.