### PR TITLE
drag and drop did not work for newly added widgets without refreshing…

### DIFF
--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -280,9 +280,9 @@ apos.define('apostrophe-areas-editor', {
 
     self.insertWidget = function($wrapper) {
       var $widget = $wrapper.children('[data-apos-widget]').first();
-      self.enhanceWidgetControls($widget);
       self.fixInsertedWidgetDotPaths($widget);
       self.insertItem($wrapper);
+      self.enhanceWidgetControls($widget);
       self.respectLimit();
       apos.emit('enhance', $widget);
     };
@@ -366,17 +366,18 @@ apos.define('apostrophe-areas-editor', {
 
     self.replaceWidget = function($old, $wrapper) {
       var $widget = $wrapper.findSafe('[data-apos-widget]', '[data-apos-area]');
-      self.enhanceWidgetControls($widget);
       var data = apos.areas.getWidgetData($widget);
       apos.areas.setWidgetData($widget, data);
       $old.replaceWith($widget);
+      self.enhanceWidgetControls($widget);
       $widget.parent('[data-apos-widget-wrapper]').attr('class', $wrapper.attr('class'));
       self.fixInsertedWidgetDotPaths($widget);
       apos.emit('enhance', $widget);
     };
 
+    // $item whould be a widget wrapper, not just the widget itself
     self.insertItem = function($item) {
-      $item.data('areaEditor', self);
+      $item.find('[data-apos-widget]:first').data('areaEditor', self);
       if (self.$selected && self.$selected.length) {
         self.$selected.parent('[data-apos-widget-wrapper]').after($item);
       } else {


### PR DESCRIPTION
… the page. Fixed. Wait until element is in the DOM before attempting to enhance widget controls. Also fixed another drag and drop related error that cropped up when I got past this.