### PR TITLE
the "groups" option to apostrophe-users causes slow startups on very …

### DIFF
--- a/lib/modules/apostrophe-users/index.js
+++ b/lib/modules/apostrophe-users/index.js
@@ -11,10 +11,15 @@
 // There is also a simplified permissions model in which you just specify
 // an array of `groups` as an option to `apostrophe-users`, and a single-select
 // dropdown menu allows you to pick one and only one of those groups for each user.
-// The properties of each group in the array are `name`, `label` and
-// `permissions`, which is an array of permission names such as `guest`, `edit` and
-// `admin`. If you specify the `groups` option when configuring
-// `apostrophe-users`, the admin interface for `apostrophe-groups` will hide itself.
+// The recommended properties of each group in the array are `title`,
+// `slug`, and `permissions`, which is an array of permission names such as
+// `guest`, `edit` and `admin`. If you specify the `groups` option when
+// configuring `apostrophe-users`, the admin interface for
+// `apostrophe-groups` will hide itself. Specifying `slug` is optional,
+// however if your site has many documents there will be a startup time
+// penalty when specifying only `title` due to the lack of indexing
+// on that property. For most larger sites we recommend not using the
+// `groups` option at all; just manage groups via the admin bar.
 //
 // ### Public "staff directories" vs. users
 //
@@ -544,6 +549,8 @@ module.exports = {
 
       if (group._id) {
         criteria._id = group._id;
+      } else if (group.slug) {
+        criteria.slug = group.slug;
       } else {
         criteria.title = group.title;
       }


### PR DESCRIPTION
…large sites due to queries by title to find the groups. Add support for specifying a slug and, if that is present, querying by the slug instead for a fast startup.