### PR TITLE
cloning a widget changes the id properly

### DIFF
--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -476,6 +476,8 @@ apos.define('apostrophe-areas-editor', {
       self.$selected = $widget;
       var type = self.$selected.attr('data-apos-widget');
       var options = self.options.widgets[type] || {};
+      // Clone first so we're not just changing the id of the original
+      $widget = $widget.clone();
       // Recursively set new widget ids for this widget and its descendants
       // with the same docId
       newIds($widget);


### PR DESCRIPTION
Cloning a widget was always supposed to create a widget with the old id, but actually we were changing the id(s) of the old one and then copying it, so we wound up with two the same 🙄 Cloning the jquery object first avoids this problem.