### PR TITLE
moved all database operations at startup into apostrophe:migrate even…

### DIFF
--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -88,6 +88,7 @@ var fs = require('fs');
 
 var _ = require('@sailshq/lodash');
 var async = require('async');
+var Promise = require('bluebird');
 // JS minifier and optimizer
 var uglifyJs = require('uglify-js');
 // LESS CSS compiler
@@ -582,17 +583,21 @@ module.exports = {
       // Create symbolic links in /modules so that our web paths can be
       // served by a static server like nginx
 
-      return async.series([
-        self.symlinkModules,
-        self.buildLessMasters,
-        self.minify,
-        self.outputAndBless
-      ], function(err) {
-        if (err) {
-          return callback(err);
-        }
-        return callback(null);
+      self.on('apostrophe:migrate', 'migrateAssets', function() {
+        return Promise.promisify(function(callback) {
+          return async.series([
+            self.symlinkModules,
+            self.buildLessMasters,
+            self.minify,
+            self.outputAndBless
+          ], callback);
+        })();
       });
+
+      // We now add a migrate handler rather than migrating assets at this point,
+      // but we keep to taking a callback for maximum bc with anyone applying
+      // the super pattern to this method
+      return callback(null);
     };
 
     // Ensure that the standard asset folders exist at project level,

--- a/lib/modules/apostrophe-db/index.js
+++ b/lib/modules/apostrophe-db/index.js
@@ -54,6 +54,9 @@ module.exports = {
       if (err) {
         return callback(err);
       }
+      if (process.env.APOS_TRACE_DB) {
+        self.trace();
+      }
       self.keepalive();
       self.bcPatch();
       return callback(null);
@@ -275,6 +278,41 @@ module.exports = {
         self.apos.db.closed = true;
         return callback(null);
       });
+    };
+
+    self.trace = function() {
+      var superCollection = self.apos.db.collection;
+      self.apos.db.collection = function(name, options, callback) {
+        if (callback) {
+          return superCollection.call(self.apos.db, name, options, function(err, collection) {
+            if (err) {
+              return callback(err);
+            }
+            decorate(collection);
+            return callback(null, collection);
+          });
+        } else {
+          var collection = superCollection.apply(self.apos.db, arguments);
+          decorate(collection);
+          return collection;
+        }
+        function decorate(collection) {
+          wrap('insert');
+          wrap('update');
+          wrap('remove');
+          wrap('aggregate');
+          wrap('count');
+          wrap('find');
+          function wrap(method) {
+            var superMethod = collection[method];
+            collection[method] = function() {
+              /* eslint-disable-next-line no-console */
+              console.trace(method);
+              return superMethod.apply(collection, arguments);
+            };
+          }
+        }
+      };
     };
   }
 };

--- a/lib/modules/apostrophe-global/index.js
+++ b/lib/modules/apostrophe-global/index.js
@@ -117,8 +117,16 @@ module.exports = {
       }
     };
 
+    // We no longer call initGlobal on modulesReady, we do it on the new
+    // apostrophe:migrate event. But to maximize bc, we still register the event
+    // handler in modulesReady. This accommodates anyone who has applied
+    // the super pattern to that method.
+
     self.modulesReady = function(callback) {
-      self.initGlobal(callback);
+      self.on('apostrophe:migrate', 'initGlobalPromisified', function(options) {
+        return Promise.promisify(self.initGlobal)();
+      });
+      return callback(null);
     };
 
     // Initialize the `global` doc, if necessary. Invoked late in the

--- a/lib/modules/apostrophe-locks/index.js
+++ b/lib/modules/apostrophe-locks/index.js
@@ -38,6 +38,11 @@ module.exports = {
 
     self.lock = function(name, options, callback) {
 
+      if (process.env.APOS_TRACE_LOCKS) {
+        /* eslint-disable-next-line no-console */
+        console.trace('Locking ' + name);
+      }
+
       // Implementation notes: since `_id` must be unique, we know
       // we have the lock if we succeed in inserting a mongodb doc with
       // an _id equal to the lock name. If we fail due to a duplicate key,
@@ -185,6 +190,11 @@ module.exports = {
     // If you call without a callback, a promise is returned instead.
 
     self.unlock = function(name, callback) {
+
+      if (process.env.APOS_TRACE_LOCKS) {
+        /* eslint-disable-next-line no-console */
+        console.trace('Unlocking ' + name);
+      }
 
       if (callback) {
         return body(callback);

--- a/lib/modules/apostrophe-migrations/index.js
+++ b/lib/modules/apostrophe-migrations/index.js
@@ -9,6 +9,8 @@
 // NO guarantee that they will not run again when the cache is cleared. If this is
 // difficult to guarantee, you may wish to write a task instead.
 
+var Promise = require('bluebird');
+
 module.exports = {
 
   alias: 'migrations',
@@ -27,5 +29,10 @@ module.exports = {
   construct: function(self, options) {
     require('./lib/api.js')(self, options);
     require('./lib/implementation.js')(self, options);
+    // Always run safe migrations at startup; why would we ever continue
+    // with an inconsistent database?
+    self.on('apostrophe:migrate', 'runRegisteredMigrations', function(options) {
+      return Promise.promisify(self.migrate)(options);
+    });
   }
 };

--- a/lib/modules/apostrophe-migrations/lib/implementation.js
+++ b/lib/modules/apostrophe-migrations/lib/implementation.js
@@ -23,11 +23,13 @@ module.exports = function(self, options) {
   };
 
   self.addMigrationTask = function() {
-    self.apos.tasks.add(self.__meta.name, 'migrate', 'Apply any necessary migrations to the database.', self.migrationTask);
+    self.apos.tasks.add(self.__meta.name, 'migrate', 'Apply any necessary migrations and consistency adjustments to the database.', self.migrationTask);
   };
 
   self.migrationTask = function(apos, argv, callback) {
-    return self.migrate(argv, callback);
+    return self.apos.emit('migrate', argv).then(function() {
+      return callback(null);
+    }).catch(callback);
   };
 
   self.addCollectionMigration = function() {

--- a/lib/modules/apostrophe-pages/index.js
+++ b/lib/modules/apostrophe-pages/index.js
@@ -242,6 +242,7 @@
 
 var async = require('async');
 var _ = require('@sailshq/lodash');
+var Promise = require('bluebird');
 
 module.exports = {
 
@@ -387,15 +388,23 @@ module.exports = {
       ], callback);
     };
 
+    self.on('apostrophe:migrate', 'parkAllPromisified', function() {
+      return Promise.try(function() {
+        return self.emit('beforeParkAll');
+      }).then(function() {
+        return Promise.promisify(self.implementParkAll)();
+      });
+    });
+
     // Wait until the last possible moment to add
     // the wildcard route for serving pages, so that
     // other routes are not blocked
 
     self.afterInit = function(callback) {
       self.apos.app.get('*', self.serve);
-      return async.series([
-        self.implementParkAll
-      ], callback);
+      // In case someone used the super pattern let's continue to behave
+      // as a callback-driven method even though we don't migrate here anymore
+      return callback(null);
     };
 
   }


### PR DESCRIPTION
…t handlers. This event is emitted right after modules run their afterInit handlers, or not at all if APOS_NO_MIGRATE or the global migrate option is set to false. In addition, dev asset generation and traditional named one-time migrations now run on this event. apostrophe-migrations:migrate thus becomes the one and only task that does startup db operations if you set APOS_NO_MIGRATE, which is helpful to enterprise clients with very large numbers of long distance replicating nodes in their mongodb configuration. One exception: we still do a query for distinct content types in the db for stability and reliability reasons. This is an indexed query on an index with a small number of values so it should not take any appreciable time and removing it could pose more stability risks than it is worth. We should test at this point.