### PR TITLE
make it possible for overrides of apos.templates.i18n to determine wh…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 2.105.0 (2020-03-17)
+
+The regular `i18n` template helpers are enhanced with an additional set of namespaced functions: `__ns()`, `__ns_l()`, etc. These take a namespace name as the first argument, for instance `__ns('apostrophe', 'Save')`. Also, all of the i18n calls in Apostrophe's core UI now use the namespace `apostrophe`.
+
+For backwards compatibility, the namespace is ignored by default. However, if you set the `namespaces: true` option for the `apostrophe-i18n` module, calls with the namespace `apostrophe` will be mapped to a separate set of translation files in the `apostrophe-locales` folder, and so on.
+
+Ordinary calls to `__()` and other non-namespaced i18n functions will continue to map to translation files in the default `locales` folder. The namespace `default` will map to this folder as well.
+
+When the `namespaces` option is present, separate instances of the `i18n` npm module are configured for each namespace, since it has no built-in support for namespacing. When you pass `namespaces: true`, the configuration passed to each them is the same, except for the name of the locales folder. You can also pass an object with separate configuration:
+
+```javascript
+// in lib/modules/apostrophe-i18n/index.js
+
+module.exports = {
+  namespaces: {
+    apostrophe: {
+      // Not interested in translating the UI, so don't update those locale files
+      // or specify any locales for it
+      update: false
+    },
+    default: {
+      // Do update the locale files for the project level namespace (this is the default)
+      update: true,
+      locales: [ 'en', 'fr' ]
+    }
+  }
+};
+```
+
 ## 2.104.0 (2020-03-11)
 
 * `apos.utils.get` and `apos.utils.post` now return a promise if invoked without a callback. This means you may use `await` with them. *It is up to you to provide a `Promise` polyfill if you use this feature without callbacks and intend to support IE11. For instance you could use the `core-js` library.* These methods are similar to `$.get` and `$.post` but do not require jQuery. `apos.utils.post` supports Apostrophe's CSRF protection natively so you do not have to add an exception if you use it. These methods are available in [lean frontend mode](https://docs.apostrophecms.org/apostrophe/core-concepts/front-end-assets/lean-frontend-assets).
@@ -2427,7 +2456,7 @@ All tests passing.
 * `apos.permissions.addPublic` accepts multiple arguments and array arguments,
 adding all of the permission names given including any listed in the arrays.
 * Permissions checks for pieces admin routes longer check for req.user, checking for the appropriate `edit-` permission is sufficient and makes addPublic more useful.
-* Updated the `i18n` module to address a problem where labels that happened to be numbers rather than strings would crash the template if passed to `__()`.
+* Updated the `i18n` module to address a problem where labels that happened to be numbers rather than strings would crash the template if passed to `__ns('apostrophe', )`.
 * Documentation improvements.
 
 ## 2.14.3
@@ -2456,7 +2485,7 @@ All tests passing.
 
 * A version rollback dialog box for the `global` doc is now opened if an element with the `data-apos-versions-global` attribute is clicked. There is currently no such element in the standard UI but you may introduce one in your own layout if you have mission-critical content in the `global` doc that is awkward to recreate after an accidental deletion, such as a custom sitewide nav.
 * An error message is correctly displayed when login fails.
-* Many UI messages are now passed through the `__()` internationalization helper correctly. Thanks to `timaebi`.
+* Many UI messages are now passed through the `__ns('apostrophe', )` internationalization helper correctly. Thanks to `timaebi`.
 
 ## 2.13.2 (2016-12-22)
 

--- a/lib/modules/apostrophe-admin-bar/views/adminBar.html
+++ b/lib/modules/apostrophe-admin-bar/views/adminBar.html
@@ -19,7 +19,7 @@
           {%- if item.options.href -%}
             <a href="{{ apos.prefix }}{{ item.options.href }}">
           {%- endif -%}
-            {{ __(item.label | d('')) }}
+            {{ __ns('apostrophe', item.label | d('')) }}
           {%- if item.options.href -%}
             </a>
           {%- endif -%}
@@ -31,7 +31,7 @@
                   {%- if subItem.options.href -%}
                     <a href="{{ apos.prefix }}{{ subItem.options.href }}">
                   {%- endif -%}
-                  {{ __(subItem.label | d('')) }}
+                  {{ __ns('apostrophe', subItem.label | d('')) }}
                   {%- if subItem.options.href -%}
                     </a>
                   {%- endif -%}

--- a/lib/modules/apostrophe-areas/lib/browser.js
+++ b/lib/modules/apostrophe-areas/lib/browser.js
@@ -23,7 +23,7 @@ module.exports = function(self, options) {
     return {
       action: self.action,
       messages: {
-        tryAgain: req.__('Server error, please try again.')
+        tryAgain: self.apos.templates.i18n(req, '__ns', 'apostrophe', 'Server error, please try again.')
       }
     };
   };

--- a/lib/modules/apostrophe-areas/lib/helpers.js
+++ b/lib/modules/apostrophe-areas/lib/helpers.js
@@ -140,7 +140,7 @@ module.exports = function(self, options) {
         }
       }
 
-      options.hint = options.hint || self.apos.templates.contextReq.__('Use the Add Content button to get started.');
+      options.hint = options.hint || self.apos.templates.i18n(self.apos.templates.contextReq, '__ns', 'apostrophe', 'Use the Add Content button to get started.');
 
       // Don't fill the session with blessings of option sets unless
       // this user actually can edit this area

--- a/lib/modules/apostrophe-areas/lib/routes.js
+++ b/lib/modules/apostrophe-areas/lib/routes.js
@@ -5,9 +5,9 @@ module.exports = function(self, options) {
   self.apiRoute('post', 'save-area', function(req, res, next) {
     return self.lockSanitizeAndSaveArea(req, req.body, function(err, info) {
       if (err === 'locked-by-me') {
-        return next('locked', null, { message: self.apos.i18n.__('You are now editing this document in another tab or window.') });
+        return next('locked', null, { message: self.apos.templates.i18n(req, '__ns', 'apostrophe', 'You are now editing this document in another tab or window.') });
       } else if (err === 'locked') {
-        return next('locked', null, { message: self.apos.i18n.__('Another user has taken control of this document.') });
+        return next('locked', null, { message: self.apos.templates.i18n(req, '__ns', 'apostrophe', 'Another user has taken control of this document.') });
       } else {
         return next(err);
       }

--- a/lib/modules/apostrophe-areas/views/areaControls.html
+++ b/lib/modules/apostrophe-areas/views/areaControls.html
@@ -8,7 +8,7 @@
         {%- for name, options in data.options.widgets -%}
           {%- if data.widgetManagers[name] -%}
             {%- if not options.readOnly -%}
-              <li class="apos-dropdown-item" data-apos-add-item="{{ name }}">{{ options.addLabel or __(data.widgetManagers[name].label) }}</li>
+              <li class="apos-dropdown-item" data-apos-add-item="{{ name }}">{{ options.addLabel or __ns('apostrophe', data.widgetManagers[name].label) }}</li>
             {% endif %}
           {%- else -%}
             {{ apos.log("Your area contains a widget of type " + name + " but there is no manager for that type. Maybe you forgot to configure the " + name + "-widgets module?") }}

--- a/lib/modules/apostrophe-attachments/views/attachment.html
+++ b/lib/modules/apostrophe-attachments/views/attachment.html
@@ -7,12 +7,12 @@
     <div class="apos-attachment-preview"><img data-preview src="" alt=""></div>
     <span class="apos-attachment-name" data-name></span>
     <div class="apos-button-group">
-      <a class="apos-button apos-button--action" href="#" data-link target="_blank">{{ __("View file") }}</a>
+      <a class="apos-button apos-button--action" href="#" data-link target="_blank">{{ __ns('apostrophe', "View file") }}</a>
       {% if field.crop or field.aspectRatio %}
-        <a class="apos-button apos-button--action" href="#" data-apos-crop-attachment>{{ __("Crop image") }}</a>
+        <a class="apos-button apos-button--action" href="#" data-apos-crop-attachment>{{ __ns('apostrophe', "Crop image") }}</a>
       {% endif %}
       {% if field.focalPoint %}
-        <a class="apos-button apos-button--action" href="#" data-apos-focal-point-attachment>{{ __("Focal point") }}</a>
+        <a class="apos-button apos-button--action" href="#" data-apos-focal-point-attachment>{{ __ns('apostrophe', "Focal point") }}</a>
       {% endif %}
       {% if field.trash %}
         {{ buttons.danger('Delete File', { action: 'trash' }) }}

--- a/lib/modules/apostrophe-attachments/views/cropEditor.html
+++ b/lib/modules/apostrophe-attachments/views/cropEditor.html
@@ -12,7 +12,7 @@
 {%- endblock -%}
 
 {%- block label -%}
-  {{ __('Crop Image') }}
+  {{ __ns('apostrophe', 'Crop Image') }}
 {%- endblock -%}
 
 {% block body %}

--- a/lib/modules/apostrophe-attachments/views/focalPointEditor.html
+++ b/lib/modules/apostrophe-attachments/views/focalPointEditor.html
@@ -12,7 +12,7 @@
 {%- endblock -%}
 
 {%- block label -%}
-  {{ __('Set Focal Point') }}
+  {{ __ns('apostrophe', 'Set Focal Point') }}
 {%- endblock -%}
 
 {% block body %}

--- a/lib/modules/apostrophe-doc-type-manager/views/chooserBase.html
+++ b/lib/modules/apostrophe-doc-type-manager/views/chooserBase.html
@@ -5,7 +5,7 @@
   <div class="apos-browse">
 {% endif %}
 {% if data.autocomplete %}
-  <input type="text" name="autocomplete" class="apos-field-input apos-field-input-text" placeholder="{{ __('Search...') }}" data-autocomplete />
+  <input type="text" name="autocomplete" class="apos-field-input apos-field-input-text" placeholder="{{ __ns('apostrophe', 'Search...') }}" data-autocomplete />
 {% endif %}
 {% if data.browse %}
   {{ buttons.action('Browse', { action: 'browse', icon: 'caret-right' }) }}
@@ -18,4 +18,4 @@
   {# AJAX populates me #}
 </div>
 {# Initially hidden #}
-<div class="apos-chooser-limit-reached">{{ __("Limit Reached") }}</div>
+<div class="apos-chooser-limit-reached">{{ __ns('apostrophe', "Limit Reached") }}</div>

--- a/lib/modules/apostrophe-doc-type-manager/views/chooserChoiceBase.html
+++ b/lib/modules/apostrophe-doc-type-manager/views/chooserChoiceBase.html
@@ -1,7 +1,7 @@
 {% import 'apostrophe-schemas:macros.html' as schemas %}
 {# choice is the object. relationship contains any relationship properties. #}
 <div class="apos-text-meta">{% block meta %}{% endblock %}</div>
-<div class="apos-text-normal">{% block title %}{{ __(choice.title | d('') or "No title property" ) }}{% endblock %}</div>
+<div class="apos-text-normal">{% block title %}{{ __ns('apostrophe', choice.title | d('') or "No title property" ) }}{% endblock %}</div>
 {%- block inline -%}
   {%- set inline = apos.utils.filterNonempty(data.relationship, 'inline') -%}
   {%- if inline.length -%}

--- a/lib/modules/apostrophe-doc-type-manager/views/relationshipEditor.html
+++ b/lib/modules/apostrophe-doc-type-manager/views/relationshipEditor.html
@@ -13,7 +13,7 @@
 
 {%- block label -%}
   {# TODO what is a better label to put here? #}
-  {{ __('Edit Relationship') }}
+  {{ __ns('apostrophe', 'Edit Relationship') }}
 {%- endblock -%}
 
 {%- block body -%}

--- a/lib/modules/apostrophe-docs/lib/api.js
+++ b/lib/modules/apostrophe-docs/lib/api.js
@@ -1042,9 +1042,9 @@ module.exports = function(self, options) {
             return callback('forbidden');
           }
           if (info.advisoryLock.username === req.user.username) {
-            return callback('locked-by-me', self.apos.i18n.__('You may be editing that document in another tab or window.\nIf you take control, you could lose work in that tab or window.\nDo you want to take control?'));
+            return callback('locked-by-me', self.apos.templates.i18n(req, '__ns', 'apostrophe', 'You may be editing that document in another tab or window.\nIf you take control, you could lose work in that tab or window.\nDo you want to take control?'));
           }
-          return callback('locked', self.apos.i18n.__(
+          return callback('locked', self.apos.templates.i18n(req, '__ns', 'apostrophe', 
             'That document may be being edited by %s (%s).\nIf you take control, they could lose unsaved work.\nDo you want to take control?',
             info.advisoryLock.title, info.advisoryLock.username
           ));
@@ -1122,10 +1122,10 @@ module.exports = function(self, options) {
           }
           if ((!info.advisoryLock) || (info.advisoryLock._id !== contextId)) {
             if (info.advisoryLock && info.advisoryLock.username === req.user.username) {
-              message = self.apos.i18n.__('You are now editing this document in another tab or window.');
+              message = self.apos.templates.i18n(req, '__ns', 'apostrophe', 'You are now editing this document in another tab or window.');
               return callback('locked-by-me');
             }
-            message = self.apos.i18n.__('Control of this document has been taken by another user.');
+            message = self.apos.templates.i18n(req, '__ns', 'apostrophe', 'Control of this document has been taken by another user.');
             return callback('locked');
           }
           return callback(null);

--- a/lib/modules/apostrophe-docs/lib/routes.js
+++ b/lib/modules/apostrophe-docs/lib/routes.js
@@ -59,7 +59,7 @@ module.exports = function(self, options) {
       if (doc) {
         var pageType = _.find(self.apos.pages.options.types, { name: doc.type });
         var label = (pageType && pageType.label) || self.apos.docs.getManager(doc.type).options.label || doc.type;
-        var hint = req.__('The slug you want to use is currently claimed by the %s %s. Do you want to edit that document in order to change its slug?', req.__(label), doc.title);
+        var hint = self.apos.templates.i18n(req, '__ns', 'apostrophe', 'The slug you want to use is currently claimed by the %s %s. Do you want to edit that document in order to change its slug?', self.apos.templates.i18n(req, '__ns', 'apostrophe', label), doc.title);
         return next('taken', null, { doc: doc, hint: hint });
       } else {
         return next(null);

--- a/lib/modules/apostrophe-files-widgets/views/widget.html
+++ b/lib/modules/apostrophe-files-widgets/views/widget.html
@@ -1,5 +1,5 @@
 {%- for piece in data.widget._pieces -%}
   {% if piece.attachment %}
-    <a href="{{ apos.attachments.url(piece.attachment) }}">{{ __(piece.title | d('')) }}</a>
+    <a href="{{ apos.attachments.url(piece.attachment) }}">{{ __ns('apostrophe', piece.title | d('')) }}</a>
   {% endif %}
 {%- endfor -%}

--- a/lib/modules/apostrophe-files/views/editorModal.html
+++ b/lib/modules/apostrophe-files/views/editorModal.html
@@ -1,7 +1,7 @@
 {% extends 'editorBase.html' %}
 
 {%- block label -%}
-{{ __("Edit File") }}
+{{ __ns('apostrophe', "Edit File") }}
 {%- endblock -%}
 
 {%- block filters -%}

--- a/lib/modules/apostrophe-global/views/busy.html
+++ b/lib/modules/apostrophe-global/views/busy.html
@@ -3,7 +3,7 @@
 <html lang="en-US">
 <head>
   <meta charset="utf-8">
-  <title>{{ __("One moment please...") }}</title>
+  <title>{{ __ns('apostrophe', "One moment please...") }}</title>
   <style type="text/css">
     body {
       background-color: #ccf;
@@ -21,8 +21,8 @@
 </head>
 <body>
   <main>
-    <h1>{{ __('One moment please...') }}</h1>
-    <p>{{ __("We're in the process of updating the site for you. This page will refresh in a few seconds.") }}</p>
+    <h1>{{ __ns('apostrophe', 'One moment please...') }}</h1>
+    <p>{{ __ns('apostrophe', "We're in the process of updating the site for you. This page will refresh in a few seconds.") }}</p>
   </main>
 </body>
 </html>

--- a/lib/modules/apostrophe-i18n/index.js
+++ b/lib/modules/apostrophe-i18n/index.js
@@ -1,6 +1,6 @@
 // This module makes an instance of the [i18n](https://npmjs.org/package/i18n) npm module available
 // as `apos.i18n`. Apostrophe also makes this available in Nunjucks templates via the
-// usual `__()` helper function. Any options passed to this module are passed on to `i18n`.
+// usual `__ns('apostrophe', )` helper function. Any options passed to this module are passed on to `i18n`.
 //
 // By default i18n locale files are generated in the `locales` subdirectory of the project.
 //
@@ -10,21 +10,40 @@
 // are stored in the `locales` subdirectory of the project root.
 
 var _ = require('@sailshq/lodash');
-var i18n = require('i18n');
+var importFresh = require('import-fresh');
 
 module.exports = {
-
+  afterConstruct: function(self) {
+    self.namespaces = {
+      'default': self.getI18nModule('default')
+    };
+    // For bc
+    self.apos.i18n = self.namespaces['default'];
+  },
   construct: function(self, options) {
-
-    var i18nOptions = self.options || {};
-    _.defaults(i18nOptions, {
-      locales: [ 'en' ],
-      cookie: self.apos.shortName + '.locale',
-      directory: self.options.localesDir || (self.apos.rootDir + '/locales')
-    });
-    i18n.configure(i18nOptions);
-
-    // Make the i18n instance available globally in Apostrophe
-    self.apos.i18n = i18n;
+    self.getI18nModule = function(namespace) {
+      var i18n = importFresh('i18n');
+      var i18nOptions;
+      if (options.namespace && options.namespace[namespace]) {
+        i18nOptions = options.namespace[namespace];
+      } else {
+        i18nOptions = _.clone(self.options || {});
+      }
+      _.defaults(i18nOptions, {
+        locales: [ 'en' ],
+        cookie: self.apos.shortName + '.locale',
+        directory: self.getLocalesDir(namespace)
+      });
+      i18n.configure(i18nOptions);
+      console.log(_.omit(i18nOptions, 'apos'));
+      return i18n;
+    };
+    self.getLocalesDir = function(namespace) {
+      if (namespace === 'default') {
+        return self.options.localesDir || (self.apos.rootDir + '/locales');
+      } else {
+        return self.apos.rootDir + '/' + namespace + '-locales';
+      }
+    };
   }
 };

--- a/lib/modules/apostrophe-images-widgets/views/widgetEditor.html
+++ b/lib/modules/apostrophe-images-widgets/views/widgetEditor.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block label %}
-{{ __("Choose Images") }}
+{{ __ns('apostrophe', "Choose Images") }}
 {% endblock %}
 
 {% block body %}

--- a/lib/modules/apostrophe-images/views/chooser.html
+++ b/lib/modules/apostrophe-images/views/chooser.html
@@ -1,11 +1,11 @@
 {%- extends "chooserBase.html" -%}
 
 {%- block label -%}
-{{ __("Image Gallery") }}
+{{ __ns('apostrophe', "Image Gallery") }}
 {%- endblock -%}
 
 {%- block instructions -%}
-{{ __("Choose images to add.") }}
+{{ __ns('apostrophe', "Choose images to add.") }}
 {%- endblock -%}
 
 

--- a/lib/modules/apostrophe-images/views/editorModal.html
+++ b/lib/modules/apostrophe-images/views/editorModal.html
@@ -1,7 +1,7 @@
 {% extends 'editorBase.html' %}
 
 {%- block label -%}
-{{ __("Edit Image") }}
+{{ __ns('apostrophe', "Edit Image") }}
 {%- endblock -%}
 
 {%- block filters -%}

--- a/lib/modules/apostrophe-images/views/manageResultLabel.html
+++ b/lib/modules/apostrophe-images/views/manageResultLabel.html
@@ -1,14 +1,14 @@
 <div class='apos-manage-result-label'>
   {%- if data.minSize -%}
-    {%- set minSize = __(' at least %sx%s pixels in size', data.minSize[0], data.minSize[1]) -%}
+    {%- set minSize = __ns('apostrophe', ' at least %sx%s pixels in size', data.minSize[0], data.minSize[1]) -%}
   {%- else -%}
     {%- set minSize = '' -%}
   {%- endif -%}
 	{%- if data.filters.q -%}
-    {{ __('Showing %s results%s for ', data.total, minSize) }}<span>"{{ data.filters.q }}"</span>
+    {{ __ns('apostrophe', 'Showing %s results%s for ', data.total, minSize) }}<span>"{{ data.filters.q }}"</span>
 	{%- elif data.total == 0 -%}
-    {{ __('No results for current filters%s', minSize) }}
+    {{ __ns('apostrophe', 'No results for current filters%s', minSize) }}
 	{%- else -%}
-    {{ __('Showing %s - %s of %s results%s', data.skip + 1, data.skip + data.pieces.length, data.total, minSize) }}
+    {{ __ns('apostrophe', 'Showing %s - %s of %s results%s', data.skip + 1, data.skip + data.pieces.length, data.total, minSize) }}
 	{%- endif -%}
 </div>

--- a/lib/modules/apostrophe-jobs/views/modal.html
+++ b/lib/modules/apostrophe-jobs/views/modal.html
@@ -17,7 +17,7 @@
 
 {%- block label -%}
   {# Default is not great, you should supply a title! #}
-  {{ __(data.job.labels.title or 'Progress') }}
+  {{ __ns('apostrophe', data.job.labels.title or 'Progress') }}
 {%- endblock -%}
 
 {%- block body -%}

--- a/lib/modules/apostrophe-jobs/views/progress.html
+++ b/lib/modules/apostrophe-jobs/views/progress.html
@@ -1,32 +1,32 @@
 {% if data.job.notfound %}
   {# Unlikely in production, but likely in development where dbs get reset #}
-  <h3 class="apos-job-failed">{{ __('The job no longer exists') }}</h3>
+  <h3 class="apos-job-failed">{{ __ns('apostrophe', 'The job no longer exists') }}</h3>
 {% elif data.job.canceling %}
   {% if data.job.canCancel %}
-    <h3 class="apos-job-failed">{{ __(data.job.labels.canceling or 'Canceling...') }}</h3>
+    <h3 class="apos-job-failed">{{ __ns('apostrophe', data.job.labels.canceling or 'Canceling...') }}</h3>
   {% else %}
-    <h3 class="apos-job-failed">{{ __(data.job.labels.stopping or 'Stopping...') }}</h3>
+    <h3 class="apos-job-failed">{{ __ns('apostrophe', data.job.labels.stopping or 'Stopping...') }}</h3>
   {% endif %}
 {% elif data.job.status == 'failed' %}
-  <h3 class="apos-job-failed">{{ __(data.job.labels.failed or 'Failed') }}</h3>
+  <h3 class="apos-job-failed">{{ __ns('apostrophe', data.job.labels.failed or 'Failed') }}</h3>
 {% elif data.job.status == 'canceled' %}
-  <h3 class="apos-job-failed">{{ __(data.job.labels.canceled or 'Canceled') }}</h3>
+  <h3 class="apos-job-failed">{{ __ns('apostrophe', data.job.labels.canceled or 'Canceled') }}</h3>
 {% elif data.job.status == 'stopped' %}
-  <h3 class="apos-job-failed">{{ __(data.job.labels.stopped or 'Stopped') }}</h3>
+  <h3 class="apos-job-failed">{{ __ns('apostrophe', data.job.labels.stopped or 'Stopped') }}</h3>
 {% elif data.job.status == 'completed' %}
-  <h3>{{ __(data.job.labels.completed or 'Completed') }}</h3>
+  <h3>{{ __ns('apostrophe', data.job.labels.completed or 'Completed') }}</h3>
 {% else %}
-  <h3>{{ __(data.job.labels.running or 'In Progress...') }}</h3>
+  <h3>{{ __ns('apostrophe', data.job.labels.running or 'In Progress...') }}</h3>
 {% endif %}
 {# Different jobs might give us more or less to work with. #}
 {# Don't display a table unless we have info on processed items #}
 {% if data.job.processed %}
   <table class="apos-job-results">
     <tr>
-      <th>{{ __(data.job.labels.good or 'Successful') }}</th><td>{{ data.job.good }}</td>
+      <th>{{ __ns('apostrophe', data.job.labels.good or 'Successful') }}</th><td>{{ data.job.good }}</td>
     </tr>
     <tr class="{{ 'apos-job-errors' if data.job.errors }}">
-      <th>{{ __(data.job.labels.bad or 'Errors') }}</th><td>{{ data.job.bad or 0 }}</td>
+      <th>{{ __ns('apostrophe', data.job.labels.bad or 'Errors') }}</th><td>{{ data.job.bad or 0 }}</td>
     </tr>
   </table>
 {% endif %}

--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -459,7 +459,7 @@ module.exports = {
                   }).then(function(user) {
                     return res.redirect('/password-reset?' + qs.stringify({
                       reset: reset,
-                      errors: [ res.__('Your password must be changed for the following reasons:') ].concat(errors)
+                      errors: [ self.apos.templates.i18n(req, '__ns', 'apostrophe', 'Your password must be changed for the following reasons:') ].concat(errors)
                     }));
                   }).catch(function(err) {
                     self.apos.utils.error(err);
@@ -574,7 +574,7 @@ module.exports = {
             return self.sendPage(req, 'passwordReset', { reset: reset, email: email, message: getMessage(), errors: req.query.errors });
           }).catch(function(err) {
             self.apos.utils.error(err);
-            return res.redirect(`${self.getLoginUrl()}?message=${req.__('That reset code was not found. It may have expired. Try resetting again.')}`);
+            return res.redirect(`${self.getLoginUrl()}?message=${self.apos.templates.i18n(req, '__ns', 'apostrophe', 'That reset code was not found. It may have expired. Try resetting again.')}`);
           });
 
           function getMessage() {
@@ -647,7 +647,7 @@ module.exports = {
           }).then(function(user) {
             return self.apos.users.forgetSecret(user, 'passwordReset');
           }).then(function(user) {
-            return res.redirect(`${self.getLoginUrl()}?message=${req.__('Your password has been reset. Please log in.')}`);
+            return res.redirect(`${self.getLoginUrl()}?message=${self.apos.templates.i18n(req, '__ns', 'apostrophe', 'Your password has been reset. Please log in.')}`);
           }).catch(function(err) {
             self.apos.utils.error(err);
             return res.redirect('/password-reset?errors[]=error');
@@ -861,7 +861,7 @@ module.exports = {
         url = require('url').format(parsed);
         return self.email(req, 'passwordResetEmail', { user: user, url: url, site: site }, {
           to: user.email,
-          subject: req.res.__(self.options.passwordResetSubject || ('Your request to reset your password on ' + site))
+          subject: self.apos.templates.i18n(req, '__ns', 'apostrophe', self.options.passwordResetSubject || ('Your request to reset your password on ' + site))
         });
       });
     };
@@ -964,7 +964,7 @@ module.exports = {
         });
       }
       errors = errors.map(function(error) {
-        return req.__(error);
+        return self.apos.templates.i18n(req, '__ns', 'apostrophe', error);
       });
       return errors;
     };

--- a/lib/modules/apostrophe-login/views/login-totp.html
+++ b/lib/modules/apostrophe-login/views/login-totp.html
@@ -1,5 +1,5 @@
 {% extends data.outerLayout %}
-{% block title %}{{ __("Password Reset Request") }}{% endblock %}
+{% block title %}{{ __ns('apostrophe', "Password Reset Request") }}{% endblock %}
 
 {% block bodyClass %}apos-login-page apos-password-reset-request-page{% endblock %}
 
@@ -8,22 +8,22 @@
     <div class="apos-login-content">
       <div class="apos-login-logo">{% block logo %}{% include "apostrophe-admin-bar:logo.html" %}{% endblock %}</div>
       <div class="apos-ui apos-login">
-        <div class="apos-login-title apos-text-title">{% block subHeading %}{{ __('Log in with Google Authenticator or a compatible app (TOTP)') }}{% endblock %}</div>
+        <div class="apos-login-title apos-text-title">{% block subHeading %}{{ __ns('apostrophe', 'Log in with Google Authenticator or a compatible app (TOTP)') }}{% endblock %}</div>
         {% block form %}
           <form action="{% block action %}{{ apos.prefix }}/login-totp{% endblock %}" method="post">
             {{ apos.log(data.error) }}
             {% if data.error %}<div class="apos-login-warning">{{ "That code was not correct." }}</div>{% endif %}
             {% block fields %}
               <div class="apos-field apos-login-code">
-                <label class="apos-field-label" for="code">{{ __('Code') }}</label>
+                <label class="apos-field-label" for="code">{{ __ns('apostrophe', 'Code') }}</label>
                 <input class="apos-field-input apos-field-input-text" type="text" name="code" id="code" autofocus />
               </div>
             {% endblock %}
             <div class="apos-login-submit">
-              <input type="submit" class="apos-button apos-button--major" value="{% block buttonLabel %}{{ __('Submit Code') }}{% endblock %}" />
+              <input type="submit" class="apos-button apos-button--major" value="{% block buttonLabel %}{{ __ns('apostrophe', 'Submit Code') }}{% endblock %}" />
             </div>
             <div class="apos-login-reset-cancel">
-              <a href="{{ apos.prefix }}/logout">{{ __('Log Out') }}</a>
+              <a href="{{ apos.prefix }}/logout">{{ __ns('apostrophe', 'Log Out') }}</a>
             </div>
             <p class="apos-login-help">You should see a code in Google Authenticator at this point in the process. Enter that code here.</p>
           </form>

--- a/lib/modules/apostrophe-login/views/loginBase.html
+++ b/lib/modules/apostrophe-login/views/loginBase.html
@@ -1,5 +1,5 @@
 {% extends data.outerLayout %}
-{% block title %}{{ __("Login") }}{% endblock %}
+{% block title %}{{ __ns('apostrophe', "Login") }}{% endblock %}
 
 {% block bodyClass %}apos-login-page{% endblock %}
 
@@ -8,7 +8,7 @@
     <div class="apos-login-content">
       <div class="apos-login-logo">{% block logo %}{% include "apostrophe-admin-bar:logo.html" %}{% endblock %}</div>
       <div class="apos-ui apos-login">
-        <div class="apos-login-title apos-text-title">{% block subHeading %}{{ __('Login') }}{% endblock %}</div>
+        <div class="apos-login-title apos-text-title">{% block subHeading %}{{ __ns('apostrophe', 'Login') }}{% endblock %}</div>
         {% block form %}
           <form action="{% block action %}{{ apos.prefix }}/login{% endblock %}" method="post">
             {% if data.errors and data.errors[0] %}
@@ -16,25 +16,25 @@
                 {{ data.errors | join(' ') }}
               </div>
             {% else %}
-              {% if data.message %}<div class="apos-login-warning">{{ __(data.message) }}</div>{% endif %}
+              {% if data.message %}<div class="apos-login-warning">{{ __ns('apostrophe', data.message) }}</div>{% endif %}
             {% endif %}
             {% block fields %}
               <div class="apos-field apos-login-username">
-                <label class="apos-field-label" for="username">{{ __('Username or Email') }} {% block usernameHint %}{% endblock %}</label>
+                <label class="apos-field-label" for="username">{{ __ns('apostrophe', 'Username or Email') }} {% block usernameHint %}{% endblock %}</label>
                 <input class="apos-field-input apos-field-input-text" type="text" name="username" id="username" autofocus />
               </div>
               <div class="apos-field apos-login-password">
-                <label class="apos-field-label" for="password">{{ __('Password') }} {% block passwordHint %}{% endblock %}</label>
+                <label class="apos-field-label" for="password">{{ __ns('apostrophe', 'Password') }} {% block passwordHint %}{% endblock %}</label>
                 <input class="apos-field-input apos-field-input-text" type="password" name="password" id="password" />
               </div>
             {% endblock %}
             <div class="apos-login-submit">
-              <input type="submit" class="apos-button apos-button--major" value="{% block buttonLabel %}{{ __('Log In') }}{% endblock %}" />
+              <input type="submit" class="apos-button apos-button--major" value="{% block buttonLabel %}{{ __ns('apostrophe', 'Log In') }}{% endblock %}" />
             </div>
             {% block passwordReset %}
               {% if data.passwordReset %}
                 <div class="apos-login-reset">
-                  <a href="{{ apos.prefix }}/password-reset-request">{{ __('Reset My Password') }}</a>
+                  <a href="{{ apos.prefix }}/password-reset-request">{{ __ns('apostrophe', 'Reset My Password') }}</a>
                 </div>
               {% endif %}
             {% endblock %}

--- a/lib/modules/apostrophe-login/views/passwordReset.html
+++ b/lib/modules/apostrophe-login/views/passwordReset.html
@@ -1,5 +1,5 @@
 {% extends data.outerLayout %}
-{% block title %}{{ __("Reset My Password") }}{% endblock %}
+{% block title %}{{ __ns('apostrophe', "Reset My Password") }}{% endblock %}
 
 {% block bodyClass %}apos-login-page apos-password-reset-page{% endblock %}
 
@@ -8,7 +8,7 @@
     <div class="apos-login-content">
       <div class="apos-login-logo">{% block logo %}{% include "apostrophe-admin-bar:logo.html" %}{% endblock %}</div>
       <div class="apos-ui apos-login">
-        <div class="apos-login-title apos-text-title">{% block subHeading %}{{ __('Reset Password') }}{% endblock %}</div>
+        <div class="apos-login-title apos-text-title">{% block subHeading %}{{ __ns('apostrophe', 'Reset Password') }}{% endblock %}</div>
         {% block form %}
           <form id="password-reset-form" action="{% block action %}{{ apos.prefix }}/password-reset{% endblock %}" method="post">
             {% if data.errors and data.errors.length %}
@@ -18,21 +18,21 @@
             {% endif %}
             {% block fields %}
               <div class="apos-field apos-login-password">
-                <label class="apos-field-label" for="password">{{ __('New Password') }} {% block passwordHint %}{% endblock %}</label>
+                <label class="apos-field-label" for="password">{{ __ns('apostrophe', 'New Password') }} {% block passwordHint %}{% endblock %}</label>
                 <input class="apos-field-input apos-field-input-text" required type="password" name="password" id="password" />
               </div>
               <div class="apos-field apos-login-password2">
-                <label class="apos-field-label" for="password2">{{ __('Confirm New Password') }} {% block passwordHint2 %}{% endblock %}</label>
+                <label class="apos-field-label" for="password2">{{ __ns('apostrophe', 'Confirm New Password') }} {% block passwordHint2 %}{% endblock %}</label>
                 <input class="apos-field-input apos-field-input-text" required type="password" name="password2" id="password2" />
               </div>
             {% endblock %}
             <input type="hidden" name="reset" value="{{ data.reset }}" />
             <input type="hidden" name="email" value="{{ data.email }}" />
             <div class="apos-login-submit">
-              <input type="submit" class="apos-button apos-button--major" value="{% block buttonLabel %}{{ __('Reset Password') }}{% endblock %}" />
+              <input type="submit" class="apos-button apos-button--major" value="{% block buttonLabel %}{{ __ns('apostrophe', 'Reset Password') }}{% endblock %}" />
             </div>
             <div class="apos-login-reset-cancel">
-              <a href="{{ apos.prefix }}{{ data.loginUrl }}">{{ __('Cancel') }}</a>
+              <a href="{{ apos.prefix }}{{ data.loginUrl }}">{{ __ns('apostrophe', 'Cancel') }}</a>
             </div>
         </form>
         {% endblock %}

--- a/lib/modules/apostrophe-login/views/passwordResetRequest.html
+++ b/lib/modules/apostrophe-login/views/passwordResetRequest.html
@@ -1,5 +1,5 @@
 {% extends data.outerLayout %}
-{% block title %}{{ __("Password Reset Request") }}{% endblock %}
+{% block title %}{{ __ns('apostrophe', "Password Reset Request") }}{% endblock %}
 {% set errors = {
   error: 'An error occurred. Please try again.',
   missing: 'You did not supply your username or email address.'
@@ -12,21 +12,21 @@
     <div class="apos-login-content">
       <div class="apos-login-logo">{% block logo %}{% include "apostrophe-admin-bar:logo.html" %}{% endblock %}</div>
       <div class="apos-ui apos-login">
-        <div class="apos-login-title apos-text-title">{% block subHeading %}{{ __('Password Reset') }}{% endblock %}</div>
+        <div class="apos-login-title apos-text-title">{% block subHeading %}{{ __ns('apostrophe', 'Password Reset') }}{% endblock %}</div>
         {% block form %}
           <form action="{% block action %}{{ apos.prefix }}/password-reset-request{% endblock %}" method="post">
-            {% if data.error %}<div class="apos-login-warning">{{ __(errors[data.error]) }}</div>{% endif %}
+            {% if data.error %}<div class="apos-login-warning">{{ __ns('apostrophe', errors[data.error]) }}</div>{% endif %}
             {% block fields %}
               <div class="apos-field apos-login-username">
-                <label class="apos-field-label" for="username">{{ __('Username or Email') }} {% block usernameHint %}{% endblock %}</label>
+                <label class="apos-field-label" for="username">{{ __ns('apostrophe', 'Username or Email') }} {% block usernameHint %}{% endblock %}</label>
                 <input class="apos-field-input apos-field-input-text" type="text" name="username" id="username" autofocus />
               </div>
             {% endblock %}
             <div class="apos-login-submit">
-              <input type="submit" class="apos-button apos-button--major" value="{% block buttonLabel %}{{ __('Request Password Reset') }}{% endblock %}" />
+              <input type="submit" class="apos-button apos-button--major" value="{% block buttonLabel %}{{ __ns('apostrophe', 'Request Password Reset') }}{% endblock %}" />
             </div>
             <div class="apos-login-reset-cancel">
-              <a href="{{ apos.prefix }}{{ data.loginUrl }}">{{ __('Cancel') }}</a>
+              <a href="{{ apos.prefix }}{{ data.loginUrl }}">{{ __ns('apostrophe', 'Cancel') }}</a>
             </div>
             <p class="apos-login-password-reset-help">After you submit this form, an email message will be sent to you with instructions to complete the process. If you still do not see it after a few minutes, make sure you check your spam folder.</p>
           </form>

--- a/lib/modules/apostrophe-login/views/resetKnownPassword.html
+++ b/lib/modules/apostrophe-login/views/resetKnownPassword.html
@@ -12,12 +12,12 @@
 {% endblock %}
 
 {% block label %}
-  {{ __('Reset Password') }}
+  {{ __ns('apostrophe', 'Reset Password') }}
 {% endblock %}
 
 {% block instructions %}
   <p>
-    {{ __('Enter your existing password, then your new password.') }}
+    {{ __ns('apostrophe', 'Enter your existing password, then your new password.') }}
   </p>
 {% endblock %}
 
@@ -26,13 +26,13 @@
   <p data-server-side-error class="apos-reset-password-error"></p>
   <form>
     <fieldset data-field="existing-password">
-      <label for="existing-password" data-apos-error-message="{{ __('Incorrect') }}">{{ __('Existing Password') }}</label><input name="existing-password" type="password" />
+      <label for="existing-password" data-apos-error-message="{{ __ns('apostrophe', 'Incorrect') }}">{{ __ns('apostrophe', 'Existing Password') }}</label><input name="existing-password" type="password" />
     </fieldset>
     <fieldset data-field="new-password">
-      <label for="new-password" data-apos-error-message="{{ __('Invalid') }}">{{ __('New Password') }}</label><input name="new-password" type="password" />
+      <label for="new-password" data-apos-error-message="{{ __ns('apostrophe', 'Invalid') }}">{{ __ns('apostrophe', 'New Password') }}</label><input name="new-password" type="password" />
     </fieldset>
     <fieldset data-field="new-password-confirm">
-      <label for="new-password-confirm" data-apos-error-message="{{ __('Does Not Match') }}">Confirm New Password</label><input name="new-password-confirm" type="password" />
+      <label for="new-password-confirm" data-apos-error-message="{{ __ns('apostrophe', 'Does Not Match') }}">Confirm New Password</label><input name="new-password-confirm" type="password" />
     </fieldset>
   </form>
 {% endblock %}

--- a/lib/modules/apostrophe-login/views/setup-totp.html
+++ b/lib/modules/apostrophe-login/views/setup-totp.html
@@ -1,5 +1,5 @@
 {% extends data.outerLayout %}
-{% block title %}{{ __("Set Up Google Authenticator") }}{% endblock %}
+{% block title %}{{ __ns('apostrophe', "Set Up Google Authenticator") }}{% endblock %}
 
 {% block bodyClass %}apos-login-page apos-setup-two-factor{% endblock %}
 
@@ -8,18 +8,18 @@
     <div class="apos-login-content">
       <div class="apos-login-logo">{% block logo %}{% include "apostrophe-admin-bar:logo.html" %}{% endblock %}</div>
       <div class="apos-ui apos-login">
-        <div class="apos-login-title apos-text-title">{% block subHeading %}{{ __('Set Up Google Authenticator') }}{% endblock %}</div>
-        <p>{{ __('Scan this QR Code in Google Authenticator or a similar app:') }}</p>
+        <div class="apos-login-title apos-text-title">{% block subHeading %}{{ __ns('apostrophe', 'Set Up Google Authenticator') }}{% endblock %}</div>
+        <p>{{ __ns('apostrophe', 'Scan this QR Code in Google Authenticator or a similar app:') }}</p>
         <img src="{{ data.qrImage }}" class="apos-totp-qr-image" />
-        <p>{{ __('Or, enter this key manually:') }}</p>
+        <p>{{ __ns('apostrophe', 'Or, enter this key manually:') }}</p>
         <code>{{ data.key }}</code>
-        <p class="apos-totp-help">{{ __('When you are finished setting up Google Authenticator, click this button to confirm:') }}</p>
+        <p class="apos-totp-help">{{ __ns('apostrophe', 'When you are finished setting up Google Authenticator, click this button to confirm:') }}</p>
         <form action="{% block action %}{{ apos.prefix }}/confirm-totp{% endblock %}" method="post">
           <div class="apos-login-submit apos-totp-submit">
-            <input type="submit" class="apos-button apos-button--major" value="{% block buttonLabel %}{{ __('I Have Added It To My App') }}{% endblock %}" />
+            <input type="submit" class="apos-button apos-button--major" value="{% block buttonLabel %}{{ __ns('apostrophe', 'I Have Added It To My App') }}{% endblock %}" />
           </div>
           <div class="apos-login-reset-cancel">
-            <a href="{{ apos.prefix }}/logout">{{ __('Log Out') }}</a>
+            <a href="{{ apos.prefix }}/logout">{{ __ns('apostrophe', 'Log Out') }}</a>
           </div>
         </form>
       </div>

--- a/lib/modules/apostrophe-modal/views/base.html
+++ b/lib/modules/apostrophe-modal/views/base.html
@@ -3,7 +3,7 @@
 <div data-modal class="apos-ui apos-modal {% block modalClass %}{% endblock %}" {% block dataAttrs %}{% endblock %}>
   <div class="apos-modal-header">{#
     #}<span class="apos-modal-title" data-modal-title>
-      {% block label %}{{ __("Give Me a Label!") }}{% endblock %}
+      {% block label %}{{ __ns('apostrophe', "Give Me a Label!") }}{% endblock %}
     </span>{#
     #}<div class="apos-modal-instructions" data-modal-instructions>
       {% block instructions %}{% endblock %}
@@ -29,7 +29,7 @@
     <div data-modal-content class="apos-modal-content apos-modal-slide-current">
 
       <div class="apos-modal-body">
-        {% block body %}{{ __("I am a Modal!") }}{% endblock %}
+        {% block body %}{{ __ns('apostrophe', "I am a Modal!") }}{% endblock %}
 
       </div>
       {% block footerContainer %}

--- a/lib/modules/apostrophe-modal/views/baseView.html
+++ b/lib/modules/apostrophe-modal/views/baseView.html
@@ -3,7 +3,7 @@
 <div>
   <div class="apos-ui-view-header">
     <span class="apos-ui-view-title">
-      {% block label %}{{ __("Give Me a Label!") }}{% endblock %}
+      {% block label %}{{ __ns('apostrophe', "Give Me a Label!") }}{% endblock %}
     </span>
     {# The parent modal controls the lifecycle #}
     {#{% block controls %}{% endblock %}#}
@@ -15,7 +15,7 @@
     {% block filters %}{% endblock %}
   </div>
   <div class="apos-ui-view-body">
-    {% block body %}{{ __("I am a Modal!") }}{% endblock %}
+    {% block body %}{{ __ns('apostrophe', "I am a Modal!") }}{% endblock %}
 
   </div>
   <div class="apos-ui-view-footer">

--- a/lib/modules/apostrophe-modal/views/batch.html
+++ b/lib/modules/apostrophe-modal/views/batch.html
@@ -8,7 +8,7 @@
       <select name="batch-operation" class="apos-field-input apos-field-input--small apos-field-input-select apos-manage-batch-operations-select">
         {% for operation in operations %}
           <option value="{{ operation.name }}">
-            {{ __('%s Selected', operation.label) }} (0)
+            {{ __ns('apostrophe', '%s Selected', operation.label) }} (0)
           </option>
         {% endfor %}
       </select>
@@ -30,7 +30,7 @@
     {% endif %}
     <div class="apos-manage-batch-operations-buttons">
       {% for operation in operations %}
-        {{ buttons.danger(__('Batch %s', operation.buttonLabel or operation.label), { action: 'batch-operation', value: operation.name }) }}
+        {{ buttons.danger(__ns('apostrophe', 'Batch %s', operation.buttonLabel or operation.label), { action: 'batch-operation', value: operation.name }) }}
       {% endfor %}
     </div>
   </div>

--- a/lib/modules/apostrophe-modal/views/macros.html
+++ b/lib/modules/apostrophe-modal/views/macros.html
@@ -12,7 +12,7 @@
         <img src="/modules/apos/images/small-spinner.gif">
       </span>
     {%- endif -%}
-    {{ __(options.label | d('')) }}
+    {{ __ns('apostrophe', options.label | d('')) }}
   </a>
 {%- endmacro -%}
 

--- a/lib/modules/apostrophe-module/index.js
+++ b/lib/modules/apostrophe-module/index.js
@@ -857,7 +857,7 @@ module.exports = {
     // to this module.
     //
     // If you need to localize `options.subject`, you can call
-    // `self.apos.i18n.__(subject)`.
+    // `req.res.__(subject)`.
     //
     // The callback receives `(err, info)`, per the Nodemailer documentation.
     // With most transports, lack of an `err` indicates the message was

--- a/lib/modules/apostrophe-pages/lib/routes.js
+++ b/lib/modules/apostrophe-pages/lib/routes.js
@@ -544,7 +544,7 @@ module.exports = function(self, options) {
             if (child.trash && (child.type === 'trash')) {
               var forJqtree = pageToJqtree(child);
               if (self.apos.docs.trashInSchema) {
-                forJqtree.label = self.apos.i18n.__('Legacy Trash');
+                forJqtree.label = self.apos.templates.i18n(req, '__ns', 'apostrophe', 'Legacy Trash');
               }
               info.children.push(forJqtree);
             }

--- a/lib/modules/apostrophe-pages/views/chooserModal.html
+++ b/lib/modules/apostrophe-pages/views/chooserModal.html
@@ -12,12 +12,12 @@
 {% endblock %}
 
 {% block label %}
-{{ __('Choose Pages') }}
+{{ __ns('apostrophe', 'Choose Pages') }}
 {% endblock %}
 
 {% block instructions %}
   <p>
-    {{ __('Choose the pages you want.') }}
+    {{ __ns('apostrophe', 'Choose the pages you want.') }}
   </p>
 {% endblock %}
 

--- a/lib/modules/apostrophe-pages/views/editor.html
+++ b/lib/modules/apostrophe-pages/views/editor.html
@@ -13,19 +13,19 @@
 
 {% block label %}
 	{% if data.verb == 'update' %}
-        {{ __('Page Settings') }}
+        {{ __ns('apostrophe', 'Page Settings') }}
 	{% elif data.verb == 'insert' %}
-        {{ __('New Page') }}
+        {{ __ns('apostrophe', 'New Page') }}
   {% elif data.verb == 'copy' %}
-        {{ __('Copy Page') }}
+        {{ __ns('apostrophe', 'Copy Page') }}
 	{% endif %}
 {% endblock %}
 
 {% block instructions %}
 	{% if data.verb == 'update' %}
-    {{ __("Change the settings of a page.") }}
+    {{ __ns('apostrophe', "Change the settings of a page.") }}
 	{% elif data.verb == 'insert' %}
-    {{ __("Set the options for a new page.") }}
+    {{ __ns('apostrophe', "Set the options for a new page.") }}
 	{% endif %}
 {% endblock %}
 

--- a/lib/modules/apostrophe-pages/views/reorganize.html
+++ b/lib/modules/apostrophe-pages/views/reorganize.html
@@ -12,12 +12,12 @@
 {% endblock %}
 
 {% block label %}
-{{ __('Reorganize Pages') }}
+{{ __ns('apostrophe', 'Reorganize Pages') }}
 {% endblock %}
 
 {% block instructions %}
   <p>
-    {{ __('Drag and drop pages wherever they need to go.') }}
+    {{ __ns('apostrophe', 'Drag and drop pages wherever they need to go.') }}
   </p>
 {% endblock %}
 

--- a/lib/modules/apostrophe-pieces/lib/routes.js
+++ b/lib/modules/apostrophe-pieces/lib/routes.js
@@ -84,7 +84,7 @@ module.exports = function(self, options) {
       } else if (options.format === 'allIds') {
         results = {
           ids: results.ids,
-          label: req.__('Select all %s item(s) that match this search', results.ids.length)
+          label: self.apos.templates.i18n(req, '__ns', 'apostrophe', 'Select all %s item(s) that match this search', results.ids.length)
         };
       } else {
         results = _.omit(results, 'cursor');

--- a/lib/modules/apostrophe-pieces/views/batchPermissionsModal.html
+++ b/lib/modules/apostrophe-pieces/views/batchPermissionsModal.html
@@ -13,12 +13,12 @@
 {%- endblock -%}
 
 {%- block label -%}
-  {{ __('Applying new permissions') }}
+  {{ __ns('apostrophe', 'Applying new permissions') }}
 {%- endblock -%}
 
 {% block instructions %}
   <p>
-    {{ __('You are applying new permissions to many documents. When you click Apply Permissions, the permissions you have selected will be the only permissions in effect for all of the currently selected documents.') }}
+    {{ __ns('apostrophe', 'You are applying new permissions to many documents. When you click Apply Permissions, the permissions you have selected will be the only permissions in effect for all of the currently selected documents.') }}
   </p>
 {% endblock %}
 

--- a/lib/modules/apostrophe-pieces/views/chooserModalBase.html
+++ b/lib/modules/apostrophe-pieces/views/chooserModalBase.html
@@ -2,9 +2,9 @@
 
 {%- block instructions -%}
   {%- if data.limit == 1 -%}
-    {{ __('Choose ' + data.options.label + ' to associate with this item.') }}
+    {{ __ns('apostrophe', 'Choose ' + data.options.label + ' to associate with this item.') }}
   {%- else -%}
-    {{ __('Choose ' + data.options.pluralLabel + ' to associate with this item.') }}
+    {{ __ns('apostrophe', 'Choose ' + data.options.pluralLabel + ' to associate with this item.') }}
   {%- endif -%}
 {%- endblock -%}
 
@@ -18,9 +18,9 @@
 
 {%- block label -%}
   {%- if data.limit == 1 -%}
-    {{ __('Choose ' + data.options.label) }}
+    {{ __ns('apostrophe', 'Choose ' + data.options.label) }}
   {%- else -%}
-    {{ __('Choose ' + data.options.pluralLabel) }}
+    {{ __ns('apostrophe', 'Choose ' + data.options.pluralLabel) }}
   {%- endif -%}
 {% endblock %}
 

--- a/lib/modules/apostrophe-pieces/views/createModal.html
+++ b/lib/modules/apostrophe-pieces/views/createModal.html
@@ -10,9 +10,9 @@
 {%- endblock -%}
 
 {%- block label -%}
-  {{ __('Create %s', data.options.label) }}
+  {{ __ns('apostrophe', 'Create %s', data.options.label) }}
 {%- endblock -%}
 
 {%- block instructions -%}
-  {{ __('Fill out the fields to add a new %s.', data.options.label | d(''))}}
+  {{ __ns('apostrophe', 'Fill out the fields to add a new %s.', data.options.label | d(''))}}
 {%- endblock -%}

--- a/lib/modules/apostrophe-pieces/views/editorBase.html
+++ b/lib/modules/apostrophe-pieces/views/editorBase.html
@@ -11,7 +11,7 @@
 {%- endblock -%}
 
 {%- block label -%}
-  {{ __('Edit %s', (data.options.label | d(''))) }}
+  {{ __ns('apostrophe', 'Edit %s', (data.options.label | d(''))) }}
 {%- endblock -%}
 
 {%- block filters -%}
@@ -27,7 +27,7 @@
 {%- endblock -%}
 
 {%- block instructions -%}
-  {{ __('Fill out the fields to edit an existing %s.', (data.options.label | d(''))) }}
+  {{ __ns('apostrophe', 'Fill out the fields to edit an existing %s.', (data.options.label | d(''))) }}
 {%- endblock -%}
 
 {% block footerContainer %}

--- a/lib/modules/apostrophe-pieces/views/manageHeadings.html
+++ b/lib/modules/apostrophe-pieces/views/manageHeadings.html
@@ -5,7 +5,7 @@
   <td>{{fields.checkbox('select-all')}}</td>
   {%- for column in data.columns -%}
   <th class="apos-manage-column apos-manage-{{ data.options.name | css }}-{{ column.name | css }}{% if column.sort %} apos-manage-column--sortable{% endif %}" {% if column.sort %}data-sort data-default-sort-direction="{{ column.defaultSortDirection or '1' }}" {% endif %}data-column-name="{{ column.name }}">{#
-      #}{{ __(column.label) }}{#
+      #}{{ __ns('apostrophe', column.label) }}{#
       #}</th>
   {%- endfor -%}
 </tr>

--- a/lib/modules/apostrophe-pieces/views/managePublished.html
+++ b/lib/modules/apostrophe-pieces/views/managePublished.html
@@ -1,6 +1,6 @@
 {# Internationalize the date format string #}
 {%- if data.value -%}
-  {{ __('Published') }}
+  {{ __ns('apostrophe', 'Published') }}
 {%- else -%}
-  {{ __('Draft') }}
+  {{ __ns('apostrophe', 'Draft') }}
 {%- endif -%}

--- a/lib/modules/apostrophe-pieces/views/manageResultLabel.html
+++ b/lib/modules/apostrophe-pieces/views/manageResultLabel.html
@@ -1,9 +1,9 @@
 <div class='apos-manage-result-label'>
   {%- if data.filters.q -%}
-    {{ __('Showing %s - %s of %s results for ', data.skip + 1, data.skip + data.pieces.length, data.total) }}<span>"{{ data.filters.q }}"</span>
+    {{ __ns('apostrophe', 'Showing %s - %s of %s results for ', data.skip + 1, data.skip + data.pieces.length, data.total) }}<span>"{{ data.filters.q }}"</span>
   {%- elif data.total == 0 -%}
-    {{ __('No results for current filters.') }}
+    {{ __ns('apostrophe', 'No results for current filters.') }}
   {%- else -%}
-    {{ __('Showing %s - %s of %s results', data.skip + 1, data.skip + data.pieces.length, data.total) }}
+    {{ __ns('apostrophe', 'Showing %s - %s of %s results', data.skip + 1, data.skip + data.pieces.length, data.total) }}
   {%- endif -%}
 </div>

--- a/lib/modules/apostrophe-pieces/views/manageUpdatedAt.html
+++ b/lib/modules/apostrophe-pieces/views/manageUpdatedAt.html
@@ -1,2 +1,2 @@
 {# Internationalize the date format string #}
-{{ data.value | date(__('MM/DD/YY[ at ]h:mma')) }}
+{{ data.value | date(__ns('apostrophe', 'MM/DD/YY[ at ]h:mma')) }}

--- a/lib/modules/apostrophe-pieces/views/managerModalBase.html
+++ b/lib/modules/apostrophe-pieces/views/managerModalBase.html
@@ -14,7 +14,7 @@
 {%- endblock -%}
 
 {%- block instructions -%}
-  {{ __('Here you can add new %s or click on existing ones to edit them.', __(data.options.pluralLabel |  d(''))) }}
+  {{ __ns('apostrophe', 'Here you can add new %s or click on existing ones to edit them.', __ns('apostrophe', data.options.pluralLabel |  d(''))) }}
 {%- endblock -%}
 
 {%- block filters -%}
@@ -24,7 +24,7 @@
 {%- endblock -%}
 
 {%- block label -%}
-  {{ __('Manage %s', __(data.options.pluralLabel | d(''))) }}
+  {{ __ns('apostrophe', 'Manage %s', __ns('apostrophe', data.options.pluralLabel | d(''))) }}
 {%- endblock -%}
 
 {%- block body -%}

--- a/lib/modules/apostrophe-pieces/views/menu.html
+++ b/lib/modules/apostrophe-pieces/views/menu.html
@@ -1,11 +1,11 @@
 {% import 'apostrophe-ui:components/dropdowns.html' as dropdowns with context -%}
 {%- macro listMenu() -%}
-  <li href="#" class="apos-dropdown-item" data-apos-create-{{ data.options.name | css }}>{{ __('New %s', __(data.options.label)) }}</li>
-  <li href="#" class="apos-dropdown-item" data-apos-manage-{{ data.options.name | css }}>{{ __('Manage %s', __(data.options.pluralLabel)) }}</li>
+  <li href="#" class="apos-dropdown-item" data-apos-create-{{ data.options.name | css }}>{{ __ns('apostrophe', 'New %s', __ns('apostrophe', data.options.label)) }}</li>
+  <li href="#" class="apos-dropdown-item" data-apos-manage-{{ data.options.name | css }}>{{ __ns('apostrophe', 'Manage %s', __ns('apostrophe', data.options.pluralLabel)) }}</li>
   {%- if data.options.import -%}
-    <li href="#" class="apos-dropdown-item" data-apos-import-{{ data.options.name | css }}>{{ __('Import %s', __(data.options.pluralLabel) ) }}</li>
+    <li href="#" class="apos-dropdown-item" data-apos-import-{{ data.options.name | css }}>{{ __ns('apostrophe', 'Import %s', __ns('apostrophe', data.options.pluralLabel) ) }}</li>
     {%- if data.options.export -%}
-      <li href="#" class="apos-dropdown-item" data-apos-export-{{ data.options.name | css }}>{{ __('Export %s', __(data.options.pluralLabel) ) }}</li>
+      <li href="#" class="apos-dropdown-item" data-apos-export-{{ data.options.name | css }}>{{ __ns('apostrophe', 'Export %s', __ns('apostrophe', data.options.pluralLabel) ) }}</li>
     {%- endif -%}
   {%- endif -%}
 {%- endmacro -%}

--- a/lib/modules/apostrophe-pieces/views/select.html
+++ b/lib/modules/apostrophe-pieces/views/select.html
@@ -3,26 +3,26 @@
 
 {% block controls %}
   <div class='apos-modal-controls'>
-    {{ modals.button({dataAttrs: 'data-save', float: 'right', color: 'base', label: __('Save')}) }}
-    {{ modals.button({dataAttrs: 'data-cancel', float: 'left', arrow: 'left', label: __('Cancel')}) }}
+    {{ modals.button({dataAttrs: 'data-save', float: 'right', color: 'base', label: __ns('apostrophe', 'Save')}) }}
+    {{ modals.button({dataAttrs: 'data-cancel', float: 'left', arrow: 'left', label: __ns('apostrophe', 'Cancel')}) }}
   </div>
 {% endblock %}
 
 {% block label %}
-{{ __('Choose %s', __(data.options.pluralLabel | d(''))) }}
+{{ __ns('apostrophe', 'Choose %s', __ns('apostrophe', data.options.pluralLabel | d(''))) }}
 {% endblock %}
 
 {% block body %}
 <ul>
-  <li><a href="#">{{ __('Individually') }}</a></li>
-  <li><a href="#">{{ __('Automatically') }}</a></li>
+  <li><a href="#">{{ __ns('apostrophe', 'Individually') }}</a></li>
+  <li><a href="#">{{ __ns('apostrophe', 'Automatically') }}</a></li>
 </ul>
 
 {# Populated via js #}
 <div data-individual-view></div>
 
 <div data-automatic-view>
-  <h4>{{ __("By Tag") }}</h4>
+  <h4>{{ __ns('apostrophe', "By Tag") }}</h4>
   <input type="text" />
 </div>
 {% endblock %}

--- a/lib/modules/apostrophe-polymorphic-manager/views/chooserModal.html
+++ b/lib/modules/apostrophe-polymorphic-manager/views/chooserModal.html
@@ -11,7 +11,7 @@
 {%- endblock -%}
 
 {%- block instructions -%}
-  {{ __('Select the appropriate tab to choose each type of content.') }}
+  {{ __ns('apostrophe', 'Select the appropriate tab to choose each type of content.') }}
 {%- endblock -%}
 
 {%- block filters -%}
@@ -19,7 +19,7 @@
 {%- endblock -%}
 
 {%- block label -%}
-  {{ __('Choose Documents') }}
+  {{ __ns('apostrophe', 'Choose Documents') }}
 {%- endblock -%}
 
 {%- block body -%}

--- a/lib/modules/apostrophe-schemas/views/arrayEditor.html
+++ b/lib/modules/apostrophe-schemas/views/arrayEditor.html
@@ -2,13 +2,13 @@
 {%- extends "apostrophe-modal:baseSlideable.html" -%}
 
 {%- block controls  -%}
-  <div class="apos-array-save-item apos-button apos-button--minor" data-apos-cancel>{{ __('Cancel') }}</div>{#
-#}<button class="apos-array-save-item apos-button" data-apos-save-array-items>{{ __('Save Items') }}</button>
+  <div class="apos-array-save-item apos-button apos-button--minor" data-apos-cancel>{{ __ns('apostrophe', 'Cancel') }}</div>{#
+#}<button class="apos-array-save-item apos-button" data-apos-save-array-items>{{ __ns('apostrophe', 'Save Items') }}</button>
 {%- endblock -%}
 {%- block body -%}
   <div class="apos-array-chooser" data-apos-array-items></div>
-  <div class="apos-array-add-item apos-button apos-button--major apos-button--square" data-apos-add-array-item>{{ __('+ Add Item') }}</div>
-  <div data-apos-array-limit-reached class="apos-array-limit-reached apos-button apos-button--major apos-button--square apos-button--disabled">{{ __("Limit Reached") }}</div>
+  <div class="apos-array-add-item apos-button apos-button--major apos-button--square" data-apos-add-array-item>{{ __ns('apostrophe', '+ Add Item') }}</div>
+  <div data-apos-array-limit-reached class="apos-array-limit-reached apos-button apos-button--major apos-button--square apos-button--disabled">{{ __ns('apostrophe', "Limit Reached") }}</div>
   <div class="apos-array-editor" data-apos-array-item></div>
   </div>
 {%- endblock -%}

--- a/lib/modules/apostrophe-schemas/views/fieldset.html
+++ b/lib/modules/apostrophe-schemas/views/fieldset.html
@@ -3,11 +3,11 @@
   {# field names. We use this class with our $.findSafe plugin. #}
   {% set options = { 'id': apos.utils.generateId(), fieldClasses: field.fieldClasses, fieldAttributes: field.fieldAttributes } %}
   <fieldset class="apos-field apos-field-{{ field.type | css }} apos-field-{{ field.name | css }} {{ field.classes }}" data-name="{{ field.name }}" {{ field.attributes }}>
-    <label for="{{ options.id }}" class="apos-field-label">{{ __(field.label | d('')) }}</label>
+    <label for="{{ options.id }}" class="apos-field-label">{{ __ns('apostrophe', field.label | d('')) }}</label>
     {%- if field.help -%}
-      <div class="apos-field-help">{{ __(field.help) }}</div>
+      <div class="apos-field-help">{{ __ns('apostrophe', field.help) }}</div>
     {%- elif field.htmlHelp -%}
-      <div class="apos-field-help">{{ __(field.htmlHelp) | safe }}</div>
+      <div class="apos-field-help">{{ __ns('apostrophe', field.htmlHelp) | safe }}</div>
     {%- endif -%}
     {{ bodyMacro(field, options) }}
   </fieldset>

--- a/lib/modules/apostrophe-schemas/views/macros.html
+++ b/lib/modules/apostrophe-schemas/views/macros.html
@@ -10,7 +10,7 @@
           {%- for group in groups -%}
             {%- if group.fields.length -%}
             <div class="apos-schema-tab{% if loop.first %} apos-active{% endif %}" data-apos-open-group="{{ group.name }}">
-              {{ __(group.label | d('')) }}
+              {{ __ns('apostrophe', group.label | d('')) }}
             </div>
             {%- endif -%}
           {%- endfor -%}
@@ -102,14 +102,14 @@
     <ul data-list class="apos-tag-list">
       <li data-item class="apos-tag-list-item">
         {% if not field.readOnly %}<a href="#" class="apos-tag-remove fa fa-remove" data-remove></a>{% endif %}
-        <span class="apos-tag-entry" data-label>{{ __('Example label') }}</span>
+        <span class="apos-tag-entry" data-label>{{ __ns('apostrophe', 'Example label') }}</span>
         {# Link to remove this choice #}
       </li>
     </ul>
     {% if not field.readOnly %}
-      <input id="{{ options.id }}" type="text" name="{{ field.name }}" data-autocomplete placeholder="{{ __('Type Here') }}" class="apos-field-input apos-field-input-text" />
-      <span class="apos-limit-indicator" data-limit-indicator>{{ __('Limit Reached!') }}</span>
-      <a href="#" class="apos-tag-add" data-add><i class="fa fa-plus"></i> {{ __("Add") }}</a>
+      <input id="{{ options.id }}" type="text" name="{{ field.name }}" data-autocomplete placeholder="{{ __ns('apostrophe', 'Type Here') }}" class="apos-field-input apos-field-input-text" />
+      <span class="apos-limit-indicator" data-limit-indicator>{{ __ns('apostrophe', 'Limit Reached!') }}</span>
+      <a href="#" class="apos-tag-add" data-add><i class="fa fa-plus"></i> {{ __ns('apostrophe', "Add") }}</a>
     {% endif %}
 
   </div>
@@ -142,7 +142,7 @@
       <label class="apos-form-checkbox-label apos-text-small">
         <input class="apos-form-checkbox-input" type="checkbox" name="{{ field.name }}" value="{{ choice.value }}"{% if field.readOnly %} disabled{% endif %}>
         <span class="apos-form-checkbox-indicator"></span>
-        {{ __(choice.label | d('')) }}
+        {{ __ns('apostrophe', choice.label | d('')) }}
       </label>
     </div>
   {%- endfor -%}
@@ -175,7 +175,7 @@
 {%- endmacro -%}
 
 {% macro booleanBody(field) %}
-  {{ selectBody(field | merge({ choices: [ { value: '1', label: __('Yes') }, { value: '0', label: __('No') }] })) }}
+  {{ selectBody(field | merge({ choices: [ { value: '1', label: __ns('apostrophe', 'Yes') }, { value: '0', label: __ns('apostrophe', 'No') }] })) }}
 {%- endmacro -%}
 
 {%- macro array(field) -%}
@@ -186,12 +186,12 @@
         <label for="{{ field.name }}" class="apos-field-label"></label>
         <label data-array-length></label><br>
         {%- if field.help -%}
-          <div class="apos-field-help">{{ __(field.help) }}</div>
+          <div class="apos-field-help">{{ __ns('apostrophe', field.help) }}</div>
         {%- elif field.htmlHelp -%}
-          <div class="apos-field-help">{{ __(field.htmlHelp) | safe }}</div>
+          <div class="apos-field-help">{{ __ns('apostrophe', field.htmlHelp) | safe }}</div>
         {%- endif -%}
         <a href="#" class="apos-control apos-button" data-apos-edit-array>
-          {{ __("Edit %s", __(field.label | d(''))) }}
+          {{ __ns('apostrophe', "Edit %s", __ns('apostrophe', field.label | d(''))) }}
           <i class="fa fa-angle-right"></i>
         </a>
       </span>

--- a/lib/modules/apostrophe-schemas/views/radioTable.html
+++ b/lib/modules/apostrophe-schemas/views/radioTable.html
@@ -1,7 +1,7 @@
 {% macro radioTableHeader(choices) %}
   <td></td>
   {%- for choice in choices -%}
-    <td>{{ __(choice.label | d('')) }}</td>
+    <td>{{ __ns('apostrophe', choice.label | d('')) }}</td>
   {%- endfor -%}
 {% endmacro %}
 
@@ -18,7 +18,7 @@
 
 
 <fieldset class="apos-fieldset apos-fieldset-radio-table apos-fieldset-{{ data.name | css }}" data-name="{{ data.name }}">
-  <label>{{ __(data.label | d('')) }}</label>
+  <label>{{ __ns('apostrophe', data.label | d('')) }}</label>
   {# Text entry for autocompleting the next item #}
   {# { label: 'Admin', value: 'admin'}
   { name:'blog', label: 'Blog' } #}

--- a/lib/modules/apostrophe-search/views/index.html
+++ b/lib/modules/apostrophe-search/views/index.html
@@ -4,7 +4,7 @@
 {% block main %}
   <form data-apos-search-page-form method="GET" action="{{ data.url | e }}#main">
     {% if data.filters %}
-      <div class="ld-meta">{{ __('Filter Results By Type') }}</div>
+      <div class="ld-meta">{{ __ns('apostrophe', 'Filter Results By Type') }}</div>
       <ul>
         {% for filter in data.filters %}
           <li>
@@ -16,7 +16,7 @@
         {% endfor %}
       </ul>
     {% endif %}
-    <div class="ld-meta">{{ __('New Search') }}</div>
+    <div class="ld-meta">{{ __ns('apostrophe', 'New Search') }}</div>
     <input type="search" data-apos-search-field value="{{ data.query.q | e }}" name="q" />
     <input type="submit" value="Search" />
   </form>

--- a/lib/modules/apostrophe-tags/views/manager.html
+++ b/lib/modules/apostrophe-tags/views/manager.html
@@ -11,15 +11,15 @@
 {%- endblock -%}
 
 {%- block label -%}
-  {{ __('Manage Tags') }}
+  {{ __ns('apostrophe', 'Manage Tags') }}
 {%- endblock -%}
 
 {% block instructions %}
 {#  <p>
-    {{ __('Create, edit, and remove tags.') }}
+    {{ __ns('apostrophe', 'Create, edit, and remove tags.') }}
   </p>#}
   <div class="apos-manage-tag-add-wrapper">
-    <input data-apos-tag-add-field type="text" class="apos-field-input apos-field-input-text" placeholder="{{ __('Find or add a tag...') }}"/>
+    <input data-apos-tag-add-field type="text" class="apos-field-input apos-field-input-text" placeholder="{{ __ns('apostrophe', 'Find or add a tag...') }}"/>
     <a href="#" data-apos-tag-add class="apos-manage-tag-add fa fa-plus"></a>
   </div>
 {% endblock %}

--- a/lib/modules/apostrophe-tags/views/menu.html
+++ b/lib/modules/apostrophe-tags/views/menu.html
@@ -1,6 +1,6 @@
 {% import 'apostrophe-ui:components/dropdowns.html' as dropdowns with context -%}
 {%- macro listMenu() -%}
-  <li href="#" class="apos-dropdown-item" data-apos-manage-tags>{{ __('Manage Tags') }}</li>
+  <li href="#" class="apos-dropdown-item" data-apos-manage-tags>{{ __ns('apostrophe', 'Manage Tags') }}</li>
 {%- endmacro -%}
 {%- if data.permissions.edit -%}
   <div class="apos-admin-bar-item">

--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -303,20 +303,10 @@ module.exports = {
 
         env.addGlobal('apos', self.templateApos);
 
-        var fns = [ '__', '__n', '__mf', '__l', '__h' ];
+        var fns = [ '__', '__n', '__mf', '__l', '__h', '__ns', '__ns_n', '__ns_mf', '__ns_l', '__ns_h' ];
         _.each(fns, function(name) {
           env.addGlobal(name, function(key) {
-            // We should have made `module` an argument to `self.i18n`, but we
-            // didn't, and it's too late to change that while maintaining bc.
-            //
-            // So we make the module that called render() available to `self.i18n`
-            // as `req.aposI18nCallingModule`. This is OK because `self.i18n` is
-            // a synchronous function. Overrides that don't care can just ignore it.
-            var previous = req.aposI18nCallingModule;
-            req.aposI18nCallingModule = module;
-            var result = self.i18n.apply(null, [ req, name ].concat(Array.prototype.slice.call(arguments)));
-            req.aposI18nCallingModule = previous;
-            return result;
+            return self.i18n.apply(null, [ req, name ].concat(Array.prototype.slice.call(arguments)));
           });
         });
 
@@ -352,9 +342,38 @@ module.exports = {
     // Invokes the specified operation of the i18n module. This
     // method exists as an override and extension point for
     // Apostrophe's static text internationalization features.
+    //
+    // In the default implementation, namespaced calls like `__ns('apostrophe', 'test')` or
+    // `__ns_n('apostrophe', '%s cat', 2)` are simply passed through to the
+    // regular, non-namespaced functions. Modules that actually leverage the
+    // namespacing are delivered as separate npm modules for those that need them.
 
     self.i18n = function(req, operation, key /* , additional arguments */) {
-      return req.res[operation].apply(null, Array.prototype.slice.call(arguments, 2));
+      const nsOperations = {
+        '__ns': '__',
+        '__ns_l': '__l',
+        '__ns_n': '__n',
+        '__ns_mf': '__mf',
+        '__ns_h': '__h'
+      };
+      var namespaces = self.apos.modules['apostrophe-i18n'].namespaces;
+      var namespace = 'default';
+      var i18nModule;
+      if (nsOperations[operation]) {
+        namespace = self.apos.modules['apostrophe-i18n'].options.namespaces ? arguments[2] : 'default';
+        if (!namespaces[namespace]) {
+          namespaces[namespace] = self.apos.modules['apostrophe-i18n'].getI18nModule(namespace);
+        }
+        i18nModule = namespaces[namespace];
+        console.log('locale is ' + req.locale);
+        i18nModule.setLocale(req.locale.replace(/-draft/, ''));
+        return i18nModule[nsOperations[operation]].apply(i18nModule, Array.prototype.slice.call(arguments, 3));
+      } else {
+        // This one always exists already
+        i18nModule = namespaces['default'];
+        i18nModule.setLocale(req.locale);
+        return i18nModule[operation].apply(i18nModule, Array.prototype.slice.call(arguments, 2));
+      }
     };
 
     self.envs = {};

--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -306,7 +306,17 @@ module.exports = {
         var fns = [ '__', '__n', '__mf', '__l', '__h' ];
         _.each(fns, function(name) {
           env.addGlobal(name, function(key) {
-            return self.i18n.apply(null, [ req, name ].concat(Array.prototype.slice.call(arguments)));
+            // We should have made `module` an argument to `self.i18n`, but we
+            // didn't, and it's too late to change that while maintaining bc.
+            //
+            // So we make the module that called render() available to `self.i18n`
+            // as `req.aposI18nCallingModule`. This is OK because `self.i18n` is
+            // a synchronous function. Overrides that don't care can just ignore it.
+            var previous = req.aposI18nCallingModule;
+            req.aposI18nCallingModule = module;
+            var result = self.i18n.apply(null, [ req, name ].concat(Array.prototype.slice.call(arguments)));
+            req.aposI18nCallingModule = previous;
+            return result;
           });
         });
 

--- a/lib/modules/apostrophe-templates/views/templateError.html
+++ b/lib/modules/apostrophe-templates/views/templateError.html
@@ -8,7 +8,7 @@
 <html lang="en-US">
 <head>
   <meta charset="utf-8">
-  <title>{{ __("An error has occurred") }}</title>
+  <title>{{ __ns('apostrophe', "An error has occurred") }}</title>
   <style type="text/css">
     body {
       background-color: #ccf;
@@ -26,8 +26,8 @@
 </head>
 <body>
   <main>
-    <h1>{{ __('An error has occurred') }}</h1>
-    <p>{{ __("An error has occurred. We're working on it. We apologize for the inconvenience.") }}</p>
+    <h1>{{ __ns('apostrophe', 'An error has occurred') }}</h1>
+    <p>{{ __ns('apostrophe', "An error has occurred. We're working on it. We apologize for the inconvenience.") }}</p>
   </main>
 </body>
 </html>

--- a/lib/modules/apostrophe-ui/views/components/buttons.html
+++ b/lib/modules/apostrophe-ui/views/components/buttons.html
@@ -1,8 +1,8 @@
 {% macro base(label, options, classes) -%}
   {%- if options.url -%}
-    <a href="{{ options.url }}" class="apos-button {{ classes }}" {% if options.tooltip %}data-apos-tooltip="{{ options.tooltip }}"{% endif %} {{ options.attributes }} data-apos-{{ options.action | css }}{% if options.value %}='{{ options.value }}'{% endif %}><span class="apos-button-label">{{ __(label | d('')) }}</span>{% if options.icon %}<i class="fa fa-{{ options.icon }}"></i>{% endif %}</a>
+    <a href="{{ options.url }}" class="apos-button {{ classes }}" {% if options.tooltip %}data-apos-tooltip="{{ options.tooltip }}"{% endif %} {{ options.attributes }} data-apos-{{ options.action | css }}{% if options.value %}='{{ options.value }}'{% endif %}><span class="apos-button-label">{{ __ns('apostrophe', label | d('')) }}</span>{% if options.icon %}<i class="fa fa-{{ options.icon }}"></i>{% endif %}</a>
   {%- else -%}
-    <button class="apos-button {{ classes }}" type="button" {% if options.tooltip %}data-apos-tooltip="{{ options.tooltip }}"{% endif %} {{ options.attributes }} data-apos-{{ options.action | css }}{% if options.value %}='{{ options.value }}'{% endif %}><span class="apos-button-label">{{ __(label | d('')) }}</span>{% if options.icon %}<i class="fa fa-{{ options.icon }}"></i>{% endif %}</button>
+    <button class="apos-button {{ classes }}" type="button" {% if options.tooltip %}data-apos-tooltip="{{ options.tooltip }}"{% endif %} {{ options.attributes }} data-apos-{{ options.action | css }}{% if options.value %}='{{ options.value }}'{% endif %}><span class="apos-button-label">{{ __ns('apostrophe', label | d('')) }}</span>{% if options.icon %}<i class="fa fa-{{ options.icon }}"></i>{% endif %}</button>
   {%- endif -%}
 {%- endmacro %}
 

--- a/lib/modules/apostrophe-ui/views/components/dropdowns.html
+++ b/lib/modules/apostrophe-ui/views/components/dropdowns.html
@@ -2,7 +2,7 @@
 
 {% macro menuItem(content, options) -%}
   <li class="apos-dropdown-item" data-apos-{{ content.action }}{% if content.value %}="{{ content.value }}"{% endif %}>
-    {{ __(content.label | d('')) }}
+    {{ __ns('apostrophe', content.label | d('')) }}
   </li>
 {%- endmacro %}
 
@@ -23,7 +23,7 @@
     {%- elif type == 'admin' -%}
       {# TODO: is this dead code? adminBar.html appears to output its own #}
       <div class="apos-admin-bar-item-inner">
-        {{ __(menu.label | d('')) }}
+        {{ __ns('apostrophe', menu.label | d('')) }}
       </div>
     {%- endif -%}
     <ul class="apos-dropdown-items" data-apos-dropdown-items>

--- a/lib/modules/apostrophe-ui/views/components/fields.html
+++ b/lib/modules/apostrophe-ui/views/components/fields.html
@@ -1,14 +1,14 @@
 {% macro string(name, placeholder, value, readOnly, options) -%}
-  <input id="{{ options.id }}" name="{{ name }}" placeholder="{{__(placeholder | d(''))}}" class="apos-field-input apos-field-input-text{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}" type="text" value="{{__(value | d(''))}}"{% if readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
+  <input id="{{ options.id }}" name="{{ name }}" placeholder="{{__ns('apostrophe', placeholder | d(''))}}" class="apos-field-input apos-field-input-text{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}" type="text" value="{{__ns('apostrophe', value | d(''))}}"{% if readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
 {%- endmacro %}
 
 {% macro textarea(name, placeholder, readOnly, options) -%}
-  <textarea id="{{ options.id }}" name="{{ name }}" placeholder="{{__(placeholder | d(''))}}" class="apos-field-input apos-field-input-textarea{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}"{% if readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}></textarea>
+  <textarea id="{{ options.id }}" name="{{ name }}" placeholder="{{__ns('apostrophe', placeholder | d(''))}}" class="apos-field-input apos-field-input-textarea{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}"{% if readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}></textarea>
 {%- endmacro %}
 
 {% macro checkbox(name, placeholder, readOnly) -%}
   <label>
-    <input name="{{ name }}" placeholder="{{__(placeholder | d(''))}}" class="apos-field-input apos-field-input-checkbox{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}" type="checkbox"{% if readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
+    <input name="{{ name }}" placeholder="{{__ns('apostrophe', placeholder | d(''))}}" class="apos-field-input apos-field-input-checkbox{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}" type="checkbox"{% if readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
     <span class="apos-field-input-checkbox-indicator"></span>
   </label>
 {%- endmacro %}
@@ -22,7 +22,7 @@
   <div class="apos-field-input-select-wrapper">
     <select name="{{ name }}" class="apos-field-input apos-field-input-select{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}"{% if readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
       {%- for option in options -%}
-        <option {{ "selected" if option.value == selected }} value="{{ option.value }}">{{ __(option.label | d('')) }}</option>
+        <option {{ "selected" if option.value == selected }} value="{{ option.value }}">{{ __ns('apostrophe', option.label | d('')) }}</option>
       {%- endfor -%}
     </select>
   </div>
@@ -31,13 +31,13 @@
 {% macro color(name, placeholder, value, readOnly, options) -%}
   <label>
     <div class="apos-field-input-color-preview" data-apos-color-preview></div>
-    <input id="{{ options.id }}" name="{{ name }}" data-apos-color-empty-label="{{ __("None selected") }}" class="apos-field-input apos-field-input-color{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}" data-apos-color type="text" value="{{__(value | d(''))}}"{% if readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
+    <input id="{{ options.id }}" name="{{ name }}" data-apos-color-empty-label="{{ __ns('apostrophe', "None selected") }}" class="apos-field-input apos-field-input-color{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}" data-apos-color type="text" value="{{__ns('apostrophe', value | d(''))}}"{% if readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
   </label>
 {%- endmacro %}
 
 {% macro range(name, min, max, step, placeholder, value, readOnly, options) -%}
   <label>
     <span class="apos-field-input-range-value" data-apos-range-value></span>
-    <input id="{{ options.id }}" name="{{ name }}" min="{{ min }}" max="{{ max }}" step="{{ step or 'any' }}" class="apos-field-input apos-field-input-range{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}" type="range" value="{{__(value | d(''))}}"{% if readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
+    <input id="{{ options.id }}" name="{{ name }}" min="{{ min }}" max="{{ max }}" step="{{ step or 'any' }}" class="apos-field-input apos-field-input-range{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}" type="range" value="{{__ns('apostrophe', value | d(''))}}"{% if readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
   </label>
 {%- endmacro %}

--- a/lib/modules/apostrophe-ui/views/components/links.html
+++ b/lib/modules/apostrophe-ui/views/components/links.html
@@ -1,5 +1,5 @@
 {% macro base(label, options, classes) -%}
-  <a {{ ('href=' + options.url) if options.url }} class="apos-link {{ classes }}" data-{{ options.action }}>{{ __(label | d('')) }}</a>
+  <a {{ ('href=' + options.url) if options.url }} class="apos-link {{ classes }}" data-{{ options.action }}>{{ __ns('apostrophe', label | d('')) }}</a>
 {%- endmacro -%}
 
 {% macro major(label, options) -%}

--- a/lib/modules/apostrophe-users/views/accountMenu.html
+++ b/lib/modules/apostrophe-users/views/accountMenu.html
@@ -1,7 +1,7 @@
 {% import 'apostrophe-ui:components/dropdowns.html' as dropdowns with context -%}
 {%- macro listMenu() -%}
-  <li href="#" class="apos-dropdown-item" data-apos-edit-{{ data.options.name | css }}="{{ data.user._id }}">{{ __('Edit Account') }}</li>
-  <li href="#" class="apos-dropdown-item" data-apos-logout>{{ __('Logout') }}</li>
+  <li href="#" class="apos-dropdown-item" data-apos-edit-{{ data.options.name | css }}="{{ data.user._id }}">{{ __ns('apostrophe', 'Edit Account') }}</li>
+  <li href="#" class="apos-dropdown-item" data-apos-logout>{{ __ns('apostrophe', 'Logout') }}</li>
 {%- endmacro -%}
 {%- if data.permissions.edit -%}
   <div class="apos-admin-bar-item">

--- a/lib/modules/apostrophe-versions/lib/browser.js
+++ b/lib/modules/apostrophe-versions/lib/browser.js
@@ -8,7 +8,9 @@ module.exports = function(self, options) {
   var browserOptions = {
     action: self.action,
     messages: {
-      tryAgain: self.apos.i18n.__('Server error, please try again.')
+      // This always yields the default translation, it should be fixed but
+      // this code does not run on a per-request basis (old bug)
+      tryAgain: self.apos.i18n.__('apostrophe', 'Server error, please try again.')
     }
   };
 

--- a/lib/modules/apostrophe-versions/views/versions.html
+++ b/lib/modules/apostrophe-versions/views/versions.html
@@ -7,16 +7,16 @@
 
 {% block controls %}
   <div class="apos-modal-controls">
-    {{ buttons.minor(__('Finished'), { action: 'cancel' }) }}
+    {{ buttons.minor(__ns('apostrophe', 'Finished'), { action: 'cancel' }) }}
   </div>
 {% endblock %}
 
 {% block label %}
-{{ __('Versions') }}
+{{ __ns('apostrophe', 'Versions') }}
 {% endblock %}
 
 {% block body %}
-<div class="apos-versions" data-no-changes="{{ __('No changes to display.') }}">
+<div class="apos-versions" data-no-changes="{{ __ns('apostrophe', 'No changes to display.') }}">
   {# Loop over all versions and render changes in each one #}
   {% for version in data.versions %}
     <div class="apos-version{% if loop.first %} apos-version-current{% endif %}" data-version="{{ version._id }}" data-previous="{{ version._previous._id }}">
@@ -25,16 +25,16 @@
         </div>
       </div>{#
       #}<div class="apos-changes-meta">
-          <cite>{{ version.author }}</cite><span>{{ __('made changes on') }}</span>
-          <h4>{{ version.createdAt | date(__('MM/DD/YY[ at ]h:mma')) }}</h4><br>
+          <cite>{{ version.author }}</cite><span>{{ __ns('apostrophe', 'made changes on') }}</span>
+          <h4>{{ version.createdAt | date(__ns('apostrophe', 'MM/DD/YY[ at ]h:mma')) }}</h4><br>
           {%- if version._previous -%}
-            <h5 data-open-changes>{{ __('See Changes') }}</h5>
+            <h5 data-open-changes>{{ __ns('apostrophe', 'See Changes') }}</h5>
           {%- endif -%}
       </div>
         {%- if loop.first -%}
-          {{ buttons.disabled(__('Current'), { action: 'none', value: version._id }) }}
+          {{ buttons.disabled(__ns('apostrophe', 'Current'), { action: 'none', value: version._id }) }}
         {%- else -%}
-          {{ buttons.major(__('Revert to'), { action: 'revert', value: version._id })}}
+          {{ buttons.major(__ns('apostrophe', 'Revert to'), { action: 'revert', value: version._id })}}
         {%- endif -%}
         <div class="apos-changes">
         {% if version._previous -%}

--- a/lib/modules/apostrophe-video-fields/views/video.html
+++ b/lib/modules/apostrophe-video-fields/views/video.html
@@ -4,8 +4,8 @@
 {% macro video(field) %}
   {% if not field.readOnly %}<input type="text" class="apos-field-input apos-field-input-text" name="{{ field.name }}" />{% endif %}
   <div class="apos-video-player" data-apos-video-player></div>
-  <div class="apos-video-error" data-apos-video-error="401">{{ __('Embedding is not allowed for this video.') }}</div>
-  <div class="apos-video-error" data-apos-video-error="404">{{ __('That video was not found. Paste a URL to the video\'s page.') }}</div>
+  <div class="apos-video-error" data-apos-video-error="401">{{ __ns('apostrophe', 'Embedding is not allowed for this video.') }}</div>
+  <div class="apos-video-error" data-apos-video-error="404">{{ __ns('apostrophe', 'That video was not found. Paste a URL to the video\'s page.') }}</div>
 {% endmacro %}
 
 {{ schemas.fieldset(data, video) }}

--- a/lib/modules/apostrophe-widgets/views/baseWidgetEditor.html
+++ b/lib/modules/apostrophe-widgets/views/baseWidgetEditor.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block label %}
-{{ __(data.label | d('')) }}
+{{ __ns('apostrophe', data.label | d('')) }}
 {% endblock %}
 
 {% block body %}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "html-to-plaintext": "^0.1.1",
     "html-to-text": "^3.3.0",
     "i18n": "^0.8.3",
+    "import-fresh": "^3.2.1",
     "joinr": "^1.0.2",
     "jpeg-exif": "^1.1.4",
     "launder": "^1.1.1",

--- a/test/lib/modules/apostrophe-pages/views/pages/i18n.html
+++ b/test/lib/modules/apostrophe-pages/views/pages/i18n.html
@@ -9,11 +9,11 @@
 counts: {{ data.global.counts }}
 
 {# Use a helper function to test template level i18n of static phrases #}
-{{ apos.test.verify(__('Test Phrase'), 'Test Phrase') }}
-{{ apos.test.verify(__({ phrase: 'Test Phrase', locale: 'es' }), 'es Test Phrase') }}
-{{ apos.test.verify(__n('Kitten', 1), 'Kitten') }}
-{{ apos.test.verify(__n('Kitten', 2), 'Kittens') }}
-{{ apos.test.verify(__mf('Interpolation {name}', { name: 'test' }), 'Interpolation test') }}
-{{ apos.test.verify(__l('Test Phrase') | join(':'), 'Test Phrase:es Test Phrase') }}
-{{ apos.test.verify(__h('Test Phrase')[0].en, 'Test Phrase') }}
-{{ apos.test.verify(__h('Test Phrase')[1].es, 'es Test Phrase') }}
+{{ apos.test.verify(__ns('apostrophe', 'Test Phrase'), 'Test Phrase') }}
+{{ apos.test.verify(__ns('apostrophe', { phrase: 'Test Phrase', locale: 'es' }), 'es Test Phrase') }}
+{{ apos.test.verify(__ns_n('apostrophe', 'Kitten', 1), 'Kitten') }}
+{{ apos.test.verify(__ns_n('apostrophe', 'Kitten', 2), 'Kittens') }}
+{{ apos.test.verify(__ns_mf('apostrophe', 'Interpolation {name}', { name: 'test' }), 'Interpolation test') }}
+{{ apos.test.verify(__ns_l('apostrophe', 'Test Phrase') | join(':'), 'Test Phrase:es Test Phrase') }}
+{{ apos.test.verify(__ns_h('apostrophe', 'Test Phrase')[0].en, 'Test Phrase') }}
+{{ apos.test.verify(__ns_h('apostrophe', 'Test Phrase')[1].es, 'es Test Phrase') }}


### PR DESCRIPTION
…at module called render(), as an inexpensive way to achieve namespacing and/or just prevent i18n of admin text when that is not desired