### PR TITLE
Fix headless by providing ways to limit the fields convert() will look at in the schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.103.1 (2020-03-04)
+
+* An incompatibility with apostrophe-headless was introduced in Apostrophe 2.102.0. This version addresses that incompatibility, however you must also upgrade apostrophe-headless to version 2.9.3. The issue had to do with a change that was made to allow users to intentionally clear default values in forms. We are updating our regression test procedures to ensure that if a new release of apostrophe would break the unit tests of apostrophe-headless, it will not be published until that issue is resolved.
+
 ## 2.103.0 (2020-03-02)
 
 * Frustrations with conflict resolution have been much improved. First, Apostrophe no longer displays the "another user has taken control of the document" message multiple times in a row. Second, due to changes in what browsers allow to happen when you leave the page, beginning in version 2.102.0 Apostrophe displayed too many messages about a conflict with your **own** work in another tab. We no longer display these messages. However, if there really *is* work lost for the same document in another tab, Apostrophe will still tell you what happened in order to teach the habit of not editing the same page in two tabs simultaneously.

--- a/lib/modules/apostrophe-pieces/lib/api.js
+++ b/lib/modules/apostrophe-pieces/lib/api.js
@@ -456,10 +456,15 @@ module.exports = function(self, options) {
   };
 
   // Convert the data supplied in `req.body` via the schema and
-  // update the piece object accordingly.
+  // update the piece object accordingly. If `req.convertOnlyTheseFields`
+  // is present, touch only the fields present in that array.
 
   self.convert = function(req, piece, callback) {
-    return self.apos.schemas.convert(req, self.allowedSchema(req), 'form', req.body, piece, callback);
+    var schema = self.allowedSchema(req);
+    if (req.convertOnlyTheseFields) {
+      schema = self.apos.schemas.subset(schema, req.convertOnlyTheseFields);
+    }
+    return self.apos.schemas.convert(req, schema, 'form', req.body, piece, callback);
   };
 
   // Invoked after apos.schemas.convert by the `insert` and

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -351,7 +351,10 @@ module.exports = {
     // Return a new schema containing only the fields named in the
     // `fields` array, while maintaining existing group relationships.
     // Any empty groups are dropped. Do NOT include group names
-    // in `fields`.
+    // in `fields`. If `fields` contains a property that is not a
+    // field name but does match the `idField` or `idsField` property
+    // of a field, that also includes the field in the subset. This is
+    // convenient when basing this call on the keys in `req.body`.
 
     self.subset = function(schema, fields) {
 
@@ -370,7 +373,7 @@ module.exports = {
         // loop over each group and remove fields from them that aren't in this subset
         _.each(groups, function(group) {
           group.fields = _.filter(group.fields, function(field) {
-            return _.contains(fields, field.name);
+            return includes(fields, field);
           });
         });
 
@@ -383,9 +386,14 @@ module.exports = {
       } else {
         // otherwise this is a simple filter
         return _.filter(schema, function(field) {
-          return _.contains(fields, field.name);
+          return includes(fields, field);
         });
       }
+
+      function includes(fields, field) {
+        return _.includes(fields, field.name) || (field.idField && _.includes(fields, field.idField)) || (field.idsField && _.includes(fields, field.idsField));
+      }
+
     };
 
     // Return a new object with all default settings

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "2.103.0",
+  "version": "2.103.1",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
These workarounds are necessary because of the changes in 2.102.0. We fixed Apostrophe to allow users to clear a field that has a default value (which is good), but this broke the tests and, for many users, the expected behavior of the headless module because it considers the undefined properties not passed to POST or PUT to be blank rather than assigning their defaults like it used to.

There is a corresponding PR coming on headless, both are needed to get the fix.