### PR TITLE
clicking edit on a widget with nested areas, like the feature widget …

### DIFF
--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -342,7 +342,7 @@ apos.define('apostrophe-areas-editor', {
       $old.replaceWith($widget);
       self.enhanceWidgetControls($widget);
       $widget.parent('[data-apos-widget-wrapper]').attr('class', $wrapper.attr('class'));
-      self.fixInsertedWidgetDotPaths($widget);
+      apos.areas.remapDotPaths();
       $widget.data('areaEditor', self);
       apos.emit('enhance', $widget);
     };


### PR DESCRIPTION
…in open museum, no longer breaks the ability to edit those nested areas immediately after saving the modal.

Closes #2026 