### PR TITLE
although a choices function for a select field will probably be async…

### DIFF
--- a/lib/modules/apostrophe-schemas/lib/routes.js
+++ b/lib/modules/apostrophe-schemas/lib/routes.js
@@ -1,5 +1,6 @@
 var async = require('async');
 var _ = require('@sailshq/lodash');
+var Promise = require('bluebird');
 
 module.exports = function(self, options) {
 
@@ -69,7 +70,9 @@ module.exports = function(self, options) {
     if (!self.apos.utils.isBlessed(req, field, 'field')) {
       return next(new Error('Unblessed choices request for field: ', field));
     }
-    return self.apos.modules[field.moduleName][field.choices](req).then(function(choices) {
+    return Promise.try(function() {
+      return self.apos.modules[field.moduleName][field.choices](req);
+    }).then(function(choices) {
       // We're in a `then` function, so any exceptions thrown by the
       // render method will be caught properly and passed to
       // the `catch` function


### PR DESCRIPTION
…, there is no need to be grumpy if it returns an array synchronously. We can handle that simply by wrapping the call in Promise.try, which wraps simple synchronous return values as promises if needed, just like invoking from then() does.

