### PR TITLE
Fix `findTestModule` on Mocha Test

### DIFF
--- a/index.js
+++ b/index.js
@@ -401,7 +401,12 @@ module.exports = function(options) {
     // and throws an exception if we don't
     function findTestModule() {
       var m = module;
-      var nodeModuleRegex = process.platform === "win32" ? new RegExp("node_modules\\\\mocha",'g') : new RegExp("node_modules\\/mocha",'g')
+      var nodeModuleRegex;
+      if (process.platform === "win32") {
+        nodeModuleRegex = /node_modules\\mocha/;
+      } else {
+        nodeModuleRegex = /node_modules\/mocha/;
+      }
       while (m) {
         if (m.parent && m.parent.filename.match(nodeModuleRegex)) {
           return m;

--- a/index.js
+++ b/index.js
@@ -401,8 +401,9 @@ module.exports = function(options) {
     // and throws an exception if we don't
     function findTestModule() {
       var m = module;
+      var nodeModuleRegex = process.platform === "win32" ? new RegExp("node_modules\\\\mocha") : new RegExp("node_modules\/mocha")
       while (m) {
-        if (m.parent && m.parent.filename.match(/node_modules\/mocha/)) {
+        if (m.parent && m.parent.filename.match(nodeModuleRegex)) {
           return m;
         }
         m = m.parent;

--- a/index.js
+++ b/index.js
@@ -392,8 +392,8 @@ module.exports = function(options) {
         fs.mkdirSync(testDependenciesDir);
       }
       // Ensure potential module scope directory exists before the symlink creation
-      if (moduleName.charAt(0) === '@' && moduleName.includes(path.sep)) {
-        var scope = moduleName.split(path.sep)[0];
+      if (moduleName.charAt(0) === '@' && moduleName.includes(require("path").sep)) {
+        var scope = moduleName.split(require("path").sep)[0];
         var scopeDir = testDependenciesDir + scope;
         if (!fs.existsSync(scopeDir)) {
           fs.mkdirSync(scopeDir);

--- a/index.js
+++ b/index.js
@@ -401,7 +401,7 @@ module.exports = function(options) {
     // and throws an exception if we don't
     function findTestModule() {
       var m = module;
-      var nodeModuleRegex = process.platform === "win32" ? new RegExp("node_modules\\\\mocha") : new RegExp("node_modules\/mocha")
+      var nodeModuleRegex = process.platform === "win32" ? new RegExp("node_modules\\\\mocha",'g') : new RegExp("node_modules\/mocha",'g')
       while (m) {
         if (m.parent && m.parent.filename.match(nodeModuleRegex)) {
           return m;

--- a/index.js
+++ b/index.js
@@ -401,7 +401,7 @@ module.exports = function(options) {
     // and throws an exception if we don't
     function findTestModule() {
       var m = module;
-      var nodeModuleRegex = process.platform === "win32" ? new RegExp("node_modules\\\\mocha",'g') : new RegExp("node_modules\/mocha",'g')
+      var nodeModuleRegex = process.platform === "win32" ? new RegExp("node_modules\\\\mocha",'g') : new RegExp("node_modules\\/mocha",'g')
       while (m) {
         if (m.parent && m.parent.filename.match(nodeModuleRegex)) {
           return m;

--- a/index.js
+++ b/index.js
@@ -369,9 +369,9 @@ module.exports = function(options) {
     var testDir = require('path').dirname(m.filename);
     var testRegex;
     if (process.platform === "win32") {
-      testRegex = /\\tests?$/
+      testRegex = /\\tests?$/;
     } else {
-      testRegex = /\/tests?$/
+      testRegex = /\/tests?$/;
     }
     var moduleDir = testDir.replace(testRegex, '');
     if (testDir === moduleDir) {
@@ -403,9 +403,9 @@ module.exports = function(options) {
       // Therefore need to have if else statement to determine type of symlinkSync uses.
       var type;
       if (process.platform === "win32") {
-        type = "junction"
+        type = "junction";
       } else {
-        type = "dir"
+        type = "dir";
       }
       fs.symlinkSync(moduleDir, testDependenciesDir + moduleName, type);
     }


### PR DESCRIPTION
The issue on `findTestModule` is resolved by using a different type of regex :

- Windows's file path using `.match()` regex appears to must-have `/\\\\file\\\\to\\\\path/g` double backward slash that is equal to `\\file\\to\\path`.

I hope this issue will raise to any file path matching using regex should follow the same format as above stated.

 