### PR TITLE
you should be able to determine an attachment url in lean mode with a…

### DIFF
--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -1648,7 +1648,10 @@ module.exports = {
           // A unique identifier for the lifetime of this
           // HTML page in the browser
             htmlPageId: self.apos.utils.generateId()
-          } : {}
+          } : {},
+        {
+          uploadsUrl: self.apos.attachments.uploadfs.getUrl()
+        }
       );
       if (!req.user && (expressModule.options.csrf && expressModule.options.csrf.disableAnonSession)) {
         properties.csrfCookieName = false;

--- a/lib/modules/apostrophe-attachments/public/js/always.js
+++ b/lib/modules/apostrophe-attachments/public/js/always.js
@@ -2,6 +2,8 @@ apos.define('apostrophe-attachments', {
   extend: 'apostrophe-context',
   construct: function(self, options) {
 
+    self.uploadsUrl = options.uploadsUrl || '';
+
     // Given an attachment field value,
     // return the file URL. If options.size is set, return the URL for
     // that size (one-third, one-half, two-thirds, full). full is

--- a/lib/modules/apostrophe-attachments/public/js/user.js
+++ b/lib/modules/apostrophe-attachments/public/js/user.js
@@ -8,7 +8,6 @@ apos.define('apostrophe-attachments', {
   construct: function(self, options) {
     self.name = options.name;
     self.action = options.action;
-    self.uploadsUrl = options.uploadsUrl || '';
 
     // Invoke with an attachment, options (such as minSize), and a callback.
     // Callback receives (err, crop). If no err, crop has coordinates and

--- a/lib/modules/apostrophe-browser-utils/public/js/lean.js
+++ b/lib/modules/apostrophe-browser-utils/public/js/lean.js
@@ -346,6 +346,7 @@
     if (crop) {
       path += '.' + crop.left + '.' + crop.top + '.' + crop.width + '.' + crop.height;
     }
+    var effectiveSize;
     if ((!options.size) || (options.size === 'original')) {
       effectiveSize = false;
     } else {

--- a/lib/modules/apostrophe-browser-utils/public/js/lean.js
+++ b/lib/modules/apostrophe-browser-utils/public/js/lean.js
@@ -316,4 +316,45 @@
     });
   }
 
+  // Given an attachment field value,
+  // return the file URL. If options.size is set, return the URL for
+  // that size (one-sixth, one-third, one-half, two-thirds, full, max).
+  // full is "full width" (1140px), not the original.
+  //
+  // If you don't pass the options object, or options does not
+  // have a size property, you'll get the URL of the original.
+  // IMPORTANT: FOR IMAGES, THIS MAY BE A VERY LARGE FILE, NOT
+  // WHAT YOU WANT. Set `size` appropriately!
+  //
+  // You can also pass a crop object (the crop must already exist).
+
+  apos.utils.attachmentUrl = function(file, options) {
+    var path = apos.uploadsUrl + '/attachments/' + file._id + '-' + file.name;
+    if (!options) {
+      options = {};
+    }
+    // NOTE: the crop must actually exist already, you can't just invent them
+    // browser-side without the crop API ever having come into play. If the
+    // width is 0 the user hit save in the cropper without cropping, use
+    // the regular version
+    var crop;
+    if (options.crop && options.crop.width) {
+      crop = options.crop;
+    } else if (file.crop && file.crop.width) {
+      crop = file.crop;
+    }
+    if (crop) {
+      path += '.' + crop.left + '.' + crop.top + '.' + crop.width + '.' + crop.height;
+    }
+    if ((!options.size) || (options.size === 'original')) {
+      effectiveSize = false;
+    } else {
+      effectiveSize = options.size;
+    }
+    if (effectiveSize) {
+      path += '.' + effectiveSize;
+    }
+    return path + '.' + file.extension;
+  };
+
 })();


### PR DESCRIPTION
…pos.utils.attachmentUrl. Also fixed apos.attachments.url for the anon scene when lean is not in effect.