### PR TITLE
allow modern mongodb atlas connection URIs since we use emulate-mongo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 2.102.2 (2020-02-11)
+
+* Removed the restriction preventing the use of `mongodb+srv` connection
+URIs with MongoDB. `emulate-mongo-2-driver` has no problem with these, since
+it passes them on to the 3.x driver.
+* Updated dependency to `emulate-mongo-2-driver` 1.1.0, which knocks out 100% of the common MongoDB deprecation warnings when using Apostrophe, with one exception: you should set the `useUnifiedTopology: true` option yourself. We do not do this for you because we cannot break legacy configurations using other topologies. However most of you can just turn this option on and enjoy more reliable connections and no more warnings.
+
+Here is how to configure that in Apostrophe:
+
+```javascript
+// in app.js, where your modules key is...
+modules: {
+  'apostrophe-db': {
+    connect: {
+      useUnifiedTopology: true
+    }
+  }
+}
+```
+
 ## 2.102.1 (2020-02-10)
 
 * Temporarily pinned to `less` version 3.10.x to work around an

--- a/lib/modules/apostrophe-db/index.js
+++ b/lib/modules/apostrophe-db/index.js
@@ -110,15 +110,6 @@ module.exports = {
         uri += options.host + ':' + options.port + '/' + options.name;
       }
 
-      if (uri.match(/^mongodb\+srv/)) {
-        return callback(new Error('You are attempting to use a mongodb+srv URI, which is only\n' +
-          'supported by the MongoDB 3.6+ driver. Apostrophe 2.x core\n' +
-          'ships with the MongoDB 2.x driver. You have two choices:\n\n' +
-          '1. Use the older type of URI to connect to your replica set.\n' +
-          'MongoDB Atlas provides both URIs.\n\n' +
-          '2. Install the apostrophe-db-mongo-3-driver module which supports the new URI.\n'));
-      }
-
       // If a comma separated host list appears, it's a replica set or sharded
       // cluster. In either case, the autoReconnect feature is undesirable and
       // will actually cause problems, per the MongoDB team:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "2.102.1",
+  "version": "2.102.2",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {
@@ -24,7 +24,7 @@
   "author": "P'unk Avenue LLC",
   "license": "MIT",
   "dependencies": {
-    "emulate-mongo-2-driver": "^1.0.3",
+    "emulate-mongo-2-driver": "^1.1.0",
     "@apostrophecms/nunjucks": "^2.5.3",
     "@sailshq/lodash": "^3.10.4",
     "async": "^1.5.2",


### PR DESCRIPTION
…-2-driver, which supports them