### PR TITLE
fix missing "enableShowFields" for checkboxes

### DIFF
--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -1190,6 +1190,7 @@ apos.define('apostrophe-schemas', {
         for (var c in data[name]) {
           self.findSafe($fieldset, 'input[name="' + name + '"][value="' + data[name][c] + '"]', '.apos-field').prop('checked', true);
         }
+        self.enableShowFields(data, name, $field, $el, field);
         return setImmediate(callback);
       },
       convert: function(data, name, $field, $el, field, callback) {


### PR DESCRIPTION
In the PR #1540 "Enable showFields on checkboxes", I forgot to add the line to hide/show fields in user.js for checkboxes.

Here is the fix.