### PR TITLE
do not crash in the notification polling route if apos has been destr…

### DIFF
--- a/lib/modules/apostrophe-db/index.js
+++ b/lib/modules/apostrophe-db/index.js
@@ -249,7 +249,10 @@ module.exports = {
 
     // Invoked by `callAll` when `apos.destroy` is called.
     // Closes the database connection and the keepalive
-    // interval timer.
+    // interval timer. Sets `apos.db.closed` to true,
+    // allowing detection of the fact that the database
+    // connection is no longer available by code that
+    // might still be in progress.
 
     self.apostropheDestroy = function(callback) {
       if (self.keepaliveInterval) {
@@ -265,7 +268,13 @@ module.exports = {
         // This responsibility should fall to the parent
         return callback(null);
       }
-      return self.apos.db.close(false, callback);
+      return self.apos.db.close(false, function(err) {
+        if (err) {
+          return callback(err);
+        }
+        self.apos.db.closed = true;
+        return callback(null);
+      });
     };
   }
 };

--- a/lib/modules/apostrophe-notifications/index.js
+++ b/lib/modules/apostrophe-notifications/index.js
@@ -259,6 +259,18 @@ module.exports = {
           ),
           dismissed: _.difference(options.displayingIds || [], _.pluck(notifications, '_id'))
         };
+      }).catch(function(err) {
+        if (self.apos.db.closed) {
+          // The database connection was intentionally closed,
+          // which often triggers a race condition with
+          // long polling requests. Send an empty response
+          return {
+            notifications: [],
+            dismissed: []
+          };
+        } else {
+          throw err;
+        }
       });
     };
 


### PR DESCRIPTION
…oyed

This is a heavily used, long-polling route that usually has a request going at the moment apos is destroyed by apostrophe-monitor, apostrophe-multisite, etc. Fix it by making it possible to detect that the database connection has been closed and return an empty response gracefully.