### PR TITLE
Check for type of asset copy operation

### DIFF
--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -670,7 +670,11 @@ module.exports = {
       if (!fs.existsSync(to)) {
         return;
       }
-      if (process.platform.match(/^win/)) {
+     
+    // Check if running in windows or in a containerized environment 
+    // indicated by a process.env.APOS_ALWAYS_COPY_ASSETS variable that 
+    // is truthy.
+      if (process.platform.match(/^win/) || process.env.APOS_ALWAYS_COPY_ASSETS) {
         self.linkAssetFolderOnWindows(from, to);
       } else {
         self.linkAssetFolderOnUnix(from, to);

--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -671,10 +671,11 @@ module.exports = {
         return;
       }
      
-    // Check if running in windows or in a containerized environment 
-    // indicated by a process.env.APOS_ALWAYS_COPY_ASSETS variable that 
-    // is truthy.
-      if (process.platform.match(/^win/) || process.env.APOS_ALWAYS_COPY_ASSETS) {
+      // Check if running in windows or in a 
+      // containerized environment indicated by a 
+      // process.env.APOS_ALWAYS_COPY_ASSETS variable 
+      // that is truthy.
+      if (process.platform.match(/^win/) || process.env.APOS_ALWAYS_COPY_ASSETS==1) {
         self.linkAssetFolderOnWindows(from, to);
       } else {
         self.linkAssetFolderOnUnix(from, to);

--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -670,12 +670,11 @@ module.exports = {
       if (!fs.existsSync(to)) {
         return;
       }
-     
-      // Check if running in windows or in a 
-      // containerized environment indicated by a 
-      // process.env.APOS_ALWAYS_COPY_ASSETS variable 
+      // Check if running in windows or in a
+      // containerized environment indicated by a
+      // process.env.APOS_ALWAYS_COPY_ASSETS variable
       // that is truthy.
-      if (process.platform.match(/^win/) || process.env.APOS_ALWAYS_COPY_ASSETS==1) {
+      if (process.platform.match(/^win/) || process.env.APOS_ALWAYS_COPY_ASSETS) {
         self.linkAssetFolderOnWindows(from, to);
       } else {
         self.linkAssetFolderOnUnix(from, to);


### PR DESCRIPTION
Added check to see if running in a container as symlinks don't play well. If true assume same processing as windows environments for copying the static assets from Apostrophe into the public folder. Documentation for Docker needs updating to include system.env.APOS_ALWAYS_COPY_ASSETS: '1'