### PR TITLE
Do not confirm when the conflict is with yourself, because that is al…

### DIFF
--- a/lib/modules/apostrophe-docs/public/js/user.js
+++ b/lib/modules/apostrophe-docs/public/js/user.js
@@ -42,9 +42,15 @@ apos.define('apostrophe-docs', {
             self.locks[_id] = true;
             return callback(null);
           } else if ((result.status === 'locked') || (result.status === 'locked-by-me')) {
-            // TODO use shiny new async confirm modal, as yet unbuilt
-            if (!confirm(result.message)) {
-              return callback('locked');
+            // If the lock belonged to us, we should just seize it, and if that tab is really
+            // still open, we'll get a notice there that it happened. This is necessary going
+            // forward because we can't reliably unlock on refresh in modern browsers, which
+            // restrict or disable synchronous requests at unload time. But if the lock belonged
+            // to someone else, ask nicely first
+            if (result.status === 'locked') {
+              if (!confirm(result.message)) {
+                return callback('locked');
+              }
             }
             return $.jsonCall(self.action + '/lock',
               {


### PR DESCRIPTION
…most always just a refresh click, but do break the bad news as always in the other tab if it actually exists.

Also, do not display the alert more than once when breaking the bad news of a conflict. This happened because page refreshes take time.