### PR TITLE
portable event emit and same site test

### DIFF
--- a/lib/modules/apostrophe-browser-utils/public/js/lean.js
+++ b/lib/modules/apostrophe-browser-utils/public/js/lean.js
@@ -447,7 +447,7 @@
   // which is generally the case.
 
   apos.utils.sameSite = function(uri) {
-    var matches = uri.match(/^(https?:)?\/\/([^\/]+)/);
+    var matches = uri.match(/^(https?:)?\/\/([^/]+)/);
     if (!matches) {
       // If URI is not absolute or protocol-relative then it is always same-origin
       return true;

--- a/lib/modules/apostrophe-browser-utils/public/js/lean.js
+++ b/lib/modules/apostrophe-browser-utils/public/js/lean.js
@@ -27,13 +27,14 @@
 
   apos.utils.emit = function(el, name, data) {
     var event;
-    if (!window.CustomEvent) {
-      // bc
+    try {
+      // Modern. We can't sniff for this, we can only try it. IE11
+      // has it but it's not a constructor and throws an exception
+      event = new window.CustomEvent(name);
+    } catch (e) {
+      // bc for IE11
       event = document.createEvent('Event');
       event.initEvent(name, true, true);
-    } else {
-      // modern browsers
-      event = new CustomEvent(name);
     }
     apos.utils.assign(event, data || {});
     el.dispatchEvent(event);
@@ -78,10 +79,7 @@
       });
     }
     if (apos.prefix) {
-      // Easy check for same origin
-      var link = document.createElement('a');
-      link.href = uri;
-      if (link.host === location.host) {
+      if (apos.utils.sameSite(uri)) {
         uri = apos.prefix + uri;
       }
     }
@@ -145,10 +143,7 @@
       });
     }
     if (apos.prefix) {
-      // Easy check for same origin
-      var link = document.createElement('a');
-      link.href = uri;
-      if (link.host === location.host) {
+      if (apos.utils.sameSite(uri)) {
         uri = apos.prefix + uri;
       }
     }
@@ -443,6 +438,21 @@
       path += '.' + effectiveSize;
     }
     return path + '.' + file.extension;
+  };
+
+  // Returns true if the uri references the same site (same host and port) as the
+  // current page. Cross-browser implementation, valid at least back to IE11.
+  // Regarding port numbers, this will match as long as the URIs are consistent
+  // about not explicitly specifying the port number when it is 80 (HTTP) or 443 (HTTPS),
+  // which is generally the case.
+
+  apos.utils.sameSite = function(uri) {
+    var matches = uri.match(/^(https?:)?\/\/([^\/]+)/);
+    if (!matches) {
+      // If URI is not absolute or protocol-relative then it is always same-origin
+      return true;
+    }
+    return window.location.host === matches[2];
   };
 
 })();


### PR DESCRIPTION
Awful IE11 truths from ECG:

* CustomEvent exists, but is not a constructor, so our old sniff for it was not valid on IE11. Ow.
* The trick of using the host property of an anchor tag to check if it is the same site as location.host is not valid on IE11. Ow ow.
