### PR TITLE
Make a fallback if self.logger is not available

### DIFF
--- a/lib/modules/apostrophe-utils/lib/api.js
+++ b/lib/modules/apostrophe-utils/lib/api.js
@@ -564,6 +564,7 @@ module.exports = function(self, options) {
   // to be used directly.
 
   self.log = function(msg) {
+    if (!self.logger) self.enableLogger();
     if (!self.logger.log) {
       return self.logger.info.apply(self.logger.info, arguments);
     }
@@ -579,6 +580,7 @@ module.exports = function(self, options) {
   // `console.log` documentation.
 
   self.info = function(msg) {
+    if (!self.logger) self.enableLogger();
     self.logger.info.apply(self.logger, arguments);
   };
 
@@ -591,6 +593,7 @@ module.exports = function(self, options) {
   // `console.warn` documentation.
 
   self.debug = function(msg) {
+    if (!self.logger) self.enableLogger();
     self.logger.debug.apply(self.logger, arguments);
   };
 
@@ -607,6 +610,7 @@ module.exports = function(self, options) {
   // `apos.utils.error`.
 
   self.warn = function(msg) {
+    if (!self.logger) self.enableLogger();
     self.logger.warn.apply(self.logger, arguments);
   };
 
@@ -619,6 +623,7 @@ module.exports = function(self, options) {
   // `console.error` documentation.
 
   self.error = function(msg) {
+    if (!self.logger) self.enableLogger();
     self.logger.error.apply(self.logger, arguments);
   };
 


### PR DESCRIPTION
This issue found on npm cache when restarting site on local development windows, it seems that the self.logger is not properly `require('./logger')` correctly. Therefore, I made a fallback to enable it by returning `self.enableLogger` to it.