### PR TITLE
schema field: property permission and readOnly also accept a callback

### DIFF
--- a/lib/modules/apostrophe-doc-type-manager/lib/api.js
+++ b/lib/modules/apostrophe-doc-type-manager/lib/api.js
@@ -254,6 +254,7 @@ module.exports = function(self, options) {
       return (!field.permission) || self.apos.permissions.can(req, field.permission);
     });
     schema = schema.map(function(field) {
+      field = _.cloneDeep(field);
       if (_.isFunction(field.readOnly)) {
         field.readOnly = !!(field.readOnly(self, req, field));
       }

--- a/lib/modules/apostrophe-doc-type-manager/lib/api.js
+++ b/lib/modules/apostrophe-doc-type-manager/lib/api.js
@@ -258,7 +258,7 @@ module.exports = function(self, options) {
         field.readOnly = !!(field.readOnly(req, field));
       }
       return field;
-    });    
+    });
     var typeIndex = _.findIndex(schema, { name: 'type' });
     if (typeIndex !== -1) {
       // This option exists so that the

--- a/lib/modules/apostrophe-doc-type-manager/lib/api.js
+++ b/lib/modules/apostrophe-doc-type-manager/lib/api.js
@@ -253,17 +253,17 @@ module.exports = function(self, options) {
     });
     
     var schema = _.filter(self.schema, function(field) {
-        if (_.isFunction(field.permission)) {
-            return !!(field.permission(req, field))
-        }
-        return (!field.permission) || self.apos.permissions.can(req, field.permission);
+      if (_.isFunction(field.permission)) {
+        return !!(field.permission(req, field));
+      }
+      return (!field.permission) || self.apos.permissions.can(req, field.permission);
     });
 
     schema = schema.map(function(field) {
-        if (_.isFunction(field.readOnly)) {
-            field.readOnly = !!(field.readOnly(req, field))
-        }
-        return field;
+      if (_.isFunction(field.readOnly)) {
+        field.readOnly = !!(field.readOnly(req, field));
+      }
+      return field;
     })
     
     var typeIndex = _.findIndex(schema, { name: 'type' });

--- a/lib/modules/apostrophe-doc-type-manager/lib/api.js
+++ b/lib/modules/apostrophe-doc-type-manager/lib/api.js
@@ -247,25 +247,18 @@ module.exports = function(self, options) {
   self.allowedSchema = function(req) {
     var disabled;
     var type;
-    
-    var schema = _.filter(self.schema, function(field) {
-      return (!field.permission) || self.apos.permissions.can(req, field.permission);
-    });
-    
     var schema = _.filter(self.schema, function(field) {
       if (_.isFunction(field.permission)) {
         return !!(field.permission(req, field));
       }
       return (!field.permission) || self.apos.permissions.can(req, field.permission);
     });
-
     schema = schema.map(function(field) {
       if (_.isFunction(field.readOnly)) {
         field.readOnly = !!(field.readOnly(req, field));
       }
       return field;
-    })
-    
+    });    
     var typeIndex = _.findIndex(schema, { name: 'type' });
     if (typeIndex !== -1) {
       // This option exists so that the

--- a/lib/modules/apostrophe-doc-type-manager/lib/api.js
+++ b/lib/modules/apostrophe-doc-type-manager/lib/api.js
@@ -249,13 +249,13 @@ module.exports = function(self, options) {
     var type;
     var schema = _.filter(self.schema, function(field) {
       if (_.isFunction(field.permission)) {
-        return !!(field.permission(self,req, field));
+        return !!(field.permission(self, req, field));
       }
       return (!field.permission) || self.apos.permissions.can(req, field.permission);
     });
     schema = schema.map(function(field) {
       if (_.isFunction(field.readOnly)) {
-        field.readOnly = !!(field.readOnly(self,req, field));
+        field.readOnly = !!(field.readOnly(self, req, field));
       }
       return field;
     });

--- a/lib/modules/apostrophe-doc-type-manager/lib/api.js
+++ b/lib/modules/apostrophe-doc-type-manager/lib/api.js
@@ -249,13 +249,13 @@ module.exports = function(self, options) {
     var type;
     var schema = _.filter(self.schema, function(field) {
       if (_.isFunction(field.permission)) {
-        return !!(field.permission(req, field));
+        return !!(field.permission(self,req, field));
       }
       return (!field.permission) || self.apos.permissions.can(req, field.permission);
     });
     schema = schema.map(function(field) {
       if (_.isFunction(field.readOnly)) {
-        field.readOnly = !!(field.readOnly(req, field));
+        field.readOnly = !!(field.readOnly(self,req, field));
       }
       return field;
     });

--- a/lib/modules/apostrophe-doc-type-manager/lib/api.js
+++ b/lib/modules/apostrophe-doc-type-manager/lib/api.js
@@ -242,13 +242,30 @@ module.exports = function(self, options) {
   // Return a new schema containing only fields for which the
   // current user has the permission specified by the `permission`
   // property of the schema field, or there is no `permission` property for the field.
+  // property permission and readOnly also accept a callback
 
   self.allowedSchema = function(req) {
     var disabled;
     var type;
+    
     var schema = _.filter(self.schema, function(field) {
       return (!field.permission) || self.apos.permissions.can(req, field.permission);
     });
+    
+    var schema = _.filter(self.schema, function(field) {
+        if (_.isFunction(field.permission)) {
+            return !!(field.permission(req, field))
+        }
+        return (!field.permission) || self.apos.permissions.can(req, field.permission);
+    });
+
+    schema = schema.map(function(field) {
+        if (_.isFunction(field.readOnly)) {
+            field.readOnly = !!(field.readOnly(req, field))
+        }
+        return field;
+    })
+    
     var typeIndex = _.findIndex(schema, { name: 'type' });
     if (typeIndex !== -1) {
       // This option exists so that the


### PR DESCRIPTION
added the possibility to use callbacks in the value of the permission and readOnly fields.