### PR TITLE
apos.utils.post now accepts a FormData object as the data parameter a…

### DIFF
--- a/lib/modules/apostrophe-browser-utils/public/js/lean.js
+++ b/lib/modules/apostrophe-browser-utils/public/js/lean.js
@@ -17,24 +17,38 @@
 
   apos.utils = apos.utils || {};
 
-  // Make a POST JSON call to the given URI. The object `data` is transferred
-  // as JSON. On success the response is delivered to the callback as
-  // `(null, response)`, following the Node.js convention.
+  // Make a POST JSON call to the given URI, which is expected to be on the
+  // Apostrophe site. CSRF headers are correctly sent and the URL is modified
+  // if needed to honor the site prefix.
+  // 
+  // The object `data` is transferred as JSON. On success the response is
+  // delivered to the callback as `(null, response)`, following the Node.js convention.
   // On failure the error is delivered as `(err)`. Specifically the
   // error will be the event object associated with the error.
+  // 
+  // If `data` is a FormData object, a standard multipart/form-data upload occurs
+  // and JSON encoding is not used. This enables multipart/form-data uploads
+  // that respect Apostrophe's CSRF token and prefix.
 
   apos.utils.post = function(uri, data, callback) {
     if (apos.prefix) {
       uri = apos.prefix + uri;
     }
+    var formData = window.FormData && (data instanceof window.FormData);
     var xmlhttp = new XMLHttpRequest();
     var csrfToken = apos.utils.getCookie(apos.csrfCookieName);
     xmlhttp.open("POST", uri);
-    xmlhttp.setRequestHeader('Content-Type', 'application/json');
+    if (!formData) {
+      xmlhttp.setRequestHeader('Content-Type', 'application/json');
+    }
     if (csrfToken) {
       xmlhttp.setRequestHeader('X-XSRF-TOKEN', csrfToken);
     }
-    xmlhttp.send(JSON.stringify(data));
+    if (formData) {
+      xmlhttp.send(data);
+    } else {
+      xmlhttp.send(JSON.stringify(data));
+    }
     monitor(xmlhttp, callback);
   };
 

--- a/lib/modules/apostrophe-db/index.js
+++ b/lib/modules/apostrophe-db/index.js
@@ -99,7 +99,7 @@ module.exports = {
           uri += options.user + ':' + options.password + '@';
         }
         if (!options.host) {
-          options.host = 'localhost';
+          options.host = '127.0.0.1';
         }
         if (!options.port) {
           options.port = 27017;


### PR DESCRIPTION
…nd does the right thing so you can do a file upload back to IE11 without a lot of fuss and still get our CSRF protection. Also: database connection to localhost now uses 127.0.0.1 to avoid a DNS lookup that might not work properly while passing through a dodgy wifi area; should not matter but I saw it several times today.