### PR TITLE
Only conditionally apply removeButtons logic to CKEDITOR

### DIFF
--- a/lib/modules/apostrophe-areas/public/js/vendor/ckeditor/config.js
+++ b/lib/modules/apostrophe-areas/public/js/vendor/ckeditor/config.js
@@ -26,10 +26,6 @@ CKEDITOR.editorConfig = function( config ) {
 		{ name: 'about' }
 	];
 
-	// Remove some buttons provided by the standard plugins, which are
-	// not needed in the Standard(s) toolbar.
-	config.removeButtons = 'Underline,Subscript,Superscript';
-
 	// Set the most common block elements.
 	config.format_tags = 'p;h1;h2;h3;pre';
 

--- a/lib/modules/apostrophe-rich-text-widgets/public/js/editor.js
+++ b/lib/modules/apostrophe-rich-text-widgets/public/js/editor.js
@@ -92,6 +92,14 @@ apos.define('apostrophe-rich-text-widgets-editor', {
 
       if (!self.toolbar.length) {
         self.config.removePlugins = 'toolbar';
+      } else {
+        // These are the buttons that we want to remove from CKEDITOR's default
+        // config, but not if the developer has requested them
+        var removeButtons = ['Underline', 'Subscript', 'Superscript'].filter(function(button) {
+          return !_.includes(self.toolbar, button);
+        });
+
+        self.config.removeButtons = removeButtons.join(',');
       }
 
       self.beforeCkeditorInline();


### PR DESCRIPTION
This will include `removeButtons` in the CKEDITOR config only if those buttons haven't been listed in the toolbar config for this CKEDITOR instance. It should make the experience of reconfiguring the CKEDITOR toolbar a lot more intuitive for end developers.