### PR TITLE
The `distinctCounts(true)` feature is now compatible with apostrophe-db-mongo-3-driver, when present

### DIFF
--- a/lib/modules/apostrophe-docs/lib/cursor.js
+++ b/lib/modules/apostrophe-docs/lib/cursor.js
@@ -988,16 +988,32 @@ module.exports = {
               }
             }
           ]);
+          console.log(self.db);
           return self.db.aggregate(pipeline, function(err, results) {
             if (err) {
               return callback(err);
             }
-            var counts = {};
-            _.each(results, function(doc) {
-              counts[doc._id] = doc.count;
-            });
-            self.set('distinctCounts', counts);
-            return callback(null, _.pluck(results, '_id'));
+            console.log('**', results);
+            if (results.toArray) {
+              // from apostrophe-db-mongo-3-driver
+              return results.toArray(function(err, results) {
+                if (err) {
+                  return callback(err);
+                }
+                return handleResults(results);
+              });
+            } else {
+              // from the 2.x driver or our compatibility wrapper
+              return handleResults(results);
+            }
+            function handleResults() {
+              var counts = {};
+              _.each(results, function(doc) {
+                counts[doc._id] = doc.count;
+              });
+              self.set('distinctCounts', counts);
+              return callback(null, _.pluck(results, '_id'));
+            }
           });
         }
       }

--- a/lib/modules/apostrophe-docs/lib/cursor.js
+++ b/lib/modules/apostrophe-docs/lib/cursor.js
@@ -988,12 +988,10 @@ module.exports = {
               }
             }
           ]);
-          console.log(self.db);
           return self.db.aggregate(pipeline, function(err, results) {
             if (err) {
               return callback(err);
             }
-            console.log('**', results);
             if (results.toArray) {
               // from apostrophe-db-mongo-3-driver
               return results.toArray(function(err, results) {
@@ -1006,7 +1004,7 @@ module.exports = {
               // from the 2.x driver or our compatibility wrapper
               return handleResults(results);
             }
-            function handleResults() {
+            function handleResults(results) {
               var counts = {};
               _.each(results, function(doc) {
                 counts[doc._id] = doc.count;


### PR DESCRIPTION
closes #2215

I attempted to incorporate a test but the burden on the project of adding the driver you're not even using to the dependencies was high and there seemed to be complex npm cache issues frustrating the test.

So instead I pushed up a branch of `apostrophe-enterprise-testbed`, named `test-distinct-count-with-mongo-3-driver`, where a command line task can be run to test this:

```
node app products:distinct-count-tags
```

This requires a new `npm install` to actually have the driver.

If you wish to test this make sure you have products in draft that have tags.

The normal case, with our regular driver, is already tested in `test/docs.js`.
