### PR TITLE
nice complete trace feature for the startup process

### DIFF
--- a/index.js
+++ b/index.js
@@ -598,4 +598,3 @@ function traceStartup(message) {
     console.debug('⌁ startup ' + message);
   }
 }
-

--- a/index.js
+++ b/index.js
@@ -14,6 +14,8 @@ var glob = require('glob');
 
 module.exports = function(options) {
 
+  traceStartup('begin');
+
   // The core is not a true moog object but it must look enough like one
   // to participate as a promise event emitter
   var self = {
@@ -46,6 +48,7 @@ module.exports = function(options) {
     // Module-based, promisified events (self.on and self.emit of each module)
     self.eventHandlers = {};
 
+    traceStartup('defineModules');
     defineModules();
   } catch (err) {
     if (options.initFailed) {
@@ -75,6 +78,7 @@ module.exports = function(options) {
         throw err;
       }
     }
+    traceStartup('startup end');
     if (self.argv._.length) {
       self.emit('runTask');
     } else {
@@ -439,8 +443,10 @@ module.exports = function(options) {
   }
 
   function instantiateModules(callback) {
+    traceStartup('instantiateModules');
     self.modules = {};
     return async.eachSeries(_.keys(self.options.modules), function(item, callback) {
+      traceStartup('Instantiating module ' + item);
       var improvement = self.synth.isImprovement(item);
       if (self.options.modules[item] && (improvement || self.options.modules[item].instantiate === false)) {
         // We don't want an actual instance of this module, we are using it
@@ -463,14 +469,17 @@ module.exports = function(options) {
   }
 
   function modulesReady(callback) {
+    traceStartup('modulesReady');
     return self.callAllAndEmit('modulesReady', 'modulesReady', callback);
   }
 
   function modulesAfterInit(callback) {
+    traceStartup('modulesAfterInit');
     return self.callAllAndEmit('afterInit', 'afterInit', callback);
   }
 
   function lintModules(callback) {
+    traceStartup('lintModules');
     _.each(self.modules, function(module, name) {
       if (name.match(/-widgets$/) && (!extending(module)) && (!module.options.ignoreNoExtendWarning)) {
         lint('The module ' + name + ' does not extend anything.\n\nA `-widgets` module usually extends `apostrophe-widgets` or\n`apostrophe-pieces-widgets`. Or possibly you forgot to npm install something.\n\nIf you are sure you are doing the right thing, set the\n`ignoreNoExtendWarning` option to `true` for this module.');
@@ -512,6 +521,7 @@ module.exports = function(options) {
   }
 
   function migrate(callback) {
+    traceStartup('migrate');
     if (self.argv._[0] === 'apostrophe-migrations:migrate') {
       // Migration task will do this later with custom arguments to
       // the event
@@ -540,6 +550,7 @@ module.exports = function(options) {
   }
 
   function afterInit(callback) {
+    traceStartup('afterInit');
     // Give project-level code a chance to run before we
     // listen or run a task
     if (!self.options.afterInit) {
@@ -580,3 +591,11 @@ module.exports.moogBundle = {
   modules: abstractClasses.concat(_.keys(defaults.modules)),
   directory: 'lib/modules'
 };
+
+function traceStartup(message) {
+  if (process.env.APOS_TRACE_STARTUP) {
+    /* eslint-disable-next-line no-console */
+    console.debug('⌁ startup ' + message);
+  }
+}
+


### PR DESCRIPTION
When Apostrophe encounters an error during startup it is difficult to know what module is responsible because async code does not produce especially good stack traces.

With this PR, we can do:

`APOS_TRACE_STARTUP=1 node app`

And find out how far the startup process went before the error.

Here is sample output. We could do more - for instance it would be useful to print module names as we proceed through phases like 'modulesReady' and 'modulesAfterInit' - but I submit that this is incremental progress and there's no reason we can't add that when we get a minute.

Also, I think the formatting here builds on the general style of what we're doing for warnings, using a cute unicode character that conveys what kind of message it is, etc.

```
boutell@roxnsox:~/apostrophecms/apostrophe-open-museum$ APOS_TRACE_STARTUP=1 node app
⌁ startup begin
⌁ startup defineModules
⌁ startup instantiateModules
⌁ startup Instantiating module apostrophe-utils
⌁ startup Instantiating module apostrophe-tasks
⌁ startup Instantiating module apostrophe-launder
⌁ startup Instantiating module apostrophe-i18n
⌁ startup Instantiating module apostrophe-db
⌁ startup Instantiating module apostrophe-locks
⌁ startup Instantiating module apostrophe-caches
⌁ startup Instantiating module apostrophe-migrations
⌁ startup Instantiating module apostrophe-express
WARNING: No session secret provided, please set the `secret` property of the `session` property of the apostrophe-express module in app.js
⌁ startup Instantiating module apostrophe-urls
⌁ startup Instantiating module apostrophe-templates
⌁ startup Instantiating module apostrophe-email
⌁ startup Instantiating module apostrophe-push
⌁ startup Instantiating module apostrophe-permissions
⌁ startup Instantiating module apostrophe-assets
⌁ startup Instantiating module apostrophe-admin-bar
⌁ startup Instantiating module apostrophe-login
⌁ startup Instantiating module apostrophe-csrf
⌁ startup Instantiating module apostrophe-notifications
⌁ startup Instantiating module apostrophe-browser-utils
⌁ startup Instantiating module apostrophe-ui
⌁ startup Instantiating module apostrophe-schemas
⌁ startup Instantiating module apostrophe-docs
⌁ startup Instantiating module apostrophe-jobs
⌁ startup Instantiating module apostrophe-versions
⌁ startup Instantiating module apostrophe-tags
⌁ startup Instantiating module apostrophe-modal
⌁ startup Instantiating module apostrophe-attachments
⌁ startup Instantiating module apostrophe-oembed
⌁ startup Instantiating module apostrophe-pager
⌁ startup Instantiating module apostrophe-global
⌁ startup Instantiating module apostrophe-polymorphic-manager
⌁ startup Instantiating module apostrophe-pages
⌁ startup Instantiating module apostrophe-search
⌁ startup Instantiating module apostrophe-any-page-manager
⌁ startup Instantiating module apostrophe-areas
⌁ startup Instantiating module apostrophe-rich-text-widgets
⌁ startup Instantiating module apostrophe-html-widgets
⌁ startup Instantiating module apostrophe-video-fields
⌁ startup Instantiating module apostrophe-video-widgets
⌁ startup Instantiating module apostrophe-groups
⌁ startup Instantiating module apostrophe-users
⌁ startup Instantiating module apostrophe-images
⌁ startup Instantiating module apostrophe-images-widgets
⌁ startup Instantiating module apostrophe-files
⌁ startup Instantiating module apostrophe-files-widgets
⌁ startup Instantiating module apostrophe-soft-redirects
⌁ startup Instantiating module apostrophe-service-bridge
⌁ startup Instantiating module helpers
⌁ startup Instantiating module styleguide
⌁ startup Instantiating module apostrophe-seo
⌁ startup Instantiating module apostrophe-open-graph
⌁ startup Instantiating module apostrophe-pieces-import
⌁ startup Instantiating module apostrophe-favicons
⌁ startup Instantiating module apostrophe-favicons-global
⌁ startup Instantiating module default-pages
⌁ startup Instantiating module category-object-types
⌁ startup Instantiating module artists
⌁ startup Instantiating module artists-pages
⌁ startup Instantiating module locations
⌁ startup Instantiating module locations-widgets
⌁ startup Instantiating module artworks
⌁ startup Instantiating module artworks-pages
⌁ startup Instantiating module artworks-widgets
⌁ startup Instantiating module articles
⌁ startup Instantiating module articles-pages
⌁ startup Instantiating module articles-widgets
⌁ startup Instantiating module articles-featured-widgets
⌁ startup Instantiating module events
⌁ startup Instantiating module events-pages
⌁ startup Instantiating module events-widgets
⌁ startup Instantiating module people
⌁ startup Instantiating module people-pages
⌁ startup Instantiating module image-widgets
⌁ startup Instantiating module slideshow-widgets
⌁ startup Instantiating module logo-mask-widgets
⌁ startup Instantiating module link-widgets
⌁ startup Instantiating module marquee-widgets
⌁ startup Instantiating module feature-widgets
⌁ startup Instantiating module two-panel-widgets
⌁ startup Instantiating module content-widgets
⌁ startup Instantiating module random-met-artwork-widgets
⌁ startup Instantiating module columns-widgets
⌁ startup Instantiating module apostrophe-seo-doc-type-manager
⌁ startup Instantiating module apostrophe-seo-files
⌁ startup Instantiating module apostrophe-seo-images
⌁ startup Instantiating module apostrophe-seo-global
⌁ startup Instantiating module apostrophe-seo-groups
⌁ startup Instantiating module apostrophe-seo-users
⌁ startup Instantiating module apostrophe-open-graph-doc-type-manager
⌁ startup Instantiating module apostrophe-open-graph-files
⌁ startup Instantiating module apostrophe-open-graph-global
⌁ startup Instantiating module apostrophe-open-graph-images
⌁ startup Instantiating module apostrophe-open-graph-groups
⌁ startup Instantiating module apostrophe-open-graph-users
⌁ startup modulesReady
⌁ startup modulesAfterInit

⚠️  doc type apostrophe-global contains unarranged field(s): demoMode, trackingID.
Arrange all of your fields with arrangeFields, using meaningful group labels.
https://apos.dev/arrange-fields

This warning appears only once to save space. Pass --all-unarranged-fields
on the command line to see the warning for all affected modules.
⌁ startup lintModules
⌁ startup migrate
⌁ startup afterInit
⌁ startup startup end
I see no data/port file, port option, forcePort option, or PORT environment variable, defaulting to port 3000
I see no data/address file, address option, forceAddress option, or ADDRESS environment variable, listening on all interfaces
Listening at http://localhost:3000
```
