### PR TITLE
Fixes urls for documentation

### DIFF
--- a/lib/modules/apostrophe-widgets/index.js
+++ b/lib/modules/apostrophe-widgets/index.js
@@ -102,7 +102,7 @@
 // were passed to the widget.
 //
 // For example, here is the `public/js/always.js` file for the
-// [apostrophe-video-widgets](../apostrophe-video-widgets/README.md) module:
+// [apostrophe-video-widgets](/modules/apostrophe-video-widgets) module:
 //
 // ```javascript
 // apos.define('apostrophe-video-widgets', {

--- a/lib/modules/apostrophe-widgets/index.js
+++ b/lib/modules/apostrophe-widgets/index.js
@@ -3,7 +3,7 @@
 // [apostrophe-pieces-widgets](/modules/apostrophe-pieces-widgets/) and
 // [apostrophe-video-widgets](/modules/apostrophe-video-widgets/).
 //
-// All widgets have a [schema](../../tutorials/getting-started/schema-guide.html).
+// All widgets have a [schema](/tutorials/schema-guide/schema-guide.md).
 // Many project-specific modules that extend this module consist entirely of an
 // `addFields` option and a `views/widget.html` file.
 //
@@ -102,7 +102,7 @@
 // were passed to the widget.
 //
 // For example, here is the `public/js/always.js` file for the
-// [apostrophe-video-widgets](../apostrophe-video-widgets/index.html) module:
+// [apostrophe-video-widgets](../apostrophe-video-widgets/README.md) module:
 //
 // ```javascript
 // apos.define('apostrophe-video-widgets', {


### PR DESCRIPTION
Changing these here to not be overwritten in documentation when generated as done here: https://github.com/apostrophecms/apostrophe-documentation/pull/216.