### PR TITLE
apos.utils.post should report HTTP errors properly (XMLHTTPRequest do…

### DIFF
--- a/lib/modules/apostrophe-browser-utils/public/js/lean.js
+++ b/lib/modules/apostrophe-browser-utils/public/js/lean.js
@@ -29,6 +29,11 @@
   // If `data` is a FormData object, a standard multipart/form-data upload occurs
   // and JSON encoding is not used. This enables multipart/form-data uploads
   // that respect Apostrophe's CSRF token and prefix.
+  // 
+  // If a browser error (status 400 or above) is reported, the
+  // object passed as the error will have a `status` property that
+  // can be inspected. The actual data of the error response is still
+  // delivered as well, in the second argument.
 
   apos.utils.post = function(uri, data, callback) {
     if (apos.prefix) {
@@ -57,6 +62,11 @@
   // in `data`; intended for simple cases where you actually want the browser
   // to cache. Like `jsonCall`, it invokes the callback Node.js style,
   // with an error if any, followed by the response as parsed JSON.
+  // 
+  // If a browser error (status 400 or above) is reported, the
+  // object passed as the error will have a `status` property that
+  // can be inspected. The actual data of the error response is still
+  // delivered as well, in the second argument.
 
   apos.utils.get = function(uri, data, callback) {
     if (apos.prefix) {
@@ -110,7 +120,19 @@
           data = this.responseText;
         }
       }
-      return callback(null, data);
+      return callback(error(), data);
+      function error() {
+        // xmlhttprequest does not consider a 404, 500, etc. to be
+        // an "error" in the sense that would trigger the error
+        // event handler function (below). It looks like only network
+        // failures and/or browser problems can do that. So we need
+        // to recognize error status codes ourselves and correctly
+        // report an error.
+        if (xmlhttp.status < 400) {
+          return null;
+        }
+        return xmlhttp;
+      }
     });
     xmlhttp.addEventListener('abort', function(evt) {
       return callback(evt);

--- a/lib/modules/apostrophe-browser-utils/public/js/lean.js
+++ b/lib/modules/apostrophe-browser-utils/public/js/lean.js
@@ -29,7 +29,7 @@
   // If `data` is a FormData object, a standard multipart/form-data upload occurs
   // and JSON encoding is not used. This enables multipart/form-data uploads
   // that respect Apostrophe's CSRF token and prefix.
-  // 
+  //
   // If a browser error (status 400 or above) is reported, the
   // object passed as the error will have a `status` property that
   // can be inspected. The actual data of the error response is still
@@ -62,7 +62,7 @@
   // in `data`; intended for simple cases where you actually want the browser
   // to cache. Like `jsonCall`, it invokes the callback Node.js style,
   // with an error if any, followed by the response as parsed JSON.
-  // 
+  //
   // If a browser error (status 400 or above) is reported, the
   // object passed as the error will have a `status` property that
   // can be inspected. The actual data of the error response is still


### PR DESCRIPTION
…es not invoke an error handler for that on its own)