### PR TITLE
Fix 1783 - update apostrophe-pages api.js

### DIFF
--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -229,6 +229,7 @@ module.exports = function(self, options) {
 
     // It's a one-time action, don't remember it
     page.applyToSubpages = false;
+    propagateSet.docPermissions = page.docPermissions;
     propagateSet.loginRequired = loginRequired;
     _.each(allowed, function(prefix) {
       var fields = [ prefix + 'GroupsIds', prefix + 'UsersIds' ];


### PR DESCRIPTION
This commit updates the docAfterDenormalizePermissions
method and makes it propagate the docPermissions property
as part of the the “Apply to sub-pages” functionality.