### PR TITLE
Support unit testing for scoped NPM modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -378,12 +378,16 @@ module.exports = function(options) {
     var testDependenciesDir = testDir + '/node_modules/';
     if (!fs.existsSync(testDependenciesDir + moduleName)) {
       // Ensure dependencies directory exists
-      !fs.existsSync(testDependenciesDir) && (fs.mkdirSync(testDependenciesDir));
+      if (!fs.existsSync(testDependenciesDir)) {
+        fs.mkdirSync(testDependenciesDir);
+      }
       // Ensure potential module scope directory exists before the symlink creation
       if (moduleName.charAt(0) === '@' && moduleName.includes('/')) {
         var scope = moduleName.split('/')[0];
         var scopeDir = testDependenciesDir + scope;
-        !fs.existsSync(scopeDir) && (fs.mkdirSync(scopeDir));
+        if (!fs.existsSync(scopeDir)) {
+          fs.mkdirSync(scopeDir);
+        }
       }
       fs.symlinkSync(moduleDir, testDependenciesDir + moduleName, 'dir');
     }

--- a/index.js
+++ b/index.js
@@ -375,15 +375,17 @@ module.exports = function(options) {
         moduleName = packageName;
       }
     } catch (e) {}
-    if (!fs.existsSync(testDir + '/node_modules/' + moduleName)) {
-      var scope = '';
+    var testDependenciesDir = testDir + '/node_modules/';
+    if (!fs.existsSync(testDependenciesDir + moduleName)) {
+      // Ensure dependencies directory exists
+      !fs.existsSync(testDependenciesDir) && (fs.mkdirSync(testDependenciesDir));
+      // Ensure potential module scope directory exists before the symlink creation
       if (moduleName.charAt(0) === '@' && moduleName.includes('/')) {
-        scope = moduleName.split('/')[0];
+        var scope = moduleName.split('/')[0];
+        var scopeDir = testDependenciesDir + scope;
+        !fs.existsSync(scopeDir) && (fs.mkdirSync(scopeDir));
       }
-      // Ensure module folder, including its potential scope, exists before the symlink creation
-      var nodeModulePath = testDir + '/node_modules/' + scope;
-      !fs.existsSync(nodeModulePath) && (fs.mkdirSync(nodeModulePath));
-      fs.symlinkSync(moduleDir, testDir + '/node_modules/' + moduleName, 'dir');
+      fs.symlinkSync(moduleDir, testDependenciesDir + moduleName, 'dir');
     }
 
     // Not quite superfluous: it'll return self.root, but


### PR DESCRIPTION
The version **2.86.0** released few days ago brings to Apostrophe the support for scoped NPM modules as apostrophe modules. Thanks for that, it's so cool! 👍

### Current behavior

I played a little with this new feature, and meet an issue to unit test a scoped npm module that extends Apostrophe. Core function `testModule()` is not fully able to work with scoped packages for several reasons:

1. It uses the directory name to determine the name of the apostrophe module tested, which is a problem with scoped modules that are at a sub-level.

2. It doesn't create the potential scope folder in `node_modules` that is necessary before the symlink creation.

### Changes

This pull request brings the following changes:

- The module name is retrieved from `name` property in `package.json` file. If the file doesn't exists, is not valid JSON, or the name property is not defined: the default behavior is still to use the local folder name.

- Symlink creation starts if module doesn't exists, not only if `node_modules` doesn't exists. This is useful to change the module name during development and testing.

- Ensure module folder, including its potential scope, exists before the symlink creation.

### Tests

Install locally Apostophe and checkout this branch. Link it with apostrophe modules and run tests to ensure the following:

- **It should not have regressions with non-scoped NPM modules**

You may try with [apostrophe-workflow](https://github.com/apostrophecms/apostrophe-workflow)


- **It should work as expected with scoped packages**

You may try with [module-bundle](https://gitlab.com/flaivour/apostrophe-modules/project-templates/module-bundle), a boilerplate for apostrophe modules I am working on. Clone the project and checkout the branch [`1-implement-initial-module-template`](https://gitlab.com/flaivour/apostrophe-modules/project-templates/module-bundle/merge_requests/1). Link Apostrophe, install dependencies and run `npm run test`.

It should work as expected and don't display the warning message below, because module properly linked in `node_modules` folder. 🎉

```bash
⚠️  It looks like you may have made a mistake in your code:

The module @flaivour/module-bundle does not extend anything and does not have a
`beforeConstruct`, `construct` or `afterConstruct` function. [...]
```