### PR TITLE
phew OK just the array bug fixes in this PR I hope

### DIFF
--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -260,10 +260,22 @@ module.exports = {
         // contain a method name. For bc don't mess with possible
         // existing usages in custom schema field types predating
         // this feature
-        field.moduleName = field.moduleName || (module && module.__meta.name);
+        self.setModuleName(field, module);
       });
 
       return schema;
+    };
+
+    // Recursively set moduleName property of the field and any subfields,
+    // as might be found in array or object fields. `module` is an actual module
+
+    self.setModuleName = function(field, module) {
+      field.moduleName = field.moduleName || (module && module.__meta.name);
+      if ((field.type === 'array') || (field.type === 'object')) {
+        _.each(field.schema || [], function(subfield) {
+          self.setModuleName(subfield, module);
+        });
+      }
     };
 
     // refine is like compose, but it starts with an existing schema array
@@ -1942,7 +1954,9 @@ module.exports = {
           }, function(err) {
             object[name] = results;
             if (field.required && (results.length === 0)) {
-              return callback(new Error('required'));
+              // Do not use Error constructor, this is always intentionally a string error for
+              // comparison purposes and network friendliness
+              return callback('required');
             }
             return callback(err);
           });

--- a/lib/modules/apostrophe-schemas/public/js/array-modal.js
+++ b/lib/modules/apostrophe-schemas/public/js/array-modal.js
@@ -19,6 +19,7 @@ apos.define('apostrophe-array-editor-modal', {
       self.$arrayItem = self.$el.find('[data-apos-array-item]');
       self.field = options.field;
       self.arrayItems = options.arrayItems || [];
+      self.originalArrayItems = _.cloneDeep(self.arrayitems);
       if (self.errorPath && self.errorPath[0]) {
         self.active = parseInt(self.errorPath[0]);
       } else {
@@ -30,6 +31,17 @@ apos.define('apostrophe-array-editor-modal', {
         self.setItemTitles();
         return self.editItem();
       }
+    };
+
+    self.beforeCancel = function(callback) {
+      // We must modify arrayItems in place, the calling code expects us
+      // to modify that array by reference and won't understand if we
+      // just reassign to the property
+      self.arrayItems.splice(0, self.arrayItems.length);
+      _.each(self.originalArrayItems, function(item) {
+        self.arrayItems.push(item);
+      });
+      return callback(null);
     };
 
     // This method is now a bc placeholder


### PR DESCRIPTION
Fixed three array bugs:

(1) a required array hidden by showFields is in effect not required (same as other field types).

(2) Cancelling an edit operation on an array actually does revert everything, notably it does not leave you with a halfassed first entry in an array you never meant to create at all.

(3) Dynamic select and checkboxes fields work in arrays.

If you wish you can experience these fixes via the array-bug-tests branch of apostrophe-enterprise-testbed, which moves a bunch of fields of "Products" into a "Profiles" array field (look at the "Info" tab). The entire array becomes visible when you check "Has Profiles." (These are not actually regression tests, just a nice testbed for validating these fixes manually.)

closes #1969