### PR TITLE
Append permissions to subpages instead of overriding them

### DIFF
--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -229,7 +229,7 @@ module.exports = function(self, options) {
     var propagateSet = {};
     var loginRequired = page.loginRequired;
     var appendPermissionsToSubpages = page.appendPermissionsToSubpages || false;
- 
+
     if (!page.applyToSubpages) {
       return setImmediate(callback);
     }
@@ -244,7 +244,7 @@ module.exports = function(self, options) {
         if (appendPermissionsToSubpages) {
           propagateSet[field] = {
             $each: page[field]
-          }
+          };
         } else {
           propagateSet[field] = page[field];
         }
@@ -271,12 +271,12 @@ module.exports = function(self, options) {
         $set: {
           loginRequired: loginRequired
         }
-      }
+      };
     } else {
       propagateSet.loginRequired = loginRequired;
       changeSet = {
         $set: propagateSet
-      }
+      };
     }
 
     return self.apos.docs.db.update(criteria, changeSet, { multi: true }, callback);

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -200,6 +200,12 @@ module.exports = function(self, options) {
   // remembered setting, so the setting itself is cleared afterwards by this
   // method.
   //
+  // If 'appendPermissionsToSubpages' option is selected then the new set of
+  // permissions is appended to the existing subpage\'s permissions instead of completly overriding them.
+  // Thus preserving any special permissions given to a subfolder or a subpage, while
+  // adding the new ones to them. Like 'applytoSubpages' choice, 'appendPermissionsToSubpages'
+  // is also a one-time action, so the setting itself is cleared afterwards by this method.
+  //
   // This method is called for us by the apostrophe-docs module on update
   // operations, so we first make sure it's a page. We also make sure it's
   // not a new page (no kids to propagate anything to).
@@ -222,19 +228,26 @@ module.exports = function(self, options) {
 
     var propagateSet = {};
     var loginRequired = page.loginRequired;
-
+    var appendPermissionsToSubpages = page.appendPermissionsToSubpages || false;
+ 
     if (!page.applyToSubpages) {
       return setImmediate(callback);
     }
 
     // It's a one-time action, don't remember it
     page.applyToSubpages = false;
+    page.appendPermissionsToSubpages = false;
     propagateSet.docPermissions = page.docPermissions;
-    propagateSet.loginRequired = loginRequired;
     _.each(allowed, function(prefix) {
       var fields = [ prefix + 'GroupsIds', prefix + 'UsersIds' ];
       _.each(fields, function(field) {
-        propagateSet[field] = page[field];
+        if (appendPermissionsToSubpages) {
+          propagateSet[field] = {
+            $each: page[field]
+          }
+        } else {
+          propagateSet[field] = page[field];
+        }
       });
     });
 
@@ -246,7 +259,27 @@ module.exports = function(self, options) {
         self.apos.permissions.criteria(req, 'edit-' + page.type)
       ]
     };
-    return self.apos.docs.db.update(criteria, { $set: propagateSet }, { multi: true }, callback);
+
+    var changeSet;
+
+    // if the appendPermissionsToSubpages is selected then $addToSet is used
+    // to prevent duplicates being pushed into permissions array. While loginRequired is set
+    // using $set since its not an array.
+    if (appendPermissionsToSubpages) {
+      changeSet = {
+        $addToSet: propagateSet,
+        $set: {
+          loginRequired: loginRequired
+        }
+      }
+    } else {
+      propagateSet.loginRequired = loginRequired;
+      changeSet = {
+        $set: propagateSet
+      }
+    }
+
+    return self.apos.docs.db.update(criteria, changeSet, { multi: true }, callback);
 
   };
 
@@ -1805,6 +1838,21 @@ module.exports = function(self, options) {
         type: 'boolean',
         name: 'applyToSubpages',
         label: 'Copy all permissions to subpages now',
+        help: 'This is a one-time operation that takes place when you click save.',
+        group: schema[index].group,
+        choices: [
+          {
+            value: true,
+            showFields: [
+              'appendPermissionsToSubpages'
+            ]
+          }
+        ]
+      },
+      {
+        type: 'boolean',
+        name: 'appendPermissionsToSubpages',
+        label: 'Append all permissions to existing subpage\'s permissions now',
         help: 'This is a one-time operation that takes place when you click save.',
         group: schema[index].group
       });

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -228,7 +228,7 @@ module.exports = function(self, options) {
 
     var propagateSet = {};
     var loginRequired = page.loginRequired;
-    var appendPermissionsToSubpages = page.appendPermissionsToSubpages || false;
+    var appendPermissionsToSubpages = page.appendPermissionsToSubpages;
 
     if (!page.applyToSubpages) {
       return setImmediate(callback);
@@ -236,12 +236,12 @@ module.exports = function(self, options) {
 
     // It's a one-time action, don't remember it
     page.applyToSubpages = false;
-    page.appendPermissionsToSubpages = false;
+    page.appendPermissionsToSubpages = 'append';
     propagateSet.docPermissions = page.docPermissions;
     _.each(allowed, function(prefix) {
       var fields = [ prefix + 'GroupsIds', prefix + 'UsersIds' ];
       _.each(fields, function(field) {
-        if (appendPermissionsToSubpages) {
+        if (appendPermissionsToSubpages === 'append') {
           propagateSet[field] = {
             $each: page[field]
           };
@@ -261,11 +261,7 @@ module.exports = function(self, options) {
     };
 
     var changeSet;
-
-    // if the appendPermissionsToSubpages is selected then $addToSet is used
-    // to prevent duplicates being pushed into permissions array. While loginRequired is set
-    // using $set since its not an array.
-    if (appendPermissionsToSubpages) {
+    if (appendPermissionsToSubpages === 'append') {
       changeSet = {
         $addToSet: propagateSet,
         $set: {
@@ -1837,7 +1833,7 @@ module.exports = function(self, options) {
       schema.splice(index + 1, 0, {
         type: 'boolean',
         name: 'applyToSubpages',
-        label: 'Copy all permissions to subpages now',
+        label: 'Apply permissions to subpages now',
         help: 'This is a one-time operation that takes place when you click save.',
         group: schema[index].group,
         choices: [
@@ -1850,11 +1846,22 @@ module.exports = function(self, options) {
         ]
       },
       {
-        type: 'boolean',
+        type: 'select',
         name: 'appendPermissionsToSubpages',
-        label: 'Append all permissions to existing subpage\'s permissions now',
+        label: 'How would you like the permissions to be applied to the subpages ?',
         help: 'This is a one-time operation that takes place when you click save.',
-        group: schema[index].group
+        group: schema[index].group,
+        def: 'append',
+        choices: [
+          {
+            value: 'append',
+            label: 'Append (Adds to the existing permissions)'
+          },
+          {
+            value: 'copy',
+            label: 'Copy (Overrides the existing permissions)'
+          }
+        ]
       });
     }
     return schema;

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -236,7 +236,7 @@ module.exports = function(self, options) {
 
     // It's a one-time action, don't remember it
     page.applyToSubpages = false;
-    page.appendPermissionsToSubpages = 'append';
+    page.appendPermissionsToSubpages = '';
     propagateSet.docPermissions = page.docPermissions;
     _.each(allowed, function(prefix) {
       var fields = [ prefix + 'GroupsIds', prefix + 'UsersIds' ];
@@ -1851,15 +1851,15 @@ module.exports = function(self, options) {
         label: 'How would you like the permissions to be applied to the subpages ?',
         help: 'This is a one-time operation that takes place when you click save.',
         group: schema[index].group,
-        def: 'append',
+        def: 'copy',
         choices: [
-          {
-            value: 'append',
-            label: 'Append (Adds to the existing permissions)'
-          },
           {
             value: 'copy',
             label: 'Copy (Overrides the existing permissions)'
+          },
+          {
+            value: 'append',
+            label: 'Append (Adds to the existing permissions)'
           }
         ]
       });


### PR DESCRIPTION
Objective: The 'Apply to subpages' option overrides the entire permission set of subfolders/subpages with the new set of permission. But in some instances we might need to keep the existing subpages permissions while adding the new set of permission from the parent page. To achieve this i have made following changes in the code

- I have added an option for user to append permissions to subpages and subfolder, instead of completely overriding them by copying the new set of permissions from parent.

- I have optionally modified the mongoDB update query to reflect the user selection.