### PR TITLE
the second argument to apostrophe "find" now becomes a parameter to p…

### DIFF
--- a/lib/modules/apostrophe-docs/lib/cursor.js
+++ b/lib/modules/apostrophe-docs/lib/cursor.js
@@ -1280,7 +1280,10 @@ module.exports = {
     // so it must be provided
 
     self.lowLevelMongoCursor = function(req, criteria, projection, options) {
-      var mongo = self.db.findWithProjection(criteria, projection);
+      var mongo = self.db.find(criteria);
+      if (projection) {
+        mongo.project(projection);
+      }
       if (_.isNumber(options.skip)) {
         mongo.skip(options.skip);
       }


### PR DESCRIPTION
…roject() in actual mongodb, which is safer, because in the 2.x mongodb driver the second parameter behaves completely differently if there is a "fields" property [eyeroll]

Closes #2093 