### PR TITLE
Implement drag and drop for arrays

### DIFF
--- a/lib/modules/apostrophe-schemas/public/js/array-modal.js
+++ b/lib/modules/apostrophe-schemas/public/js/array-modal.js
@@ -335,7 +335,7 @@ apos.define('apostrophe-array-editor-modal', {
         // Dragged Element is the element that is being dropped at some other location
         var draggedElementIndex = parseInt(e.originalEvent.dataTransfer.getData('text'));
 
-        // Handle Few Edge Cases. 
+        // Handle Few Edge Cases.
         // If dragstart and drop location are the same return.
         if (currentElementIndex === draggedElementIndex) {
           return;
@@ -347,17 +347,19 @@ apos.define('apostrophe-array-editor-modal', {
         self.arrayItems[currentElementIndex] = draggedElementCopy;
         self.active = currentElementIndex;
 
+        // Initialize Variables
+        var i, temp, temp2;
         // Element is dragged from bottom to top. Will be placed above the drop zone.
         if (currentElementIndex < draggedElementIndex) {
-          for (var i = currentElementIndex + 1, temp = currentElementCopy; i <= draggedElementIndex; i++) {
-            var temp2 = self.arrayItems[i];
+          for (i = currentElementIndex + 1, temp = currentElementCopy; i <= draggedElementIndex; i++) {
+            temp2 = self.arrayItems[i];
             self.arrayItems[i] = temp;
             temp = temp2;
           }
           // Element is dragged from top to bottom. Will be placed above the drop zone.
         } else {
-          for (var i = currentElementIndex - 1, temp = currentElementCopy; i >= draggedElementIndex; i--) {
-            var temp2 = self.arrayItems[i];
+          for (i = currentElementIndex - 1, temp = currentElementCopy; i >= draggedElementIndex; i--) {
+            temp2 = self.arrayItems[i];
             self.arrayItems[i] = temp;
             temp = temp2;
           }
@@ -367,7 +369,7 @@ apos.define('apostrophe-array-editor-modal', {
         self.setItemTitles();
         self.refresh();
       });
-    }
+    };
 
     // This method removes the item with the specified `id` property from the
     // array.

--- a/lib/modules/apostrophe-schemas/public/js/array-modal.js
+++ b/lib/modules/apostrophe-schemas/public/js/array-modal.js
@@ -55,6 +55,7 @@ apos.define('apostrophe-array-editor-modal', {
 
     self.beforeShow = function(callback) {
       self.bindClickHandlers();
+      self.bindDragHandlers();
       self.addSaveHandler();
       return callback(null);
     };
@@ -314,6 +315,59 @@ apos.define('apostrophe-array-editor-modal', {
         });
       }
     };
+
+    self.bindDragHandlers = function () {
+      self.$el.on('dragstart', '.apos-array-item', function (e) {
+        e.dataTransfer = e.originalEvent.dataTransfer;
+        // We are only interested in the index of the element currently dragged.
+        e.dataTransfer.setData('text', e.target.getAttribute('data-apos-array-items-trigger'));
+      });
+
+      self.$el.on('dragenter dragover', '.apos-array-item', function (e) {
+        // We need this for the drop event to fire.
+        e.preventDefault();
+      });
+
+      self.$el.on('drop', '.apos-array-item', function (e) {
+        e.preventDefault();
+        // Current Element is the element where another item is dropped.
+        var currentElementIndex = parseInt(e.target.getAttribute('data-apos-array-items-trigger'));
+        // Dragged Element is the element that is being dropped at some other location
+        var draggedElementIndex = parseInt(e.originalEvent.dataTransfer.getData('text'));
+
+        // Handle Few Edge Cases. 
+        // If dragstart and drop location are the same return.
+        if (currentElementIndex === draggedElementIndex) {
+          return;
+        }
+        // Make copies of the elements for future reference.
+        var currentElementCopy = self.arrayItems[currentElementIndex];
+        var draggedElementCopy = self.arrayItems[draggedElementIndex];
+        // Change the element at the drop point first and make it active.
+        self.arrayItems[currentElementIndex] = draggedElementCopy;
+        self.active = currentElementIndex;
+
+        // Element is dragged from bottom to top. Will be placed above the drop zone.
+        if (currentElementIndex < draggedElementIndex) {
+          for (var i = currentElementIndex + 1, temp = currentElementCopy; i <= draggedElementIndex; i++) {
+            var temp2 = self.arrayItems[i];
+            self.arrayItems[i] = temp;
+            temp = temp2;
+          }
+          // Element is dragged from top to bottom. Will be placed above the drop zone.
+        } else {
+          for (var i = currentElementIndex - 1, temp = currentElementCopy; i >= draggedElementIndex; i--) {
+            var temp2 = self.arrayItems[i];
+            self.arrayItems[i] = temp;
+            temp = temp2;
+          }
+        }
+
+        self.editItem();
+        self.setItemTitles();
+        self.refresh();
+      });
+    }
 
     // This method removes the item with the specified `id` property from the
     // array.

--- a/lib/modules/apostrophe-schemas/views/arrayItems.html
+++ b/lib/modules/apostrophe-schemas/views/arrayItems.html
@@ -1,6 +1,6 @@
 <div class="apos-schema-tabs apos-array-items" data-schema-tabs>
   {% for item in data.arrayItems %}
-    <div class="apos-schema-tab apos-array-item{{ ' apos-active' if (data.active == loop.index0)}}" data-apos-array-items-trigger="{{loop.index0}}" data-id="{{ item.id }}">
+    <div class="apos-schema-tab apos-array-item{{ ' apos-active' if (data.active == loop.index0)}}" data-apos-array-items-trigger="{{loop.index0}}" data-id="{{ item.id }}" draggable="true">
       {% if not data.field.readOnly %}
         <div class="apos-array-item-controls">
           <i class="fa fa-remove" data-apos-delete-array-item></i>


### PR DESCRIPTION
**Demo**
![array-drag-drop](https://user-images.githubusercontent.com/12910216/64470965-ef1d7580-d168-11e9-972d-78459d036131.gif)

**Quick Note Regarding Implementation**
To keep the UX Clean and less confusing I have implemented drag and drop based on the following options

1. An element dragged from top to bottom will always be placed below the drop point.
2. An element dragged from bottom to top will be always placed above the drop point.
3. I have retained the move up, move down button for now. Even though it would feel its no longer needed now that drag and drop is here but I feel it's still handy and less of an effort if we want to move just one level top/bottom.