### PR TITLE
enable attachment to be non-required

### DIFF
--- a/lib/modules/apostrophe-attachments/public/js/user.js
+++ b/lib/modules/apostrophe-attachments/public/js/user.js
@@ -184,7 +184,7 @@ apos.define('apostrophe-attachments', {
         return;
       }
       data[name] = $fieldset.find('[data-existing]').data('existing');
-      if ((!data[name].crop) && field.aspectRatio) {
+      if (data[name] && (!data[name].crop) && field.aspectRatio) {
         return self.autocrop(field, data[name], function(err) {
           if (err) {
             return callback(err);


### PR DESCRIPTION
I stumbled upon an error with schemas having an optional attachment. If I had no attachment, there was an error in the browser console saying "cannot read crop of undefined in user.js". I figured out it might be due to recent changes in this file.

If the attachment is null, the error was triggered. So, here is a fix to not enter in the `if` condition where no attachement added by the user in the apostrophe modal of a piece.