### PR TITLE
1349: support heic images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.109.0 (2020-06-18)
+
+* Add [heic-to-jpeg-middleware](https://github.com/boutell/heic-to-jpeg-middleware) to support uploading `heic/heif` images (the standard format for recent iPhones/iPads).
+
 ## 2.108.0 (2020-06-07)
 
 * UX improvement: if a piece type has the `contextual: true` option set and workflow is present, do not default published to `false`. There is already a good opportunity to review before the public sees the piece afforded by workflow.

--- a/lib/modules/apostrophe-attachments/lib/routes.js
+++ b/lib/modules/apostrophe-attachments/lib/routes.js
@@ -2,26 +2,30 @@ var _ = require('@sailshq/lodash');
 
 module.exports = function(self, options) {
 
-  self.apiRoute('post', 'upload', self.middleware.canUpload, self.apos.middleware.files, function(req, res, next) {
-    // Must use text/plain for file upload responses in IE <= 9,
-    // doesn't hurt in other browsers. -Tom
-    res.header("Content-Type", "text/plain");
-    // The name attribute could be anything because of how fileupload
-    // controls work; we don't really care.
-    var file = _.values(req.files || {})[0];
-    if (!file) {
-      return next('notfound');
-    }
-    return self.accept(req, file, function(err, file) {
-      if (err) {
-        return next(err);
+  self.apiRoute('post', 'upload',
+    self.middleware.canUpload,
+    self.apos.middleware.files,
+    self.apos.middleware.heicImages,
+    function(req, res, next) {
+      // Must use text/plain for file upload responses in IE <= 9,
+      // doesn't hurt in other browsers. -Tom
+      res.header("Content-Type", "text/plain");
+      // The name attribute could be anything because of how fileupload
+      // controls work; we don't really care.
+      var file = _.values(req.files || {})[0];
+      if (!file) {
+        return next('notfound');
       }
-      if (req.query.html) {
-        res.setHeader('Content-Type', 'text/html');
-      }
-      return next(null, { file: file });
+      return self.accept(req, file, function(err, file) {
+        if (err) {
+          return next(err);
+        }
+        if (req.query.html) {
+          res.setHeader('Content-Type', 'text/html');
+        }
+        return next(null, { file: file });
+      });
     });
-  });
 
   // Crop a previously uploaded image, based on the `id` POST parameter
   // and the `crop` POST parameter. `id` should refer to an existing

--- a/lib/modules/apostrophe-express/index.js
+++ b/lib/modules/apostrophe-express/index.js
@@ -564,7 +564,8 @@ module.exports = {
       // every route but is recommended for use in your own
       // routes when needful
       self.apos.middleware = {
-        files: require('connect-multiparty')()
+        files: require('connect-multiparty')(),
+        heicImages: require('heic-to-jpeg-middleware')()
       };
     };
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "express-session": "^1.17.0",
     "glob": "^5.0.15",
     "he": "^0.5.0",
-    "heic-to-jpeg-middleware": "^1.0.2",
+    "heic-to-jpeg-middleware": "^2.0.0",
     "html-to-plaintext": "^0.1.1",
     "html-to-text": "^5.1.1",
     "i18n": "^0.8.6",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "express-session": "^1.17.0",
     "glob": "^5.0.15",
     "he": "^0.5.0",
+    "heic-to-jpeg-middleware": "^1.0.2",
     "html-to-plaintext": "^0.1.1",
     "html-to-text": "^5.1.1",
     "i18n": "^0.8.6",


### PR DESCRIPTION
This adds a [middleware](https://github.com/boutell/heic-to-jpeg-middleware) to handle heic/heif image uploads coming from recent iPhones.

closes #1349 