### PR TITLE
Updates recursion warning to ref pieces-widgets

### DIFF
--- a/lib/modules/apostrophe-areas/lib/cursor.js
+++ b/lib/modules/apostrophe-areas/lib/cursor.js
@@ -41,7 +41,7 @@ module.exports = {
             }
             if (req.areasLoadedFor[doc._id] >= 5) {
               if (!req.suppressAreaLoaderRecursionWarnings) {
-                self.apos.utils.warn('WARNING: reached maximum area loader recursion level. Doc _id is ' + doc._id + '. Are you using projections for all joins?');
+                self.apos.utils.warn('WARNING: Reached maximum area loader recursion level. Doc _id is ' + doc._id + '. Are you using projections for all joins (including pieces widgets)?');
               }
               // In any case, we can't recurse infinitely
               return;


### PR DESCRIPTION
We too often forget that pieces-widgets have joins built-in as well that can contribute to this.