### PR TITLE
Migration progress and fixes

### DIFF
--- a/lib/modules/apostrophe-db/index.js
+++ b/lib/modules/apostrophe-db/index.js
@@ -60,6 +60,7 @@ module.exports = {
     });
   },
   construct: function(self, options) {
+    console.log('CONSTRUCTING');
     // Open the database connection. Always use MongoClient with its
     // sensible defaults. Build a URI if we need to, so we can call it
     // in a consistent way.
@@ -68,7 +69,9 @@ module.exports = {
     // attempting to reconnect forever. This is the most sensible behavior
     // for a persistent process that requires MongoDB in order to operate.
     self.connectToMongo = function(callback) {
+      console.log('ENTRY');
       if (self.options.db) {
+	console.log('REUSE');
         // Reuse a single connection http://mongodb.github.io/node-mongodb-native/2.2/api/Db.html#db
         self.apos.db = self.options.db.db(options.name || self.apos.shortName);
         self.connectionReused = true;

--- a/lib/modules/apostrophe-db/index.js
+++ b/lib/modules/apostrophe-db/index.js
@@ -60,7 +60,6 @@ module.exports = {
     });
   },
   construct: function(self, options) {
-    console.log('CONSTRUCTING');
     // Open the database connection. Always use MongoClient with its
     // sensible defaults. Build a URI if we need to, so we can call it
     // in a consistent way.
@@ -69,9 +68,7 @@ module.exports = {
     // attempting to reconnect forever. This is the most sensible behavior
     // for a persistent process that requires MongoDB in order to operate.
     self.connectToMongo = function(callback) {
-      console.log('ENTRY');
       if (self.options.db) {
-	console.log('REUSE');
         // Reuse a single connection http://mongodb.github.io/node-mongodb-native/2.2/api/Db.html#db
         self.apos.db = self.options.db.db(options.name || self.apos.shortName);
         self.connectionReused = true;

--- a/lib/modules/apostrophe-migrations/lib/api.js
+++ b/lib/modules/apostrophe-migrations/lib/api.js
@@ -1,6 +1,7 @@
 var broadband = require('broadband');
 var async = require('async');
 var Promise = require('bluebird');
+var ProgressBar = require('progress');
 
 module.exports = function(self, options) {
 
@@ -56,6 +57,11 @@ module.exports = function(self, options) {
   // The iterator is passed a document and a callback. If the iterator
   // accepts only one parameter, it is assumed to return a promise,
   // which is awaited in lieu of a callback.
+  //
+  // If it is determined that node is running in an interactive terminal,
+  // a simple plaintext progress display is shown. If this is not
+  // desired, the `progressDisplay` option of this module may be
+  // set to `false`.
 
   self.each = function(collection, criteria, limit, iterator, callback) {
     if ((typeof limit) === 'function') {
@@ -81,20 +87,73 @@ module.exports = function(self, options) {
       // affect the remainder of the query.
       //
       // https://groups.google.com/forum/#!topic/mongodb-user/AFC1ia7MHzk
-      cursor.sort({ _id: 1 });
-      return broadband(cursor, limit, function(doc, callback) {
-        if (iterator.length === 1) {
-          return Promise.try(function() {
-            return iterator(doc);
-          }).then(function() {
-            return callback(null);
-          }).catch(function(err) {
-            return callback(err);
-          });
-        } else {
-          return iterator(doc, callback);
+
+      var progressDisplay = process.stdout.isTTY && (self.options.progressDisplay !== false);
+      console.log('progressDisplay is ' + progressDisplay);
+      var progress;
+
+      return async.series([ count, execute ], callback);
+
+      function count(callback) {
+        if (!progressDisplay) {
+          return callback(null);
         }
-      }, callback);
+        if (progressDisplay) { 
+          console.log('Determining total...');
+        }
+        return cursor.count(function(err, result) {
+          if (err) {
+            return callback(err);
+          }
+          if (progressDisplay) { 
+            console.log('Total determined');
+          }
+          progress = new ProgressBar('  migrating [:bar] :percent :etas seconds left', {
+            total: result
+          });
+          return callback(null);
+        });
+      }
+
+      function execute(callback) {
+        cursor.sort({ _id: 1 });
+        let ticks = 0;
+        // Minimize performance impact of the progress module itself,
+        // but update at least every quarter second
+        const interval = setInterval(function() {
+          progress.tick(ticks);
+          ticks = 0;
+        }, 250);
+        return broadband(cursor, limit, function(doc, callback) {
+          return doOne(function(err) {
+            if (err) {
+              return callback(err);
+            }
+            if (progressDisplay) {
+              ticks++;
+            }
+            return callback(null);
+          });
+          function doOne(callback) {
+            if (iterator.length === 1) {
+              return Promise.try(function() {
+                return iterator(doc);
+              }).then(function() {
+                // Shaddap: http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it
+                callback(null);
+                return null;
+              }).catch(function(err) {
+                return callback(err);
+              });
+            } else {
+              return iterator(doc, callback);
+            }
+          }
+        }, function(err) {
+          clearInterval(interval);
+          return callback(err);
+        });
+      }
     }
   };
 

--- a/lib/modules/apostrophe-migrations/lib/api.js
+++ b/lib/modules/apostrophe-migrations/lib/api.js
@@ -1,7 +1,7 @@
 var broadband = require('broadband');
 var async = require('async');
 var Promise = require('bluebird');
-var ProgressBar = require('progress');
+var cliProgress = require('cli-progress');
 
 module.exports = function(self, options) {
 
@@ -89,7 +89,6 @@ module.exports = function(self, options) {
       // https://groups.google.com/forum/#!topic/mongodb-user/AFC1ia7MHzk
 
       var progressDisplay = process.stdout.isTTY && (self.options.progressDisplay !== false);
-      console.log('progressDisplay is ' + progressDisplay);
       var progress;
 
       return async.series([ count, execute ], callback);
@@ -99,38 +98,32 @@ module.exports = function(self, options) {
           return callback(null);
         }
         if (progressDisplay) { 
-          console.log('Determining total...');
+          console.error('Determining total...');
         }
         return cursor.count(function(err, result) {
           if (err) {
             return callback(err);
           }
-          if (progressDisplay) { 
-            console.log('Total determined');
-          }
-          progress = new ProgressBar('  migrating [:bar] :percent :etas seconds left', {
-            total: result
-          });
+          progress = new cliProgress.Bar({
+            fps: 4,
+            format: 'progress [{bar}] {percentage}% | ETA: {eta_formatted} | {value}/{total}',
+            // Default of 10 gives us an ETA that jumps around wildly and is hard to look at
+            etaBuffer: 500
+          }, cliProgress.Presets.shades_classic);
+          progress.start(result, 0);
           return callback(null);
         });
       }
 
       function execute(callback) {
         cursor.sort({ _id: 1 });
-        let ticks = 0;
-        // Minimize performance impact of the progress module itself,
-        // but update at least every quarter second
-        const interval = setInterval(function() {
-          progress.tick(ticks);
-          ticks = 0;
-        }, 250);
         return broadband(cursor, limit, function(doc, callback) {
           return doOne(function(err) {
             if (err) {
               return callback(err);
             }
             if (progressDisplay) {
-              ticks++;
+              progress.increment();
             }
             return callback(null);
           });
@@ -150,7 +143,7 @@ module.exports = function(self, options) {
             }
           }
         }, function(err) {
-          clearInterval(interval);
+          progress.stop();
           return callback(err);
         });
       }

--- a/lib/modules/apostrophe-migrations/lib/implementation.js
+++ b/lib/modules/apostrophe-migrations/lib/implementation.js
@@ -194,8 +194,8 @@ module.exports = function(self, options) {
           return Promise.try(function() {
             return migration.callback();
           }).then(function() {
-            return done(null);
-          }).catch(done);
+            return callback(null);
+          }).catch(callback);
         };
       }
       return fn(function(err) {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "broadband": "^1.0.0",
     "cheerio": "^0.22.0",
     "clean-css": "^3.4.28",
+    "cli-progress": "^2.1.1",
     "connect-flash": "^0.1.1",
     "connect-mongo": "^1.3.2",
     "connect-multiparty": "^2.1.1",


### PR DESCRIPTION
* Progress display for `apostrophe-migrations:migrate` when individual migrations take time. If node is not running in a TTY (an interactive terminal) this automatically goes away to avoid flooding log files with progress information or creating problems for people who have already scripted Apostrophe.
* Previously if a migration function returned a promise it was executed, but its success was not recorded, so it got re-run each time. This has been fixed.
