### PR TITLE
option to convert strings as rich text when importing areas

### DIFF
--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -1035,7 +1035,11 @@ module.exports = {
       name: 'area',
       converters: {
         string: function(req, data, name, object, field, callback) {
-          object[name] = self.apos.areas.fromPlaintext(data[name]);
+          if (field.importAsRichText) {
+            object[name] = self.apos.areas.fromRichText(data[name]);
+          } else {
+            object[name] = self.apos.areas.fromPlaintext(data[name]);
+          }
           return setImmediate(callback);
         },
         form: function(req, data, name, object, field, callback) {


### PR DESCRIPTION
Allows pieces-import to be fully compatible with pieces-export (unfortunately we're stuck with the difference in default behavior for bc)