### PR TITLE
Changes documentation comment style

### DIFF
--- a/lib/modules/apostrophe-widgets/index.js
+++ b/lib/modules/apostrophe-widgets/index.js
@@ -372,9 +372,9 @@ module.exports = {
     };
 
     // Implement the command line task that lists all widgets of
-    // this type found in the database:
+    // a particular type found in the database:
     //
-    // `node app your-module-name-here-widgets:list`
+    // `node app some-widgets:list`
 
     self.list = function(apos, argv, callback) {
 


### PR DESCRIPTION
This change is to get a consistent example style that uses "my-widget," "my-module" etc. In this case that didn't even seem necessary, but the "your" would buck the convention.