### PR TITLE
make apos.utils.get and apos.utils.post awaitable, but give a clear e…

### DIFF
--- a/lib/modules/apostrophe-browser-utils/public/js/lean.js
+++ b/lib/modules/apostrophe-browser-utils/public/js/lean.js
@@ -36,6 +36,19 @@
   // delivered as well, in the second argument.
 
   apos.utils.post = function(uri, data, callback) {
+    if (!callback) {
+      if (!window.Promise) {
+        throw new Error('If you wish to receive a promise from apos.utils.post in older browsers you must have a Promise polyfill.');
+      }
+      return new window.Promise(function(resolve, reject) {
+        return apos.utils.post(uri, data, function(err, result) {
+          if (err) {
+            return reject(err);
+          }
+          return resolve(result);
+        });
+      });
+    }
     if (apos.prefix) {
       uri = apos.prefix + uri;
     }
@@ -69,6 +82,19 @@
   // delivered as well, in the second argument.
 
   apos.utils.get = function(uri, data, callback) {
+    if (!callback) {
+      if (!window.Promise) {
+        throw new Error('If you wish to receive a promise from apos.utils.get in older browsers you must have a Promise polyfill.');
+      }
+      return new window.Promise(function(resolve, reject) {
+        return apos.utils.get(uri, data, function(err, result) {
+          if (err) {
+            return reject(err);
+          }
+          return resolve(result);
+        });
+      });
+    }
     if (apos.prefix) {
       uri = apos.prefix + uri;
     }


### PR DESCRIPTION
…rror if called this way without promise support in the browser

Per team discussion, this will allow us to write better code in our own 2.x projects and help other developers as well.

(A typical webpack project will have the corejs library promise polyfill for IE11.)