### PR TITLE
Fix three array bugs boom

### DIFF
--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -27,11 +27,14 @@
 //
 // ### `minify`
 //
+// Set for you automatically if `APOS_BUNDLE=1` or `APOS_MINIFY=1` in the environment.
+//
 // If set to true, both stylesheets and scripts are combined into a single file
 // and unnecessary whitespace removed to speed delivery. It is strongly recommended
 // that you enable this option in production, and also in staging so you can see
-// any unexpected effects. If this option is undefined, the APOS_MINIFY
-// environment variable is consulted.
+// any unexpected effects.
+//
+// It never makes sense to run with no minified assets in production.
 //
 // ### `lean`
 //
@@ -70,25 +73,36 @@
 //
 // ### `APOS_BUNDLE`
 //
-// If set to the name of a static asset bundle, the specified bundle is unpacked
-// at startup. See [Deploying Apostrophe in the Cloud with Heroku](https://docs.apostrophecms.org/apostrophe/tutorials/howtos/deploying-apostrophe-in-the-cloud-with-heroku)
-// for more information.
+// Set APOS_BUNDLE=1 for a simple way to handle copying static assets to the cloud in production.
+//
+// First run this task in a production environment:
+//
+// `APOS_BUNDLE=1 node app apostrophe:generation`
+//
+// Then make sure the variable is also set when running actual production instances of the site:
+//
+// `APOS_BUNDLE=1 node app`
+//
+// Alternatively, if you specified an explicit bundle name to `--create-bundle` when using `apostrophe:generation`,
+// stored it to git and deployed it, you can specify that bundle name as the value of APOS_BUNDLE. But this is
+// more work; we recommend the easy way.
 //
 // ### `APOS_BUNDLE_IN_UPLOADFS`
 //
-// If set, static asset URLs are generated to the bundle in uploadfs rather than being
-// served locally. Since not every module that utilizes static assets of modules will
-// necessarily participate, the bundle is still unpacked locally as well. See
-// [Deploying Apostrophe in the Cloud with Heroku](https://docs.apostrophecms.org/apostrophe/tutorials/howtos/deploying-apostrophe-in-the-cloud-with-heroku)
-// for more information.
+// Legacy. For use when `APOS_BUNDLE` is set to an explicit bundle name but you still wish static asset URLs to be
+// generated to reference those filesvia uploadfs. But this is the hard way; just run `apostrophe:generation` with
+// APOS_BUNDLE=1, and also set `APOS_BUNDLE=1` in the environment when launching Apostrophe. That's really all you
+// have to do.
+// See [Deploying Apostrophe in the Cloud with Heroku](https://apostrophecms.org/docs/tutorials/howtos/deploying-apostrophe-in-the-cloud-with-heroku.html) for more information.
 //
 // ### `APOS_BUNDLE_CLEANUP_DELAY`
 //
 // If set to a number of milliseconds, Apostrophe delays that long before
 // cleaning up obsolete static asset bundles in uploadfs. The default
 // is 5 minutes. The assumption is that all production servers have received
-// the new deployment and finished serving any straggler HTTP requests by this point.
-// See [Deploying Apostrophe in the Cloud with Heroku](https://docs.apostrophecms.org/apostrophe/tutorials/howtos/deploying-apostrophe-in-the-cloud-with-heroku)
+// the new deployment and finished serving any straggler HTTP requests 5 minutes after
+// a new version is first launched.
+// See [Deploying Apostrophe in the Cloud with Heroku](https://apostrophecms.org/docs/tutorials/howtos/deploying-apostrophe-in-the-cloud-with-heroku.html)
 // for more information.
 
 var path = require('path');
@@ -104,6 +118,10 @@ var glob = require('glob');
 var bless = require('bless');
 var lessMiddleware = require('less-middleware');
 var rimraf = require('rimraf');
+var Promise = require('bluebird');
+var tar = require('tar');
+var mkdirp = require('mkdirp');
+var Binary = require('mongodb').Binary;
 
 module.exports = {
 
@@ -117,9 +135,15 @@ module.exports = {
       'tasks, then exit. This happens on a normal startup too, but if you are running\n' +
       'multiple processes or servers you should avoid race conditions by running\n' +
       'this task before starting them all.\n\n' +
-      'To create a bundle folder for later use on a production server, use the\n' +
-      '--create-bundle=NAME option. Later, on production, start the site normally\n' +
-      'with the APOS_BUNDLE environment variable set to the same NAME.',
+      'To create an asset bundle zipfile in uploadfs as a predeployment task on production,\n' +
+      'run:\n\n' +
+      'APOS_BUNDLE=1 node app apostrophe:generation\n\n' +
+      'After that, on production, start the site normally with APOS_BUNDLE=1 every time and the\n' +
+      'bundle will be extracted if needed.\n\n' +
+      'You can also specify a bundle name in both cases in which case\n' +
+      'it is written to the project root as a folder by that name and will be extracted from\n' +
+      'there as well. That approach is used only if you prefer to run this task in dev and\n' +
+      'commit the results.',
       function(apos, argv, callback) {
         return self.generationTask(callback);
       }
@@ -131,10 +155,10 @@ module.exports = {
     self.enableCsrf();
     self.enableHtmlPageId();
     self.enablePrefix();
-    self.determineGeneration();
     self.enableLessMiddleware();
     self.servePublicAssets();
     self.pushDefaults();
+    self.isGenerationTask = (self.apos.argv._[0] === 'apostrophe:generation');
     self.pushCreateSingleton();
   },
 
@@ -147,6 +171,11 @@ module.exports = {
   },
 
   construct: function(self, options) {
+
+    if ((process.env.APOS_BUNDLE === '1') || (options.apos.argv['create-bundle'] === true)) {
+      self.simpleBundle = true;
+      self.options.minify = true;
+    }
 
     self.minified = {};
 
@@ -282,17 +311,56 @@ module.exports = {
       };
     };
 
-    self.determineGeneration = function() {
+    // If self.simpleBundle is true, determine the current asset generation via the database and
+    // set `self.generation` accordingly. If we are running the generation task in that situation,
+    // set the generation id in the database. In all other cases, determine the generation via legacy methods.
 
-      self.isGenerationTask = (self.apos.argv._[0] === 'apostrophe:generation');
+    self.determineGenerationFromDb = function() {
+      if (self.isGenerationTask && self.simpleBundle) {
+        self.determineGeneration();
+        return self.generationCollection.update({
+          _id: 'current'
+        }, {
+          generation: self.generation
+        }, {
+          upsert: true
+        });
+      }
+      if (!self.simpleBundle) {
+        return self.determineGeneration();
+      }
+      return Promise.try(function() {
+        return self.generationCollection.findOne({ _id: 'current' });
+      }).then(function(c) {
+        if (!c) {
+          throw new Error('You must first run the apostrophe:generation task, with APOS_BUNDLE=1 set in the environment');
+        }
+        self.generation = c.generation;
+      });
+    };
+
+    // Determine the current asset generation identifier (self.generation) and prep the
+    // bundle folder, if any is needed.
+
+    self.determineGeneration = function() {
 
       var generation;
 
       if (self.isGenerationTask) {
+        // Create a new generation identifier. The assets module
+        // will use this to create asset files that are distinctly
+        // named on a new deployment.
+        generation = self.apos.utils.generateId();
 
-        if (self.apos.argv['create-bundle']) {
-          self.toBundleName = self.apos.argv['create-bundle'];
-          self.toBundle = self.apos.rootDir + '/' + self.toBundleName;
+        var bundle = self.apos.argv['create-bundle'] || self.simpleBundle;
+        if (bundle) {
+          if (bundle === true) {
+            self.toBundleName = 'assets-' + generation;
+            self.toBundle = self.apos.rootDir + '/data/temp/' + self.toBundleName;
+          } else {
+            self.toBundleName = bundle;
+            self.toBundle = self.apos.rootDir + '/' + self.toBundleName;
+          }
           rimraf.sync(self.toBundle);
           var ensure = [
             self.toBundle,
@@ -303,21 +371,22 @@ module.exports = {
           ];
           _.each(ensure, function(folder) {
             if (!fs.existsSync(folder)) {
-              fs.mkdirSync(folder);
+              self.mkdirp(folder);
             }
           });
         }
 
-        // Create a new generation identifier. The assets module
-        // will use this to create asset files that are distinctly
-        // named on a new deployment.
-        generation = self.apos.utils.generateId();
-        fs.writeFileSync(self.getAssetRoot() + '/data/generation', generation);
+        if (self.apos.argv['create-bundle'] !== true) {
+          fs.writeFileSync(self.getAssetRoot() + '/data/generation', generation);
+        }
+
       }
 
-      if (fs.existsSync(self.getAssetRoot() + '/data/generation')) {
-        generation = fs.readFileSync(self.getAssetRoot() + '/data/generation', 'utf8');
-        generation = generation.replace(/\s/g, '');
+      if (self.apos.argv['create-bundle'] !== true) {
+        if (fs.existsSync(self.getAssetRoot() + '/data/generation')) {
+          generation = fs.readFileSync(self.getAssetRoot() + '/data/generation', 'utf8');
+          generation = generation.replace(/\s/g, '');
+        }
       }
 
       if (!generation) {
@@ -328,21 +397,91 @@ module.exports = {
       self.generation = generation;
     };
 
+    self.mkdirp = function(path) {
+      try {
+        mkdirp.sync(path);
+      } catch (e) {
+        if (require('fs').existsSync(path)) {
+          // race condition in mkdirp but all is well
+        } else {
+          throw e;
+        }
+      }
+    };
+
     // Initialize services required for asset bundles. Obtains the
     // self.generations mongodb collection and extracts a bundle if
     // appropriate.
 
     self.enableBundles = function() {
+      // Used for cleanup purposes. Inconsistent name is legacy
       self.generations = self.apos.db.collection('apostropheGenerations');
+      // Used to identify the current generation, based on a fixed _id, separate in purpose
+      // from self.generations
+      self.generationCollection = self.apos.db.collection('aposGeneration');
+      // Handles the synchronous filesystem bundle case, See also extractBundleFromGenerationCollection
       self.extractBundleIfAppropriate();
     };
 
-    // Extract an asset bundle if appropriate. The default implementation
-    // looks for an APOS_BUNDLE=XYZ environment variable and, if present, extracts
-    // a bundle with the name XYZ
+    // Extracts the appropriate asset bundle from uploadfs if we are using simple bundles
+    // and this is not a command line task.
+    //
+    // Returns a promise. Called on the modulesReady event.
+
+    self.extractBundleFromGenerationCollection = function() {
+      if (self.apos.isTask()) {
+        return;
+      }
+      if (!self.simpleBundle) {
+        return;
+      }
+      return Promise.try(function() {
+        return self.generationCollection.findOne({ _id: 'current' });
+      }).then(function(generation) {
+        if (!(generation && generation.tarball)) {
+          throw new Error('Asset bundle is not in generationCollection');
+        }
+        return fs.writeFileSync(self.getUploadfsBundleTempName(), generation.tarball.buffer);
+      }).then(function() {
+        return tar.extract({
+          file: self.getUploadfsBundleTempName(),
+          gzip: true,
+          cwd: self.apos.rootDir
+        });
+      }).then(function() {
+        self.extractedTarFiles = [];
+        return tar.t({
+          onentry: function(entry) {
+            if (entry.type === 'File') {
+              self.extractedTarFiles.push(entry.path);
+            }
+          },
+          file: self.getUploadfsBundleTempName()
+        });
+      }).then(function() {
+        return Promise.promisify(function(callback) {
+          return fs.remove(self.getUploadfsBundleTempName(), callback);
+        });
+      }).then(function() {
+        self.fromBundle = true;
+      });
+    };
+
+    self.on('apostrophe:modulesReady', 'determineGenerationAndExtract', function() {
+      return Promise.try(function() {
+        return self.determineGenerationFromDb();
+      }).then(function() {
+        return self.extractBundleFromGenerationCollection();
+      });
+    });
+
+    // This method supports the less common case where an explicit bundle name
+    // is in APOS_BUNDLE and it should be extracted from the filesystem. The
+    // more common case, APOS_BUNDLE=1, is implemented elsewhere. The name of
+    // this method is kept for bc reasons.
 
     self.extractBundleIfAppropriate = function() {
-      if (process.env.APOS_BUNDLE) {
+      if (process.env.APOS_BUNDLE && (process.env.APOS_BUNDLE !== '1')) {
         self.extractBundle(process.env.APOS_BUNDLE);
         self.fromBundle = true;
       }
@@ -356,7 +495,10 @@ module.exports = {
       var locked = false;
       var generations;
 
-      setTimeout(cleanup, process.env.APOS_BUNDLE_CLEANUP_DELAY ? parseInt(process.env.APOS_BUNDLE_CLEANUP_DELAY) : 5 * 1000 * 60);
+      // By default, allow old assets to exist for a full five hours after
+      // a new deployment. They aren't hurting anything and it could
+      // take quite a while to completely transition a big deployment
+      setTimeout(cleanup, process.env.APOS_BUNDLE_CLEANUP_DELAY ? parseInt(process.env.APOS_BUNDLE_CLEANUP_DELAY) : 5 * 60 * 60 * 1000);
 
       function cleanup() {
         return async.series([
@@ -403,7 +545,11 @@ module.exports = {
           // Enumerate the copies the same way they were enumerated when
           // this bundle was copied into uploadfs. Note that the bundle
           // exists both locally and in uploadfs so we can do that here too
-          var current = { _id: self.generation, copies: self.enumerateCopies(self.apos.rootDir + '/' + process.env.APOS_BUNDLE + '/public', '/assets/' + self.generation), when: new Date() };
+          var current = {
+            _id: self.generation,
+            copies: self.enumerateCopies(self.extractedTarFiles ? { files: self.extractedTarFiles, prefix: './public' } : (self.apos.rootDir + '/' + self.toBundleName + '/public'), '/assets/' + self.generation),
+            when: new Date()
+          };
           generations.push(current);
           return self.generations.insert(current, callback);
         }
@@ -426,7 +572,7 @@ module.exports = {
 
           function removeFiles(callback) {
             return async.eachLimit(generation.copies, 5, function(copy, callback) {
-              return self.apos.attachments.uploadfs.remove(copy.to, function(err) {
+              return self.uploadfs().remove(copy.to, function(err) {
                 // Failure to remove a stale asset is nonfatal
                 if (err) {
                   self.apos.utils.error(err);
@@ -572,13 +718,15 @@ module.exports = {
 
     self.afterInit = function(callback) {
       if (self.apos.isTask() && !self.isGenerationTask) {
+        // Tasks other than apostrophe:generation should not waste time and create conflicts by
+        // attempting to generate assets
         return setImmediate(callback);
       }
 
       self.tooLateToPushAssets = true;
 
-      if (self.fromBundle) {
-        if (process.env.APOS_BUNDLE_IN_UPLOADFS) {
+      if (self.fromBundle && (!self.isGenerationTask)) {
+        if (process.env.APOS_BUNDLE_IN_UPLOADFS || self.simpleBundle) {
           if (self.options.uploadfsBundleCleanup !== false) {
             self.uploadfsBundleCleanup();
           }
@@ -821,12 +969,11 @@ module.exports = {
       var copies = [];
 
       copies = self.enumerateCopies(from, to);
-
       return performCopies(callback);
 
       function performCopies(callback) {
         return async.eachLimit(copies, 5, function(copy, callback) {
-          return self.apos.attachments.uploadfs.copyIn(copy.from, copy.to, callback);
+          return self.uploadfs().copyIn(copy.from, copy.to, callback);
         }, callback);
       }
 
@@ -838,6 +985,23 @@ module.exports = {
     // and `to` properties
 
     self.enumerateCopies = function(from, to) {
+
+      if (from.files && from.prefix) {
+        var result = _.filter(from.files, function(file) {
+          if (file.substring(0, from.prefix.length) !== from.prefix) {
+            return false;
+          }
+          return true;
+        });
+        result = result.map(function(file) {
+          file = file.substring(from.prefix.length);
+          return {
+            from: file,
+            to: to + file
+          };
+        });
+        return result;
+      }
 
       var copies = [];
       enumerateDir(from, to);
@@ -1175,7 +1339,7 @@ module.exports = {
         }
         css = css.css;
         if (self.apos.argv['sync-to-uploadfs']) {
-          css = self.prefixCssUrlsWith(css, self.apos.attachments.uploadfs.getUrl() + '/assets/' + self.generation);
+          css = self.prefixCssUrlsWith(css, self.uploadfs().getUrl() + '/assets/' + self.generation);
         } else if (self.apos.prefix) {
           css = self.prefixCssUrls(css);
         }
@@ -1447,11 +1611,11 @@ module.exports = {
 
     // Given the site-relative URL an asset would have when hosting assets locally,
     // return the asset URL to be used in script or link tags. Often the same, but
-    // when APOS_S3_BUNDLE is in effect it can point elsewhere
+    // when APOS_BUNDLE is in effect it can point elsewhere
 
     self.assetUrl = function(web) {
-      if (process.env.APOS_BUNDLE_IN_UPLOADFS) {
-        return self.apos.attachments.uploadfs.getUrl() + '/assets/' + self.generation + web;
+      if (process.env.APOS_BUNDLE_IN_UPLOADFS || self.simpleBundle) {
+        return self.uploadfs().getUrl() + '/assets/' + self.generation + web;
       }
       return self.apos.prefix + web;
     };
@@ -1479,11 +1643,61 @@ module.exports = {
     // that part.
 
     self.generationTask = function(callback) {
-      if (self.apos.argv['sync-to-uploadfs']) {
-        return self.syncToUploadfs(self.apos.rootDir + '/' + self.toBundleName + '/public',
+      return async.series([
+        copyFilesToUploadfs,
+        copyTarballToGenerationCollection
+      ], function(err) {
+        return callback(err);
+      });
+
+      function copyFilesToUploadfs(callback) {
+        if (!(self.apos.argv['sync-to-uploadfs'] || (self.isGenerationTask && self.simpleBundle))) {
+          return callback(null);
+        }
+        return self.syncToUploadfs(self.toBundle + '/public',
           '/assets/' + self.generation, callback);
       }
-      return callback(null);
+
+      function copyTarballToGenerationCollection(callback) {
+        if (!self.simpleBundle) {
+          return callback(null);
+        }
+        // `true`, rather than an explicit bundle name, means we should copy it to a tarfile in
+        // uploadfs with a name based on the bundle id and record the bundle id in the
+        // database so we can find it later at startup time
+        var temp = self.getUploadfsBundleTempName();
+        return tar.create({
+          file: temp,
+          gzip: true,
+          cwd: self.toBundle
+        },
+        [
+          '.'
+        ]).then(function() {
+          return self.generationCollection.update({
+            _id: 'current'
+          }, {
+            $set: {
+              tarball: Binary(fs.readFileSync(temp))
+            }
+          });
+        }).then(function() {
+          return callback(null);
+        }).catch(callback);
+      }
+    };
+
+    self.getUploadfsBundleTempName = function() {
+      const temp = self.apos.rootDir + '/data/temp';
+      if (!self.__tempMkdir) {
+        self.mkdirp(temp);
+        self.__tempMkdir = true;
+      }
+      return temp + '/assets-' + self.generation + '.tar.gz';
+    };
+
+    self.getUploadfsBundlePath = function() {
+      return '/asset-tarballs/assets-' + self.generation + '.tar.gz';
     };
 
     // Implementation of stylesheeets helper, as a method for
@@ -1532,6 +1746,12 @@ module.exports = {
           return '<script src="' + self.assetUrl(script.web) + '"></script>';
         }).join("\n");
       }
+    };
+
+    // Override point to use a separate uploadfs instance, for
+    // instance in a multisite project with shared assets
+    self.uploadfs = function() {
+      return self.apos.attachments.uploadfs;
     };
 
     self.addHelpers({

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -260,10 +260,22 @@ module.exports = {
         // contain a method name. For bc don't mess with possible
         // existing usages in custom schema field types predating
         // this feature
-        field.moduleName = field.moduleName || (module && module.__meta.name);
+        self.setModuleName(field, module);
       });
 
       return schema;
+    };
+
+    // Recursively set moduleName property of the field and any subfields,
+    // as might be found in array or object fields. `module` is an actual module
+
+    self.setModuleName = function(field, module) {
+      field.moduleName = field.moduleName || (module && module.__meta.name);
+      if ((field.type === 'array') || (field.type === 'object')) {
+        _.each(field.schema || [], function(subfield) {
+          self.setModuleName(subfield, module);
+        });
+      }
     };
 
     // refine is like compose, but it starts with an existing schema array
@@ -1942,7 +1954,9 @@ module.exports = {
           }, function(err) {
             object[name] = results;
             if (field.required && (results.length === 0)) {
-              return callback(new Error('required'));
+              // Do not use Error constructor, this is always intentionally a string error for
+              // comparison purposes and network friendliness
+              return callback('required');
             }
             return callback(err);
           });

--- a/lib/modules/apostrophe-schemas/public/js/array-modal.js
+++ b/lib/modules/apostrophe-schemas/public/js/array-modal.js
@@ -19,6 +19,7 @@ apos.define('apostrophe-array-editor-modal', {
       self.$arrayItem = self.$el.find('[data-apos-array-item]');
       self.field = options.field;
       self.arrayItems = options.arrayItems || [];
+      self.originalArrayItems = _.cloneDeep(self.arrayitems);
       if (self.errorPath && self.errorPath[0]) {
         self.active = parseInt(self.errorPath[0]);
       } else {
@@ -30,6 +31,17 @@ apos.define('apostrophe-array-editor-modal', {
         self.setItemTitles();
         return self.editItem();
       }
+    };
+
+    self.beforeCancel = function(callback) {
+      // We must modify arrayItems in place, the calling code expects us
+      // to modify that array by reference and won't understand if we
+      // just reassign to the property
+      self.arrayItems.splice(0, self.arrayItems.length);
+      _.each(self.originalArrayItems, function(item) {
+        self.arrayItems.push(item);
+      });
+      return callback(null);
     };
 
     // This method is now a bc placeholder


### PR DESCRIPTION
Fixed three array bugs:

(1) a required array hidden by showFields is in effect not required (same as other field types).

(2) Cancelling an edit operation on an array actually does revert everything, notably it does not leave you with a halfassed first entry in an array you never meant to create at all.

(3) Dynamic select and checkboxes fields work in arrays.

If you wish you can experience these fixes via the array-bug-tests branch of apostrophe-enterprise-testbed, which moves a bunch of fields of "Products" into a "Profiles" array field (look at the "Info" tab). The entire array becomes visible when you check "Has Profiles." (These are not actually regression tests, just a nice testbed for validating these fixes manually.)