### PR TITLE
Bless nested widgets under object

### DIFF
--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -1934,6 +1934,15 @@ module.exports = {
           type: options.type,
           subtype: options.subtype ? (options.subtype + '.' + field.name) : field.name
         });
+      },
+      bless: function (req, field) {
+        // Bless nested field types inside object.
+        _.each(field.schema || [], function (field) {
+          const fieldType = field.type;
+          if (self.fieldTypes[fieldType].bless) {
+            self.fieldTypes[fieldType].bless(req, field);
+          }
+        });
       }
     });
 


### PR DESCRIPTION
Issue -> Nested Field Types under type **object** were not blessed and the call to edit-virtual-area threw an unblessed error.

Steps to Reproduce => https://www.notion.so/Unblessed-Object-d219424afd954f7f80b82bb26a144da8

Changes => Add a new bless method for type object that will internally call the bless method of nested field types.