### PR TITLE
Fixes `def: null` handling for `type: 'date'` in schemas

### DIFF
--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -1867,7 +1867,7 @@ module.exports = {
       name: 'date',
       converters: {
         string: function(req, data, name, object, field, callback) {
-          object[name] = self.apos.launder.date(data[name]);
+          object[name] = self.apos.launder.date(data[name], field.def);
           return setImmediate(callback);
         },
         form: 'string'


### PR DESCRIPTION
`def: null` is not working for `type: 'date'`, it is set to current date always if left empty or cleared in editor, because this is default `launder` behavior fo dates when no default value is provided to `launder.date` call.

This simple fix resolves the issue.