### PR TITLE
Support ''apostrophe-templates': { viewsFolderFallback:' by accepting an array of views folder.

### DIFF
--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -23,7 +23,8 @@
 // ### `viewsFolderFallback`: specifies a folder to be checked for templates
 // if they are not found in the module that called `self.render` or `self.partial`
 // or those it extends. This is a handy place for project-wide macro files.
-// Often set to `__dirname + '/views'` in `app.js`.
+// Often set to `__dirname + '/views'` in `app.js` or
+// { viewsFolderFallback: [path.join(__dirname, '/views'), path.join(__dirname, 'lib/modules/widget-views')] }
 
 var _ = require('@sailshq/lodash');
 var moment = require('moment');

--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -357,8 +357,10 @@ module.exports = {
       });
       // Final class should win
       dirs.reverse();
-      if (options.viewsFolderFallback) {
+      if (options.viewsFolderFallback && typeof options.viewsFolderFallback === "string") {
         dirs.push(options.viewsFolderFallback);
+      } else {
+        dirs.push(...options.viewsFolderFallback);
       }
       return dirs;
     };


### PR DESCRIPTION
This could be an optional to other devs that wanted to organize their views on multiple project views. This could be done as example :

```js
// in app.js
const path = require('path');
module.exports = {
   // other modules ...
   'apostrophe-templates': { viewsFolderFallback: [path.join(__dirname, 'main-views'), path.join(__dirname, 'lib/modules/widget-views')] }
}
```