### PR TITLE
Apostrophe-schemas/index: check if value is array

### DIFF
--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -1381,7 +1381,8 @@ module.exports = {
       },
       index: function(value, field, texts) {
         var silent = (field.silent === undefined) ? true : field.silent;
-        texts.push({ weight: field.weight || 15, text: (value || []).join(' '), silent: silent });
+        var text = Array.isArray(value) ? value : [];
+        texts.push({ weight: field.weight || 15, text: text.join(' '), silent: silent });
       },
       addFilter: function(field, cursor) {
         return cursor.addFilter(field.name, {


### PR DESCRIPTION
Fix the error below by checking `value` is an array:

```
TypeError: (value || []).join is not a function
    at Object.index (/app/node_modules/apostrophe/lib/modules/apostrophe-schemas/index.js:1384:70)
    at /app/node_modules/apostrophe/lib/modules/apostrophe-schemas/index.js:435:19
    at arrayEach (/app/node_modules/@sailshq/lodash/lib/index.js:1463:13)
    at Function.<anonymous> (/app/node_modules/@sailshq/lodash/lib/index.js:3525:13)
    at Object.self.indexFields (/app/node_modules/apostrophe/lib/modules/apostrophe-schemas/index.js:427:9)
    at Object.self.searchIndexListener (/app/node_modules/apostrophe/lib/modules/apostrophe-doc-type-manager/lib/api.js:422:23)
    at Object.self.emit (/app/node_modules/apostrophe/index.js:105:19)
    at Object.self.getSearchTexts (/app/node_modules/apostrophe/lib/modules/apostrophe-search/index.js:372:17)
    at Object.self.indexDoc (/app/node_modules/apostrophe/lib/modules/apostrophe-search/index.js:302:24)
    at Object.self.docBeforeSave (/app/node_modules/apostrophe/lib/modules/apostrophe-search/index.js:295:19)
    at Immediate._onImmediate (/app/node_modules/apostrophe/index.js:516:20)
    at runCallback (timers.js:781:20)
    at tryOnImmediate (timers.js:743:5)
    at processImmediate [as _immediateCallback] (timers.js:714:5)
```