### PR TITLE
Dgad 862: optional password complexity rules for apostrophe

### DIFF
--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -307,7 +307,7 @@ module.exports = {
             // failureFlash does not appear to work properly, let's just
             // use a query parameter
             failureRedirect: '/login?' + qs.stringify({
-              message: 'Incorret login or password',
+              message: 'Incorrect login or password',
               // bc
               error: '1'
             })

--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -274,17 +274,17 @@ module.exports = {
             return res.redirect('/');
           }
           req.scene = 'user';
-          // message is supported as a way of delivering all errors
-          // for bc but if present errors is shown by preference
-          // by the modern template
+          // message is supported as a simple way of delivering all errors
+          // but we also provide `errors` for templates that wish to do more
           return self.sendPage(req, 'login', { passwordReset: self.options.passwordReset, message: getMessage(), errors: req.query.errors });
           function getMessage() {
+            let message;
             if (req.query.message) {
-              return req.query.message;
+              message = req.query.message;
+            } else if (req.query.errors && req.query.errors.length) {
+              message = req.query.errors.join(', ');
             }
-            if (req.query.errors && req.query.errors.length) {
-              return req.query.errors.join(', ');
-            }
+            return self.apos.utils.capitalizeFirst(message);
           }
         });
         self.apos.app.post('/login',
@@ -375,12 +375,17 @@ module.exports = {
           });
 
           function getMessage() {
+            let message;
             if (req.query.message) {
-              return req.query.message;
+              message = req.query.message;
             }
             if (req.query.errors && req.query.errors.length) {
-              return req.query.errors.join(', ');
+              message = req.query.errors.join(', ');
             }
+            if (message === undefined) {
+              return undefined;
+            }
+            return self.apos.utils.capitalizeFirst(message);
           }
         });
 
@@ -540,7 +545,7 @@ module.exports = {
       var errors = [];
       var minLength = self.options.passwordMinLength || 1;
       if (password.length < minLength) {
-        errors.push('Passwords must be at least ' + minLength + ' characters long');
+        errors.push('password must be at least ' + minLength + ' characters long');
       }
       if (self.options.passwordRules) {
         _.each(self.options.passwordRules, function(name) {
@@ -561,25 +566,25 @@ module.exports = {
         test: function(password) {
           return !((password.indexOf('/') !== -1) || (password.indexOf('\\') !== -1));
         },
-        message: '/ and \\ characters are not allowed'
+        message: '/ and \\ characters are not allowed in password'
       },
       noSpaces: {
         test: function(password) {
           return !password.match(/\s/);
         },
-        message: 'Spaces are not allowed'
+        message: 'spaces are not allowed in password'
       },
       mixedCase: {
         test: function(password) {
           return password.match(/[a-z]/) && password.match(/[A-Z]/);
         },
-        message: 'Must contain both uppercase and lowercase characters'
+        message: 'password must contain both uppercase and lowercase characters'
       },
       digits: {
         test: function(password) {
           return password.match(/\d/);
         },
-        message: 'Must contain digits'
+        message: 'password must contain digits'
       },
       noTripleRepeats: {
         test: function(password) {
@@ -588,7 +593,7 @@ module.exports = {
             var char0 = password.charAt(i);
             var char1 = password.charAt(i + 1);
             var char2 = password.charAt(i + 2);
-            if ((char0 === char1) || (char0 === char2)) {
+            if ((char0 === char1) && (char0 === char2)) {
               return false;
             }
           }

--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -540,7 +540,7 @@ module.exports = {
     // Returns an array of error messages, which will be
     // empty if there are no errors. The error messages
     // will be internationalized for you.
- 
+
     self.checkPasswordRules = function(req, password) {
       var errors = [];
       var minLength = self.options.passwordMinLength || 1;
@@ -612,7 +612,7 @@ module.exports = {
     // is a short message to be shown to the user in the
     // event the rule fails, which will automatically be
     // internationalized for you.
- 
+
     self.addPasswordRule = function(name, test, message) {
       self.passwordRules[name] = {
         test: test,

--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -10,6 +10,32 @@
 // the `apostrophe-passport` module, which adds support for login via
 // Google, Twitter, gitlab, etc.
 //
+// `passwordMinLength`
+//
+// The minimum length for passwords. You should set this, as there
+// is no default for bc reasons (effectively the default is `1`).
+//
+// `passwordRules`
+//
+// An optional array of password rule names, as strings. The standard rules
+// available are `noSlashes`, `noSpaces`, `mixedCase`, `digits`, and
+// `noTripleRepeats`. The `noTripleRepeats` rule forbids repeating a
+// character three times in a row. By default no rules are in effect.
+//
+// When this option is set, the rules are consulted when a password
+// is set or reset. Existing passwords that do not follow the rules
+// are tolerated. If you wish to enforce them for existing passwords
+// as well, see below.
+//
+// `passwordRulesAtLoginTime`
+//
+// By default, password rules are enforced only when a password is
+// being set or reset. If you wish, you can set `passwordRulesAtLoginTime: true`
+// to apply them at login time so that even an existing password will
+// not work unless it passes the rules. This can be useful if you don't
+// mind a few irritated users and you have the `passwordReset` option
+// properly configured (see below).
+//
 // `passwordReset`
 //
 // If set to `true`, the user is given the option to reset their password,
@@ -248,16 +274,43 @@ module.exports = {
             return res.redirect('/');
           }
           req.scene = 'user';
-          // Gets i18n'd in the template, also bc with what templates that tried to work
-          // before certain fixes would expect (this is why we still pass a string and not
-          // a flag, and why we call it `message`)
-          return self.sendPage(req, 'login', { passwordReset: self.options.passwordReset, message: req.query.message || (req.query.error && req.__('your username or password was incorrect')) });
+          // message is supported as a way of delivering all errors
+          // for bc but if present errors is shown by preference
+          // by the modern template
+          return self.sendPage(req, 'login', { passwordReset: self.options.passwordReset, message: getMessage(), errors: req.query.errors });
+          function getMessage() {
+            if (req.query.message) {
+              return req.query.message;
+            }
+            if (req.query.errors && req.query.errors.length) {
+              return req.query.errors.join(', ');
+            }
+          }
         });
         self.apos.app.post('/login',
+          function(req, res, next) {
+            if (!self.options.passwordRulesAtLoginTime) {
+              return next();
+            }
+            var password = req.body.password;
+            var errors = self.checkPasswordRules(req, password);
+            if (errors.length) {
+              return res.redirect('/login?' + qs.stringify({
+                errors: errors,
+                // bc
+                error: '1'
+              }));
+            }
+            return next();
+          },
           self.passport.authenticate('local', {
             // failureFlash does not appear to work properly, let's just
             // use a query parameter
-            failureRedirect: '/login?error=1'
+            failureRedirect: '/login?' + qs.stringify({
+              message: 'Incorret login or password',
+              // bc
+              error: '1'
+            })
           }),
           self.afterLogin
         );
@@ -274,7 +327,7 @@ module.exports = {
           // Gets i18n'd in the template, also bc with what templates that tried to work
           // before certain fixes would expect (this is why we still pass a string and not
           // a flag, and why we call it `message`)
-          return self.sendPage(req, 'passwordResetRequest', { message: req.query.error ? 'That is not a valid email address or username, or the user has no email address on record.' : undefined });
+          return self.sendPage(req, 'passwordResetRequest', { error: req.query.error });
         });
 
         self.apos.app.post('/password-reset-request', function(req, res) {
@@ -315,22 +368,47 @@ module.exports = {
             if (!user) {
               throw 'notfound';
             }
-            // Gets i18n'd in the template, also bc with what templates that tried to work
-            // before certain fixes would expect (this is why we still pass a string and not
-            // a flag, and why we call it `message`)
-            return self.sendPage(req, 'passwordReset', { reset: reset, email: email });
+            return self.sendPage(req, 'passwordReset', { reset: reset, email: email, message: getMessage(), errors: req.query.errors });
           }).catch(function(err) {
             self.apos.utils.error(err);
             return res.redirect('/login?message=' + req.__('That reset code was not found. It may have expired. Try resetting again.'));
           });
+
+          function getMessage() {
+            if (req.query.message) {
+              return req.query.message;
+            }
+            if (req.query.errors && req.query.errors.length) {
+              return req.query.errors.join(', ');
+            }
+          }
         });
 
         self.apos.app.post('/password-reset', function(req, res) {
           var reset = self.apos.launder.string(req.body.reset);
           var email = self.apos.launder.string(req.body.email);
           var password = self.apos.launder.string(req.body.password);
-          if ((!reset.length) || (!password.length)) {
-            return res.redirect('/password-reset-request?error=missing');
+          if (!reset.length) {
+            return res.redirect('/password-reset?' + qs.stringify({
+              errors: [ 'The password reset code is missing from your link. Try resetting your password again.' ],
+              email: email,
+              reset: reset
+            }));
+          }
+          if (!password.length) {
+            return res.redirect('/password-reset?' + qs.stringify({
+              errors: [ 'You did not enter a new password.' ],
+              email: email,
+              reset: reset
+            }));
+          }
+          var errors = self.checkPasswordRules(req, password);
+          if (errors.length) {
+            return res.redirect('/password-reset?' + qs.stringify({
+              errors: errors,
+              email: email,
+              reset: reset
+            }));
           }
           var adminReq = self.apos.tasks.getReq();
           return Promise.try(function() {
@@ -352,10 +430,10 @@ module.exports = {
           }).then(function(user) {
             return self.apos.users.forgetSecret(user, 'passwordReset');
           }).then(function(user) {
-            return res.redirect('/login?message=' + req.__('Password has been reset. Please log in.'));
+            return res.redirect('/login?message=' + req.__('Your password has been reset. Please log in.'));
           }).catch(function(err) {
             self.apos.utils.error(err);
-            return res.redirect('/password-reset-request?error=error');
+            return res.redirect('/password-reset?errors[]=error');
           });
         });
 
@@ -452,6 +530,89 @@ module.exports = {
         req.redirect = req.redirect || '/';
         return res.redirect(req.redirect);
       });
+    };
+
+    // Returns an array of error messages, which will be
+    // empty if there are no errors. The error messages
+    // will be internationalized for you.
+ 
+    self.checkPasswordRules = function(req, password) {
+      var errors = [];
+      var minLength = self.options.passwordMinLength || 1;
+      if (password.length < minLength) {
+        errors.push('Passwords must be at least ' + minLength + ' characters long');
+      }
+      if (self.options.passwordRules) {
+        _.each(self.options.passwordRules, function(name) {
+          var rule = self.passwordRules[name];
+          if (!rule.test(password)) {
+            errors.push(rule.message);
+          }
+        });
+      }
+      errors = errors.map(function(error) {
+        return req.__(error);
+      });
+      return errors;
+    };
+
+    self.passwordRules = {
+      noSlashes: {
+        test: function(password) {
+          return !((password.indexOf('/') !== -1) || (password.indexOf('\\') !== -1));
+        },
+        message: '/ and \\ characters are not allowed'
+      },
+      noSpaces: {
+        test: function(password) {
+          return !password.match(/\s/);
+        },
+        message: 'Spaces are not allowed'
+      },
+      mixedCase: {
+        test: function(password) {
+          return password.match(/[a-z]/) && password.match(/[A-Z]/);
+        },
+        message: 'Must contain both uppercase and lowercase characters'
+      },
+      digits: {
+        test: function(password) {
+          return password.match(/\d/);
+        },
+        message: 'Must contain digits'
+      },
+      noTripleRepeats: {
+        test: function(password) {
+          var i;
+          for (i = 0; (i < (password.length - 2)); i++) {
+            var char0 = password.charAt(i);
+            var char1 = password.charAt(i + 1);
+            var char2 = password.charAt(i + 2);
+            if ((char0 === char1) || (char0 === char2)) {
+              return false;
+            }
+          }
+          return true;
+        },
+        message: 'No character may be repeated three times in a row'
+      }
+    };
+
+    // Register a password validation rule. Does not
+    // activate it, see the passwordRules option.
+    // `name` is a unique name to be included in the
+    // `passwordRules` option array, `test` is a function
+    // that accepts the password and returns `true` only
+    // if the password passes the rule, and `message`
+    // is a short message to be shown to the user in the
+    // event the rule fails, which will automatically be
+    // internationalized for you.
+ 
+    self.addPasswordRule = function(name, test, message) {
+      self.passwordRules[name] = {
+        test: test,
+        message: message
+      };
     };
 
     self.modulesReady = function() {

--- a/lib/modules/apostrophe-login/views/loginBase.html
+++ b/lib/modules/apostrophe-login/views/loginBase.html
@@ -11,13 +11,7 @@
         <div class="apos-login-title apos-text-title">{% block subHeading %}{{ __('Login') }}{% endblock %}</div>
         {% block form %}
           <form action="{% block action %}{{ apos.prefix }}/login{% endblock %}" method="post">
-            {% if data.errors and data.errors[0] %}
-              <div class="apos-login-warning">
-                {{ data.errors | join(', ') }}
-              </div>
-            {% else %}
-              {% if data.message %}<div class="apos-login-warning">{{ __(data.message) }}</div>{% endif %}
-            {% endif %}
+            {% if data.message %}<div class="apos-login-warning">{{ __(data.message) }}</div>{% endif %}
             {% block fields %}
               <div class="apos-field apos-login-username">
                 <label class="apos-field-label" for="username">{{ __('Username or Email') }} {% block usernameHint %}{% endblock %}</label>

--- a/lib/modules/apostrophe-login/views/loginBase.html
+++ b/lib/modules/apostrophe-login/views/loginBase.html
@@ -11,7 +11,13 @@
         <div class="apos-login-title apos-text-title">{% block subHeading %}{{ __('Login') }}{% endblock %}</div>
         {% block form %}
           <form action="{% block action %}{{ apos.prefix }}/login{% endblock %}" method="post">
-            {% if data.message %}<div class="apos-login-warning">{{ __(data.message) }}</div>{% endif %}
+            {% if data.errors and data.errors[0] %}
+              <div class="apos-login-warning">
+                {{ data.errors | join(', ') }}
+              </div>
+            {% else %}
+              {% if data.message %}<div class="apos-login-warning">{{ __(data.message) }}</div>{% endif %}
+            {% endif %}
             {% block fields %}
               <div class="apos-field apos-login-username">
                 <label class="apos-field-label" for="username">{{ __('Username or Email') }} {% block usernameHint %}{% endblock %}</label>

--- a/lib/modules/apostrophe-login/views/passwordReset.html
+++ b/lib/modules/apostrophe-login/views/passwordReset.html
@@ -13,7 +13,7 @@
           <form id="password-reset-form" action="{% block action %}{{ apos.prefix }}/password-reset{% endblock %}" method="post">
             {% if data.errors and data.errors.length %}
               <div class="apos-login-warning">
-                Incorrect input: {{ data.errors | join(', ') }}
+                {{ __('Incorrect input: ') }}{{ data.errors | join(', ') }}
               </div>
             {% endif %}
             {% block fields %}

--- a/lib/modules/apostrophe-login/views/passwordReset.html
+++ b/lib/modules/apostrophe-login/views/passwordReset.html
@@ -11,6 +11,11 @@
         <div class="apos-login-title apos-text-title">{% block subHeading %}{{ __('Reset Password') }}{% endblock %}</div>
         {% block form %}
           <form id="password-reset-form" action="{% block action %}{{ apos.prefix }}/password-reset{% endblock %}" method="post">
+            {% if data.errors and data.errors.length %}
+              <div class="apos-login-warning">
+                Incorrect input: {{ data.errors | join(', ') }}
+              </div>
+            {% endif %}
             {% block fields %}
               <div class="apos-field apos-login-password">
                 <label class="apos-field-label" for="password">{{ __('New Password') }} {% block passwordHint %}{% endblock %}</label>

--- a/lib/modules/apostrophe-login/views/passwordResetRequest.html
+++ b/lib/modules/apostrophe-login/views/passwordResetRequest.html
@@ -1,5 +1,9 @@
 {% extends data.outerLayout %}
 {% block title %}{{ __("Password Reset Request") }}{% endblock %}
+{% set errors = {
+  error: 'An error occurred. Please try again.',
+  missing: 'You did not supply your username or email address.'
+} %}
 
 {% block bodyClass %}apos-login-page apos-password-reset-request-page{% endblock %}
 
@@ -11,7 +15,7 @@
         <div class="apos-login-title apos-text-title">{% block subHeading %}{{ __('Password Reset') }}{% endblock %}</div>
         {% block form %}
           <form action="{% block action %}{{ apos.prefix }}/password-reset-request{% endblock %}" method="post">
-            {% if data.message %}<div class="apos-login-warning">{{ __(data.message) }}</div>{% endif %}
+            {% if data.error %}<div class="apos-login-warning">{{ __(errors[data.error]) }}</div>{% endif %}
             {% block fields %}
               <div class="apos-field apos-login-username">
                 <label class="apos-field-label" for="username">{{ __('Username or Email') }} {% block usernameHint %}{% endblock %}</label>

--- a/lib/modules/apostrophe-module/index.js
+++ b/lib/modules/apostrophe-module/index.js
@@ -150,6 +150,12 @@ module.exports = {
     // for an error, you can pass an object containing them as the
     // third argument to `next`. This is separate from the success value
     // to avoid accidentally disclosing information on errors.
+    //
+    // In addition, if `req.errorMessages` is set, it is
+    // passed as the `messages` property of the JSON object.
+    // This is a helpful way to accommodate percolating detailed
+    // error messages up from a nested function call through a
+    // stack that otherwise only accommodates simple string errors.
 
     self.apiRoute = function(method, path, fn) {
       return self.route.apply(self, [ method, path, 'apiResponder' ].concat(Array.prototype.slice.call(arguments, 2)));
@@ -216,7 +222,13 @@ module.exports = {
           }
         }
         if (req && req.res) {
-          return req.res.send(Object.assign({ status: err }, extraError || {}));
+          var response = {
+            status: err
+          };
+          if (req.errorMessages) {
+            response.messages = req.errorMessages;
+          }
+          return req.res.send(Object.assign(response, extraError || {}));
         } else {
           // We already flagged this as a developer mistake
 

--- a/lib/modules/apostrophe-pieces/public/js/editor-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/editor-modal.js
@@ -156,7 +156,7 @@ apos.define('apostrophe-pieces-editor-modal', {
         }
         self.api(verb, piece, function(result) {
           if (result.status !== 'ok') {
-            apos.notify(self.getErrorMessage(result.status), { type: 'error' });
+            apos.notify(self.getErrorMessage(result.status, result), { type: 'error' });
             return callback('error');
           }
           self.unsavedChanges = false;
@@ -170,7 +170,7 @@ apos.define('apostrophe-pieces-editor-modal', {
       });
     };
 
-    self.getErrorMessage = function(err) {
+    self.getErrorMessage = function(err, result) {
       apos.utils.error(err);
       return 'An error occurred. Please try again.';
     };

--- a/lib/modules/apostrophe-pieces/public/js/editor-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/editor-modal.js
@@ -177,7 +177,7 @@ apos.define('apostrophe-pieces-editor-modal', {
     // candidate for overrides because it has access to the
     // entire result object. Invoked when result.status
     // is not `ok`.
- 
+
     self.displayError = function(result) {
       apos.notify(self.getErrorMessage(result.status), { type: 'error' });
     };

--- a/lib/modules/apostrophe-pieces/public/js/editor-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/editor-modal.js
@@ -156,7 +156,7 @@ apos.define('apostrophe-pieces-editor-modal', {
         }
         self.api(verb, piece, function(result) {
           if (result.status !== 'ok') {
-            apos.notify(self.getErrorMessage(result.status, result), { type: 'error' });
+            self.displayError(result);
             return callback('error');
           }
           self.unsavedChanges = false;
@@ -164,10 +164,22 @@ apos.define('apostrophe-pieces-editor-modal', {
           self.savedPiece = result.data;
           return self.displayResponse(result, callback);
         }, function() {
+          // This is a network error. No useful information
+          // is available, display a simple notification
           apos.notify('An error occurred. Please try again', { type: 'error', dismiss: true });
           return callback(err);
         });
       });
+    };
+
+    // Calls getErrorMessage with result.status and passes the
+    // returned string to apos.notify. This method is a good
+    // candidate for overrides because it has access to the
+    // entire result object. Invoked when result.status
+    // is not `ok`.
+ 
+    self.displayError = function(result) {
+      apos.notify(self.getErrorMessage(result.status), { type: 'error' });
     };
 
     self.getErrorMessage = function(err, result) {

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -205,9 +205,9 @@ apos.define('apostrophe-schemas', {
     };
 
     // Create a valid error object to be reported from a converter.
-    // You can also report a string in which case self.convert creates
-    // one of these for you. The object is nice if you want to extend it
-    // with extra properties
+    // You can also report a string as an error in which case self.convert
+    // creates one of these for you. The object is nice if you want to
+    // extend it with extra properties
 
     self.error = function(field, type) {
       var error = {

--- a/lib/modules/apostrophe-schemas/views/macros.html
+++ b/lib/modules/apostrophe-schemas/views/macros.html
@@ -87,7 +87,7 @@
 {%- endmacro -%}
 
 {%- macro passwordBody(field, options) -%}
-  <input id="{{ options.id }}" class="apos-field-input apos-field-input-text{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}" name="{{ field.name }}" type="password"{% if field.readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
+  <input id="{{ options.id }}" class="apos-field-input apos-field-input-text{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}" name="{{ field.name }}" autocomplete="off" type="password"{% if field.readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
 {%- endmacro -%}
 
 {%- macro tags(field) -%}

--- a/lib/modules/apostrophe-users/index.js
+++ b/lib/modules/apostrophe-users/index.js
@@ -242,8 +242,21 @@ module.exports = {
     // For security, on **ANY** insert of a doc, we check to see if it is
     // an `apostrophe-user` and, if so, hash the password, remove it from the doc
     // and store the hash in the safe instead.
+    //
+    // This method also checks password rules if they are in force
+    // and local logins are enabled.
 
     self.docBeforeInsert = function(req, doc, options, callback) {
+      if (doc.type !== self.name) {
+        return setImmediate(callback);
+      }
+      if (self.apos.login.options.localLogin !== false) {
+        var errors = self.apos.login.checkPasswordRules(req, doc.password);
+        if (errors.length) {
+          req.errorMessages = errors;
+          return callback('rules');
+        }
+      }
       return self.insertOrUpdateSafe(req, doc, 'insert', callback);
     };
 
@@ -252,6 +265,19 @@ module.exports = {
     // and store the hash in the safe instead.
 
     self.docBeforeUpdate = function(req, doc, options, callback) {
+      if (doc.type !== self.name) {
+        return setImmediate(callback);
+      }
+      // For an update we are only concerned with the password rules if a
+      // new value is being set
+      if (((typeof doc.password) === 'string') && doc.password.length && self.apos.login.options.localLogin !== false) {
+        console.log('checking and password is: ^' + doc.password + '$');
+        var errors = self.apos.login.checkPasswordRules(req, doc.password);
+        if (errors.length) {
+          req.errorMessages = errors;
+          return callback('rules');
+        }
+      }
       return self.insertOrUpdateSafe(req, doc, 'update', callback);
     };
 

--- a/lib/modules/apostrophe-users/index.js
+++ b/lib/modules/apostrophe-users/index.js
@@ -271,7 +271,6 @@ module.exports = {
       // For an update we are only concerned with the password rules if a
       // new value is being set
       if (((typeof doc.password) === 'string') && doc.password.length && self.apos.login.options.localLogin !== false) {
-        console.log('checking and password is: ^' + doc.password + '$');
         var errors = self.apos.login.checkPasswordRules(req, doc.password);
         if (errors.length) {
           req.errorMessages = errors;

--- a/lib/modules/apostrophe-users/public/js/editor-modal.js
+++ b/lib/modules/apostrophe-users/public/js/editor-modal.js
@@ -77,9 +77,12 @@ apos.define('apostrophe-users-editor-modal', {
       });
     };
 
-    self.getErrorMessage = function(err) {
+    self.getErrorMessage = function(err, result) {
       if (err === 'unique') {
         return 'Please make sure the username and email address fields are unique.';
+      }
+      if (err === 'rules') {
+        return 'Invalid password: ' + result.messages.join(', ');
       }
       return 'An error occurred. Please try again.';
     };

--- a/lib/modules/apostrophe-users/public/js/editor-modal.js
+++ b/lib/modules/apostrophe-users/public/js/editor-modal.js
@@ -77,12 +77,21 @@ apos.define('apostrophe-users-editor-modal', {
       });
     };
 
-    self.getErrorMessage = function(err, result) {
+    var superDisplayError = self.displayError;
+    self.displayError = function(result) {
+      if (result.status === 'rules') {
+        var error = apos.schemas.error(_.find(self.schema, { name: 'password' }), 'rules');
+        error.message = result.messages.join(', ');
+        apos.schemas.showError(self.$form, error);
+        apos.schemas.scrollToError(self.$form);
+      } else {
+        return superDisplayError(result);
+      }
+    };
+ 
+    self.getErrorMessage = function(err) {
       if (err === 'unique') {
         return 'Please make sure the username and email address fields are unique.';
-      }
-      if (err === 'rules') {
-        return 'Invalid password: ' + result.messages.join(', ');
       }
       return 'An error occurred. Please try again.';
     };

--- a/lib/modules/apostrophe-users/public/js/editor-modal.js
+++ b/lib/modules/apostrophe-users/public/js/editor-modal.js
@@ -88,7 +88,7 @@ apos.define('apostrophe-users-editor-modal', {
         return superDisplayError(result);
       }
     };
- 
+
     self.getErrorMessage = function(err) {
       if (err === 'unique') {
         return 'Please make sure the username and email address fields are unique.';


### PR DESCRIPTION
`passwordMinLength`

The minimum length for passwords. You should set this, as there
is no default for bc reasons (effectively the default is `1`).

`passwordRules`

An optional array of password rule names, as strings. The standard rules
available are `noSlashes`, `noSpaces`, `mixedCase`, `digits`, and
`noTripleRepeats`. The `noTripleRepeats` rule forbids repeating a
character three times in a row. By default no rules are in effect.

When this option is set, the rules are consulted when a password
is set or reset. Existing passwords that do not follow the rules
are tolerated. If you wish to enforce them for existing passwords
as well, see below.

`passwordRulesAtLoginTime`

By default, password rules are enforced only when a password is 
being set or reset. If you wish, you can set `passwordRulesAtLoginTime: true`
to apply them at login time so that even an existing password will
not work unless it passes the rules. This can be useful if you don't
mind a few irritated users and you have the `passwordReset` option
properly configured (see below).
