### PR TITLE
sped up "select all that match this search" by (1) preventing the eve…

### DIFF
--- a/lib/modules/apostrophe-pieces/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/manager-modal.js
@@ -637,13 +637,9 @@ apos.define('apostrophe-pieces-manager-modal', {
       self.onElOrFilters('change', 'input[name="select-everything"]', function() {
         var checked = $(this).prop('checked');
         if (checked) {
-          var start = Date.now();
           self.checkEverythingChoices();
-          console.log(Date.now() - start);
         } else {
-          var start = Date.now();
           self.clearEverythingChoices();
-          console.log(Date.now() - start);
         }
       });
     };
@@ -700,7 +696,7 @@ apos.define('apostrophe-pieces-manager-modal', {
       self.$el.addClass('apos-manager-modal--has-no-choices');
       self.reflectChoiceCount();
     };
-    
+
     // When the "select everything" checkbox is checked,
     // we select all of the content
 
@@ -715,7 +711,6 @@ apos.define('apostrophe-pieces-manager-modal', {
 
       self.reflectChoiceCount();
     };
-
 
     // When the "select everything" checkbox is cleared,
     // we go back to selecting just the current page

--- a/lib/modules/apostrophe-pieces/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/manager-modal.js
@@ -560,10 +560,7 @@ apos.define('apostrophe-pieces-manager-modal', {
 
     self.enableCheckboxEvents = function() {
 
-      if (!$.contains(self.$el[0], self.$filters[0])) {
-        self.$filters.on('change', 'input[type="checkbox"][name="select-all"]', selectAllHandler);
-      }
-      self.$el.on('change', 'input[type="checkbox"][name="select-all"]', selectAllHandler);
+      self.onElOrFilters('change', 'input[type="checkbox"][name="select-all"]', selectAllHandler);
       function selectAllHandler(e) {
         var checked = $(this).prop('checked');
         var $pieces = self.$el.find('[data-piece]');
@@ -637,16 +634,32 @@ apos.define('apostrophe-pieces-manager-modal', {
     };
 
     self.enableSelectEverything = function() {
-      self.$el.add(self.$filters).on('change', 'input[name="select-everything"]', function() {
+      self.onElOrFilters('change', 'input[name="select-everything"]', function() {
         var checked = $(this).prop('checked');
         if (checked) {
-          _.each(self.allIds, function(id) {
-            self.addChoice(id);
-          });
+          var start = Date.now();
+          self.checkEverythingChoices();
+          console.log(Date.now() - start);
         } else {
+          var start = Date.now();
           self.clearEverythingChoices();
+          console.log(Date.now() - start);
         }
       });
+    };
+
+    // Execute `fn` when the event `e` fires on the delegated selector `sel`.
+    // If `self.$filters` is contained in `self.$el` the delegation is done
+    // via `self.$el`, otherwise via `self.$filters`.
+    self.onElOrFilters = function(e, sel, fn) {
+      // A simple .and() should solve this problem, but that gives us double
+      // event firing, for reasons that are unclear - event delegation bug
+      // in jQuery? -Tom
+      if (!$.contains(self.$el[0], self.$filters[0])) {
+        self.$filters.on(e, sel, fn);
+      } else {
+        self.$el.on(e, sel, fn);
+      }
     };
 
     self.addChoice = function(id) {
@@ -687,27 +700,42 @@ apos.define('apostrophe-pieces-manager-modal', {
       self.$el.addClass('apos-manager-modal--has-no-choices');
       self.reflectChoiceCount();
     };
+    
+    // When the "select everything" checkbox is checked,
+    // we select all of the content
+
+    self.checkEverythingChoices = function() {
+      _.each(self.allIds, function(id) {
+        self.addChoiceToState(id);
+      });
+      var ids = self.getVisibleChoiceIds();
+      _.each(ids, function(id) {
+        self.reflectChoiceInCheckbox(id);
+      });
+
+      self.reflectChoiceCount();
+    };
+
 
     // When the "select everything" checkbox is cleared,
     // we go back to selecting just the current page
     // of content
     self.clearEverythingChoices = function() {
-      var $pieces = self.$el.find('[data-piece]');
-
       self.clearChoices();
 
-      var ids = $pieces.map(function() {
-        if ($(this).find('input[type="checkbox"]').is(':checked')) {
-          return $(this).attr('data-piece');
-        }
-      }).get();
-
-      _.each(ids, function(id) {
+      _.each(self.getVisibleChoiceIds(), function(id) {
         self.addChoice(id);
       });
 
       self.reflectChoiceCount();
+    };
 
+    // Get the ids of the currently visible choices (not necessarily checked)
+    self.getVisibleChoiceIds = function() {
+      var $pieces = self.$el.find('[data-piece]');
+      return $pieces.map(function() {
+        return $(this).attr('data-piece');
+      }).get();
     };
 
     self.refreshSelectEverything = function() {


### PR DESCRIPTION
…nt from firing twice, and (2) eliminating expensive DOM manipulation for the vast majority of ids that are not part of the current page of results