### PR TITLE
Update api.js

### DIFF
--- a/lib/modules/apostrophe-docs/lib/api.js
+++ b/lib/modules/apostrophe-docs/lib/api.js
@@ -955,7 +955,7 @@ module.exports = function(self, options) {
             return callback('notfound');
           }
           // A stale lock is effectively a missing lock
-          if (info.advisoryLock.updatedAt < self.getAdvisoryLockExpiration()) {
+          if (info.advisoryLock && info.advisoryLock.updatedAt < self.getAdvisoryLockExpiration()) {
             return callback('notfound');
           }
           if ((!info.advisoryLock) || (info.advisoryLock._id !== contextId)) {


### PR DESCRIPTION
I've seen this line crash the system recently, there seems to be no check for info.advisoryLock actually being present although the check is on the following lines.