### PR TITLE
API does not support slugs with path separators

### DIFF
--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -102,7 +102,7 @@ module.exports = function(self, options) {
           return self.beforeSave(req, page, options, callback);
         },
         insert: function(callback) {
-          var slugBasename = require('path').basename(self.apos.utils.slugify(page.slug));
+          var slugBasename = require('path').basename(self.apos.utils.slugify(page.slug, { allow: '/' }));
           var pathFrom;
           if (slugBasename.length && (slugBasename !== 'none')) {
             pathFrom = slugBasename;


### PR DESCRIPTION
This fixes a bug where, when creating pages via the API (eg via `apostrophe-headless` REST API), pages which have a multi-path slug cannot be created because "/about-us/members/someone" is translated into a slug of "about-us-members-someone".