### PR TITLE
getSchemaOptions is not a good candidate to throw errors because it i…

### DIFF
--- a/lib/modules/apostrophe-areas/lib/api.js
+++ b/lib/modules/apostrophe-areas/lib/api.js
@@ -350,10 +350,16 @@ module.exports = function(self, options) {
 
   self.getSchemaOptions = function(doc, name) {
     if (!(doc && doc.type)) {
-      throw new Error('You did not pass a doc as the first argument to getSchemaOptions, which expects (doc, name)');
+      // Probably an area or singleton helper call without a
+      // doc object, we cannot find a schema, but nor should
+      // we crash
+      return {};
     }
     if ((!name) || ((typeof name) !== 'string')) {
-      throw new Error('You did not pass a doc type name as the second argument to getSchemaOptions, which expects (doc, name)');
+      // Probably an area or singleton helper call without a
+      // doc object, we cannot find a schema, but nor should
+      // we crash
+      return {};
     }
     var manager = self.apos.docs.getManager(doc.type);
     if (!manager) {


### PR DESCRIPTION
…s sometimes called in contexts without a good doc and that is not an error or even a warning-worthy situation, it has to do with alternate syntaxes for apos.area. Just politely return an empty object, in these cases the options must be restated