### PR TITLE
add return false to preventi href redirect

### DIFF
--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -822,6 +822,7 @@ apos.define('apostrophe-schemas', {
               apos.utils.error(err);
             }
           });
+          return false;
         });
         return setImmediate(callback);
       },


### PR DESCRIPTION
With the <base> tag in html, the href='#' in button to open the array modal redirect in home, return false in this function prevents this redirect.