### PR TITLE
Cause of regression in autocomplete support for tags and joins: in Ju…

### DIFF
--- a/lib/modules/apostrophe-assets/public/css/vendor/jquery-ui-3.less
+++ b/lib/modules/apostrophe-assets/public/css/vendor/jquery-ui-3.less
@@ -53,9 +53,8 @@
 }
 
 .ui-front {
-	z-index: 100;
+  z-index: @apos-z-index-max;
 }
-
 
 /* Interaction Cues
 ----------------------------------*/


### PR DESCRIPTION
…ly I copied in the jquery ui 1.12.1 CSS without checking for modifications made in apostrophe. I have brought back the critical z-index setting. There were also some background image settings but they only apply to jquery-ui "widgets," and it looks like we might not be using any jquery-ui widgets anymore. Autocompelte looks good now and we are using pikaday, not jquery ui datepicker.

Closes #2022 