### PR TITLE
beforeSend event should be emitted from apostrophe-pages even if some…

### DIFF
--- a/lib/modules/apostrophe-module/index.js
+++ b/lib/modules/apostrophe-module/index.js
@@ -565,7 +565,13 @@ module.exports = {
       });
 
       function pageBeforeSend(callback) {
-        return self.callAllAndEmit('pageBeforeSend', 'beforeSend', req, callback);
+        // For consistency with the legacy `pageBeforeSend` callAll behavior,
+        // this should emit the `beforeSend` event from the expected module
+        // (apostrophe-pages), not this module. Otherwise we fail at both the
+        // intended purpose and the past behavior of sendPage: rendering it
+        // exactly like any standard page even though it's implemented by a custom route.
+        req.sendPageModuleName = self.__meta.name;
+        return self.apos.pages.callAllAndEmit('pageBeforeSend', 'beforeSend', req, callback);
       }
 
       function loadDeferredWidgets(callback) {


### PR DESCRIPTION
… other module called sendPage. This aligns with past behavior i.e. we always called pageBeforeSend, not somethingElseBeforeSend. Also with the intent of the sendPage method which is to be exactly like an ordinary page send in every possible way, but from your custom route