### PR TITLE
docs: Fix simple typo, sesions -> sessions

### DIFF
--- a/lib/modules/apostrophe-express/index.js
+++ b/lib/modules/apostrophe-express/index.js
@@ -71,7 +71,7 @@
 //
 // ```javascript
 // {
-//   // Do not save sesions until something is stored in them.
+//   // Do not save sessions until something is stored in them.
 //   // Greatly reduces aposSessions collection size
 //   saveUninitialized: false,
 //   // The mongo store uses TTL which means we do need
@@ -301,14 +301,14 @@ module.exports = {
       return next();
     };
 
-    // Establish Express sesions. See [options](#options)
+    // Establish Express sessions. See [options](#options)
 
     self.sessions = function() {
       var Store;
       self.options.session = self.options.session || {};
       var sessionOptions = self.options.session;
       _.defaults(sessionOptions, {
-        // Do not save sesions until something is stored in them.
+        // Do not save sessions until something is stored in them.
         // Greatly reduces aposSessions collection size
         saveUninitialized: false,
         // The mongo store uses TTL which means we do need


### PR DESCRIPTION
There is a small typo in lib/modules/apostrophe-express/index.js.

Should read `sessions` rather than `sesions`.

