### PR TITLE
Use (less) keyword to import CSS files instead of (import)

### DIFF
--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -889,10 +889,10 @@ module.exports = {
                 }
               });
             } else if (/\.css$/.test(importName)) {
-              // Make less treat CSS files the same as LESS files
-              // to get the same URL rewrite behavior we had with
+              // Make less inline CSS files and add them to dependency
+              // graph to get the same URL rewrite behavior we had with
               // clean-css, bc
-              keywords.push('less');
+              keywords.push('css');
             }
             if (keywords.length) {
               keywords = '(' + keywords.join(',') + ') ';

--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -889,9 +889,10 @@ module.exports = {
                 }
               });
             } else if (/\.css$/.test(importName)) {
-              // Always inline CSS to get the same URL rewrite
-              // behavior we had with clean-css, bc
-              keywords.push('inline');
+              // Make less treat CSS files the same as LESS files
+              // to get the same URL rewrite behavior we had with
+              // clean-css, bc
+              keywords.push('less');
             }
             if (keywords.length) {
               keywords = '(' + keywords.join(',') + ') ';


### PR DESCRIPTION
Apparently, less doesn't include `(import)`ed files in the dependency graph that's generated when files are built. This is a problem for less-middleware, because that module has its own cache for imported files and won't trigger a rebuild unless it sees that imported modules have been updated. 

Effectively, one has to restart the whole app right now to get CSS files that are watched with a separate module to be loaded :( With this change, that should no longer be necessary!