### PR TITLE
merge of lean frontend into core

### DIFF
--- a/lib/modules/apostrophe-areas/public/js/always.js
+++ b/lib/modules/apostrophe-areas/public/js/always.js
@@ -1,7 +1,10 @@
 apos.define('apostrophe-areas', {
 
   afterConstruct: function(self) {
-    self.enablePlayers();
+    if (!apos.assets.options.lean) {
+      // Not in strictly lean mode so we offer the classic widget players
+      self.enablePlayers();
+    }
   },
 
   construct: function(self, options) {
@@ -37,6 +40,7 @@ apos.define('apostrophe-areas', {
     // widget type.
 
     self.enablePlayers = function() {
+
       apos.on('enhance', function($el) {
 
         $el.find('[data-apos-widget]').each(enhance);
@@ -51,6 +55,14 @@ apos.define('apostrophe-areas', {
           var data = self.getWidgetData($widget);
           var options = self.getWidgetOptions($widget);
 
+          var type = $widget.attr('data-apos-widget');
+          if (apos.utils.widgetPlayers[type]) {
+            // If a lean player is present, it always wins, so we
+            // can progressively migrate to lean mode before
+            // setting `lean: true` for `apostrophe-assets` to completely
+            // disable the classic frontend js players and libraries
+            return;
+          }
           var manager = self.getWidgetManager($widget.attr('data-apos-widget'));
           if (manager && manager.play) {
             manager.play($widget, data, options);

--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -127,7 +127,7 @@ module.exports = {
     self.enableLessMiddleware();
     self.servePublicAssets();
     self.pushDefaults();
-
+    self.pushCreateSingleton();
   },
 
   beforeConstruct: function(self, options) {
@@ -1184,6 +1184,14 @@ module.exports = {
     // If minifiable is true you get back the assets that can be minified;
     // if set false you get those that cannot; if it is not specified
     // you get both.
+    //
+    // If `options: lean` is true, "always" is treated as "user".
+    // This maintains bc in the logged-in experience without pushing anything
+    // unnecessary to the lean logged-out experience.
+    // 
+    // Regardless of the `lean` module-level option, anything pushed as
+    // "lean" is delivered to both the "anon" and "user" scenes. This
+    // provides an upgrade path for gradual migration to `lean: true`.
 
     self.filterAssets = function(assets, when, minifiable) {
       // Support older layouts
@@ -1207,7 +1215,21 @@ module.exports = {
             }
           }
         }
-        var relevant = (asset.when === 'always') || (when === 'all') || (asset.when === when);
+        var relevant;
+        if (asset.when === 'lean') {
+          relevant = true;
+        } else if ((!self.options.lean) || (asset.type !== 'script' && asset.type !== 'stylesheet')) {
+          // Traditional logic
+          relevant = (asset.when === 'always') || (when === 'all') || (asset.when === when);
+        } else {
+          // Override
+          relevant = ((when === 'user') && (asset.when === 'always')) ||
+            (asset.when === 'lean') ||
+            // Has this ever been used?
+            (when === 'all') ||
+            (asset.when === when);
+        }
+
         if (!relevant) {
           return false;
         }
@@ -1219,6 +1241,27 @@ module.exports = {
         return true;
       });
       return results;
+    };
+
+    // Override pushConfigured so that self configured assets are always served,
+    // unless specified otherwise
+
+    self.pushConfigured = function() {
+      _.each(self.options.stylesheets || [], function(item) {
+        self.pushAsset('stylesheet', item.name, self.options.lean ? self.setWhenIfNotConfigured(item, 'lean') : item);
+      });
+      _.each(self.options.scripts || [], function(item) {
+        self.pushAsset('script', item.name, self.options.lean ? self.setWhenIfNotConfigured(item, 'lean') : item);
+      });
+    };
+
+    // If "when" is not specified, specify a default
+
+    self.setWhenIfNotConfigured = function(item, defaultWhen) {
+      if (!('when' in item)) {
+        item['when'] = defaultWhen;
+      }
+      return item;
     };
 
     // Fetch an asset chain by name. Note that the
@@ -1244,15 +1287,6 @@ module.exports = {
       // Push project-level configured assets last, to make it easier to
       // override Apostrophe-level styles
       self.pushConfigured();
-    };
-
-    self.pushConfigured = function() {
-      _.each(self.options.stylesheets || [], function(item) {
-        self.pushAsset('stylesheet', item.name, item);
-      });
-      _.each(self.options.scripts || [], function(item) {
-        self.pushAsset('script', item.name, item);
-      });
     };
 
     self.splitWithBless = function(filename, content) {
@@ -1559,5 +1593,10 @@ module.exports = {
       });
     });
 
+    self.getCreateSingletonOptions = function() {
+      return {
+        lean: self.options.lean
+      };
+    };
   }
 };

--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -1593,7 +1593,6 @@ module.exports = {
       });
     });
 
-
     self.pushCreateSingleton = function() {
       // There is no shortcut to "always" push a singleton,
       // so implement that here

--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -1188,7 +1188,7 @@ module.exports = {
     // If `options: lean` is true, "always" is treated as "user".
     // This maintains bc in the logged-in experience without pushing anything
     // unnecessary to the lean logged-out experience.
-    // 
+    //
     // Regardless of the `lean` module-level option, anything pushed as
     // "lean" is delivered to both the "anon" and "user" scenes. This
     // provides an upgrade path for gradual migration to `lean: true`.

--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -1593,10 +1593,16 @@ module.exports = {
       });
     });
 
-    self.getCreateSingletonOptions = function() {
-      return {
-        lean: self.options.lean
-      };
+
+    self.pushCreateSingleton = function() {
+      // There is no shortcut to "always" push a singleton,
+      // so implement that here
+      self.apos.push.browserCall('always',
+        'apos.create("apostrophe-assets", ?)',
+        {
+          lean: self.options.lean
+        }
+      );
     };
   }
 };

--- a/lib/modules/apostrophe-assets/public/js/always.js
+++ b/lib/modules/apostrophe-assets/public/js/always.js
@@ -182,3 +182,12 @@ _.extend(apos, {
   }
 
 });
+
+// So that it can be instantiated with options passed from the server
+
+apos.define('apostrophe-assets', {
+  construct: function(self, options) {
+    self.options = options;
+    apos.assets = self;
+  }
+});

--- a/lib/modules/apostrophe-browser-utils/index.js
+++ b/lib/modules/apostrophe-browser-utils/index.js
@@ -4,7 +4,10 @@
 
 module.exports = {
   construct: function(self, options) {
+    self.pushAsset('script', 'lean');
     self.pushAsset('script', 'always');
-    self.apos.push.browserCall('always', 'apos.create("apostrophe-browser-utils")');
+    // Extend the lean apos.utils object with the properties of the
+    // legacy moog one, so that everybody sees what they expect to see
+    self.apos.push.browserCall('always', 'apos.utils.assign(apos.utils, apos.create("apostrophe-browser-utils"))');
   }
 };

--- a/lib/modules/apostrophe-browser-utils/index.js
+++ b/lib/modules/apostrophe-browser-utils/index.js
@@ -4,7 +4,7 @@
 
 module.exports = {
   construct: function(self, options) {
-    self.pushAsset('script', 'lean');
+    self.pushAsset('script', 'lean', { when: 'lean' });
     self.pushAsset('script', 'always');
     // Extend the lean apos.utils object with the properties of the
     // legacy moog one, so that everybody sees what they expect to see

--- a/lib/modules/apostrophe-browser-utils/public/js/always.js
+++ b/lib/modules/apostrophe-browser-utils/public/js/always.js
@@ -50,9 +50,12 @@ apos.define('apostrophe-browser-utils', {
       }
       return n;
     };
-
+ 
     // Convert other name formats such as underscore and camelCase to a hyphenated css-style
     // name.
+    //
+    // NOTE: this method is not available if `lean: true` is active
+    // for `apostrophe-assets` and the user is not logged in.
 
     self.cssName = function(camel) {
       // Keep in sync with client side version
@@ -103,6 +106,9 @@ apos.define('apostrophe-browser-utils', {
     //
     // This method is often useful both when triggering and when listening.
     // No need to remember the correct way to construct an event name.
+    //
+    // NOTE: this method is not available if `lean: true` is active
+    // for `apostrophe-assets` and the user is not logged in.
 
     self.eventName = function() {
       var args = Array.prototype.slice.call(arguments, 0);
@@ -113,6 +119,9 @@ apos.define('apostrophe-browser-utils', {
     // we find that useful, so avoid hyphens. Prefixed with a `w` so it can
     // always be distinguished from a cuid that came from the server; if we
     // start using cuid in the browser we must keep the `w` prefix
+    //
+    // NOTE: this method is not available if `lean: true` is active
+    // for `apostrophe-assets` and the user is not logged in.
 
     self.generateId = function() {
       return 'w' + Math.floor(Math.random() * 1000000000) + Math.floor(Math.random() * 1000000000);
@@ -127,6 +136,10 @@ apos.define('apostrophe-browser-utils', {
       "/": '&#x2F;'
     };
 
+    // Escape HTML as plaintext.
+    //
+    // NOTE: this method is not available if `lean: true` is active
+    // for `apostrophe-assets` and the user is not logged in.
     self.escapeHtml = function(string) {
       return String(string).replace(/[&<>"'/]/g, function (s) {
         return self.entityMap[s];
@@ -136,6 +149,9 @@ apos.define('apostrophe-browser-utils', {
     // String.replace does NOT do this
     // Regexps can but they can't be trusted with unicode ):
     // Keep in sync with server side version
+    //
+    // NOTE: this method is not available if `lean: true` is active
+    // for `apostrophe-assets` and the user is not logged in.
 
     self.globalReplace = function(haystack, needle, replacement) {
       var result = '';
@@ -154,7 +170,11 @@ apos.define('apostrophe-browser-utils', {
       }
     };
 
-    // pad an integer with leading zeroes, creating a string
+    // pad an integer with leading zeroes, creating a string.
+    //
+    // NOTE: this method is not available if `lean: true` is active
+    // for `apostrophe-assets` and the user is not logged in.
+
     self.padInteger = function(i, places) {
       var s = i + '';
       while (s.length < places) {
@@ -163,9 +183,11 @@ apos.define('apostrophe-browser-utils', {
       return s;
     };
 
-    /**
-     * Capitalize the first letter of a string
-     */
+    // Capitalize the first letter of a string.
+    //
+    // NOTE: this method is not available if `lean: true` is active
+    // for `apostrophe-assets` and the user is not logged in.
+
     self.capitalizeFirst = function(s) {
       return s.charAt(0).toUpperCase() + s.substr(1);
     };
@@ -174,6 +196,9 @@ apos.define('apostrophe-browser-utils', {
     // ONE punctuation character normally forbidden in slugs may
     // optionally be permitted by specifying it via options.allow.
     // The separator may be changed via options.separator.
+    //
+    // NOTE: this method is not available if `lean: true` is active
+    // for `apostrophe-assets` and the user is not logged in.
 
     self.slugify = function(s, options) {
       return sluggo(s, options);
@@ -203,6 +228,9 @@ apos.define('apostrophe-browser-utils', {
     // (Array.isArray returns true). Otherwise all objects with
     // a length property would be treated as arrays, which is
     // an unrealistic restriction on apostrophe doc schemas.
+    //
+    // NOTE: this method is not available if `lean: true` is active
+    // for `apostrophe-assets` and the user is not logged in.
 
     self.clonePermanent = function(o, keepScalars) {
       var c;
@@ -249,6 +277,9 @@ apos.define('apostrophe-browser-utils', {
     // Overrides should be written with support for
     // substitution strings in mind. See the
     // `console.log` documentation.
+    //
+    // NOTE: this method is not available if `lean: true` is active
+    // for `apostrophe-assets` and the user is not logged in.
 
     self.log = function(msg) {
       if ((typeof window.console) === 'object') {
@@ -265,6 +296,9 @@ apos.define('apostrophe-browser-utils', {
     // Overrides should be written with support for
     // substitution strings in mind. See the
     // `console.log` documentation.
+    //
+    // NOTE: this method is not available if `lean: true` is active
+    // for `apostrophe-assets` and the user is not logged in.
 
     self.info = function(msg) {
       if ((typeof window.console) === 'object') {
@@ -283,6 +317,9 @@ apos.define('apostrophe-browser-utils', {
     // Overrides should be written with support for
     // substitution strings in mind. See the
     // `console.log` documentation.
+    //
+    // NOTE: this method is not available if `lean: true` is active
+    // for `apostrophe-assets` and the user is not logged in.
 
     self.error = function(msg) {
       if ((typeof window.console) === 'object') {
@@ -303,6 +340,9 @@ apos.define('apostrophe-browser-utils', {
     // The intention is that `apos.utils.warn` should be
     // called for situations less dire than
     // `apos.utils.error`.
+    //
+    // NOTE: this method is not available if `lean: true` is active
+    // for `apostrophe-assets` and the user is not logged in.
 
     self.warn = function(msg) {
       if ((typeof window.console) === 'object') {
@@ -314,6 +354,5 @@ apos.define('apostrophe-browser-utils', {
       apos.utils.error.apply(apos, arguments);
     };
 
-    apos.utils = self;
   }
 });

--- a/lib/modules/apostrophe-browser-utils/public/js/always.js
+++ b/lib/modules/apostrophe-browser-utils/public/js/always.js
@@ -50,7 +50,7 @@ apos.define('apostrophe-browser-utils', {
       }
       return n;
     };
- 
+
     // Convert other name formats such as underscore and camelCase to a hyphenated css-style
     // name.
     //

--- a/lib/modules/apostrophe-browser-utils/public/js/lean.js
+++ b/lib/modules/apostrophe-browser-utils/public/js/lean.js
@@ -228,7 +228,8 @@
       var data = JSON.parse(widget.getAttribute('data'));
       var options = JSON.parse(widget.getAttribute('data-options'));
       widget.setAttribute('data-apos-played', '1');
-      var player = apos.utils.widgetPlayers[data.type];
+      // bc with the old lean module
+      var player = apos.utils.widgetPlayers[data.type] || (apos.lean && apos.lean.widgetPlayers && apos.lean.widgetPlayers[data.type]);
       if (!player) {
         return;
       }

--- a/lib/modules/apostrophe-browser-utils/public/js/lean.js
+++ b/lib/modules/apostrophe-browser-utils/public/js/lean.js
@@ -1,0 +1,255 @@
+// Adds minimal services to the apos object replacing
+// functionality widget players can't live without,
+// and provides the `runPlayers` method to run all players
+// once if not run previously.
+//
+// Also schedules that method to run automatically when
+// the DOM is ready.
+//
+// Adds apos to window if not already present.
+
+/* eslint-env browser */
+
+(function() {
+
+  window.apos = window.apos || {};
+  var apos = window.apos;
+
+  apos.utils = apos.utils || {};
+
+  // Make a POST JSON call to the given URI. The object `data` is transferred
+  // as JSON. On success the response is delivered to the callback as
+  // `(null, response)`, following the Node.js convention.
+  // On failure the error is delivered as `(err)`. Specifically the
+  // error will be the event object associated with the error.
+
+  apos.utils.post = function(uri, data, callback) {
+    if (apos.prefix) {
+      uri = apos.prefix + uri;
+    }
+    var xmlhttp = new XMLHttpRequest();
+    var csrfToken = apos.utils.getCookie('csrfCookieName');
+    xmlhttp.open("POST", uri);
+    xmlhttp.setRequestHeader('Content-Type', 'application/json');
+    if (csrfToken) {
+      xmlhttp.setRequestHeader('X-XSRF-TOKEN', csrfToken);
+    }
+    xmlhttp.send(JSON.stringify(data));
+    monitor(xmlhttp, callback);
+  };
+
+  // Like `apos.utils.post` but uses a GET request, with the properties of `data`
+  // added with query string encoding. Currently no support for nested properties
+  // in `data`; intended for simple cases where you actually want the browser
+  // to cache. Like `jsonCall`, it invokes the callback Node.js style,
+  // with an error if any, followed by the response as parsed JSON.
+
+  apos.utils.get = function(uri, data, callback) {
+    if (apos.prefix) {
+      uri = apos.prefix + uri;
+    }
+    uri += '?';
+    var keys = Object.keys(data);
+    var i;
+    for (i = 0; (i < keys.length); i++) {
+      if (i > 0) {
+        uri += '&';
+      }
+      uri += encodeURIComponent(keys[i]) + '=' + encodeURIComponent(data[keys[i]]);
+    }
+    var xmlhttp = new XMLHttpRequest();
+    xmlhttp.open("GET", uri);
+    xmlhttp.setRequestHeader("Content-Type", "application/json");
+    xmlhttp.send(JSON.stringify(data));
+    monitor(xmlhttp, callback);
+  };
+
+  // Fetch the cookie by the given name
+  apos.utils.getCookie = function(name) {
+    var match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+    return match && match[2];
+  };
+
+  // Implementation detail of `apos.utils.post` and `apos.utils.get`
+  function monitor(xmlhttp, callback) {
+    xmlhttp.addEventListener("load", function() {
+      var data;
+      try {
+        data = JSON.parse(this.responseText);
+      } catch (e) {
+        return callback(e);
+      }
+      return callback(null, data);
+    });
+    xmlhttp.addEventListener('abort', function(evt) {
+      return callback(evt);
+    });
+    xmlhttp.addEventListener('error', function(evt) {
+      return callback(evt);
+    });
+  };
+
+  // Remove a CSS class, if present.
+  // http://youmightnotneedjquery.com/
+
+  apos.utils.removeClass = function(el, className) {
+    if (el.classList) {
+      el.classList.remove(className);
+    } else {
+      el.className = el.className.replace(new RegExp('(^|\\b)' + className.split(' ').join('|') + '(\\b|$)', 'gi'), ' ');
+    }
+  };
+
+  // Add a CSS class, if missing.
+  // http://youmightnotneedjquery.com/
+
+  apos.utils.addClass = function(el, className) {
+    if (el.classList) {
+      el.classList.add(className);
+    } else {
+      el.className += ' ' + className;
+    }
+  };
+
+  // A wrapper for the native closest() method of DOM elements,
+  // where available, otherwise a polyfill for IE9+. Returns the
+  // closest ancestor of el that matches selector, where
+  // el itself is considered the closest possible ancestor.
+
+  apos.utils.closest = function(el, selector) {
+    if (el.closest) {
+      return el.closest(selector);
+    }
+    // Polyfill per https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
+    if (!Element.prototype.matches) {
+      Element.prototype.matches = Element.prototype.msMatchesSelector ||
+        Element.prototype.webkitMatchesSelector;
+    }
+    Element.prototype.closest = function(s) {
+      var el = this;
+      if (!document.documentElement.contains(el)) return null;
+      do {
+        if (el.matches(s)) {
+          return el;
+        }
+        el = el.parentElement || el.parentNode;
+      } while (el !== null && el.nodeType === 1);
+      return null;
+    };
+    return el.closest(selector);
+  };
+
+  // Like Object.assign. Uses Object.assign where available.
+  // (Takes us back to IE9)
+
+  apos.utils.assign = function(obj1, obj2 /*,  obj3... */) {
+    if (Object.assign) {
+      return Object.assign.apply(Object, arguments);
+    }
+    var i, j, keys, key;
+    for (i = 1; (i < arguments.length); i++) {
+      keys = Object.keys(arguments[i]);
+      for (j = 0; (j < keys.length); j++) {
+        key = keys[j];
+        obj1[key] = arguments[i][key];
+      }
+    }
+    return obj1;
+  };
+
+  // Map of widget players. Adding one is as simple as:
+  // window.apos.utils.widgetPlayers['widget-name'] = function(el, data, options) {}
+  //
+  // Use the widget's name, like "apostrophe-images", NOT the name of its module.
+  //
+  // Your player receives the DOM element of the widget and the
+  // pre-parsed `data` and `options` objects associated with it,
+  // as objects. el is NOT a jQuery object, because jQuery is not pushed
+  // (we push no libraries in the lean world).
+  //
+  // Your player should add any needed javascript effects to
+  // THAT ONE WIDGET and NO OTHER. Don't worry about finding the
+  // others, we will do that for you and we guarantee only one call per widget.
+
+  apos.utils.widgetPlayers = {};
+
+  // On DOMready, similar to jQuery. Always defers at least to next tick.
+  // http://youmightnotneedjquery.com/
+
+  apos.utils.onReady = function(fn) {
+    if (document.readyState !== 'loading') {
+      setTimeout(fn, 0);
+    } else if (document.addEventListener) {
+      document.addEventListener('DOMContentLoaded', fn);
+    } else {
+      document.attachEvent('onreadystatechange', function() {
+        if (document.readyState !== 'loading') {
+          fn();
+        }
+      });
+    }
+  };
+
+  // Run all the players that haven't been run. Invoked for you at DOMready
+  // time. You may also invoke it if you just AJAXed in some content and
+  // have reason to suspect there could be widgets in there. You may pass:
+  //
+  // * Nothing at all - entire document is searched for new widgets to enhance, or
+  // * A DOM element - new widgets to enhance are found within this scope only.
+  //
+  // To register a widget player for the `apostrophe-images` widget, write:
+  //
+  // `apos.utils.widgetPlayers['apostrophe-images'] = function(el, data, options) { ... }`
+  //
+  // `el` is a DOM element, not a jQuery object. Otherwise identical to
+  // traditional Apostrophe widget players. `data` contains the properties
+  // of the widget itself, `options` contains the options that were
+  // passed to it at the area or singleton level.
+  //
+  // Your player is guaranteed to run only once per widget. Hint:
+  // DON'T try to find all the widgets. DO just enhance `el`.
+  // This is a computer science principle known as "separation of concerns."
+
+  apos.utils.runPlayers = function(el) {
+    var widgets = (el || document).querySelectorAll('[data-apos-widget]');
+    var i;
+    if (el && el.getAttribute('data-apos-widget')) {
+      // el is itself a widget. Might still contain some too
+      play(el);
+    }
+    for (i = 0; (i < widgets.length); i++) {
+      play(widgets[i]);
+    }
+
+    function play(widget) {
+      if (widget.getAttribute('data-apos-played')) {
+        return;
+      }
+      var data = JSON.parse(widget.getAttribute('data'));
+      var options = JSON.parse(widget.getAttribute('data-options'));
+      widget.setAttribute('data-apos-played', '1');
+      var player = apos.utils.widgetPlayers[data.type];
+      if (!player) {
+        return;
+      }
+      player(widget, data, options);
+    }
+  };
+
+  // Schedule runPlayers to run as soon as the document is ready.
+  // You can run it again with apos.utils.runPlayers() if you AJAX-load some widgets.
+
+  apos.utils.onReady(function() {
+    // Indirection so you can override `apos.utils.runPlayers` first if you want to for some reason
+    apos.utils.runPlayers();
+  });
+
+  // In the event (cough) that we're in the full-blown Apostrophe editing world,
+  // we also need to run widget players when content is edited
+  if (apos.on) {
+    apos.on('enhance', function($el) {
+      apos.utils.runPlayers($el[0]);
+    });
+  }
+
+})();

--- a/lib/modules/apostrophe-push/index.js
+++ b/lib/modules/apostrophe-push/index.js
@@ -249,5 +249,36 @@ module.exports = {
       }
     });
 
+    // If lean: true is active for assets, modify the behavior as follows:
+    //
+    // * browser calls pushed for a particular request for "anon" don't
+    // go anywhere at all (they are associated with legacy js that won't
+    // be there to receive them).
+    //
+    // * browser calls pushed for the "always" scene in general are
+    // still pushed, but only for the "user" scene where the necessary
+    // code exists.
+
+    var superReqGetBrowserCalls = self.apos.app.request.getBrowserCalls;
+    self.apos.app.request.getBrowserCalls = function() {
+      if (self.apos.assets.options.lean) {
+        var scene = this.scene || (this.user ? 'user' : 'anon');
+        if (scene === 'anon') {
+          return '';
+        }
+      }
+      return superReqGetBrowserCalls.apply(this, arguments);
+    };
+    var superBrowserCall = self.browserCall;
+    self.browserCall = function(when, pattern /* , arg1, arg2... */) {
+      if (self.apos.assets.options.lean) {
+        if (arguments[0] === 'always') {
+          arguments[0] = 'user';
+        }
+      }
+      return superBrowserCall.apply(self, arguments);
+    };
+
   }
+
 };

--- a/lib/modules/apostrophe-rich-text-widgets/index.js
+++ b/lib/modules/apostrophe-rich-text-widgets/index.js
@@ -109,6 +109,12 @@ module.exports = {
     self.pushAssets = function() {
       superPushAssets();
       self.pushAsset('stylesheet', 'user', { when: 'user' });
+      if (self.apos.assets.options.lean) {
+        // Intentionally pushed only for the user scene, this player triggers
+        // the rich text editor on click when the classic player is
+        // not used due to lean assets
+        self.pushAsset('script', 'lean-user', { when: 'user' });
+      }
     };
 
   }

--- a/lib/modules/apostrophe-rich-text-widgets/public/js/lean-user.js
+++ b/lib/modules/apostrophe-rich-text-widgets/public/js/lean-user.js
@@ -1,0 +1,14 @@
+// If we're logged in, rich text has a "player"
+// to implement the "click to start editing" behavior.
+// Provide a "lean" player that just wraps that play method,
+// which would not otherwise be invoked in the lean world.
+// This file is pushed only for the "user" scene, so there
+// is no overhead in the truly lean logged-out world.
+
+(function() {
+  apos.utils.widgetPlayers['apostrophe-rich-text'] = function(el, data, options) {
+    var richText = apos.modules['apostrophe-rich-text-widgets'];
+    return richText.play(window.$(el), data, options);
+  };
+})();
+

--- a/lib/modules/apostrophe-rich-text-widgets/public/js/lean-user.js
+++ b/lib/modules/apostrophe-rich-text-widgets/public/js/lean-user.js
@@ -11,4 +11,3 @@
     return richText.play(window.$(el), data, options);
   };
 })();
-

--- a/lib/modules/apostrophe-video-widgets/index.js
+++ b/lib/modules/apostrophe-video-widgets/index.js
@@ -8,6 +8,19 @@
 // for that module to handle video sites that don't natively support oembed.
 //
 // Videos are not actually hosted or stored by Apostrophe.
+//
+// ## Options
+//
+// ### player: true
+//
+// If you have set `lean: true` for the `apostrophe-assets` module,
+// the standard oembed-based video player does not get pushed to the
+// browser, as it is part of the legacy jQuery-based frontend.
+// 
+// However, you may opt in to a similar player that uses only a
+// few lines of lean JavaScript by setting the `player` option
+// of this module to `true`. You may of course skip this and
+// write your own.
 
 module.exports = {
   extend: 'apostrophe-widgets',
@@ -24,6 +37,8 @@ module.exports = {
     ].concat(options.addFields || []);
   },
   construct: function(self, options) {
-    self.pushAsset('stylesheet', 'always', { when: 'always' });
+    if (self.apos.assets.options.lean && self.options.player) {
+      self.pushAsset('script', 'lean', { when: 'lean' });
+    }
   }
 };

--- a/lib/modules/apostrophe-video-widgets/index.js
+++ b/lib/modules/apostrophe-video-widgets/index.js
@@ -16,7 +16,7 @@
 // If you have set `lean: true` for the `apostrophe-assets` module,
 // the standard oembed-based video player does not get pushed to the
 // browser, as it is part of the legacy jQuery-based frontend.
-// 
+//
 // However, you may opt in to a similar player that uses only a
 // few lines of lean JavaScript by setting the `player` option
 // of this module to `true`. You may of course skip this and

--- a/lib/modules/apostrophe-video-widgets/index.js
+++ b/lib/modules/apostrophe-video-widgets/index.js
@@ -37,8 +37,12 @@ module.exports = {
     ].concat(options.addFields || []);
   },
   construct: function(self, options) {
-    if (self.apos.assets.options.lean && self.options.player) {
-      self.pushAsset('script', 'lean', { when: 'lean' });
+    if (self.apos.assets.options.lean) {
+      if (self.options.player) {
+        self.pushAsset('script', 'lean', { when: 'lean' });
+      }
+    } else {
+      self.pushAsset('script', 'always', { when: 'always' });
     }
   }
 };

--- a/lib/modules/apostrophe-video-widgets/public/js/lean.js
+++ b/lib/modules/apostrophe-video-widgets/public/js/lean.js
@@ -1,0 +1,62 @@
+apos.utils.widgetPlayers['apostrophe-video'] = function(el, data, options) {
+
+  queryAndPlay(
+    el.querySelector('[data-apos-video-player]'),
+    apos.utils.assign(data.video, {
+      neverOpenGraph: 1
+    })
+  );
+
+  function queryAndPlay(el, options) {
+    apos.utils.removeClass(el, 'apos-oembed-invalid');
+    apos.utils.addClass(el, 'apos-oembed-busy');
+    if (!options.url) {
+      return fail('undefined');
+    }
+    return query(options, function(err, result) {
+      if (err || (options.type && (result.type !== options.type))) {
+        return fail(err || 'inappropriate');
+      }
+      apos.utils.removeClass(el, 'apos-oembed-busy');
+      return play(el, result);
+    });
+  }
+
+  function query(options, callback) {
+    return apos.utils.get('/modules/apostrophe-oembed/query', options, callback);
+  }
+
+  function play(el, result) {
+    var shaker = document.createElement('div');
+    shaker.innerHTML = result.html;
+    var inner = shaker.firstChild;
+    el.innerHTML = '';
+    if (!inner) {
+      return;
+    }
+    inner.removeAttribute('width');
+    inner.removeAttribute('height');
+    el.append(inner);
+    // wait for CSS width to be known
+    apos.utils.onReady(function() {
+      // If oembed results include width and height we can get the
+      // video aspect ratio right
+      if (result.width && result.height) {
+        inner.style.height = ((result.height / result.width) * inner.offsetWidth) + 'px';
+      } else {
+        // No, so assume the oembed HTML code is responsive.
+      }
+    });
+  }
+
+  function fail(err) {
+    apos.utils.removeClass(el, 'apos-oembed-busy');
+    apos.utils.addClass(el, 'apos-oembed-invalid');
+    if (err !== 'undefined') {
+      el.innerHTML = 'Ⓧ';
+    } else {
+      el.innerHTML = '';
+    }
+  }
+
+};


### PR DESCRIPTION
Implements #1938. 

This is a WIP until I test what happens if you try to use the existing `apostrophe-lean-frontend` module with it. Probably nothing good, so I'll have to figure out a workaround to let that work before we merge.

But otherwise this works well, see the `lean-tests` branch of `apostrophe-enterprise-testbed`.