### PR TITLE
Select multiple checkboxes with shift key.

### DIFF
--- a/index.js
+++ b/index.js
@@ -491,7 +491,7 @@ module.exports = function(options) {
   }
 
   function lint(s) {
-    self.utils.warn('\n⚠️  It looks like you may have made a mistake in your code:\n\n' + s + '\n');
+    self.utils.warnDev('\n⚠️  It looks like you may have made a mistake in your code:\n\n' + s + '\n');
   }
 
   function afterInit(callback) {

--- a/lib/modules/apostrophe-pages/public/js/reorganize.js
+++ b/lib/modules/apostrophe-pages/public/js/reorganize.js
@@ -535,7 +535,7 @@ apos.define('apostrophe-pages-reorganize', {
         // If shift key is pressed and the checkbox is checked.
         if (e.shiftKey && this.checked) {
           // Get the siblings for the checkboxes that are being checked.
-          var $checkboxesInScope = $(this).closest('ul.jqtree_common').find('input');
+          var $checkboxesInScope = $(this).closest('ul.jqtree_common').find('input') || [];
           // Get the Index of the currently selected checkbox. (The one checked with holiding shift)
           var startIndex = $checkboxesInScope.index(this);
           // Get the index of the previously selected checkbox.

--- a/lib/modules/apostrophe-pages/public/js/reorganize.js
+++ b/lib/modules/apostrophe-pages/public/js/reorganize.js
@@ -522,6 +522,33 @@ apos.define('apostrophe-pages-reorganize', {
         }
       });
 
+      // Add ability to select multiple checkboxes (Using Left Shift)
+      var lastChecked;
+      self.$el.on('click', 'input[name="selected"][type="checkbox"]', function (e) {
+        // Store a variable called lastchecked to point to the last checked checkbox. If it is undefined it's the first checkbox that's selected.
+
+        if (!lastChecked) {
+          lastChecked = this;
+          return;
+        }
+
+        // If shift key is pressed and the checkbox is checked.
+        if (e.shiftKey && this.checked) {
+          // Get the siblings for the checkboxes that are being checked.
+          var $checkboxesInScope = $(this).closest('ul.jqtree_common').find('input');
+          // Get the Index of the currently selected checkbox. (The one checked with holiding shift)
+          var startIndex = $checkboxesInScope.index(this);
+          // Get the index of the previously selected checkbox.
+          var endIndex = $checkboxesInScope.index(lastChecked);
+          // Get a list of all checkboxes inbetween both the indexes and make them checked.
+          $checkboxesInScope.slice(Math.min(startIndex, endIndex), Math.max(startIndex, endIndex) + 1).each(function (i, el) {
+            $(el).prop('checked', true);
+            $(el).trigger('change');
+          });
+        }
+        lastChecked = this;
+      });
+
     };
 
     self.addChoice = function(id) {

--- a/lib/modules/apostrophe-pieces/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/manager-modal.js
@@ -604,6 +604,37 @@ apos.define('apostrophe-pieces-manager-modal', {
           self.removeChoice(id);
         }
       });
+
+      // Add ability to select multiple checkboxes (Using Left Shift)
+      var lastChecked;
+      // Clicks on checkbox directly are not possible because as visibility:hidden is set on it and clicks won't be detected.
+      self.$el.on('click', '.apos-field-input-checkbox-indicator', function (e) {
+        var box = $(this).siblings('.apos-field-input-checkbox')[0];
+
+        // Store a variable called lastchecked to point to the last checked checkbox. If it is undefined it's the first checkbox that's selected.  
+        if (!lastChecked) {
+          lastChecked = box;
+          return;
+        }
+
+        // If shift key is pressed and the checkbox is not checked.
+        if (e.shiftKey && !box.checked) {
+          // Get the siblings for the checkboxes that are being checked.
+          var $checkboxesInScope = $(box).closest('tbody').find('input') || [];
+          // Get the Index of the currently selected checkbox. (The one checked with holiding shift)
+          var startIndex = $checkboxesInScope.index(box);
+          // Get the index of the previously selected checkbox. 
+          var endIndex = $checkboxesInScope.index(lastChecked);
+          // Get a list of all checkboxes inbetween both the indexes and make them checked.
+          $checkboxesInScope.slice(Math.min(startIndex, endIndex), Math.max(startIndex, endIndex) + 1).each(function (i, el) {
+            if (el !== box) {
+              $(el).prop('checked', true);
+              $(el).trigger('change');
+            }
+          });
+        }
+        lastChecked = box;
+      });
     };
 
     // shrink and grow make visual reflectments to accommodate the the new Select Everything element

--- a/lib/modules/apostrophe-pieces/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/manager-modal.js
@@ -611,7 +611,7 @@ apos.define('apostrophe-pieces-manager-modal', {
       self.$el.on('click', '.apos-field-input-checkbox-indicator', function (e) {
         var box = $(this).siblings('.apos-field-input-checkbox')[0];
 
-        // Store a variable called lastchecked to point to the last checked checkbox. If it is undefined it's the first checkbox that's selected.  
+        // Store a variable called lastchecked to point to the last checked checkbox. If it is undefined it's the first checkbox that's selected.
         if (!lastChecked) {
           lastChecked = box;
           return;
@@ -623,7 +623,7 @@ apos.define('apostrophe-pieces-manager-modal', {
           var $checkboxesInScope = $(box).closest('tbody').find('input') || [];
           // Get the Index of the currently selected checkbox. (The one checked with holiding shift)
           var startIndex = $checkboxesInScope.index(box);
-          // Get the index of the previously selected checkbox. 
+          // Get the index of the previously selected checkbox.
           var endIndex = $checkboxesInScope.index(lastChecked);
           // Get a list of all checkboxes inbetween both the indexes and make them checked.
           $checkboxesInScope.slice(Math.min(startIndex, endIndex), Math.max(startIndex, endIndex) + 1).each(function (i, el) {

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -533,7 +533,7 @@ module.exports = {
         if (!field) {
           // Do not crash. The linter at startup also catches this,
           // but is a nonfatal warning for bc, so we should also catch it
-          self.apos.utils.warn('⚠️ showFields misconfigured, attempts to show/hide ' + name + ' which does not exist');
+          self.apos.utils.warnDev('⚠️ showFields misconfigured, attempts to show/hide ' + name + ' which does not exist');
           return;
         }
         _.each(field.choices || [], function(choice) {
@@ -2547,6 +2547,7 @@ module.exports = {
         return;
       }
       self.validatedSchemas[options.type + ':' + options.subtype] = true;
+      var ungrouped = [];
       _.each(schema, function(field) {
         var fieldType = self.fieldTypes[field.type];
         if (!fieldType) {
@@ -2561,16 +2562,31 @@ module.exports = {
         if (fieldType.validate) {
           fieldType.validate(field, options, warn, fail, schema);
         }
+        // If at least one field is in a non-default group and this one is in the
+        // default group, complain about halfassed grouping. The "Info" tab indicates
+        // insufficient UX consideration, unless it contains all the fields, which
+        // usually indicates a simple array schema that does not need any groups.
+        // Don't ding the developer for things that aren't their fault and are
+        // probably not that obnoxious in practice, like the withTags field of all
+        // pieces-pages, which is usually alone in the default group.
+        if (field.group && (!field.contextual) && (field.name !== 'withTags') && (field.group.name === 'default') && (_.find(schema, function(field) {
+          return (field.group) && (field.group.name !== 'default');
+        }))) {
+          ungrouped.push(field);
+        }
         function fail(s) {
           throw new Error(format(s));
         }
         function warn(s) {
-          self.apos.utils.warn(format(s));
+          self.apos.utils.warnDev(format(s));
         }
         function format(s) {
           return '\n⚠️  ' + options.type + ' ' + options.subtype + ', field name ' + field.name + ':\n\n' + s + '\n';
         }
       });
+      if (ungrouped.length) {
+        self.apos.utils.warnDev('\n⚠️  ' + options.type + ' ' + options.subtype + ' contains ungrouped field(s): ' + _.pluck(ungrouped, 'name').join(', ') + '.\nArrange all of your fields with arrangeFields, using meaningful group labels.\nhttps://apos.dev/arrange-fields');
+      }
     };
 
     // Return all standard field names currently associated with permissions editing,

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -2570,7 +2570,7 @@ module.exports = {
         // probably not that obnoxious in practice, like the withTags field of all
         // pieces-pages, which is usually alone in the default group.
         if (
-            field.group &&
+          field.group &&
             (!field.contextual) &&
             (field.name !== 'withTags') &&
             (field.group.name === 'default') &&

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -2569,9 +2569,14 @@ module.exports = {
         // Don't ding the developer for things that aren't their fault and are
         // probably not that obnoxious in practice, like the withTags field of all
         // pieces-pages, which is usually alone in the default group.
-        if (field.group && (!field.contextual) && (field.name !== 'withTags') && (field.group.name === 'default') && (_.find(schema, function(field) {
-          return (field.group) && (field.group.name !== 'default');
-        }))) {
+        if (
+            field.group &&
+            (!field.contextual) &&
+            (field.name !== 'withTags') &&
+            (field.group.name === 'default') &&
+            (_.find(schema, function(field) {
+              return (field.group) && (field.group.name !== 'default');
+            }))) {
           ungrouped.push(field);
         }
         function fail(s) {

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -1934,6 +1934,15 @@ module.exports = {
           type: options.type,
           subtype: options.subtype ? (options.subtype + '.' + field.name) : field.name
         });
+      },
+      bless: function (req, field) {
+        // Bless nested field types inside object.
+        _.each(field.schema || [], function (field) {
+          const fieldType = field.type;
+          if (self.fieldTypes[fieldType].bless) {
+            self.fieldTypes[fieldType].bless(req, field);
+          }
+        });
       }
     });
 

--- a/lib/modules/apostrophe-utils/lib/api.js
+++ b/lib/modules/apostrophe-utils/lib/api.js
@@ -621,7 +621,7 @@ module.exports = function(self, options) {
       return;
     }
     self.warn.apply(self, arguments);
-  }
+  };
 
   // Log an error message. The default implementation
   // wraps `console.error` and passes on all arguments,

--- a/lib/modules/apostrophe-utils/lib/api.js
+++ b/lib/modules/apostrophe-utils/lib/api.js
@@ -614,6 +614,15 @@ module.exports = function(self, options) {
     self.logger.warn.apply(self.logger, arguments);
   };
 
+  // Identical to `apos.utils.warn`, except that the warning is
+  // not displayed if `process.env.NODE_ENV` is `production`.
+  self.warnDev = function(msg) {
+    if (process.env.NODE_ENV === 'production') {
+      return;
+    }
+    self.warn.apply(self, arguments);
+  }
+
   // Log an error message. The default implementation
   // wraps `console.error` and passes on all arguments,
   // so substitution strings may be used.


### PR DESCRIPTION
Add the ability to select multiple checkboxes by holding on to left shift (Something like Gmail) on the Reorganize Pages Module.