### PR TITLE
new warning for failure to use arrangeFields. Also, new `apos.utils.w…

### DIFF
--- a/index.js
+++ b/index.js
@@ -491,7 +491,7 @@ module.exports = function(options) {
   }
 
   function lint(s) {
-    self.utils.warn('\n⚠️  It looks like you may have made a mistake in your code:\n\n' + s + '\n');
+    self.utils.warnDev('\n⚠️  It looks like you may have made a mistake in your code:\n\n' + s + '\n');
   }
 
   function afterInit(callback) {

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -533,7 +533,7 @@ module.exports = {
         if (!field) {
           // Do not crash. The linter at startup also catches this,
           // but is a nonfatal warning for bc, so we should also catch it
-          self.apos.utils.warn('⚠️ showFields misconfigured, attempts to show/hide ' + name + ' which does not exist');
+          self.apos.utils.warnDev('⚠️ showFields misconfigured, attempts to show/hide ' + name + ' which does not exist');
           return;
         }
         _.each(field.choices || [], function(choice) {
@@ -2547,6 +2547,7 @@ module.exports = {
         return;
       }
       self.validatedSchemas[options.type + ':' + options.subtype] = true;
+      var ungrouped = [];
       _.each(schema, function(field) {
         var fieldType = self.fieldTypes[field.type];
         if (!fieldType) {
@@ -2561,16 +2562,31 @@ module.exports = {
         if (fieldType.validate) {
           fieldType.validate(field, options, warn, fail, schema);
         }
+        // If at least one field is in a non-default group and this one is in the
+        // default group, complain about halfassed grouping. The "Info" tab indicates
+        // insufficient UX consideration, unless it contains all the fields, which
+        // usually indicates a simple array schema that does not need any groups.
+        // Don't ding the developer for things that aren't their fault and are
+        // probably not that obnoxious in practice, like the withTags field of all
+        // pieces-pages, which is usually alone in the default group.
+        if (field.group && (!field.contextual) && (field.name !== 'withTags') && (field.group.name === 'default') && (_.find(schema, function(field) {
+          return (field.group) && (field.group.name !== 'default');
+        }))) {
+          ungrouped.push(field);
+        }
         function fail(s) {
           throw new Error(format(s));
         }
         function warn(s) {
-          self.apos.utils.warn(format(s));
+          self.apos.utils.warnDev(format(s));
         }
         function format(s) {
           return '\n⚠️  ' + options.type + ' ' + options.subtype + ', field name ' + field.name + ':\n\n' + s + '\n';
         }
       });
+      if (ungrouped.length) {
+        self.apos.utils.warnDev('\n⚠️  ' + options.type + ' ' + options.subtype + ' contains ungrouped field(s): ' + _.pluck(ungrouped, 'name').join(', ') + '.\nArrange all of your fields with arrangeFields, using meaningful group labels.\nhttps://apos.dev/arrange-fields');
+      }
     };
 
     // Return all standard field names currently associated with permissions editing,

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -2569,9 +2569,14 @@ module.exports = {
         // Don't ding the developer for things that aren't their fault and are
         // probably not that obnoxious in practice, like the withTags field of all
         // pieces-pages, which is usually alone in the default group.
-        if (field.group && (!field.contextual) && (field.name !== 'withTags') && (field.group.name === 'default') && (_.find(schema, function(field) {
-          return (field.group) && (field.group.name !== 'default');
-        }))) {
+        if (
+            field.group &&
+            (!field.contextual) &&
+            (field.name !== 'withTags') &&
+            (field.group.name === 'default') &&
+            (_.find(schema, function(field) {
+              return (field.group) && (field.group.name !== 'default');
+            }))) {
           ungrouped.push(field);
         }
         function fail(s) {

--- a/lib/modules/apostrophe-utils/lib/api.js
+++ b/lib/modules/apostrophe-utils/lib/api.js
@@ -614,6 +614,15 @@ module.exports = function(self, options) {
     self.logger.warn.apply(self.logger, arguments);
   };
 
+  // Identical to `apos.utils.warn`, except that the warning is
+  // not displayed if `process.env.NODE_ENV` is `production`.
+  self.warnDev = function(msg) {
+    if (process.env.NODE_ENV === 'production') {
+      return;
+    }
+    self.warn.apply(self, arguments);
+  }
+
   // Log an error message. The default implementation
   // wraps `console.error` and passes on all arguments,
   // so substitution strings may be used.


### PR DESCRIPTION
…arnDev` method, identical to `apos.utils.warn` except that it does nothing when the NODE_ENV production variable is set to production (this matches express behavior).