### PR TITLE
Active array item in last to be resetted when deleting other items

### DIFF
--- a/lib/modules/apostrophe-schemas/public/js/array-modal.js
+++ b/lib/modules/apostrophe-schemas/public/js/array-modal.js
@@ -294,6 +294,11 @@ apos.define('apostrophe-array-editor-modal', {
             self.active = Math.max(parseInt(self.active) - 1, 0);
             self.editItem();
           }
+          // If an active item in an array is last and delete an any item above the last item
+          // Then the active item of an array to be resetted to the last item
+          if (self.active === self.arrayItems.length) {
+            self.active = self.active - 1;
+          }
         });
       }
     };


### PR DESCRIPTION
**Steps to reproduce :-**

1. In schema, add a two item back to back in an array
2. Ensure the active item in an array to be a last item
3. Delete any one item in an array other than last item
4. Now click add new item in an array. It’ll throw an error and the whole saved items in an array will become lose.