### PR TITLE
support for namespacing asset themes. By default it is turned off, if…

### DIFF
--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -319,7 +319,7 @@ module.exports = {
       if (self.isGenerationTask && self.simpleBundle) {
         self.determineGeneration();
         return self.generationCollection.update({
-          _id: 'current'
+          _id: self.getThemed('current')
         }, {
           generation: self.generation
         }, {
@@ -330,7 +330,7 @@ module.exports = {
         return self.determineGeneration();
       }
       return Promise.try(function() {
-        return self.generationCollection.findOne({ _id: 'current' });
+        return self.generationCollection.findOne({ _id: self.getThemed('current') });
       }).then(function(c) {
         if (!c) {
           throw new Error('You must first run the apostrophe:generation task, with APOS_BUNDLE=1 set in the environment');
@@ -355,7 +355,7 @@ module.exports = {
         var bundle = self.apos.argv['create-bundle'] || self.simpleBundle;
         if (bundle) {
           if (bundle === true) {
-            self.toBundleName = 'assets-' + generation;
+            self.toBundleName = 'assets-' + self.getThemed(generation);
             self.toBundle = self.apos.rootDir + '/data/temp/' + self.toBundleName;
           } else {
             self.toBundleName = bundle;
@@ -443,7 +443,7 @@ module.exports = {
         return;
       }
       return Promise.try(function() {
-        return self.generationCollection.findOne({ _id: 'current' });
+        return self.generationCollection.findOne({ _id: self.getThemed('current') });
       }).then(function(generation) {
         if (!(generation && generation.tarball)) {
           throw new Error('Asset bundle is not in generationCollection');
@@ -561,7 +561,7 @@ module.exports = {
           // exists both locally and in uploadfs so we can do that here too
           var current = {
             _id: self.generation,
-            copies: self.enumerateCopies(self.extractedTarFiles ? { files: self.extractedTarFiles, prefix: './public' } : (self.apos.rootDir + '/' + self.toBundleName + '/public'), '/assets/' + self.generation),
+            copies: self.enumerateCopies(self.extractedTarFiles ? { files: self.extractedTarFiles, prefix: './public' } : (self.apos.rootDir + '/' + self.toBundleName + '/public'), self.getGenerationPath()),
             when: new Date()
           };
           generations.push(current);
@@ -1055,7 +1055,7 @@ module.exports = {
       return self.forAllAssetScenes(function(scene, callback) {
         var base = self.getStylesheetsMasterBase() + '-' + scene + '-';
         self.purgeExcept(base + '*', '-' + self.generation);
-        var masterWeb = base + self.generation + '.less';
+        var masterWeb = base + self.getThemedGeneration() + '.less';
         var masterFile = self.getAssetRoot() + '/public' + masterWeb;
         var stylesheets = self.filterAssets(self.pushed.stylesheets, scene, true);
         // Avoid race conditions, if apostrophe:generation created
@@ -1121,7 +1121,7 @@ module.exports = {
     };
 
     self.getStylesheetsMasterBase = function() {
-      return '/css/master';
+      return '/css/' + self.getThemed('master');
     };
 
     self.minify = function(callback) {
@@ -1138,8 +1138,9 @@ module.exports = {
       var needed = false;
       return self.forAllAssetScenes(function(scene, callback) {
         return async.eachSeries([ 'stylesheets', 'scripts' ], function(type, callback) {
-          self.purgeExcept('/apos-minified/' + scene + '-*.' + self.typeMap[type], '-' + self.generation);
-          var file = self.getAssetRoot() + '/public/apos-minified/' + scene + '-' + self.generation + '.' + self.typeMap[type];
+          var themedGeneration = self.getThemedGeneration();
+          self.purgeExcept('/apos-minified/' + scene + '-' + self.getThemedGeneration().replace(self.generation, '*') + '.' + self.typeMap[type], '-' + self.generation);
+          var file = self.getAssetRoot() + '/public/apos-minified/' + scene + '-' + self.getThemedGeneration() + '.' + self.typeMap[type];
           if (fs.existsSync(file)) {
             // Someone has already compiled it for the
             // current deployment's asset generation!
@@ -1175,7 +1176,7 @@ module.exports = {
           if (!fs.existsSync(dir)) {
             fs.mkdirSync(dir);
           }
-          var filename = dir + '/' + scene + '-' + self.generation + '.' + self.typeMap[type];
+          var filename = dir + '/' + scene + '-' + self.getThemedGeneration() + '.' + self.typeMap[type];
           // Avoid race conditions - don't try to write the
           // same file again if apostrophe:generation already
           // created it for us
@@ -1357,7 +1358,7 @@ module.exports = {
         }
         css = css.css;
         if ((self.isGenerationTask && self.simpleBundle) || self.apos.argv['sync-to-uploadfs']) {
-          css = self.prefixCssUrlsWith(css, self.uploadfs().getUrl() + '/assets/' + self.generation);
+          css = self.prefixCssUrlsWith(css, self.uploadfs().getUrl() + self.getGenerationPath());
         } else if (self.apos.prefix) {
           css = self.prefixCssUrls(css);
         }
@@ -1633,7 +1634,7 @@ module.exports = {
 
     self.assetUrl = function(web) {
       if (process.env.APOS_BUNDLE_IN_UPLOADFS || self.simpleBundle) {
-        return self.uploadfs().getUrl() + '/assets/' + self.generation + web;
+        return self.uploadfs().getUrl() + self.getGenerationPath() + web;
       }
       return self.apos.prefix + web;
     };
@@ -1673,7 +1674,7 @@ module.exports = {
           return callback(null);
         }
         return self.syncToUploadfs(self.toBundle + '/public',
-          '/assets/' + self.generation, callback);
+          self.getGenerationPath(), callback);
       }
 
       function copyTarballToGenerationCollection(callback) {
@@ -1693,7 +1694,7 @@ module.exports = {
           '.'
         ]).then(function() {
           return self.generationCollection.update({
-            _id: 'current'
+            _id: self.getThemed('current')
           }, {
             $set: {
               tarball: Binary(fs.readFileSync(temp))
@@ -1711,11 +1712,11 @@ module.exports = {
         self.mkdirp(temp);
         self.__tempMkdir = true;
       }
-      return temp + '/assets-' + self.generation + '.tar.gz';
+      return temp + '/assets-' + self.getThemedGeneration() + '.tar.gz';
     };
 
     self.getUploadfsBundlePath = function() {
-      return '/asset-tarballs/assets-' + self.generation + '.tar.gz';
+      return '/asset-tarballs/assets-' + self.getThemedGeneration() + '.tar.gz';
     };
 
     // Implementation of stylesheeets helper, as a method for
@@ -1725,7 +1726,7 @@ module.exports = {
 
     self.stylesheetsHelper = function(when) {
       if (self.options.minify) {
-        return self.apos.templates.safe('<link href="' + self.assetUrl('/apos-minified/' + when + '-' + self.generation + '.css') + '" rel="stylesheet" />');
+        return self.apos.templates.safe('<link href="' + self.assetUrl('/apos-minified/' + when + '-' + self.getThemedGeneration() + '.css') + '" rel="stylesheet" />');
       } else {
         if (self.lessMasters && self.lessMasters[when]) {
           return self.apos.templates.safe('<link href="' + self.assetUrl(self.lessMasters[when].web) + '" rel="stylesheet" />');
@@ -1751,7 +1752,7 @@ module.exports = {
       if (self.options.minify) {
         var unminifiable = self.filterAssets(self.pushed['scripts'], when, false);
         result += scriptTags(unminifiable);
-        result += '<script src="' + self.assetUrl('/apos-minified/' + when + '-' + self.generation + '.js') + '"></script>\n';
+        result += '<script src="' + self.assetUrl('/apos-minified/' + when + '-' + self.getThemedGeneration() + '.js') + '"></script>\n';
         return self.apos.templates.safe(result);
       } else {
         var scriptsWhen = self.filterAssets(self.pushed['scripts'], when);
@@ -1848,6 +1849,29 @@ module.exports = {
           lean: self.options.lean
         }
       );
+    };
+
+    self.getGenerationPath = function() {
+      return '/assets/' + self.getThemedGeneration();
+    };
+
+    self.getThemedGeneration = function() {
+      return self.getThemed(self.generation);
+    };
+
+    self.getThemed = function(s) {
+      var theme = self.getThemeName();
+      if (theme) {
+        return theme + '-' + s;
+      }
+      return s;
+    };
+
+    // Can be overridden by modules like apostrophe-multisite
+    // to namespace minified asset bundles and LESS masters.
+    // Env var option is for unit testing only
+    self.getThemeName = function() {
+      return process.env.APOS_DEBUG_THEME || '';
     };
   }
 };


### PR DESCRIPTION
… getThemeName is overridden to return a theme name then asset masters, minified assets, bundles in the collection, etc. all get namespaced to play side by side with other themes used by other apos objects in the same project. Meant for use with apostrophe-multisite, this is not the same thing as a wordpress theme per se.