### PR TITLE
Set line height for Apostrophe UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.109.0 (2020-07-15)
 
 * Add [heic-to-jpeg-middleware](https://github.com/boutell/heic-to-jpeg-middleware) to support uploading `heic/heif` images (the standard format for recent iPhones/iPads). Many thanks to Gabriel L. Maljkovich for their contributions to the underlying middleware as well as the integration with Apostrophe.
-
+* Add css to maintain spacing of admin UI.
 ## 2.108.1 (2020-07-01)
 
 * Updates documentation of the `clonePermanent` utility method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 2.109.0 (2020-07-15)
 
 * Add [heic-to-jpeg-middleware](https://github.com/boutell/heic-to-jpeg-middleware) to support uploading `heic/heif` images (the standard format for recent iPhones/iPads). Many thanks to Gabriel L. Maljkovich for their contributions to the underlying middleware as well as the integration with Apostrophe.
-* Add css to maintain spacing of admin UI.
+* Add CSS to maintain spacing of admin UI.
+
 ## 2.108.1 (2020-07-01)
 
 * Updates documentation of the `clonePermanent` utility method.

--- a/lib/modules/apostrophe-ui/public/css/user.less
+++ b/lib/modules/apostrophe-ui/public/css/user.less
@@ -14,6 +14,7 @@
   // they find themselves in project level grids with font-size: 0.
   // -Tom, Stuart, Brian
   font-size: 16px;
+  line-height: 20px;
 
 	// Globals =================================
 	@import 'global/reset.less';


### PR DESCRIPTION
With no `line-height` set for `.apos-ui` it will use the `line-height` on `<body>` if one is present, which can lead to drastic sizing changes for the UI. Explicitly setting one will ensure the UI remains consistent across projects.