### PR TITLE
if workflow is present do not default published to false just because…

### DIFF
--- a/lib/modules/apostrophe-pieces/index.js
+++ b/lib/modules/apostrophe-pieces/index.js
@@ -68,7 +68,10 @@ module.exports = {
           type: 'boolean',
           name: 'published',
           label: 'Published',
-          def: false
+          // Patched later with a final ruling of true or false
+          // if it is not overridden at project level, see
+          // patchPublished method
+          def: 'contextual'
         }
       ].concat(options.addFields || []);
     }
@@ -266,6 +269,21 @@ module.exports = {
     if (self.options.piecesFilters) {
       self.apos.utils.warnDev('⚠️ The piecesFilters option was passed to ' + self.__meta.name + ', which\nextends apostrophe-pieces. This option should be passed to the corresponding\nmodule that extends apostrophe-pieces-pages.');
     }
-  }
 
+    self.on('apostrophe:modulesReady', 'patchPublished', function() {
+      var published = _.find(self.schema, { name: 'published' });
+      if (!published) {
+        return;
+      }
+      if (published.def !== 'contextual') {
+        return;
+      }
+      var workflow = self.apos.modules['apostrophe-workflow'];
+      if (workflow && workflow.includeType(self.name)) {
+        published.def = true;
+      } else {
+        published.def = false;
+      }
+    });
+  }
 };


### PR DESCRIPTION
… a piece type is contextual. There is already a good opportunity to review it afforded by workflow. One less open manhole cover on the way to getting something done!

This grew out of notes taken on Lindsay and the Kimpton team's bruising experiences with workflow UX.
