### PR TITLE
Send a signal to less to inline CSS files (not LESS) when minifying

### DIFF
--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -899,6 +899,8 @@ module.exports = {
                   keywords.push(key);
                 }
               });
+            } else if (/\.css/.test(importName)) {
+              keywords.push('inline');
             }
             if (keywords.length) {
               keywords = '(' + keywords.join(',') + ') ';


### PR DESCRIPTION
This is probably a fairly urgent fix. Don't know if this is the ideal implementation, but it was minimal and worked!

Btw, if you want to push a quick release, please note that I had to update the required version of `moog-require` in package.json to get the latest `master` to run.

As of e3282c64244b051a42616cfc60e2e0e3c6a3711f, clean-css is no longer being used, instead LESS does all the minification. But where clean-css flattened all `@import` statements, LESS will only flatten those that target LESS files by default. `@import` statements targeting CSS files are left as they are. This change makes it so that we always signal to LESS to inline CSS files when minifying the CSS.