### PR TITLE
Allow picking a random port for Apostrophe to listen to

### DIFF
--- a/lib/modules/apostrophe-express/index.js
+++ b/lib/modules/apostrophe-express/index.js
@@ -562,9 +562,9 @@ module.exports = {
         var address;
 
         try {
-          if (self.options.forcePort) {
+          if (self.options.forcePort !== undefined) {
             port = self.options.forcePort;
-          } else if (self.options.port) {
+          } else if (self.options.port !== undefined) {
             port = self.options.port;
           }
 
@@ -610,16 +610,18 @@ module.exports = {
             self.apos.utils.log('I see no data/address file, address option, forceAddress option, or ADDRESS environment variable,\nlistening on all interfaces');
           }
 
+          if (address !== false) {
+            self.server = self.apos.baseApp.listen(port, address);
+            port = self.server.address().port;
+            self.apos.utils.log('Listening on http://' + address + ':' + port);
+          } else {
+            self.server = self.apos.baseApp.listen(port);
+            port = self.server.address().port;
+            self.apos.utils.log('Listening at http://localhost:' + port);
+          }
+
           self.port = port;
           self.address = address;
-
-          if (address !== false) {
-            self.apos.utils.log('Listening on http://' + address + ':' + port);
-            self.server = self.apos.baseApp.listen(port, address);
-          } else {
-            self.apos.utils.log('Listening at http://localhost:' + port);
-            self.server = self.apos.baseApp.listen(port);
-          }
         } catch (e) {
           if (self.apos.options.afterListen) {
             return self.apos.options.afterListen(e);

--- a/test/express-random-port.js
+++ b/test/express-random-port.js
@@ -1,0 +1,59 @@
+var t = require('../test-lib/test.js');
+var assert = require('assert');
+var apos;
+var temporaryServer;
+
+describe('Express', function() {
+
+  this.timeout(t.timeout);
+
+  before(function() {
+    // Create and bind a server on port 3000. This way
+    // when Apostrophe starts up we are guaranteed it won't
+    // randomly be assigned this port, nor be confused by
+    // the falsiness of port 0 and use the default value.
+    temporaryServer = require('http').createServer();
+    temporaryServer.listen(3000).on('error', function() {
+      // The port is likely already in use, which is
+      // good enough for us, no need to raise an error.
+    });
+  });
+
+  after(function(done) {
+    return t.destroy(apos, function() {
+      if (temporaryServer.listening) {
+        temporaryServer.close(done);
+      } else {
+        done();
+      }
+    });
+  });
+
+  it('express should exist on the apos object', function(done) {
+    apos = require('../index.js')({
+      root: module,
+      shortName: 'test',
+      modules: {
+        'apostrophe-express': {
+          secret: 'xxx',
+          port: 0
+        }
+      },
+      afterInit: function(callback) {
+        assert(apos.express);
+        return callback(null);
+      },
+      afterListen: function(err) {
+        assert(!err);
+        done();
+      }
+    });
+  });
+
+  it('should bind the server to a random port when given port 0', function(done) {
+    var server = apos.modules['apostrophe-express'].server;
+    assert(server.address().port !== 3000);
+    done();
+  });
+
+});


### PR DESCRIPTION
_Original issue:_ https://github.com/apostrophecms/apostrophe/issues/1992

This PR removes the limitation that prevents using the port 0 for `apostrophe-express` (due to 0 being falsy). Using this port (either via the `data/port` file, `PORT` environment, or `port`/`forcePort` options) requests a random available port to the operating system, thus avoiding the trouble of finding one by trial and error ourselves.

The code has been tested successfully on Linux/*NIX systems and Windows, and on Node versions 6, 8, 10 and 12 (probably overkill, but just in case).

I included a test case in the PR. Not sure it abides by your guidelines and best practices though.