### PR TITLE
Remove callback on Widget Editor afterShow method

### DIFF
--- a/lib/modules/apostrophe-widgets/public/js/editor.js
+++ b/lib/modules/apostrophe-widgets/public/js/editor.js
@@ -56,7 +56,7 @@ apos.define('apostrophe-widgets-editor', {
     };
 
     // Wait for afterShow to do things that might pop more modals
-    self.afterShow = function(callback) {
+    self.afterShow = function() {
       return async.series({
         errorPath: function(callback) {
           if (self.errorPath && self.errorPath.length) {
@@ -70,7 +70,12 @@ apos.define('apostrophe-widgets-editor', {
           self.errorPath = null;
           return callback(null);
         }
-      }, callback);
+      }, function(err) {
+        if (err) {
+          return console.warn(err);
+        }
+        return;
+      });
     };
 
     self.getData = function() {

--- a/lib/modules/apostrophe-widgets/public/js/editor.js
+++ b/lib/modules/apostrophe-widgets/public/js/editor.js
@@ -72,9 +72,9 @@ apos.define('apostrophe-widgets-editor', {
         }
       }, function(err) {
         if (err) {
-          return console.warn(err);
+          return apos.utils.warn(err);
         }
-        return;
+
       });
     };
 


### PR DESCRIPTION
This changes brought from [Remove `callback` from afterShow(callback)](https://github.com/apostrophecms/apostrophe-documentation/pull/160) . 

I don't know what to do on the `async.series` callback, and I just return `console.error` for that case. Let me know if you wanted me to change on anything.