### PR TITLE
apos.utils.post and apos.utils.http should tolerate no content type o…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-.nyc_output
-coverage
 *.swp
 package-lock.json
 test/public/modules/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.nyc_output
+coverage
 *.swp
 package-lock.json
 test/public/modules/*

--- a/lib/modules/apostrophe-browser-utils/public/js/lean.js
+++ b/lib/modules/apostrophe-browser-utils/public/js/lean.js
@@ -182,6 +182,11 @@
       var responseHeader = this.getResponseHeader("Content-Type");
       var trimResponse = this.responseText.trim();
       var data;
+      if (!responseHeader) {
+        // Can happen, usually when the response body is null and
+        // Express sees no reason to set a content type
+        return callback(error(), this.responseText);
+      }
       if (responseHeader.match(/^application\/json/)) {
         // Definitely JSON, treat as such
         try {


### PR DESCRIPTION
…n the response

Don't crash when there is no content type. Backport from A3.