### PR TITLE
findGlobal now officially supports returning a promise. In most cases…

### DIFF
--- a/lib/modules/apostrophe-global/index.js
+++ b/lib/modules/apostrophe-global/index.js
@@ -76,44 +76,51 @@ module.exports = {
     self.slug = options.slug || 'global';
 
     // Fetch the `global` doc object. On success, the callback is invoked
-    // with `(null, global)`.
+    // with `(null, global)`. If no callback is passed a promise is returned.
 
     self.findGlobal = function(req, callback) {
-      var global;
-      var cursor;
-      return async.series([
-        find, after
-      ], function(err) {
-        if (err) {
-          return callback(err);
-        }
-        return callback(null, global);
-      });
-      function find(callback) {
-        cursor = self.find(req, { slug: self.slug })
-          .permission(false)
-          .sort(false)
-          .joins(false)
-          .areas(false);
-        return cursor.toObject(function(err, doc) {
-          global = doc;
-          // Make this available early, sans joins and area loaders,
-          // to avoid race conditions for modules like
-          // apostrophe-pieces-orderings-bundle if we wait
-          // for joins that might also need the global doc to find their
-          // default orderings, etc.
-          req.aposGlobalCore = global;
-          return callback(err);
-        });
+      if (callback) {
+        return body(callback);
+      } else {
+        return Promise.promisify(body)();
       }
-      function after(callback) {
-        if (!global) {
-          return callback(null);
+      function body(callback) {
+        var global;
+        var cursor;
+        return async.series([
+          find, after
+        ], function(err) {
+          if (err) {
+            return callback(err);
+          }
+          return callback(null, global);
+        });
+        function find(callback) {
+          cursor = self.find(req, { slug: self.slug })
+            .permission(false)
+            .sort(false)
+            .joins(false)
+            .areas(false);
+          return cursor.toObject(function(err, doc) {
+            global = doc;
+            // Make this available early, sans joins and area loaders,
+            // to avoid race conditions for modules like
+            // apostrophe-pieces-orderings-bundle if we wait
+            // for joins that might also need the global doc to find their
+            // default orderings, etc.
+            req.aposGlobalCore = global;
+            return callback(err);
+          });
         }
-        cursor = cursor.clone();
-        cursor.joins(true);
-        cursor.areas(true);
-        return cursor.after([ global ], callback);
+        function after(callback) {
+          if (!global) {
+            return callback(null);
+          }
+          cursor = cursor.clone();
+          cursor.joins(true);
+          cursor.areas(true);
+          return cursor.after([ global ], callback);
+        }
       }
     };
 

--- a/test/global.js
+++ b/test/global.js
@@ -458,6 +458,24 @@ describe('Global with separateWhileBusyMiddleware', function() {
     });
   });
 
+  it('test findGlobal with callback', function(done) {
+    var req = apos.tasks.getReq();
+    return apos.global.findGlobal(req, function(err, global) {
+      assert(!err);
+      assert(global);
+      assert(global.type === 'apostrophe-global');
+      done();
+    });
+  });
+
+  it('test findGlobal with promise', function() {
+    var req = apos.tasks.getReq();
+    return apos.global.findGlobal(req).then(function(global) {
+      assert(global);
+      assert(global.type === 'apostrophe-global');
+    });
+  });
+
   it('give global doc a workflowLocale property to simulate use with workflow', function() {
     return apos.docs.db.update({
       type: 'apostrophe-global'


### PR DESCRIPTION
… you should be calling addGlobalToData though. That method already supports promises and will not do extra work if global was already fetched. Also be aware that middleware loads the global doc anyway so this is mostly a concern for tasks.