### PR TITLE
in the lean library, use the csrf-fallback value for the csrf token i…

### DIFF
--- a/lib/modules/apostrophe-browser-utils/public/js/lean.js
+++ b/lib/modules/apostrophe-browser-utils/public/js/lean.js
@@ -36,7 +36,7 @@
     }
     var formData = window.FormData && (data instanceof window.FormData);
     var xmlhttp = new XMLHttpRequest();
-    var csrfToken = apos.utils.getCookie(apos.csrfCookieName);
+    var csrfToken = apos.csrfCookieName ? apos.utils.getCookie(apos.csrfCookieName) : 'csrf-fallback';
     xmlhttp.open("POST", uri);
     if (!formData) {
       xmlhttp.setRequestHeader('Content-Type', 'application/json');


### PR DESCRIPTION
…f there is no csrf cookie name, same as the regular jquery library would

makes forms module compatible with disableAnonSessions flag which will soon be used by an enterprise client