### PR TITLE
load the global doc in two steps, first the actual doc and then any j…

### DIFF
--- a/lib/modules/apostrophe-global/index.js
+++ b/lib/modules/apostrophe-global/index.js
@@ -79,10 +79,42 @@ module.exports = {
     // with `(null, global)`.
 
     self.findGlobal = function(req, callback) {
-      return self.find(req, { slug: self.slug })
-        .permission(false)
-        .sort(false)
-        .toObject(callback);
+      var global;
+      var cursor;
+      return async.series([
+        find, after
+      ], function(err) {
+        if (err) {
+          return callback(err);
+        }
+        return callback(null, global);
+      });
+      function find(callback) {
+        cursor = self.find(req, { slug: self.slug })
+          .permission(false)
+          .sort(false)
+          .joins(false)
+          .areas(false);
+        return cursor.toObject(function(err, doc) {
+          global = doc;
+          // Make this available early, sans joins and area loaders,
+          // to avoid race conditions for modules like
+          // apostrophe-pieces-orderings-bundle if we wait
+          // for joins that might also need the global doc to find their
+          // default orderings, etc.
+          req.aposGlobalCore = global;
+          return callback(err);
+        });
+      }
+      function after(callback) {
+        if (!global) {
+          return callback(null);
+        }
+        cursor = cursor.clone();
+        cursor.joins(true);
+        cursor.areas(true);
+        return cursor.after([ global ], callback);
+      }
     };
 
     self.modulesReady = function(callback) {


### PR DESCRIPTION
…oins and area loaders, in order to make it possible for modules like apostrophe-pieces-orderings-bundle to avoid recursion and race conditions when they only care about the direct properties of the doc itself. See corresponding apostrophe-pieces-orderings-bundle PR.
