### PR TITLE
bug fix: "def" was never meant to forbid clearing the value. That is …

### DIFF
--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -1670,7 +1670,7 @@ module.exports = {
       name: 'integer',
       converters: {
         string: function(req, data, name, object, field, callback) {
-          object[name] = self.apos.launder.integer(data[name], null, field.min, field.max);
+          object[name] = self.apos.launder.integer(data[name], undefined, field.min, field.max);
           if (field.required && ((data[name] == null) || !data[name].toString().length)) {
             return callback('required');
           }
@@ -1717,7 +1717,7 @@ module.exports = {
       name: 'float',
       converters: {
         string: function(req, data, name, object, field, callback) {
-          object[name] = self.apos.launder.float(data[name], null, field.min, field.max);
+          object[name] = self.apos.launder.float(data[name], undefined, field.min, field.max);
           if (field.required && ((data[name] == null) || !data[name].toString().length)) {
             return callback('required');
           }
@@ -1758,7 +1758,7 @@ module.exports = {
       name: 'email',
       converters: {
         string: function (req, data, name, object, field, callback) {
-          data[name] = self.apos.launder.string(data[name], null, field.min, field.max);
+          data[name] = self.apos.launder.string(data[name], undefined, field.min, field.max);
 
           if (!data[name].length) {
             if (field.required) {
@@ -1801,7 +1801,7 @@ module.exports = {
       name: 'range',
       converters: {
         string: function (req, data, name, object, field, callback) {
-          object[name] = self.apos.launder.float(data[name], null, field.min, field.max);
+          object[name] = self.apos.launder.float(data[name], undefined, field.min, field.max);
           return setImmediate(callback);
         },
         form: 'string'

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -1122,7 +1122,7 @@ module.exports = {
       name: 'string',
       converters: {
         string: function(req, data, name, object, field, callback) {
-          object[name] = self.apos.launder.string(data[name], field.def);
+          object[name] = self.apos.launder.string(data[name]);
           if (object[name] && field.min && (object[name].length < field.min)) {
             // Would be unpleasant, but shouldn't happen since the browser
             // also implements this. We're just checking for naughty scripts
@@ -1188,7 +1188,7 @@ module.exports = {
           if (field.page) {
             options.allow = '/';
           }
-          object[name] = self.apos.utils.slugify(self.apos.launder.string(data[name], field.def), options);
+          object[name] = self.apos.utils.slugify(self.apos.launder.string(data[name]), options);
           if (field.page) {
             if (!(object[name].charAt(0) === '/')) {
               object[name] = '/' + object[name];
@@ -1312,7 +1312,7 @@ module.exports = {
       name: 'boolean',
       converters: {
         string: function(req, data, name, object, field, callback) {
-          object[name] = self.apos.launder.boolean(data[name], field.def);
+          object[name] = self.apos.launder.boolean(data[name]);
           if (field.mandatory && object[name] === false) {
             return callback('mandatory');
           }
@@ -1550,9 +1550,7 @@ module.exports = {
           var results = {};
           _.each(field.rows, function(row) {
             if (_.has(submission, row.name)) {
-              results[row.name] = self.apos.launder.select(submission[row.name], field.choices, field.def);
-            } else {
-              results[row.name] = field.def;
+              results[row.name] = self.apos.launder.select(submission[row.name], field.choices);
             }
           });
 
@@ -1575,7 +1573,7 @@ module.exports = {
               return field.choices;
             }
           }).then(function(choices) {
-            object[name] = self.apos.launder.select(data[name], choices, field.def);
+            object[name] = self.apos.launder.select(data[name], choices);
             return setImmediate(callback);
           }).catch(callback);
         },
@@ -1672,7 +1670,7 @@ module.exports = {
       name: 'integer',
       converters: {
         string: function(req, data, name, object, field, callback) {
-          object[name] = self.apos.launder.integer(data[name], field.def, field.min, field.max);
+          object[name] = self.apos.launder.integer(data[name], null, field.min, field.max);
           if (field.required && ((data[name] == null) || !data[name].toString().length)) {
             return callback('required');
           }
@@ -1719,7 +1717,7 @@ module.exports = {
       name: 'float',
       converters: {
         string: function(req, data, name, object, field, callback) {
-          object[name] = self.apos.launder.float(data[name], field.def, field.min, field.max);
+          object[name] = self.apos.launder.float(data[name], null, field.min, field.max);
           if (field.required && ((data[name] == null) || !data[name].toString().length)) {
             return callback('required');
           }
@@ -1760,7 +1758,7 @@ module.exports = {
       name: 'email',
       converters: {
         string: function (req, data, name, object, field, callback) {
-          data[name] = self.apos.launder.string(data[name], field.def, field.min, field.max);
+          data[name] = self.apos.launder.string(data[name], null, field.min, field.max);
 
           if (!data[name].length) {
             if (field.required) {
@@ -1803,7 +1801,7 @@ module.exports = {
       name: 'range',
       converters: {
         string: function (req, data, name, object, field, callback) {
-          object[name] = self.apos.launder.float(data[name], field.def, field.min, field.max);
+          object[name] = self.apos.launder.float(data[name], null, field.min, field.max);
           return setImmediate(callback);
         },
         form: 'string'
@@ -1814,7 +1812,7 @@ module.exports = {
       name: 'url',
       converters: {
         string: function(req, data, name, object, field, callback) {
-          object[name] = self.apos.launder.url(data[name], field.def);
+          object[name] = self.apos.launder.url(data[name]);
           return setImmediate(callback);
         },
         form: 'string'
@@ -1853,7 +1851,7 @@ module.exports = {
       name: 'date',
       converters: {
         string: function(req, data, name, object, field, callback) {
-          object[name] = self.apos.launder.date(data[name], field.def);
+          object[name] = self.apos.launder.date(data[name]);
           return setImmediate(callback);
         },
         form: 'string'
@@ -1904,7 +1902,7 @@ module.exports = {
       name: 'time',
       converters: {
         string: function(req, data, name, object, field, callback) {
-          object[name] = self.apos.launder.time(data[name], field.def);
+          object[name] = self.apos.launder.time(data[name]);
           return setImmediate(callback);
         },
         form: 'string'
@@ -1918,7 +1916,7 @@ module.exports = {
           // This is the only field type that we never update unless
           // there is actually a new value — a blank password is not cool. -Tom
           if (data[name]) {
-            object[name] = self.apos.launder.string(data[name], field.def);
+            object[name] = self.apos.launder.string(data[name]);
           }
           return setImmediate(callback);
         },

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -1387,12 +1387,13 @@ describe('Schemas', function() {
       addFields: simpleFields
     });
     assert(schema.length === 5);
-    var input = {
+    var input = apos.schemas.newInstance(schema);
+    Object.assign(input, {
       name: 'Bob Smith',
       address: '5017 Awesome Street\nPhiladelphia, PA 19147',
       irrelevant: 'Irrelevant',
       slug: 'This Is Cool'
-    };
+    });
     var req = apos.tasks.getReq();
     var result = {};
     return apos.schemas.convert(req, schema, 'form', input, result, function(err) {


### PR DESCRIPTION
…what required is for.

The current code passes field.def to all of the launder functions but this is not necessary or correct, the object was created via "newInstance" which already utilized field.def. Passing a default to launder every time can result in unexpected resets to the default when a field is intentionally cleared.