### PR TITLE
aspect ratio support for direct attachment properties in a doc schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.100.2 (2019-12-02)
+
+* The `aspectRatio` option to the `attachments` schema field type is now fully implemented. We always had this for selecting images, e.g. in our `apostrophe-images-widgets` module, but it is now also available when directly using an `attachment` schema field as a property of your own doc. You can also set `crop: true` to allow manual cropping in that case. This is a useful technique when including the image in a reusable media library does not make sense.
+
 ## 2.100.1 (2019-11-21)
 
 * Must confirm when resetting password, since there are no do-overs if we do not have the email confirmation method available (with `resetLegacyPassword: true`) and since it's generally a pain not to have this.

--- a/lib/modules/apostrophe-attachments/public/js/user.js
+++ b/lib/modules/apostrophe-attachments/public/js/user.js
@@ -184,7 +184,7 @@ apos.define('apostrophe-attachments', {
         return;
       }
       data[name] = $fieldset.find('[data-existing]').data('existing');
-      if (field.crop && (!data[name].crop) && field.aspectRatio) {  
+      if (field.crop && (!data[name].crop) && field.aspectRatio) {
         return self.autocrop(field, data[name], function(err) {
           if (err) {
             return callback(err);

--- a/lib/modules/apostrophe-attachments/public/js/user.js
+++ b/lib/modules/apostrophe-attachments/public/js/user.js
@@ -184,10 +184,60 @@ apos.define('apostrophe-attachments', {
         return;
       }
       data[name] = $fieldset.find('[data-existing]').data('existing');
-      if (field.required && (!data[name])) {
-        return setImmediate(_.partial(callback, 'required'));
+      if (field.crop && (!data[name].crop) && field.aspectRatio) {  
+        return self.autocrop(field, data[name], function(err) {
+          if (err) {
+            return callback(err);
+          }
+          return finish();
+        });
+      } else {
+        return finish();
       }
-      return setImmediate(callback);
+      function finish() {
+        if (field.required && (!data[name])) {
+          return setImmediate(_.partial(callback, 'required'));
+        }
+        return setImmediate(callback);
+      }
+    };
+
+    self.autocrop = function(field, attachment, callback) {
+      var aspectRatio = field.aspectRatio;
+      if (!aspectRatio) {
+        return callback(null);
+      }
+      aspectRatio = aspectRatio[0] / aspectRatio[1];
+      var width = attachment.width;
+      var height = attachment.width / aspectRatio;
+      var left = 0;
+      var top = (attachment.height - height) / 2;
+      if (height > attachment.height) {
+        width = attachment.height * aspectRatio;
+        height = attachment.height;
+        left = (attachment.width - width) / 2;
+        top = 0;
+      }
+      return apos.attachments.api(
+        'crop',
+        {
+          _id: attachment._id,
+          crop: { top: top, left: left, width: width, height: height }
+        },
+        function(data) {
+          if (data.status !== 'ok') {
+            apos.notify('An error occurred while cropping.', { type: 'error', dismiss: true });
+            return callback('fail');
+          }
+          attachment.crop = {
+            top: top,
+            left: left,
+            width: width,
+            height: height
+          };
+          return callback(null);
+        }
+      );
     };
 
     self.addHandlers = function() {
@@ -197,11 +247,10 @@ apos.define('apostrophe-attachments', {
         var attachment = $existing.data('existing');
         var field = $existing.data('field');
         var $fieldset = $el.closest('[data-name]');
-        // TODO what about minSize, etc. in this context?
         var options = {};
-        options.focalPoint = (field.hints && field.hints.focalPoint);
-        options.minSize = (field.hints && field.hints.minSize);
-        options.aspectRatio = (field.hints && field.hints.aspectRatio);
+        options.focalPoint = field.focalPoint || (field.hints && field.hints.focalPoint);
+        options.minSize = field.minSize || (field.hints && field.hints.minSize);
+        options.aspectRatio = field.aspectRatio || (field.hints && field.hints.aspectRatio);
         self.crop(attachment, options, function(err, crop) {
           if (!err) {
             attachment.crop = crop;
@@ -209,6 +258,7 @@ apos.define('apostrophe-attachments', {
           }
         });
       });
+
       apos.ui.link('apos-focal-point', 'attachment', function($el, _id) {
         var $existing = $el.closest('[data-existing]');
 
@@ -216,7 +266,7 @@ apos.define('apostrophe-attachments', {
         var field = $existing.data('field');
         var $fieldset = $el.closest('[data-name]');
         var options = {};
-        options.focalPoint = (field.hints && field.hints.focalPoint);
+        options.focalPoint = field.focalPoint || (field.hints && field.hints.focalPoint);
         self.focalPoint(attachment, options, function(err, focalPoint) {
           if (!err) {
             attachment.focalPoint = focalPoint;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "2.100.1",
+  "version": "2.100.2",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Attachments can be direct properties of any doc type, not just images or files. And we use this feature, but we have mostly used it for PDFs and the like. Now I want to use it for an image in apostrophe-global to better implement apostrophe-favicons 3.x, and I run into the fact that we never fleshed out support for the aspectRatio option at the attachment level. Introduce support for this, as well as the necessary autocropping if the user doesn't manually crop (this is not new UX, it's taken directly from how we handle it when choosing images if the aspect ratio does not match and the user does not crop).