### PR TITLE
http response to dismissing notification should not include informati…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.108.1 (2020-06-24)
+
+* The http response to dismissing a notification should not include any information about the mongodb connection. The response previously included relatively low-risk information, including the IP address of the MongoDB server but not enough to make an unauthorized connection when the MongoDB server and/or firewall are properly configured.
+
 ## 2.108.0 (2020-06-07)
 
 * UX improvement: if a piece type has the `contextual: true` option set and workflow is present, do not default published to `false`. There is already a good opportunity to review before the public sees the piece afforded by workflow.

--- a/lib/modules/apostrophe-notifications/index.js
+++ b/lib/modules/apostrophe-notifications/index.js
@@ -150,7 +150,11 @@ module.exports = {
       var _id = self.apos.launder.id(req.body._id);
       return self.db.remove({
         _id: _id
-      }, next);
+      }).then(function() {
+        // Explicitly do not return the details from mongodb, just
+        // success
+        return next(null);
+      }).catch(next);
     });
 
     // This middleware is essentially a POST route at

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "2.108.0",
+  "version": "2.108.1",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
…on about the mongodb connection, closes #2227

This was something that only logged in users had the potential to see, and the information in question was not enough to get an unauthorized database connection, but it was still inappropriate to disclose.