### PR TITLE
Centered .apos-login-content relative block, fixed #2081

### DIFF
--- a/lib/modules/apostrophe-login/public/css/always.less
+++ b/lib/modules/apostrophe-login/public/css/always.less
@@ -10,9 +10,10 @@
   background-color: @apos-primary;
   position: relative;
   top: @apos-margin-5;
-  left: 50%;
-  -webkit-transform: translateX(-50%);
-          transform: translateX(-50%);
+  left: 0;
+  right: 0;
+  margin-left: auto;
+  margin-right: auto;
 }
 .apos-login-logo
 {


### PR DESCRIPTION
translateX(-50%) was causing horizontal scroll in edge, centered .apos-login-content block in a way that doesn't create horizontal scroll in edge.
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/13475965/