### PR TITLE
expose res.rawRedirect

### DIFF
--- a/lib/modules/apostrophe-express/index.js
+++ b/lib/modules/apostrophe-express/index.js
@@ -254,9 +254,11 @@ module.exports = {
         // Use middleware to patch the redirect method to accommodate
         // the prefix. This is cleaner than patching the prototype, which
         // breaks if you have multiple instances of Apostrophe, such as
-        // in our unit tests. -Tom
+        // in our unit tests. Also make res.rawRedirect available for
+        // edge cases where a new URL is built from a URL that is
+        // already prefixed.
         self.apos.app.use(function(req, res, next) {
-          var superRedirect = res.redirect;
+          res.rawRedirect = res.redirect;
           res.redirect = function(status, url) {
             if (arguments.length === 1) {
               url = status;
@@ -265,7 +267,7 @@ module.exports = {
             if (!url.match(/^[a-zA-Z]+:/)) {
               url = self.apos.prefix + url;
             }
-            return superRedirect.call(this, status, url);
+            return res.rawRedirect.call(res, status, url);
           };
           return next();
         });


### PR DESCRIPTION
Provide access to the original version of res.redirect, which does not automatically add the sitewide URL prefix. This is needed if you are building a URL to redirect to starting with a `_url` property, which will already contain the prefix. See:

https://github.com/apostrophecms/apostrophe-workflow/issues/268