### PR TITLE
Color picker spectrum options

### DIFF
--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -1475,7 +1475,7 @@ apos.define('apostrophe-schemas', {
       name: 'color',
       populate: function (data, name, $field, $el, field, callback) {
         $field.val(data[name]);
-        apos.ui.enhanceColorpicker($field);
+        apos.ui.enhanceColorpicker($field, field.spectrumOptions);
         return setImmediate(callback);
       },
       convert: function (data, name, $field, $el, field, callback) {

--- a/lib/modules/apostrophe-ui/public/js/ui.js
+++ b/lib/modules/apostrophe-ui/public/js/ui.js
@@ -375,7 +375,6 @@ apos.define('apostrophe-ui', {
         preferredFormat: "hex",
         showInput: true,
         allowEmpty: true,
-        spectrumOptions: options.spectrumOptions,
         move: function(color) {
 
           if (color) {

--- a/lib/modules/apostrophe-ui/public/js/ui.js
+++ b/lib/modules/apostrophe-ui/public/js/ui.js
@@ -375,6 +375,7 @@ apos.define('apostrophe-ui', {
         preferredFormat: "hex",
         showInput: true,
         allowEmpty: true,
+        spectrumOptions: options.spectrumOptions,
         move: function(color) {
 
           if (color) {


### PR DESCRIPTION
These changes will allow for a person to pass in spectrumOptions for a field type of color. Spectrum is the plugin used for the color picker.

On a widget I was able to configure a field like this to show color pallets.
```
{
		      name: 'bgColor',
		      label: 'Background Color',
				type: 'color',
				spectrumOptions: {
				showPalette: true,
				    palette: [
				        ['black', 'white', 'blanchedalmond'],
				        ['rgb(255, 128, 0);', 'hsv 100 70 50', 'lightyellow']
				    ]
				}
			},
```