### PR TITLE
the registry of existing area editors was removed because dot paths a…

### DIFF
--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -10,7 +10,6 @@ apos.define('apostrophe-areas-editor', {
   },
 
   construct: function(self, options) {
-
     self.options = options;
     self.$el = self.options.$el;
     self.$body = $('body');
@@ -38,6 +37,7 @@ apos.define('apostrophe-areas-editor', {
         // and avoid trying to autosave on their own
         self.$el.attr('data-apos-area-virtual', '1');
       }
+      apos.areas.register(self.$el.attr('data-doc-id'), self.$el.attr('data-dot-path'), self);
       var canceled = false;
       self.$el.parents('[data-apos-area]').each(function() {
         if (canceled) {
@@ -188,6 +188,7 @@ apos.define('apostrophe-areas-editor', {
       } else if (direction === 'bottom') {
         $wrapper.parent().children(':last').after($wrapper);
       }
+      apos.areas.remapDotPaths();
       apos.emit('widgetMoved', $wrapper.find('[data-apos-widget]'));
     };
 
@@ -205,6 +206,7 @@ apos.define('apostrophe-areas-editor', {
         $undoer.replaceWith($wrapper);
         self.checkEmptyAreas();
         self.respectLimit();
+        apos.areas.remapDotPaths();
         clearTimeout(undoerTimeout);
         return false;
       });
@@ -222,6 +224,7 @@ apos.define('apostrophe-areas-editor', {
           $wrapper.remove();
         });
       }, 7000);
+      apos.areas.remapDotPaths();
       apos.emit('widgetTrashed', $widget);
     };
 
@@ -293,65 +296,14 @@ apos.define('apostrophe-areas-editor', {
     self.insertWidget = function($wrapper) {
       var $widget = $wrapper.children('[data-apos-widget]').first();
       self.insertItem($wrapper);
-      self.fixInsertedWidgetDotPaths($widget);
       self.enhanceWidgetControls($widget);
       self.respectLimit();
+      apos.areas.remapDotPaths();
       apos.emit('enhance', $widget);
     };
 
-    // A newly inserted widget that contains subareas cannot autosave
-    // correctly as part of the parent unless its doc id and
-    // dot path are correctly set to show that relationship. But
-    // render-widget has no way of knowing how to set these for us,
-    // plus all the widgets below it now have dotPaths that are off
-    // by one. Fix the whole mess
-
-    self.fixInsertedWidgetDotPaths = function($widget) {
-      self.recalculateDotPathsInArea(self.$el);
-    };
-
-    self.recalculateDotPathsInArea = function($area) {
-      var docId = $area.attr('data-doc-id');
-      var dotPath = $area.attr('data-dot-path');
-      var $widgets = $area.findSafe('[data-apos-widget]', '[data-apos-area]');
-      var ordinal = 0;
-      $widgets.each(function() {
-        var widgetDotPath = dotPath + '.items.' + ordinal;
-        try {
-          var $widget = $(this);
-          var data = JSON.parse($widget.attr('data') || '{}');
-          data.__docId = docId;
-          data.__dotPath = widgetDotPath;
-          $widget.attr('data', JSON.stringify(data));
-          self.recalculateDotPathsOfAreasInWidget($widget, docId, widgetDotPath);
-        } catch (e) {
-          // Do not fail outright if a widget has an unusual storage mode
-          apos.utils.warn(e);
-        }
-        ordinal++;
-      });
-    };
-
-    self.recalculateDotPathsOfAreasInWidget = function($widget, docId, dotPath) {
-      var $areas = $widget.findSafe('[data-apos-area]', '[data-apos-widget]');
-      $areas.each(function() {
-        var $area = $(this);
-        var areaDocId = $area.attr('data-doc-id');
-        if ((areaDocId !== docId) && areaDocId && (areaDocId.substring(0, 1) === 'w')) {
-          $area.attr('data-doc-id', docId);
-          areaDocId = docId;
-        }
-        if (areaDocId === docId) {
-          var areaDotPath = $area.attr('data-dot-path');
-          if (areaDotPath) {
-            var components = areaDotPath.split('.');
-            var name = components.pop();
-            $area.attr('data-dot-path', dotPath + '.' + name);
-            self.recalculateDotPathsInArea($area);
-          }
-        }
-      });
-    };
+    // Legacy, kept for bc, we now call remapDotPaths at a better time
+    self.fixInsertedWidgetDotPaths = function($widget) {};
 
     self.enhanceWidgetControls = function($widget) {
       var $controls = $widget.findSafe('[data-apos-widget-controls]', '[data-apos-area]');
@@ -468,7 +420,7 @@ apos.define('apostrophe-areas-editor', {
       // rule out areas that do not allow the widget type in question
       return $('[data-apos-area]').filter(function() {
         var editor = $(this).data('editor');
-        if ((editor && !editor.limitReached()) || ($widget.data('areaEditor') === editor)) {
+        if (editor && ((!editor.limitReached()) || ($widget.data('areaEditor') === editor))) {
           var movableOptionKey = [$widget.attr('data-apos-widget'), 'controls', 'movable'];
           var hasWidget = _.has(editor.options.widgets, $widget.attr('data-apos-widget'));
 
@@ -662,6 +614,7 @@ apos.define('apostrophe-areas-editor', {
         var oldEditor = self;
         var $newArea = $(event.target).closest('[data-apos-area]');
         var newEditor = $newArea.data('editor');
+        apos.areas.remapDotPaths();
         $oldWidget.data('areaEditor', newEditor);
         self.disableDroppables();
         oldEditor.startAutosavingThen(function() {
@@ -673,6 +626,7 @@ apos.define('apostrophe-areas-editor', {
                 return;
               }
               newEditor.respectLimit();
+              apos.areas.remapDotPaths();
             });
           });
         });

--- a/lib/modules/apostrophe-areas/public/js/user.js
+++ b/lib/modules/apostrophe-areas/public/js/user.js
@@ -148,10 +148,94 @@ apos.define('apostrophe-areas', {
         if ($el.attr('data-initialized')) {
           return;
         }
-        apos.create('apostrophe-areas-editor', { $el: $el, action: self.options.action });
+        var areaId = $el.attr('data-doc-id') + '.' + $el.attr('data-dot-path');
+        if (_.has(self.editors, areaId)) {
+          // If there is already an existing editor for this area, use that.
+          // Without this, inserting an image piece as part of editing a
+          // widget will destroy our ability to accept the widget's new
+          // value and save the area.
+          self.editors[areaId].resetEl($el);
+        } else {
+          apos.create('apostrophe-areas-editor', { $el: $el, action: self.options.action });
+        }
       });
       self.enhanceControlsHover(sel);
     };
+
+    self.register = function(docId, dotPath, editor) {
+      self.editors[docId + '.' + dotPath] = editor;
+    };
+
+    self.remapDotPaths = function() {
+      $('body').find('[data-apos-area]').each(function() {
+        var $area = $(this);
+        var docId = $area.attr('data-doc-id');
+        if (!docId) {
+          return;
+        }
+        if ($area.parents('[data-doc-id="' + docId + '"]').length) {
+          return;
+        }
+        self.recalculateDotPathsInArea($area);
+      });
+      self.editors = {};
+      $('body').find('[data-apos-area]').each(function() {
+        var $area = $(this);
+        var docId = $area.attr('data-doc-id');
+        var dotPath = $area.attr('data-dot-path');
+        if (!(docId && dotPath)) {
+          return;
+        }
+        if (!$area.data('editor')) {
+          return;
+        }
+        self.register(docId, dotPath, $area.data('editor'));
+      });
+    };
+
+    self.recalculateDotPathsInArea = function($area) {
+      var docId = $area.attr('data-doc-id');
+      var dotPath = $area.attr('data-dot-path');
+      var $widgets = $area.findSafe('[data-apos-widget]', '[data-apos-area]');
+      var ordinal = 0;
+      $widgets.each(function() {
+        var widgetDotPath = dotPath + '.items.' + ordinal;
+        try {
+          var $widget = $(this);
+          var data = JSON.parse($widget.attr('data') || '{}');
+          data.__docId = docId;
+          data.__dotPath = widgetDotPath;
+          $widget.attr('data', JSON.stringify(data));
+          self.recalculateDotPathsOfAreasInWidget($widget, docId, widgetDotPath);
+        } catch (e) {
+          // Do not fail outright if a widget has an unusual storage mode
+          apos.utils.warn(e);
+        }
+        ordinal++;
+      });
+    };
+
+    self.recalculateDotPathsOfAreasInWidget = function($widget, docId, dotPath) {
+      var $areas = $widget.findSafe('[data-apos-area]', '[data-apos-widget]');
+      $areas.each(function() {
+        var $area = $(this);
+        var areaDocId = $area.attr('data-doc-id');
+        if ((areaDocId !== docId) && areaDocId && (areaDocId.substring(0, 1) === 'w')) {
+          $area.attr('data-doc-id', docId);
+          areaDocId = docId;
+        }
+        if (areaDocId === docId) {
+          var areaDotPath = $area.attr('data-dot-path');
+          if (areaDotPath) {
+            var components = areaDotPath.split('.');
+            var name = components.pop();
+            $area.attr('data-dot-path', dotPath + '.' + name);
+            self.recalculateDotPathsInArea($area);
+          }
+        }
+      });
+    };
+
 
     self.enableShift = function() {
 


### PR DESCRIPTION
…re not good unique identifiers (drag and drop changes them), however this registry is essential to figure out what to do when part of the DOM is rerendered due to creating a new piece during a join editing operation. Resolve it by bringing back the registry, but recomputing it on all inserts, removals, moves and drags. What a... drag. In 3.x consider having area _ids to solve this.