### PR TITLE
Updates the major version of diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "credential": "^2.0.0",
     "cuid": "^1.3.8",
     "deep-get-set": "^0.1.1",
-    "diff": "^2.2.3",
+    "diff": "^3.5.0",
     "express": "^4.16.4",
     "express-session": "^1.16.1",
     "glob": "^5.0.15",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "credential": "^2.0.0",
     "cuid": "^1.3.8",
     "deep-get-set": "^0.1.1",
-    "diff": "^3.5.0",
+    "diff": "^4.0.1",
     "express": "^4.16.4",
     "express-session": "^1.16.1",
     "glob": "^5.0.15",


### PR DESCRIPTION
This is in response to a vulnerability alert: https://github.com/apostrophecms/apostrophe/network/alert/package.json/diff/open. The only reported v3 breaking change reported is on a method we're not using and all tests are passing.