### PR TITLE
reverse joins should not cause empty tabs

### DIFF
--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -262,7 +262,6 @@ module.exports = {
         // this feature
         self.setModuleName(field, module);
       });
-
       return schema;
     };
 
@@ -325,6 +324,9 @@ module.exports = {
       var currentGroup = -1;
       _.each(fields, function(field) {
         if (field.contextual) {
+          return;
+        }
+        if (self.fieldTypes[field.type].ui === false) {
           return;
         }
         if (!field.group) {
@@ -2137,6 +2139,7 @@ module.exports = {
 
     self.addFieldType({
       name: 'joinByOneReverse',
+      ui: false,
       join: function(req, field, objects, options, callback) {
         return self.joinDriver(req, joinr.byOneReverse, true, objects, field.idField, undefined, field.name, options, callback);
       },
@@ -2504,6 +2507,7 @@ module.exports = {
 
     self.addFieldType({
       name: 'joinByArrayReverse',
+      ui: false,
       join: function(req, field, objects, options, callback) {
         return self.joinDriver(req, joinr.byArrayReverse, true, objects, field.idsField, field.relationshipsField, field.name, options, callback);
       },


### PR DESCRIPTION
closes #1991 

We now have a `ui: false` option available for schema field types. Specifically, reverse joins have no ui (neither contextually nor in a modal, just plain not editable, therefore "contextual" wouldn't sound right). This beats adding hardcoded checks for the (currently) two kinds of reverse joins.

As a result `artists` does not have an empty `Info` tab due to the `_artworks` reverse join.