### PR TITLE
the docIds and trashDocIds properties of attachments were wrong becau…

### DIFF
--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -688,7 +688,7 @@ module.exports = function(self, options) {
     // incorrect and leads to failure to make it
     // unavailable at the proper time
 
-    self.apos.migrations.add(self.__meta.name + '.docReferencesCorrected', function(callback) {
+    self.apos.migrations.add(self.__meta.name + '.docReferencesContained', function(callback) {
       var attachmentUpdates = {};
 
       return async.series([ reset, docs, attachments, self.updatePermissions ], callback);

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -681,26 +681,31 @@ module.exports = function(self, options) {
   };
 
   self.addDocReferencesMigration = function() {
-    self.apos.migrations.add(self.__meta.name + '.docReferences', function(callback) {
+
+    // This migration is needed because formerly,
+    // docs that only referenced this attachment via
+    // a join were counted as "owning" it, which is
+    // incorrect and leads to failure to make it
+    // unavailable at the proper time
+
+    self.apos.migrations.add(self.__meta.name + '.docReferencesCorrected', function(callback) {
       var needed;
       var attachmentUpdates = {};
 
-      return async.series([ checkNeeded, docs, attachments, self.updatePermissions ], callback);
+      return async.series([ reset, docs, attachments, self.updatePermissions ], callback);
 
-      function checkNeeded(callback) {
-        return self.db.findOne({ docIds: { $exists: 0 } }, function(err, found) {
-          if (err) {
-            return callback(err);
+      function reset(callback) {
+        return self.db.update({}, { 
+          $set: {
+            docIds: [],
+            trashDocIds: []
           }
-          needed = !!found;
-          return callback(null);
-        });
+        }, {
+          multi: true
+        }, callback);
       }
 
       function docs(callback) {
-        if (!needed) {
-          return setImmediate(callback);
-        }
         return self.apos.migrations.eachDoc({}, 5, addAttachmentUpdates, callback);
       }
 
@@ -725,43 +730,14 @@ module.exports = function(self, options) {
       }
 
       function attachments(callback) {
-        if (!needed) {
-          return setImmediate(callback);
-        }
-        return async.series([ applyAttachmentUpdates, docIds, trashDocIds ], callback);
-        function applyAttachmentUpdates(callback) {
-          return async.eachLimit(_.keys(attachmentUpdates).slice(), 5, function(id, callback) {
-            return self.db.update(
-              {
-                _id: id
-              },
-              attachmentUpdates[id],
-              callback
-            );
-          }, callback);
-        }
-        function docIds(callback) {
-          return self.db.update({
-            docIds: { $exists: 0 }
-          }, {
-            $set: {
-              docIds: []
-            }
-          }, {
-            multi: true
-          }, callback);
-        }
-        function trashDocIds(callback) {
-          return self.db.update({
-            trashDocIds: { $exists: 0 }
-          }, {
-            $set: {
-              trashDocIds: []
-            }
-          }, {
-            multi: true
-          }, callback);
-        }
+        var bulk = self.db.initializeUnorderedBulkOp();
+        _.each(attachmentUpdates, function(updates, id) {
+          const c = bulk.find({ _id: id });
+          _.each(updates, function(update) {
+            c.updateOne(attachmentUpdates[id]);
+          });
+        });
+        return bulk.execute(callback);
       }
 
     }, {
@@ -807,7 +783,12 @@ module.exports = function(self, options) {
 
   self.updateDocReferences = function(doc, callback) {
 
-    var attachments = self.all(doc);
+    // We "own" only the attachments that are permanent properties
+    // of the doc, drop any joins first
+    doc = self.apos.utils.clonePermanent(doc);
+
+    var attachments = self.all(self.apos.utils.clonePermanent(doc));
+
     var ids = _.uniq(_.pluck(attachments, '_id'));
 
     // Build an array of mongo commands to run. Each

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -689,13 +689,12 @@ module.exports = function(self, options) {
     // unavailable at the proper time
 
     self.apos.migrations.add(self.__meta.name + '.docReferencesCorrected', function(callback) {
-      var needed;
       var attachmentUpdates = {};
 
       return async.series([ reset, docs, attachments, self.updatePermissions ], callback);
 
       function reset(callback) {
-        return self.db.update({}, { 
+        return self.db.update({}, {
           $set: {
             docIds: [],
             trashDocIds: []

--- a/lib/modules/apostrophe-migrations/lib/api.js
+++ b/lib/modules/apostrophe-migrations/lib/api.js
@@ -97,7 +97,8 @@ module.exports = function(self, options) {
         if (!progressDisplay) {
           return callback(null);
         }
-        if (progressDisplay) { 
+        if (progressDisplay) {
+          // eslint-disable-next-line no-console
           console.error('Determining total...');
         }
         return cursor.count(function(err, result) {


### PR DESCRIPTION
…se they included docs merely referencing the attachment via joins. They now reference direct ownership only, and the migration that originally populated these has been renamed to run again and rewritten to be faster thanks to mongodb batch operations. But the really important line of code is the clonePermanent call to make sure self.all does not find any attachments in joined docs.

This fix ensures that images and files are made inaccessible when the last one goes in the trash, and also enables the new, optional apostrophe-secure-attachments module to calculate permissions properly.