### PR TITLE
Enhance the ways to improve apostrophe-email module

### DIFF
--- a/lib/modules/apostrophe-email/index.js
+++ b/lib/modules/apostrophe-email/index.js
@@ -65,7 +65,7 @@ module.exports = {
     // configured for the `apostrophe-email` module. If there is none,
     // a fatal error is thrown.
 
-    self.getTransport = function(data) {
+    self.getTransport = function() {
       if (!self.transport) {
         if (!self.options.nodemailer) {
           throw new Error('The nodemailer option must be configured for the apostrophe-email module before any module can call its email() method. The option accepts an object to be passed to nodemailer.createTransport, per the nodemailer documentation.');

--- a/lib/modules/apostrophe-email/index.js
+++ b/lib/modules/apostrophe-email/index.js
@@ -24,7 +24,22 @@ module.exports = {
     // every module has. You won't need to call `emailForModule` directly.
 
     self.emailForModule = function(req, templateName, data, options, module, callback) {
-      var transport = self.getTransport();
+      var transport = self.getTransport(data);
+      var content = self.getContent(req, templateName, data, module);
+      var args = _.assign({
+        from: (module.options.email && module.options.email.from) || self.options.from
+      }, content, options);
+      if (process.env.APOS_LOG_EMAIL) {
+        self.apos.utils.debug(args);
+      }
+      return transport.sendMail(args, callback);
+    };
+
+    // Compute the content of the email. This is an interesting override point
+    // to add properties that will be passed in to nodemailer transport when
+    // sending the mail.
+
+    self.getContent = function(req, templateName, data, module) {
       var html = module.render(req, templateName, data);
       var text = htmlToText.fromString(html, {
         format: {
@@ -41,15 +56,7 @@ module.exports = {
           }
         }
       });
-      var args = _.assign({
-        html: html,
-        text: text,
-        from: (module.options.email && module.options.email.from) || self.options.from
-      }, options);
-      if (process.env.APOS_LOG_EMAIL) {
-        self.apos.utils.debug(args);
-      }
-      return transport.sendMail(args, callback);
+      return { html, text };
     };
 
     // Fetch the nodemailer-compatible transport object. The default
@@ -58,7 +65,7 @@ module.exports = {
     // configured for the `apostrophe-email` module. If there is none,
     // a fatal error is thrown.
 
-    self.getTransport = function() {
+    self.getTransport = function(data) {
       if (!self.transport) {
         if (!self.options.nodemailer) {
           throw new Error('The nodemailer option must be configured for the apostrophe-email module before any module can call its email() method. The option accepts an object to be passed to nodemailer.createTransport, per the nodemailer documentation.');


### PR DESCRIPTION
## Context

Starting working with [apostrophe-forms](https://github.com/apostrophecms/apostrophe-forms), I quickly encountered a problem when I wanted to use a specific provider to send emails for each form.

## Issue

`apostrophe-email` is designed to allow you to specify a nodemailer transporter to use when sending emails, by setting a configuration for nodemailer through module options or overwriting it's `self.getTransport` method. The problem is that this is only suitable for determining a single sending provider for all emails, because no parameters are passed to this function.

## Changes

### getTransport

The `self.getTransport` function is now called with the `data` parameter, which can therefore contain fields to determine the transport object to return.

For example by improving `apostrophe-forms` this way:

```javascript
// index.js
improve: 'apostrophe-forms',

beforeConstruct: (self, options) => {
  options.addFields = [
    {
      name: 'provider',
      label: 'Provider',
      help: 'Provider used to send emails',
      type: 'select',
      required: true,
      choices: [
        {
          label: 'Mailjet',
          value: 'mailjet'
        },
        {
          label: 'Console (testing purpose)',
          value: 'console'
        },
      ],
    },
  ]).concat(options.addFields || [])
}
```

It is now possible to determine the email provider to use:

```javascript
// index.js
improve: 'apostrophe-email',

construct: (self, options) => {
  const superGetTransport = self.getTransport
  self.getTransport = (data) => {
    switch(data.form.provider) {
      case 'console':
        // console provider
        return transport
      case 'mailjet':
        // mailjet provider
        return transport
      default:
        return superGetTransport(data)
    }
  }
}
```

### getContent

Introduction of a new method that aims to manage the rendering of the email content. It becomes an interesting overwrite point, possibly to introduce a specific rendering according to the data or provider selected. By default, the behavior remains the same.

## Tests

The tests pass, the default behavior remaining exactly the same.