### PR TITLE
Sets video height (and width) based on parent

### DIFF
--- a/lib/modules/apostrophe-video-widgets/public/js/lean.js
+++ b/lib/modules/apostrophe-video-widgets/public/js/lean.js
@@ -41,8 +41,11 @@ apos.utils.widgetPlayers['apostrophe-video'] = function(el, data, options) {
     apos.utils.onReady(function() {
       // If oembed results include width and height we can get the
       // video aspect ratio right
+      var parent = apos.utils.closest(inner, '[data-apos-video-player]');
+
       if (result.width && result.height) {
-        inner.style.height = ((result.height / result.width) * inner.offsetWidth) + 'px';
+        inner.style.height = ((result.height / result.width) * parent.offsetWidth) + 'px';
+        inner.style.width = parent.offsetWidth + 'px';
       } else {
         // No, so assume the oembed HTML code is responsive.
       }


### PR DESCRIPTION
The height was being set against something its size, so could end up staying very small. This uses the parent to get the dimensions instead.