### PR TITLE
Adds empty alt tag to video placeholder img

### DIFF
--- a/lib/modules/apostrophe-video-widgets/views/widget.html
+++ b/lib/modules/apostrophe-video-widgets/views/widget.html
@@ -1,6 +1,6 @@
 {# oembed repopulates me #}
 <div class="apos-video-player" data-apos-video-player>
   <h4 class="apos-video-thumbnail-title">{{ data.widget.video.title }}</h4>
-  <img class="apos-video-thumbnail" src="{{ data.widget.video.thumbnail }}" />
+  <img class="apos-video-thumbnail" src="{{ data.widget.video.thumbnail }}" alt="" />
   <div class="apos-video-busy-indicator"></div>
 </div>


### PR DESCRIPTION
To tell screen readers to ignore these. The image shouldn't be shown long, and the heading would state the title already.