### PR TITLE
add istanbul for code coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ test/public/css/master-*
 npm-debug.log
 *.DS_Store
 *.npmignore
+.nyc_output
+coverage
 node_modules
 test/node_modules
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {
-    "test": "npm run lint && npm run audit && mocha",
+    "pretest": "npm run lint",
+    "test": "nyc --reporter=html mocha",
     "audit": "npm audit",
     "lint": "eslint ."
   },
@@ -89,6 +90,7 @@
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-standard": "^3.1.0",
-    "mocha": "^7.0.0"
+    "mocha": "^7.0.0",
+    "nyc": "^15.0.1"
   }
 }

--- a/test/admin-bar.js
+++ b/test/admin-bar.js
@@ -11,7 +11,8 @@ describe('Admin bar', function() {
   /// ///
 
   it('should allow a group reversing the current order', function(done) {
-    this.timeout(10000);
+    // This is the first one, allow for sleepy computers
+    this.timeout(30000);
     apos = require('../index.js')({
       root: module,
       shortName: 'test',


### PR DESCRIPTION
To view the code coverage report open `coverage/index.html` in a browser. 