### PR TITLE
Workaround for cloning widgets with nested sub-areas

### DIFF
--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -277,10 +277,13 @@ apos.define('apostrophe-areas-editor', {
 
     // Implementation detail of `addItem`, should not be called directly.
     // Adds the given widget wrapper to the DOM, respecting the limit.
-
-    self.insertWidget = function($wrapper) {
+    //
+    // Added isCloned to function so that we can pass this through
+    // to the fixInsertedWidgetDotPaths so that all areas cloned can be 
+    // dot path corrected. - hexitex 
+    self.insertWidget = function($wrapper,isCloned) {
       var $widget = $wrapper.children('[data-apos-widget]').first();
-      self.fixInsertedWidgetDotPaths($widget);
+      self.fixInsertedWidgetDotPaths($widget,isCloned);
       self.insertItem($wrapper);
       self.enhanceWidgetControls($widget);
       self.respectLimit();
@@ -292,8 +295,18 @@ apos.define('apostrophe-areas-editor', {
     // dot path are correctly set to show that relationship. But
     // render-widget has no way of knowing how to set these for us,
     // so we need to fix them up
-    self.fixInsertedWidgetDotPaths = function($widget) {
+    //
+    // This didn't do anything for cloned widgets but it needed to.
+    // isCloned would be true from the cloneWidget function and indicates
+    // we need to correct dot path on all sub areas as they were being
+    // duplicated/shared preventing edits - hexitex
+    self.fixInsertedWidgetDotPaths = function($widget,isCloned) {
+      if (!isCloned){
       var $areas = $widget.findSafe('[data-apos-area]', '[data-apos-widget]');
+      } else{
+        // cloned widget, get all sub areas
+      var $areas = $widget.find('[data-apos-area]');
+      }
       var id = self.$el.attr('data-doc-id');
       var p = self.$el.attr('data-dot-path');
       var ordinal = 0;
@@ -327,7 +340,8 @@ apos.define('apostrophe-areas-editor', {
         var $area = $(this);
         var wid = $area.attr('data-doc-id');
         var wp = $area.attr('data-dot-path');
-        if (wid.substr(0, 1) === 'w') {
+        // check if is new or is from a cloned widget
+        if (wid.substr(0, 1) === 'w'||isCloned) {
           $area.attr('data-doc-id', id);
           var dotPath = p + '.items.' + ordinal + '.' + wp;
           $area.attr('data-dot-path', dotPath);
@@ -520,7 +534,11 @@ apos.define('apostrophe-areas-editor', {
           // various situations in which jquery is
           // picky about HTML
           var $wrapper = $($.parseHTML($.trim(html), null, true));
-          self.insertWidget($wrapper);
+          // Second arg in the insertWidget call indicates
+          // that the insert came from a clone 
+          // and we need to fixup the dot path for
+          // all sub areas
+          self.insertWidget($wrapper,true);
           self.checkEmptyAreas();
         }
       );


### PR DESCRIPTION
This is a temp fix for the cloning issue where the 'could not take control of the document' message was being displayed and preventing edits on cloned widget sub-areas.