### PR TITLE
Fix incontext editing after modal save

### DIFF
--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -937,6 +937,13 @@ apos.define('apostrophe-areas-editor', {
         // if found; they will recursively save our contents
         return callback(null);
       }
+
+      // Replace Widget Doc IDs with OuterMost Area Doc ID.
+      // Assumes that all widget doc IDs begin with w
+      if (_id[0] === 'w') {
+        _id = self.$el.parents('[data-apos-area]').last().attr('data-doc-id');
+      }
+
       // Without this, race conditions on double click are easy
       // to encounter on a slower connection
       apos.ui.globalBusy(true);


### PR DESCRIPTION
More Details About the Bug => https://www.notion.so/InContext-editing-errors-out-after-modal-editor-is-saved-a27cc8f0c2cc47a9b2c4eecca9eb640d

I'm not completely confident about the fix as I'm not sure what other modules this change would affect.