### PR TITLE
behave reasonably if a scoped npm module name is also used as the nam…

### DIFF
--- a/lib/modules/apostrophe-browser-utils/public/js/always.js
+++ b/lib/modules/apostrophe-browser-utils/public/js/always.js
@@ -62,15 +62,19 @@ apos.define('apostrophe-browser-utils', {
       var i;
       var css = '';
       var dash = false;
+      var start = true;
       for (i = 0; (i < camel.length); i++) {
         var c = camel.charAt(i);
         var lower = ((c >= 'a') && (c <= 'z'));
         var upper = ((c >= 'A') && (c <= 'Z'));
         var digit = ((c >= '0') && (c <= '9'));
         if (!(lower || upper || digit)) {
-          dash = true;
+          if (!start) {
+            dash = true;
+          }
           continue;
         }
+        start = false;
         if (upper) {
           if (i > 0) {
             dash = true;

--- a/lib/modules/apostrophe-pieces/public/js/user.js
+++ b/lib/modules/apostrophe-pieces/public/js/user.js
@@ -15,25 +15,31 @@ apos.define('apostrophe-pieces', {
     self.options = options;
     self.name = self.options.name;
 
+    // Globally link up clicks on data-apos-${action} where the piece
+    // type name is made properly attribute-name-friendly
+    self.globalLink = function(action, fn) {
+      apos.ui.link(action, apos.utils.cssName(self.name), fn);
+    };
+
     self.clickHandlers = function() {
       apos.adminBar.link(self.__meta.name, function() {
         self.manage();
       });
       // The rest of these are not part of the admin bar, follow our own convention
-      apos.ui.link('apos-manage', self.name, function($button, _id) {
+      self.globalLink('apos-manage', function($button, _id) {
         self.manage();
       });
-      apos.ui.link('apos-edit', self.name, function($button, _id) {
+      self.globalLink('apos-edit', function($button, _id) {
         var hint = $button.attr('data-apos-edit-hint');
         self.edit(_id, { hint: hint });
       });
-      apos.ui.link('apos-rescue', self.name, function($button, _id) {
+      self.globalLink('apos-rescue', function($button, _id) {
         self.rescue(_id);
       });
-      apos.ui.link('apos-create', self.name, function($button) {
+      self.globalLink('apos-create', function($button) {
         self.create();
       });
-      apos.ui.link('apos-publish', self.name, function($button, id) {
+      self.globalLink('apos-publish', function($button, id) {
         var piece = { _id: id };
         self.api('publish', piece, function(data) {
           if (data.status !== 'ok') {
@@ -43,12 +49,12 @@ apos.define('apostrophe-pieces', {
           window.location.reload(true);
         });
       });
-      apos.ui.link('apos-versions', self.name, function($button, id) {
+      self.globalLink('apos-versions', function($button, id) {
         apos.versions.edit(id, function() {
           apos.change(self.name);
         });
       });
-      apos.ui.link('apos-trash', self.name, function($button, id) {
+      self.globalLink('apos-trash', function($button, id) {
         if (!confirm("Are you sure you want to trash this " + self.options.label + "?")) {
           return;
         }

--- a/lib/modules/apostrophe-users/views/accountMenu.html
+++ b/lib/modules/apostrophe-users/views/accountMenu.html
@@ -1,6 +1,6 @@
 {% import 'apostrophe-ui:components/dropdowns.html' as dropdowns with context -%}
 {%- macro listMenu() -%}
-  <li href="#" class="apos-dropdown-item" data-apos-edit-{{ data.options.name }}="{{ data.user._id }}">{{ __('Edit Account') }}</li>
+  <li href="#" class="apos-dropdown-item" data-apos-edit-{{ data.options.name | css }}="{{ data.user._id }}">{{ __('Edit Account') }}</li>
   <li href="#" class="apos-dropdown-item" data-apos-logout>{{ __('Logout') }}</li>
 {%- endmacro -%}
 {%- if data.permissions.edit -%}

--- a/lib/modules/apostrophe-utils/lib/api.js
+++ b/lib/modules/apostrophe-utils/lib/api.js
@@ -136,15 +136,19 @@ module.exports = function(self, options) {
     var i;
     var css = '';
     var dash = false;
+    var start = true;
     for (i = 0; (i < camel.length); i++) {
       var c = camel.charAt(i);
       var lower = ((c >= 'a') && (c <= 'z'));
       var upper = ((c >= 'A') && (c <= 'Z'));
       var digit = ((c >= '0') && (c <= '9'));
       if (!(lower || upper || digit)) {
-        dash = true;
+        if (!start) {
+          dash = true;
+        }
         continue;
       }
+      start = false;
       if (upper) {
         if (i > 0) {
           dash = true;


### PR DESCRIPTION
…e option of a pieces module

Background: since you can now have a pieces module like @company/articles, an enterprise client reasonably assumed they could set the `name` option of the module to `@company/article`. This didn't work because of issues with inconsistent conversion to a "cssName" friendly for use as an attribute name.

We now convert to a CSS name consistently both when outputting the button and when setting up a click handler for it, thus resolving the issue.

Also the `cssName` function itself now never outputs a leading `-`, which was never desired behavior.