### PR TITLE
Handles duplicate ids when dragging area widgets

### DIFF
--- a/lib/modules/apostrophe-areas/src/apos/components/ApostropheAreaEditor.vue
+++ b/lib/modules/apostrophe-areas/src/apos/components/ApostropheAreaEditor.vue
@@ -1,12 +1,17 @@
 <template>
   <div class="apos-area">
     <ApostropheAddWidgetMenu @widgetAdded="insert" :index="0" :choices="choices" :widgetOptions="options.widgets" />
-    <vddl-list :allowed-types="types" class="apos-areas-widgets-list" :list="next" :horizontal="false">
+    <vddl-list :allowed-types="types" class="apos-areas-widgets-list"
+      :list="next"
+      :horizontal="false"
+      :drop="handleDrop"
+    >
       <vddl-draggable class="panel__body--item" v-for="(wrapped, i) in next" :key="wrapped.widget._id"
           :type="wrapped.widget.type"
           :draggable="wrapped"
           :index="i"
           :wrapper="next"
+          :moved="handleMoved"
           effect-allowed="move"
       >
         <div class="apos-area-controls">
@@ -41,7 +46,8 @@ export default {
   data() {
     return {
       next: this.items.map(widget => ({ widget })),
-      editing: {}
+      editing: {},
+      droppedItem : {}
     };
   },
   watch: {
@@ -88,6 +94,21 @@ export default {
     },
     nextItems() {
       return this.next.map(wrapped => Object.assign({}, wrapped.widget));
+    },
+    handleDrop(data) {
+      const { index, list, item } = data;
+      item.widget._id = `${item.widget._id}_dropped`;
+      this.droppedItem = item;
+
+      list.splice(index, 0, item);
+    },
+    handleMoved(data) {
+      const { index, list, draggable } = data;
+      const id = draggable.widget._id;
+      draggable.widget._id = `${draggable.widget._id}_moved`;
+      this.droppedItem.widget._id = id;
+
+      list.splice(index, 1);
     }
   },
   computed: {


### PR DESCRIPTION
VDDL drops the ball by creating a duplicate with a duplicate ID when a thing is moved. [They note a change in Vue's `nextTick` implementation.](https://github.com/hejianxian/vddl#warning)

This is [their current recommendation](https://github.com/hejianxian/vddl/blob/master/example/src/views/simple.vue#L131-L144) for dealing with that issue, but keeping IDs as we want them in Apos.

VDDL issue: https://github.com/hejianxian/vddl/issues/23