### PR TITLE
we do not invent our own event bus in lean mode, because DOM events w…

### DIFF
--- a/lib/modules/apostrophe-browser-utils/public/js/lean.js
+++ b/lib/modules/apostrophe-browser-utils/public/js/lean.js
@@ -17,6 +17,22 @@
 
   apos.utils = apos.utils || {};
 
+  // emit a custom event on the specified DOM element in a cross-browser way.
+  // If `data` is present, the properties of `data` will be available on the event object
+  // in your event listeners. For events unrelated to the DOM, we often emit on
+  // `document.body` and call `addEventListener` on `document.body` elsewhere.
+  //
+  // "Where is `apos.utils.on`?" You don't need it, use `addEventListener`, which is
+  // standard.
+
+  apos.utils.emit = function(el, name, data) {
+    // IE-compatible custom DOM event
+    const event = document.createEvent('Event');
+    event.initEvent(name, true, true);
+    apos.utils.assign(event, data || {});
+    el.dispatchEvent(event);
+  };
+
   // Make a POST JSON call to the given URI, which is expected to be on the
   // Apostrophe site. CSRF headers are correctly sent and the URL is modified
   // if needed to honor the site prefix.
@@ -34,6 +50,12 @@
   // object passed as the error will have a `status` property that
   // can be inspected. The actual data of the error response is still
   // delivered as well, in the second argument.
+  //
+  // Just before the XMLHTTPRequest is sent this method emits an
+  // `apos-before-post` event on `document.body`. The event object
+  // has `uri`, `data` and `request` properties. `request` is the
+  // XMLHTTPRequest object. You can use this to set custom headers
+  // on all lean requests, etc.
 
   apos.utils.post = function(uri, data, callback) {
     if (!callback) {
@@ -62,6 +84,11 @@
     if (csrfToken) {
       xmlhttp.setRequestHeader('X-XSRF-TOKEN', csrfToken);
     }
+    apos.utils.emit(document.body, 'apos-before-post', {
+      uri: uri,
+      data: data,
+      request: xmlhttp
+    });
     if (formData) {
       xmlhttp.send(data);
     } else {
@@ -83,6 +110,12 @@
   // object passed as the error will have a `status` property that
   // can be inspected. The actual data of the error response is still
   // delivered as well, in the second argument.
+  //
+  // Just before the XMLHTTPRequest is sent this method emits an
+  // `apos-before-get` event on `document.body`. The event object
+  // has `uri`, `data` and `request` properties. `request` is the
+  // XMLHTTPRequest object. You can use this to set custom headers
+  // on all lean requests, etc.
 
   apos.utils.get = function(uri, data, callback) {
     var keys, i;
@@ -117,6 +150,11 @@
     var xmlhttp = new XMLHttpRequest();
     xmlhttp.open("GET", uri);
     xmlhttp.setRequestHeader("Content-Type", "application/json");
+    apos.utils.emit(document.body, 'apos-before-get', {
+      uri: uri,
+      data: data,
+      request: xmlhttp
+    });
     xmlhttp.send(JSON.stringify(data));
     monitor(xmlhttp, callback);
   };


### PR DESCRIPTION
…ork just fine, but we do now provide a convenience method to emit one, with the convention being to emit non-DOM-related events as custom event names on "body"