### PR TITLE
Allow empty values in time fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.106.4 (2020-05-20)
+
+* Users may now intentionally clear a `time` field, whether or not it has a `def` setting, in which case it is stored as `null` (unless `required: true` is present). The inability to do this was a regression introduced in version 2.102.0.
+
 ## 2.106.3 (2020-05-06)
 
 * Fixes a page tree interface bug that would cause pages to be lost when they

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -1924,6 +1924,12 @@ module.exports = {
       name: 'time',
       converters: {
         string: function(req, data, name, object, field, callback) {
+          if (!data[name]) {
+            object[name] = null;
+
+            return setImmediate(callback);
+          }
+
           object[name] = self.apos.launder.time(data[name]);
           return setImmediate(callback);
         },

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -529,6 +529,30 @@ describe('Schemas', function() {
     });
   });
 
+  it('should keep an empty submitted field value null for a date field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'date',
+          name: 'date',
+          label: 'date'
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      date: ''
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.date === null);
+      done();
+    });
+  });
+
   it('should ensure a max value is being trimmed to the max length for a string field type', function(done) {
     var schema = apos.schemas.compose({
       addFields: [

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -505,6 +505,30 @@ describe('Schemas', function() {
     });
   });
 
+  it('should keep an empty submitted field value null for a time field type', function(done) {
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          type: 'time',
+          name: 'time',
+          label: 'time'
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    var input = {
+      time: ''
+    };
+    var req = apos.tasks.getReq();
+    var result = {};
+    return apos.schemas.convert(req, schema, 'form', input, result, function(err) {
+      assert(!err);
+      assert(_.keys(result).length === 1);
+      assert(result.time === null);
+      done();
+    });
+  });
+
   it('should ensure a max value is being trimmed to the max length for a string field type', function(done) {
     var schema = apos.schemas.compose({
       addFields: [


### PR DESCRIPTION
Time fields do not currently seem to support empty values, defaulting to current time. Included is a fix using the approach that was used to allow empty values for dates in PR #2171. I've also included a test for the handling of empty values for date fields.