### PR TITLE
the CSRF cookie should always be reset, in case the lifetimes of the …

### DIFF
--- a/lib/modules/apostrophe-express/index.js
+++ b/lib/modules/apostrophe-express/index.js
@@ -511,11 +511,11 @@ module.exports = {
           } else {
             token = self.apos.utils.generateId();
             req.session['XSRF-TOKEN'] = token;
-            // Reset the cookie so that if its lifetime somehow detaches from
-            // that of the session cookie we're still OK
-            res.cookie(self.apos.csrfCookieName, token, (self.options.csrf && self.options.csrf.cookie) || {});
           }
         }
+        // Always reset the cookie so that if its lifetime somehow detaches from
+        // that of the session cookie we're still OK
+        res.cookie(self.apos.csrfCookieName, token, (self.options.csrf && self.options.csrf.cookie) || {});
       } else {
         // All non-safe requests must be preceded by a safe request that establishes
         // the CSRF token, both as a cookie and in the session. Otherwise a user who is logged


### PR DESCRIPTION
…session and the CSRF cookie diverge. This fixes an obvious issue when switching locales for which hostnames are configured with workflow. It also likely fixes more subtle issues raised by various users. This change restores pre-2.88 behavior in this one area.