### PR TITLE
Clarifies clonePermanent docs

### DIFF
--- a/lib/modules/apostrophe-utils/lib/api.js
+++ b/lib/modules/apostrophe-utils/lib/api.js
@@ -327,8 +327,8 @@ module.exports = function(self, options) {
   // a length property would be treated as arrays, which is
   // an unrealistic restriction on apostrophe doc schemas.
   //
-  // If o itself is a string, boolean or other scalar type it is returned
-  // as-is.
+  // If `o` (usually the object) itself is a string, boolean or other scalar
+  // type it is returned as-is.
 
   self.clonePermanent = function(o, keepScalars) {
     var c;


### PR DESCRIPTION
I was thrown by the original phrasing at first since the `o` naming is not immediately obvious.