### PR TITLE
Prevent partial deletes of pages

### DIFF
--- a/lib/modules/apostrophe-docs/lib/routes.js
+++ b/lib/modules/apostrophe-docs/lib/routes.js
@@ -62,7 +62,38 @@ module.exports = function(self, options) {
         var hint = req.__('The slug you want to use is currently claimed by the %s %s. Do you want to edit that document in order to change its slug?', req.__(label), doc.title);
         return next('taken', null, { doc: doc, hint: hint });
       } else {
-        return next(null);
+        if (req.body.workflowLocale) {
+          // check the live mode as well to make sure no page with same slug exists
+          return self.find(req, criteria).workflowLocale(req.body.workflowLocale).permission(false).trash(null).published(null).projection({ _url: 1, title: 1, workflowGuid: 1 }).toObject().then(function(doc) {
+            /*
+             * If a doc exits in the live mode then find the respective draft mode version.
+             * Since the slug has been de-duplicated, we are using the workflowGuid
+             * to find the doc.
+            */
+            if (doc) {
+              criteria = {};
+              criteria.workflowGuid = doc.workflowGuid;
+              return self.find(req, criteria).permission(false).trash(null).published(null).projection({ _url: 1, title: 1 }).toObject().then(function(doc) {
+                if (doc) {
+                  var pageType = _.find(self.apos.pages.options.types, { name: doc.type });
+                  var label = (pageType && pageType.label) || self.apos.docs.getManager(doc.type).options.label || doc.type;
+                  var hint = req.__('The slug you want to use is already being used by %s %s in live mode, i.e., someone has deleted that page but didn\'t commit the changes. Please commit those changes before re-using the slug or contact admin \n\nworkflow --> commit', req.__(label), doc.title);
+                  return next('taken', null, { doc: doc, hint: hint });
+                } else {
+                  return next(null);
+                }
+              }).catch(function(err) {
+                return next(err);
+              });
+            } else {
+              return next(null);
+            }
+          }).catch(function(err) {
+            return next(err);
+          });
+        } else {
+          return next(null);
+        }
       }
     }).catch(function(err) {
       return next(err);

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -1207,6 +1207,17 @@ apos.define('apostrophe-schemas', {
       populate: populateString,
       convert: function(data, name, $field, $el, field, callback) {
         return convertString(data, name, $field, $el, field, function(err) {
+          var workflowLocale;
+          var docType = $('.apos-modal-title').text().trim().toLowerCase();
+          /*
+           * Only if the created document is a page, we set the workflowLocale variable
+           * which ensures that no page with same slug is present in the live mode as well,
+           * to prevent discripensies such as addition of a random number to the slug when
+           * the page is commited in the future.
+          */
+          if (apos.workflow && docType === 'new page') {
+            workflowLocale = apos.workflow.liveLocale;
+          }
           if (field.prefix) {
             if (data[name].length && (data[name].substring(0, field.prefix.length) !== field.prefix)) {
               var error = self.error(field, 'prefix');
@@ -1224,7 +1235,7 @@ apos.define('apostrophe-schemas', {
           }
           $.jsonCall(
             apos.docs.options.action + '/slug-taken',
-            { slug: data[name], _id: data._id },
+            { slug: data[name], _id: data._id, workflowLocale },
             function(data) {
               if (data.status === 'ok') {
                 return callback(null);


### PR DESCRIPTION
#1985 

_Problem statement_ :
    While creating a new page we only check the draft mode documents to make sure there's no other page with the same slug. In this scenario if user has done a partial delete (i.e., Consider a user has deleted a page which de-duplicates the slug in draft mode and did not commit those changes, which means the slug is still being used by another page in live mode) then we would be able to create a new page with the same slug in draft mode but when we commit to the live mode the slug gets an random number attached to it to maintain the uniqueness of the slug field.

_Explanation_ : 
     

- consider a page with slug "**/sample-page**"
- **User A** has deleted the page but did not commit the changes, which means the document in the draft mode would have a slug similar to "**sample-page-de-duplicate12232434**".
- Now another user **User B** would like to create a new page with the same slug "**/sample-page**", and during the page creation slug is checked against all the other slugs in draft mode to make sure no other page is currently using them. Since the slug property has to be unique.
- This checks lets him create a new page with that slug since no other page in draft mode is having a page with the slug "**/sample-page**". And that user would be allowed to customise the page according to his need.
- Once the editing of the document is done, **User B** will try to commit the page and make it live. But in the live mode there exists a page with the same slug, hence to maintain the uniqueness the apostrophe adds a random number at the end of the slug. So the slug would now look like "**/sample-page9**" in the live mode. 
- This was not the url expected. And now the user would have contact the admin to change the slug manually and even after editing it there is an unnecessary entry of the slug into the "Historic-urls" array.

_Solution_:

To prevent this scenario I have modified the "**slug-taken**" api slightly to check the live documents as well while creating a new page. Thus prompting the user to commit the changes before actually **re-using** a slug after the delete operation.


