### PR TITLE
clean up the context menu in several ways

### DIFF
--- a/lib/modules/apostrophe-jobs/lib/api.js
+++ b/lib/modules/apostrophe-jobs/lib/api.js
@@ -100,7 +100,7 @@ module.exports = function(self, options) {
             }
           });
         }
-        return self.apiResponder(req, {
+        return self.apiResponder(req, null, {
           // legacy
           data: single || {},
           // preferred

--- a/lib/modules/apostrophe-pages/views/publishMenu.html
+++ b/lib/modules/apostrophe-pages/views/publishMenu.html
@@ -1,5 +1,5 @@
 {% import 'apostrophe-ui:components/dropdowns.html' as dropdowns with context -%}
-{%- if not data.page.published or (data.piece and not data.piece.published) -%}
+{%- if not (data.page and data.page.published) or (data.piece and not data.piece.published) -%}
 <div class="apos-context-menu">
   {{ dropdowns.base({
       label: "Unpublished",

--- a/lib/modules/apostrophe-pieces-pages/index.js
+++ b/lib/modules/apostrophe-pieces-pages/index.js
@@ -77,14 +77,6 @@ module.exports = {
       }
     ];
 
-    self.publishMenu = options.publishMenu || [
-      {
-        action: 'publish-' + self.piecesCssName,
-        label: 'Publish ' + self.pieces.label,
-        value: true
-      }
-    ];
-
     // Extend this method for your piece type to call additional
     // chainable filters by default. You should not add entirely new
     // filters here. For that, define the appropriate subclass of
@@ -113,11 +105,6 @@ module.exports = {
           // Add the standard items, they have to be available sometime
           // when working with an index page
         }).concat(self.apos.pages.options.contextMenu);
-        req.publishMenu = _.filter(self.publishMenu, function(item) {
-          // Items specific to a particular piece don't make sense
-          // on the index page
-          return !item.value;
-        });
       }
 
       var cursor = self.indexCursor(req);
@@ -222,15 +209,13 @@ module.exports = {
             }
             return item;
           });
-          req.publishMenu = _.map(self.publishMenu, function(item) {
-            if (item.value) {
-              // Don't modify a shared item, race conditions
-              // could give us the wrong ids
-              item = _.clone(item);
-              item.value = doc._id;
+          req.publishMenu = [
+            {
+              action: 'publish-' + self.piecesCssName,
+              label: 'Publish ' + self.pieces.label,
+              value: doc._id
             }
-            return item;
-          });
+          ];
         }
         req.template = self.renderer('show');
         req.data.piece = doc;

--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -825,9 +825,26 @@ module.exports = {
       return self.inserted('append', location);
     };
 
+    // Determines whether the aposContextMenu block, which contains
+    // the "Page Settings" and "Published" UIs in the lower left corner
+    // in addition to further UI pushed by modules like workflow, should
+    // appear or not. Override to add additional nuances to this decision.
+
+    self.showContextMenu = function(req) {
+      return req.user && (
+        (req.data.page && req.data.page._edit) || (req.data.piece && req.data.piece._edit)
+      );
+    };
+
     self.enableHelpers = function() {
       self.addHelpers(_.pick(self, 'prepended', 'appended'));
+      self.addHelpers({
+        showContextMenu: function() {
+          return self.showContextMenu(self.contextReq);
+        }
+      });
     };
 
   }
+
 };

--- a/lib/modules/apostrophe-templates/views/outerLayoutBase.html
+++ b/lib/modules/apostrophe-templates/views/outerLayoutBase.html
@@ -20,7 +20,7 @@
     {% endblock %}
 
     {% block apostropheContextMenu %}
-      {% if data.user %}
+      {% if apos.templates.showContextMenu() %}
         <div class="apos-ui">
           <div class="apos-context-menu-container">
             {{ apos.templates.prepended('contextMenu') }}

--- a/test/templates.js
+++ b/test/templates.js
@@ -112,6 +112,11 @@ describe('Templates', function() {
 
   it('should render pages successfully with prepend and append to locations', function() {
     var req = apos.tasks.getReq();
+    // Otherwise there is no context menu (we need a page or a piece)
+    req.data.page = {
+      _id: 'imadethisup',
+      _edit: true
+    };
     apos.templates.prepend('head', function(req) {
       assert(req.res);
       return '<meta name="before-test" />';


### PR DESCRIPTION
Closes #1982 
Closes #2000 

TL;DR: the context menu is no longer popping up at dumb times, busted-feeling and generally confusing people.

In #1982 we see there is a context menu when sendPage is being used to render a page directly with no `data.page` or `data.piece`. There should be none. The context menu's visibility is now predicated on both `req.user` and at least one of `req.data.page._edit` and `req.data.piece._edit`. This eliminates a great many situations where people wind up overriding things they shouldn't just to get rid of the context menu.

We used to be afraid to do this because "Reorganize" had, wrongly, crept into the "context" menu and in theory you might want to "Reorganize" from a specialized template that has no `data.page`. However (1) "Reorganize" has also been available as "Pages" on the admin bar for a long time now and (2) this is a far-fetched scenario anyway.

In theory, someone could be using `apos.templates.prepend('aposContextMenu')` to set up some cool contextual UI of their own that doesn't require a page or a piece. I don't think this is  likely. However, I wrapped the "show it / don't show it" decision in the new method `apos.templates.showContextMenu`, which can be overridden to suit custom needs.

In #2000 there is a simple "oops, wrong number of parameters" error that prevents the correct UI feedback after successfully publishing a piece via the "Unpublished" dropdown on the context menu. I fixed that too as without it the other fix was a bit underwhelming.