### PR TITLE
Simple typo breaks important functionality

### DIFF
--- a/lib/modules/apostrophe-schemas/public/js/array-modal.js
+++ b/lib/modules/apostrophe-schemas/public/js/array-modal.js
@@ -19,7 +19,7 @@ apos.define('apostrophe-array-editor-modal', {
       self.$arrayItem = self.$el.find('[data-apos-array-item]');
       self.field = options.field;
       self.arrayItems = options.arrayItems || [];
-      self.originalArrayItems = _.cloneDeep(self.arrayitems);
+      self.originalArrayItems = _.cloneDeep(self.arrayItems);
       if (self.errorPath && self.errorPath[0]) {
         self.active = parseInt(self.errorPath[0]);
       } else {


### PR DESCRIPTION
Hey guys. I found myself very frustrating when I tried to edit an array schema after I cancel the array editor modal. When I want to edit the array schema again for the second time, guess what?! My array schema is missing! The only to fix this behavior is to cancel the entire editor-modal and edit it again, then edit array schema again to view my array schema on placed. 

Well, I decided to take a look deep dive on apostrophe schemas code on array-editor modal. At first thought, it was something to do with `beforeCancel` method. But turns out, it just a simple typo when you guys wanted to clone the array items from `_.cloneDeep(self.arrayitems)` to `_.cloneDeep(self.arrayItems)`. 

Hopefully, this fix is going to patch as soon as possible. I believe other users might face this problem as well for those that have array schema on modal.