### PR TITLE
a simple bundle pushes assets to uploadfs too, but we were only check…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 package-lock.json
 test/public/modules/*
 test/public/css/master-*

--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -1338,7 +1338,7 @@ module.exports = {
           self.apos.utils.error(err);
         }
         css = css.css;
-        if (self.apos.argv['sync-to-uploadfs']) {
+        if ((self.isGenerationTask && self.simpleBundle) || self.apos.argv['sync-to-uploadfs']) {
           css = self.prefixCssUrlsWith(css, self.uploadfs().getUrl() + '/assets/' + self.generation);
         } else if (self.apos.prefix) {
           css = self.prefixCssUrls(css);


### PR DESCRIPTION
…ing for the old command line flag for that, and thus missed the need to prefix asset URLs