### PR TITLE
3/events tests

### DIFF
--- a/test/events.js
+++ b/test/events.js
@@ -1,33 +1,37 @@
-let t = require('../test-lib/test.js');
-let assert = require('assert');
-let Promise = require('bluebird');
+const t = require('../test-lib/test.js');
+const assert = require('assert');
 
 describe('Promisified Events Core', function() {
-
   this.timeout(50000);
 
   let apos;
 
-  after(function(done) {
-    return t.destroy(apos, done);
+  after(function() {
+    return t.destroy(apos);
   });
 
-  it('should execute handlers for several events in the proper order', function(done) {
-    apos = require('../index.js')({
+  it('should execute handlers for several events in the proper order', async function() {
+    apos = await require('../index.js')({
       root: module,
       shortName: 'test',
+      argv: {
+        _: []
+      },
       modules: {
         'test1': {
           alias: 'test1',
           construct: function(self, options) {
             let sameNameFail = false;
             let niceFinished = false;
+
             try {
               self.on('ready1', 'ready1');
             } catch (e) {
               sameNameFail = true;
             }
+
             assert(sameNameFail);
+
             self.on('ready1', 'ready1AddA');
             self.ready1AddA = function(context) {
               return Promise.delay(100).then(function() {
@@ -35,17 +39,20 @@ describe('Promisified Events Core', function() {
                 context.a = true;
               });
             };
+
             self.on('ready2', 'ready2AddB');
             self.ready2AddB = function(context) {
               assert(context.a);
               context.b = true;
             };
+
             self.on('ready3', 'ready3HeyNice');
             self.ready3HeyNice = function() {
               return Promise.delay(100).then(function() {
                 niceFinished = true;
               });
             };
+
             self.on('ready2', 'ready2AddC', function(context) {
               return Promise.delay(10).then(function() {
                 assert(context.a);
@@ -53,26 +60,27 @@ describe('Promisified Events Core', function() {
                 context.c = true;
               });
             });
+
             assert(self.ready2AddC);
-            self.modulesReady = function(callback) {
-              let context = {};
-              return self.emit('ready1', context).then(function() {
-                assert(context.a);
-                return self.emit('ready2', context);
-              }).then(function() {
-                assert(context.a);
-                assert(context.b);
-                assert(context.c);
-                return self.emit('ready3');
-              }).then(function() {
-                assert(context.a);
-                assert(context.b);
-                assert(context.c);
-                assert(context.d);
-                assert(niceFinished);
-                assert(true);
-                done();
-              });
+
+            self.modulesReady = async function() {
+              const context = {};
+              await self.emit('ready1', context);
+
+              assert(context.a);
+              await self.emit('ready2', context);
+
+              assert(context.a);
+              assert(context.b);
+              assert(context.c);
+
+              await self.emit('ready3');
+
+              assert(context.a);
+              assert(context.b);
+              assert(context.c);
+              assert(context.d);
+              assert(niceFinished);
             };
           }
         },
@@ -82,24 +90,22 @@ describe('Promisified Events Core', function() {
             self.on('test1:ready1', 'ready1SetD', function(context) {
               context.d = true;
             });
+
             try {
               self.on('test1:ready1', 'ready1', function(context) {
                 context.d = true;
               });
             } catch (e) {
-              // event name and method name being the same should fail, even for cross-module events
+              // Event name and method name being the same should fail, even
+              // for cross-module events.
+              assert(e);
             }
           }
         },
         'test3': {
           alias: 'test3'
         }
-      },
-      afterInit: function(callback) {
-        callback();
-        return done();
       }
     });
   });
-
 });

--- a/test/events2.js
+++ b/test/events2.js
@@ -1,22 +1,24 @@
-let t = require('../test-lib/test.js');
-let assert = require('assert');
-let Promise = require('bluebird');
+const t = require('../test-lib/test.js');
+const assert = require('assert');
 
-describe('Promisified Events: apostrophe-docs:beforeInses', function() {
+describe('Promisified Events: apostrophe-docs:beforeInsert', function() {
 
   this.timeout(50000);
 
-  after(function(done) {
-    return t.destroy(apos, done);
+  after(function() {
+    return t.destroy(apos);
   });
 
   let apos;
   let coreEventsWork = false;
 
-  it('should implement apostrophe-docs:beforeInsert handlers properly', function(done) {
-    apos = require('../index.js')({
+  it('should implement apostrophe-docs:beforeInsert handlers properly', async function() {
+    apos = await require('../index.js')({
       root: module,
       shortName: 'test2',
+      argv: {
+        _: []
+      },
       modules: {
         'test1': {
           alias: 'test1',
@@ -28,14 +30,10 @@ describe('Promisified Events: apostrophe-docs:beforeInses', function() {
                 });
               }
             });
+
             self.on('apostrophe:modulesReady', 'modulesReadyCoreEventsWork', function() {
               coreEventsWork = true;
             });
-            // Old school callAll works too (for now)
-            self.docBeforeInsert = function(req, doc, options, callback) {
-              doc.oldSchool = true;
-              return setImmediate(callback);
-            };
           }
         },
         'apostrophe-pages': {
@@ -49,22 +47,15 @@ describe('Promisified Events: apostrophe-docs:beforeInses', function() {
             }
           ]
         }
-      },
-      afterInit: function(callback) {
-        apos.argv._ = [];
-        done();
       }
     });
   });
 
-  it('should find the results', function(done) {
-    return apos.docs.db.findOne({ findMeAgain: true }, function(err, doc) {
-      assert(!err);
-      assert(doc);
-      assert(doc.title === 'tseT');
-      assert(doc.oldSchool);
-      assert(coreEventsWork);
-      done();
-    });
+  it('should find the results', async function() {
+    const doc = await apos.docs.db.findOne({ findMeAgain: true });
+
+    assert(doc);
+    assert(doc.title === 'Test');
+    assert(coreEventsWork);
   });
 });


### PR DESCRIPTION
Converted events tests to async-await. Removed `docBeforeInsert` step from the second since we're removing callAll functions.