### PR TITLE
WIP: replace synchronous save on beforeunload with a warning and a subsequ…

### DIFF
--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -755,6 +755,7 @@ apos.define('apostrophe-areas-editor', {
       if (!request) {
         return callback && callback(null);
       }
+      apos.areas.markUnsaved();
       $.jsonCall(
         self.options.action + '/save-area',
         {

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -703,9 +703,13 @@ apos.define('apostrophe-areas-editor', {
     // of the returned object, if and only if it succeeds
     // in actually saving the data. This ensures that
     // retries are made automatically in the event
-    // of network errors.
+    // of network errors. `self.previousData` is
+    // updated as the basis of comparison next time,
+    // unless `options.updatePreviousData` is explicitly `false`.
+    // `options` may be entirely omitted.
 
-    self.prepareAutosaveRequest = function() {
+    self.prepareAutosaveRequest = function(options) {
+      options = options || {};
       if (!self.autosaving) {
         // This area does not autosave
         // (it does not invoke the save-area route)
@@ -723,7 +727,9 @@ apos.define('apostrophe-areas-editor', {
       if (_.isEqual(items, self.previousData)) {
         return null;
       }
-      self.previousData = items;
+      if (options.updatePreviousData !== false) {
+        self.previousData = items;
+      }
       return {
         docId: self.$el.attr('data-doc-id'),
         dotPath: self.$el.attr('data-dot-path'),
@@ -734,8 +740,7 @@ apos.define('apostrophe-areas-editor', {
 
     // If the area editor believes its content has changed, send it to the
     // save-area route. If `sync` is true, make a synchronous AJAX call
-    // (for bc only; we now use the saveAllIfNeededAndUnlock method of
-    // the areas module singleton for faster synchronous saves on page unload).
+    // (supported for bc only, we use a beforeUnload warning now).
     //
     // `callback` is optional and is invoked when the work is complete,
     // or immediately if there is no work to do.
@@ -757,6 +762,7 @@ apos.define('apostrophe-areas-editor', {
         },
         request,
         function(result) {
+          apos.areas.markSavedIfReady();
           if (result.status !== 'ok') {
             if ((result.status === 'locked') || (result.status === 'locked-by-me')) {
               // apos.notify unsuitable because this is quite modal.

--- a/lib/modules/apostrophe-areas/public/js/user.js
+++ b/lib/modules/apostrophe-areas/public/js/user.js
@@ -328,6 +328,8 @@ apos.define('apostrophe-areas', {
     //
     // Both the sync flag and the callback may be
     // omitted entirely. The default is asynchronous.
+    // The sync flag is supported for bc only, we use
+    // a beforeUnload warning now.
     //
     // This method is ideal in situations where
     // you wish to be sure everything has been saved
@@ -347,6 +349,10 @@ apos.define('apostrophe-areas', {
       });
     };
 
+    // For bc only, we use an onBeforeUnload warning now as
+    // most browsers now refuse to do sync API calls in
+    // onBeforeUnload.
+    //
     // Similar to `saveAllIfNeeded`, this method is
     // invoked on a `beforeunload` event, when the user
     // navigates away or closes the tab. However this method
@@ -380,11 +386,49 @@ apos.define('apostrophe-areas', {
 
     self.enableUnload = function() {
       $(window).on('beforeunload', function() {
-        // If there are outstanding changes when the user leaves the page,
-        // attempt a synchronous save operation so we have a chance to complete
-        // before leaving
-        self.saveAllIfNeededAndUnlock();
+        var editors = self.getEditors();
+        var requests = [];
+        _.each(editors, function(editor) {
+          var request = editor.prepareAutosaveRequest({
+            updatePreviousData: false
+          });
+          if (request) {
+            requests.push(request);
+          }
+        });
+        if (requests.length) {
+          self.markUnsaved();
+          // Not shown in all but IE, an appropriate browser specific
+          // message appears instead, but we must set it
+          return 'You may have unsaved changes. Are you sure?';
+        }
       });
+    };
+
+    self.markUnsaved = function() {
+      if (!$('.apos-unsaved').length) {
+        $('.apos-context-menu-container').append('<span class="apos-unsaved"></span>');
+      }
+    };
+
+    self.markSavedIfReady = function() {
+      // If there are now zero areas requiring a save operation, we
+      // can remove the apos-unsaved class
+      if ($('.apos-unsaved').length) {
+        var editors = self.getEditors();
+        var requests = [];
+        _.each(editors, function(editor) {
+          var request = editor.prepareAutosaveRequest({
+            updatePreviousData: false
+          });
+          if (request) {
+            requests.push(request);
+          }
+        });
+        if (!requests.length) {
+          $('.apos-unsaved').remove();
+        }
+      }
     };
 
     apos.areas = self;

--- a/lib/modules/apostrophe-areas/public/js/user.js
+++ b/lib/modules/apostrophe-areas/public/js/user.js
@@ -407,7 +407,7 @@ apos.define('apostrophe-areas', {
 
     self.markUnsaved = function() {
       if (!$('.apos-unsaved').length) {
-        $('.apos-context-menu-container').append('<span class="apos-unsaved"></span>');
+        $('.apos-context-menu-container').append('<span class="apos-button apos-unsaved">Saving...</span>');
       }
     };
 
@@ -426,7 +426,12 @@ apos.define('apostrophe-areas', {
           }
         });
         if (!requests.length) {
-          $('.apos-unsaved').remove();
+          $('.apos-unsaved')
+            .addClass('apos-unsaved--complete')
+            .text('Saved!');
+          setTimeout(function() {
+            $('.apos-unsaved').fadeOut();
+          }, 800);
         }
       }
     };

--- a/lib/modules/apostrophe-areas/public/js/user.js
+++ b/lib/modules/apostrophe-areas/public/js/user.js
@@ -430,7 +430,9 @@ apos.define('apostrophe-areas', {
             .addClass('apos-unsaved--complete')
             .text('Saved!');
           setTimeout(function() {
-            $('.apos-unsaved').fadeOut();
+            $('.apos-unsaved').fadeOut(function() {
+              $('.apos-unsaved').remove();
+            });
           }, 800);
         }
       }

--- a/lib/modules/apostrophe-docs/index.js
+++ b/lib/modules/apostrophe-docs/index.js
@@ -39,16 +39,14 @@
 // being edited so that another user, or another tab for the same user,
 // does not inadvertently interfere. These locks are refreshed frequently
 // by the browser while they are held. By default, if the browser
-// is not heard from for 300 seconds, the lock expires. Note that
-// the browser refreshes the lock every 5 seconds. It would not make
-// sense to set this option lower than about 60 seconds to allow for
-// changing Internet conditions. Setting this option too high leads
-// to annoyance if the browser chooses not to deliver an unlock request
-// when a page is closed.
+// is not heard from for 30 seconds, the lock expires. Note that
+// the browser refreshes the lock every 5 seconds. This timeout should
+// be quite short as there is no longer any reliable way to force a browser
+// to unlock the document when leaving the page.
 
 module.exports = {
 
-  advisoryLockTimeout: 300,
+  advisoryLockTimeout: 30,
 
   alias: 'docs',
 

--- a/lib/modules/apostrophe-ui/public/css/components/admin-bar.less
+++ b/lib/modules/apostrophe-ui/public/css/components/admin-bar.less
@@ -46,7 +46,7 @@
       max-width: 36px;
     }
   }
-
+  
 }
 
 .apos-admin-bar-items

--- a/lib/modules/apostrophe-ui/public/css/components/context-menu.less
+++ b/lib/modules/apostrophe-ui/public/css/components/context-menu.less
@@ -24,4 +24,9 @@
     // also note we need this to pass functional tests
     display: none;
   }
+  .apos-unsaved::after {
+    content: 'Saving...';
+    .apos-button;
+    margin-left: @apos-padding-1;
+  }
 }

--- a/lib/modules/apostrophe-ui/public/css/components/context-menu.less
+++ b/lib/modules/apostrophe-ui/public/css/components/context-menu.less
@@ -24,9 +24,11 @@
     // also note we need this to pass functional tests
     display: none;
   }
-  .apos-unsaved::after {
-    content: 'Saving...';
-    .apos-button;
+  .apos-unsaved {
     margin-left: @apos-padding-1;
+    &:hover, &:focus {
+      cursor: initial;
+      box-shadow: none;
+    }
   }
 }


### PR DESCRIPTION
…ent indicator display until save is complete

Our existing "save when closing the page" mechanism does not work in most non-Chrome browsers anymore, and it is not reliable in Chrome. This is because all browsers are deprecating or ignoring attempts to make synchronous HTTP requests during beforeunload events.

This is a major concern for an enterprise client.

The resolution is to use a beforeunload prompt instead. These are still fully supported, although the actual text you return is not displayed in any modern browser (instead, you get a standardized prompt, which is fine).

That much is simple. However, after the prompt appears, the user needs some indication of whether enough time has passed to save the content and they can close the page.

As a WIP, I resolved this with a simple "Saving..." fake button in the context menu.

I put it down there because that is always on the screen. The admin bar and logo are not always on the screen so I am concerned that they are inappropriate if you are typing halfway down a long page, but I defer to you on the UX decision there.

Note that this "Saving..." indicator only appears if you try to leave to leave the page *and* there are unsaved changes (type a bunch and quickly try to close the tab). Of course it would be great to have "saving..." indicators all the time as well as a "saved" indicator that disappears when you start to type. However, that is much more technically ambitious for several reasons, so I would prefer to save it for 3.x.

You will note that "Saving..." usually only appears for a moment. That's because considerable time passes while you are looking at the prompt, and the next save operation arrives within five seconds, which may have already elapsed by the time you hit "cancel" to permit execution to continue in this way.