### PR TITLE
Fix #1984: apostrophe losing content of nested sub-areas when editing their attributes

### DIFF
--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -38,7 +38,6 @@ apos.define('apostrophe-areas-editor', {
         // and avoid trying to autosave on their own
         self.$el.attr('data-apos-area-virtual', '1');
       }
-      apos.areas.register(self.$el.attr('data-doc-id'), self.$el.attr('data-dot-path'), self);
       var canceled = false;
       self.$el.parents('[data-apos-area]').each(function() {
         if (canceled) {
@@ -293,8 +292,8 @@ apos.define('apostrophe-areas-editor', {
 
     self.insertWidget = function($wrapper) {
       var $widget = $wrapper.children('[data-apos-widget]').first();
-      self.fixInsertedWidgetDotPaths($widget);
       self.insertItem($wrapper);
+      self.fixInsertedWidgetDotPaths($widget);
       self.enhanceWidgetControls($widget);
       self.respectLimit();
       apos.emit('enhance', $widget);
@@ -304,46 +303,52 @@ apos.define('apostrophe-areas-editor', {
     // correctly as part of the parent unless its doc id and
     // dot path are correctly set to show that relationship. But
     // render-widget has no way of knowing how to set these for us,
-    // so we need to fix them up
+    // plus all the widgets below it now have dotPaths that are off
+    // by one. Fix the whole mess
+
     self.fixInsertedWidgetDotPaths = function($widget) {
-      var $areas = $widget.findSafe('[data-apos-area]', '[data-apos-widget]');
-      var id = self.$el.attr('data-doc-id');
-      var p = self.$el.attr('data-dot-path');
+      self.recalculateDotPathsInArea(self.$el);
+    };
+    
+    self.recalculateDotPathsInArea = function($area) {
+      var docId = $area.attr('data-doc-id');
+      var dotPath = $area.attr('data-dot-path');
+      var $widgets = $area.findSafe('[data-apos-widget]', '[data-apos-area]');
       var ordinal = 0;
-      var found = false;
-      // Which widget are we among the widgets in this area?
-      // We need to count those without making big assumptions
-      // about the markup. So walk widgets found without crossing
-      // into a nested area until we find ourselves. -Tom
-      var $peers = self.$el.findSafe('[data-apos-widget]', '[data-apos-area]');
-      $peers.each(function() {
-        if (found) {
-          return;
+      $widgets.each(function() {
+        var widgetDotPath = dotPath + '.items.' + ordinal;
+        try {
+          var $widget = $(this);
+          var data = JSON.parse($widget.attr('data') || '{}');
+          data.__docId = docId;
+          data.__dotPath = widgetDotPath;
+          $widget.attr('data', JSON.stringify(data));
+          self.recalculateDotPathsOfAreasInWidget($widget, docId, widgetDotPath);
+        } catch (e) {
+          // Do not fail outright if a widget has an unusual storage mode
+          apos.utils.warn(e);
         }
-        if (this !== $widget[0]) {
-          ordinal++;
-        } else {
-          found = true;
-        }
+        ordinal++;
       });
-      try {
-        var data = JSON.parse($widget.attr('data') || '{}');
-        data.__docId = id;
-        data.__dotPath = p + '.items.' + ordinal;
-        $widget.attr('data', JSON.stringify(data));
-      } catch (e) {
-        // Do not fail outright if the widget has a very unusual
-        // data storage mode
-        apos.utils.warn(e);
-      }
+    };
+
+    self.recalculateDotPathsOfAreasInWidget = function($widget, docId, dotPath) {
+      $areas = $widget.findSafe('[data-apos-area]', '[data-apos-widget]');
       $areas.each(function() {
         var $area = $(this);
-        var wid = $area.attr('data-doc-id');
-        var wp = $area.attr('data-dot-path');
-        if (wid.substr(0, 1) === 'w') {
-          $area.attr('data-doc-id', id);
-          var dotPath = p + '.items.' + ordinal + '.' + wp;
-          $area.attr('data-dot-path', dotPath);
+        var areaDocId = $area.attr('data-doc-id');
+        if ((areaDocId !== docId) && areaDocId && (areaDocId.substring(0, 1) === 'w')) {
+          $area.attr('data-doc-id', docId);
+          areaDocId = docId;
+        }
+        if (areaDocId === docId) {
+          var areaDotPath = $area.attr('data-dot-path');
+          if (areaDotPath) {
+            var components = areaDotPath.split('.');
+            var name = components.pop();
+            $area.attr('data-dot-path', dotPath + '.' + name);
+            self.recalculateDotPathsInArea($area);
+          }
         }
       });
     };
@@ -683,7 +688,7 @@ apos.define('apostrophe-areas-editor', {
       self.stopEditingRichText();
       var $widget = $wrapper.find('[data-apos-widget]');
       var type = $widget.attr('data-apos-widget');
-      var data = apos.areas.getWidgetData($widget, true);
+      var data = apos.areas.getWidgetData($widget);
       var originalData = _.clone(data);
       var options = self.options.widgets[type] || {};
       apos.ui.globalBusy(true);

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -309,7 +309,7 @@ apos.define('apostrophe-areas-editor', {
     self.fixInsertedWidgetDotPaths = function($widget) {
       self.recalculateDotPathsInArea(self.$el);
     };
-    
+
     self.recalculateDotPathsInArea = function($area) {
       var docId = $area.attr('data-doc-id');
       var dotPath = $area.attr('data-dot-path');
@@ -333,7 +333,7 @@ apos.define('apostrophe-areas-editor', {
     };
 
     self.recalculateDotPathsOfAreasInWidget = function($widget, docId, dotPath) {
-      $areas = $widget.findSafe('[data-apos-area]', '[data-apos-widget]');
+      var $areas = $widget.findSafe('[data-apos-area]', '[data-apos-widget]');
       $areas.each(function() {
         var $area = $(this);
         var areaDocId = $area.attr('data-doc-id');

--- a/lib/modules/apostrophe-areas/public/js/user.js
+++ b/lib/modules/apostrophe-areas/public/js/user.js
@@ -148,19 +148,9 @@ apos.define('apostrophe-areas', {
         if ($el.attr('data-initialized')) {
           return;
         }
-        var areaId = $el.attr('data-doc-id') + $el.attr('data-dot-path');
-        if (_.has(self.editors, areaId)) {
-          // If there is already an existing editor for this area, use that.
-          self.editors[areaId].resetEl($el);
-        } else {
-          apos.create('apostrophe-areas-editor', { $el: $el, action: self.options.action });
-        }
+        apos.create('apostrophe-areas-editor', { $el: $el, action: self.options.action });
       });
       self.enhanceControlsHover(sel);
-    };
-
-    self.register = function(docId, dotPath, editor) {
-      self.editors[docId + dotPath] = editor;
     };
 
     self.enableShift = function() {

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -255,7 +255,8 @@ apos.define('apostrophe-schemas', {
     // Convert an in-context area, storing it in data[name],
     // if an editor is active
     self.contextualConvertArea = function(data, name, $el, field) {
-      var editor = $el.findSafe('[data-apos-area][data-dot-path$="' + name + '"]', '[data-apos-area]').data('editor');
+      var $area = $el.findSafe('[data-apos-area][data-dot-path$="' + name + '"]', '[data-apos-area]');
+      var editor = $area.data('editor');
       if (editor) {
         data[name] = {
           type: 'area',


### PR DESCRIPTION
See #1984

Solution: robust recalculation of dotPath attributes, correction of a timing error, and elimination of area editor reuse mechanism that does not make sense because a dotPath is not a permanently unique identifier and the order changes, associating the editor with the wrong data.

Man I can't wait for 3.x to make this logic obsolete.