### PR TITLE
Adds select image exif data to the image document if available.

### DIFF
--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -127,6 +127,9 @@ module.exports = function(self, options) {
                 }
 
                 const data = exifData;
+
+                if (!data) { return callback(null); }
+
                 info.description = data.ImageDescription ? data.ImageDescription.trim() : null;
 
                 if (data.Make && data.Model) {

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -122,21 +122,21 @@ module.exports = function(self, options) {
             if (info.extension === 'jpg') {
               exif.parse(file.path, (err, exifData) => {
                 if (err) {
-                  console.log(err);
-                } else {
-
-                  const data = exifData;
-                  info.description = data.ImageDescription ? data.ImageDescription.trim() : null;
-
-                  if (data.Make && data.Model) {
-                    info.camera = data.Make.trim() + ' ' + data.Model.trim();
-                  } else if (data.Model) {
-                    info.camera = data.Model.trim();
-                  }
-
-                  info.captureDate = data.DateTime ? data.DateTime : null;
-                  info.credit = data.Copyright ? data.Copyright.trim() : null;
+                  self.apos.utils.error('jpeg-exif error:', err);
+                  return callback(null);
                 }
+
+                const data = exifData;
+                info.description = data.ImageDescription ? data.ImageDescription.trim() : null;
+
+                if (data.Make && data.Model) {
+                  info.camera = data.Make.trim() + ' ' + data.Model.trim();
+                } else if (data.Model) {
+                  info.camera = data.Model.trim();
+                }
+
+                info.captureDate = data.DateTime ? data.DateTime : null;
+                info.credit = data.Copyright ? data.Copyright.trim() : null;
 
                 return callback(null);
               });

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -119,19 +119,19 @@ module.exports = function(self, options) {
               info.portrait = true;
             }
 
-            if (info.extension === 'jpg' || info.extension === 'jpeg') {
+            if (info.extension === 'jpg') {
               const data = exif.parseSync(file.path);
-
-              info.description = data.ImageDescription ? data.ImageDescription : null;
+              console.log(data);
+              info.description = data.ImageDescription ? data.ImageDescription.trim() : null;
 
               if (data.Make && data.Model) {
-                info.camera = data.Make + ' ' + data.Model;
+                info.camera = data.Make.trim() + ' ' + data.Model.trim();
               } else if (data.Model) {
-                info.camera = data.Model;
+                info.camera = data.Model.trim();
               }
 
               info.captureDate = data.DateTime ? data.DateTime : null;
-              info.credit = data.Copyright ? data.Copyright : null;
+              info.credit = data.Copyright ? data.Copyright.trim() : null;
             }
 
             return callback(null);

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -120,7 +120,7 @@ module.exports = function(self, options) {
             }
 
             if (info.extension === 'jpg') {
-              exif.parse(file.path, (err, exifData) => {
+              return exif.parse(file.path, (err, exifData) => {
                 if (err) {
                   self.apos.utils.error('jpeg-exif error:', err);
                   return callback(null);

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -3,6 +3,7 @@ var async = require('async');
 var path = require('path');
 var fs = require('fs');
 var Promise = require('bluebird');
+const exif = require('jpeg-exif');
 
 module.exports = function(self, options) {
 
@@ -101,9 +102,11 @@ module.exports = function(self, options) {
       }
 
       function upload(callback) {
+        const targetPath = '/attachments/' + info._id + '-' + info.name;
+
         if (self.isSized(extension)) {
           // For images we correct automatically for common file extension mistakes
-          return self.uploadfs.copyImageIn(file.path, '/attachments/' + info._id + '-' + info.name, function(err, result) {
+          return self.uploadfs.copyImageIn(file.path, targetPath, function(err, result) {
             if (err) {
               return callback(err);
             }
@@ -115,13 +118,24 @@ module.exports = function(self, options) {
             } else {
               info.portrait = true;
             }
+
+            if (info.extension === 'jpg' || info.extension === 'jpeg') {
+              // const exifPath = `${process.cwd()}/public/uploads${result.basePath}.${info.extension}`;
+              const data = exif.parseSync(file.path);
+
+              info.description = data.ImageDescription ? data.ImageDescription : null;
+              info.camera = data.Model ? data.Model : null;
+              info.captureDate = data.DateTime ? data.DateTime : null;
+              info.credit = data.Copyright ? data.Copyright : null;
+            }
+
             return callback(null);
           });
         } else {
           // For non-image files we have to trust the file extension
           // (but we only serve it as that content type, so this should
           // be reasonably safe)
-          return self.uploadfs.copyIn(file.path, '/attachments/' + info._id + '-' + info.name + '.' + info.extension, callback);
+          return self.uploadfs.copyIn(file.path, targetPath + '.' + info.extension, callback);
         }
       }
 

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -120,21 +120,29 @@ module.exports = function(self, options) {
             }
 
             if (info.extension === 'jpg') {
-              const data = exif.parseSync(file.path);
-              console.log(data);
-              info.description = data.ImageDescription ? data.ImageDescription.trim() : null;
+              exif.parse(file.path, (err, exifData) => {
+                if (err) {
+                  console.log(err);
+                } else {
 
-              if (data.Make && data.Model) {
-                info.camera = data.Make.trim() + ' ' + data.Model.trim();
-              } else if (data.Model) {
-                info.camera = data.Model.trim();
-              }
+                  const data = exifData;
+                  info.description = data.ImageDescription ? data.ImageDescription.trim() : null;
 
-              info.captureDate = data.DateTime ? data.DateTime : null;
-              info.credit = data.Copyright ? data.Copyright.trim() : null;
+                  if (data.Make && data.Model) {
+                    info.camera = data.Make.trim() + ' ' + data.Model.trim();
+                  } else if (data.Model) {
+                    info.camera = data.Model.trim();
+                  }
+
+                  info.captureDate = data.DateTime ? data.DateTime : null;
+                  info.credit = data.Copyright ? data.Copyright.trim() : null;
+                }
+
+                return callback(null);
+              });
+            } else {
+              return callback(null);
             }
-
-            return callback(null);
           });
         } else {
           // For non-image files we have to trust the file extension

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -120,11 +120,16 @@ module.exports = function(self, options) {
             }
 
             if (info.extension === 'jpg' || info.extension === 'jpeg') {
-              // const exifPath = `${process.cwd()}/public/uploads${result.basePath}.${info.extension}`;
               const data = exif.parseSync(file.path);
 
               info.description = data.ImageDescription ? data.ImageDescription : null;
-              info.camera = data.Model ? data.Model : null;
+
+              if (data.Make && data.Model) {
+                info.camera = data.Make + ' ' + data.Model;
+              } else if (data.Model) {
+                info.camera = data.Model;
+              }
+
               info.captureDate = data.DateTime ? data.DateTime : null;
               info.credit = data.Copyright ? data.Copyright : null;
             }

--- a/lib/modules/apostrophe-images/index.js
+++ b/lib/modules/apostrophe-images/index.js
@@ -49,6 +49,16 @@ module.exports = {
         type: 'url',
         name: 'creditUrl',
         label: 'Credit URL'
+      },
+      {
+        name: 'camera',
+        label: 'Camera Model',
+        type: 'string'
+      },
+      {
+        name: 'captureDate',
+        label: 'Capture Date',
+        type: 'string'
       }
     ].concat(options.addFields || []);
     options.arrangeFields = [
@@ -69,7 +79,9 @@ module.exports = {
         fields: [
           'description',
           'credit',
-          'creditUrl'
+          'creditUrl',
+          'camera',
+          'captureDate'
         ]
       }
     ].concat(options.arrangeFields || []);

--- a/lib/modules/apostrophe-pieces/lib/routes.js
+++ b/lib/modules/apostrophe-pieces/lib/routes.js
@@ -360,7 +360,7 @@ module.exports = function(self, options) {
 
       piece.slug = attachment.name;
 
-      for (let prop of properties) {
+      for (const prop of properties) {
         piece[prop] = attachment[prop];
       }
 

--- a/lib/modules/apostrophe-pieces/lib/routes.js
+++ b/lib/modules/apostrophe-pieces/lib/routes.js
@@ -346,10 +346,24 @@ module.exports = function(self, options) {
       if (!attachment) {
         return callback(null);
       }
+
       piece = self.newInstance();
       piece[field.name] = attachment;
-      piece.title = attachment.title;
+
+      const properties = [
+        'title',
+        'description',
+        'credit',
+        'camera',
+        'captureDate'
+      ];
+
       piece.slug = attachment.name;
+
+      for (let prop of properties) {
+        piece[prop] = attachment[prop];
+      }
+
       return self.insert(req, piece, callback);
     }
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "author": "P'unk Avenue LLC",
   "license": "MIT",
   "dependencies": {
+    "@apostrophecms/nunjucks": "^2.5.3",
     "@sailshq/lodash": "^3.10.3",
     "async": "^1.5.2",
     "bless": "^3.0.3",
@@ -47,6 +48,7 @@
     "html-to-text": "^3.3.0",
     "i18n": "^0.8.3",
     "joinr": "^1.0.2",
+    "jpeg-exif": "^1.1.3",
     "launder": "^1.1.1",
     "less": "^3.9.0",
     "less-middleware": "^3.0.1",
@@ -56,7 +58,6 @@
     "mongodb": "^2.2.36",
     "moog-require": "^1.1.0",
     "nodemailer": "^4.7.0",
-    "@apostrophecms/nunjucks": "^2.5.3",
     "oembetter": "^0.1.19",
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",


### PR DESCRIPTION
This adds select exif metadata to apostrophe-images when available. There's a ton that could be pulled from EXIF data, but I'm keeping it limited at the moment. Location was a good next candidate, but there are privacy implications to suddenly having that stored in newly updated Apostrophe sites.

Regarding the schema update, one option would be to start a new "Metadata" tab group, but "Info" currently overlaps with that pretty significantly.