### PR TITLE
adding eps file type

### DIFF
--- a/lib/modules/apostrophe-attachments/index.js
+++ b/lib/modules/apostrophe-attachments/index.js
@@ -174,7 +174,7 @@ module.exports = {
       {
         name: 'office',
         label: 'Office',
-        extensions: [ 'txt', 'rtf', 'pdf', 'xls', 'ppt', 'doc', 'pptx', 'sldx', 'ppsx', 'potx', 'xlsx', 'xltx', 'csv', 'docx', 'dotx' ],
+        extensions: [ 'txt', 'rtf', 'pdf', 'eps', 'xls', 'ppt', 'doc', 'pptx', 'sldx', 'ppsx', 'potx', 'xlsx', 'xltx', 'csv', 'docx', 'dotx' ],
         extensionMaps: {},
         // uploadfs should just accept this file as-is
         image: false


### PR DESCRIPTION
Making this request per the instruction of @boutell to enable EPS files as a valid file attachment for `apostrophe-attachments`.