### PR TITLE
Only add footer height to modal if footer is present

### DIFF
--- a/lib/modules/apostrophe-modal/public/js/modal.js
+++ b/lib/modules/apostrophe-modal/public/js/modal.js
@@ -549,7 +549,7 @@ apos.define('apostrophe-modal', {
       var breadcrumbHeight = $container.find('.apos-modal-breadcrumb').outerHeight() || 0;
       var footerHeight = $container.find('.apos-modal-footer').outerHeight() || 0;
 
-      var contentHeight = 'calc(100vh - 50px - ' + (headerHeight + breadcrumbHeight) + 'px)';
+      var contentHeight = 'calc(100vh - ' + footerHeight + 'px - ' + (headerHeight + breadcrumbHeight) + 'px)';
 
       // Set height on .apos-modal-content.
       // Check if self.$el is a sliding .apos-modal-content or modal wrapper


### PR DESCRIPTION
Previously this method would always undersize the modal by 50px. I believe 50px was a stand-in for footerHeight, so this commit replaces the hardcoded value with the calculated footer height. In my testing, this change does work to:
* Size the window appropriately if there is a footer present in the modal
* Size the window to leave no space for the footer if no footer is present