### PR TITLE
Login throttle dgad 1005

### DIFF
--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -306,7 +306,12 @@ module.exports = {
           if (err) {
             // Slow down and keep 'em hanging to make brute force attacks less easy
             return setTimeout(function () {
-              return callback(null, false);
+              // string error = OK to pass on to browser (like "throttle")
+              if ((typeof err) === 'string') {
+                return callback(err);
+              } else {
+                return callback(null, false);
+              }
             }, 1000);
           }
           return self.checkIfActive(user, callback);
@@ -363,10 +368,13 @@ module.exports = {
         try {
           await verify(user, password);
         } catch (e) {
+          let err = e;
           await addAttempt();
-          await lockoutIfNeeded();
+          if (await lockoutIfNeeded()) {
+            err = 'throttle';
+          }
           await cleanUpAttempts();
-          throw e;
+          throw err;
         }
       }
 
@@ -396,6 +404,7 @@ module.exports = {
               lockout: new Date()
             }
           });
+          return true;
         }
       }
 
@@ -561,6 +570,9 @@ module.exports = {
                 // allow them to fix it
                 return self.verifyLogin(req.body.username, password, function(err, user) {
                   if (err || (!user)) {
+                    if (err === 'throttle') {
+                      errors.unshift(req.__ns_n('apostrophe', 'Too many login attempts. You may try again in %s minute(s).', self.options.throttle.lockout));
+                    }
                     return fail(errors);
                   }
                   req.session.resetLegacyPasswordId = user._id;
@@ -598,6 +610,13 @@ module.exports = {
           function(req, res, next) {
             self.passport.authenticate('local', function(err, user, info) {
               if (err) {
+                if (err === 'throttle') {
+                  // verifyPassword does not take req, so we i18n the error here
+                  //
+                  // Use of __ns_n means that the "minute(s)" string can be pluralized
+                  // more nicely if desired via i18n json config, even for English
+                  err = new Error(req.__ns_n('apostrophe', 'Too many login attempts. You may try again in %s minute(s).', self.options.throttle.lockout));
+                }
                 return res.redirect(`${self.getLoginUrl()}?` + qs.stringify({
                   message: err.message,
                   error: '1'
@@ -605,7 +624,7 @@ module.exports = {
               }
               if (!user) {
                 return res.redirect(`${self.getLoginUrl()}?` + qs.stringify({
-                  message: 'Incorrect login or password or account disabled',
+                  message: req.__ns('apostrophe', 'Incorrect login or password or account disabled'),
                   error: '1'
                 }));
               }

--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -350,9 +350,6 @@ module.exports = {
 
       async function throttleAttempts() {
         if (self.options.throttle) {
-          if (!allowedAttempts) {
-            throw new Error('If the throttle option is set for apostrophe-login, then the allowedAttempts subproperty is required.');
-          }
           const userSafe = await safe.findOne({
             _id: user._id
           });

--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -76,11 +76,11 @@
 //
 // `throttle`
 //
-// If the `throttle` option is set to `{ attempts: 3, per: 1, lockout: 10 }` for
+// If the `throttle` option is set to `{ allowedAttempts: 3, perMinutes: 1, lockoutMinutes: 10 }` for
 // this module then no more than three failed attempts per minute are permitted
 // for the same account, after which the user is locked out for 10 minutes. If
-// `throttle` exists, `per` defaults to 1 minute, `lockout` also defaults
-// to 1 minute, and `attempts` must be specified.
+// `throttle` exists, `allowedAttempts` defaults to 3, `perMinutes` defaults to 1,
+// and `lockoutMinutes` also defaults to 1.
 //
 // ## Notable properties of apos.modules['apostrophe-login']
 //
@@ -324,14 +324,14 @@ module.exports = {
     // on failure, otherwise with `null`.
     //
     // `user` is an `apostrophe-user` doc. If `options.throttle` is set to
-    // `{ attempts: 3, per: 1, lockout: 10 }` for this module then no more than three failed
+    // `{ allowedAttempts: 3, perMinutes: 1, lockoutMinutes: 10 }` for this module then no more than three failed
     // attempts per minute are permitted for the same account, after which the user is locked out
-    // for 10 minutes. If `options.throttle` exists, `per` defaults to
-    // 1 minute, `lockout` also defaults to 1 minute, and `attempts` must
+    // for 10 minutes. If `options.throttle` exists, `perMinutes` defaults to
+    // 1 minute, `lockoutMinutes` also defaults to 1 minute, and `allowedAttempts` must
     // be specified.
 
     self.verifyPassword = function(user, password, callback) {
-      let { attempts, per = 1, lockout = 1 } = self.options.throttle || {};
+      let { allowedAttempts = 3, perMinutes = 1, lockoutMinutes = 1 } = self.options.throttle || {};
       const safe = self.apos.users.safe;
 
       // Implementation is an async function, but the interface is a legacy callback.
@@ -350,8 +350,8 @@ module.exports = {
 
       async function throttleAttempts() {
         if (self.options.throttle) {
-          if (!attempts) {
-            throw new Error('If the throttle option is set for apostrophe-login, then the attempts subproperty is required.');
+          if (!allowedAttempts) {
+            throw new Error('If the throttle option is set for apostrophe-login, then the allowedAttempts subproperty is required.');
           }
           const userSafe = await safe.findOne({
             _id: user._id
@@ -396,7 +396,7 @@ module.exports = {
           _id: user._id
         });
         const perSince = getPerSince();
-        if (userSafe.attempts && userSafe.attempts.filter(attempt => (attempt >= perSince)).length >= attempts) {
+        if (userSafe.attempts && userSafe.attempts.filter(attempt => (attempt >= perSince)).length >= allowedAttempts) {
           await safe.update({
             _id: user._id
           }, {
@@ -422,11 +422,11 @@ module.exports = {
       }
 
       function getPerSince() {
-        return new Date(Date.now() - per * 60 * 1000);
+        return new Date(Date.now() - perMinutes * 60 * 1000);
       }
 
       function getLockoutSince() {
-        return new Date(Date.now() - lockout * 60 * 1000);
+        return new Date(Date.now() - lockoutMinutes * 60 * 1000);
       }
 
     };
@@ -615,7 +615,7 @@ module.exports = {
                   //
                   // Use of __ns_n means that the "minute(s)" string can be pluralized
                   // more nicely if desired via i18n json config, even for English
-                  err = new Error(req.__ns_n('apostrophe', 'Too many login attempts. You may try again in %s minute(s).', self.options.throttle.lockout));
+                  err = new Error(req.__ns_n('apostrophe', 'Too many failed login attempts. You may try again in %s minute(s).', self.options.throttle.lockout));
                 }
                 return res.redirect(`${self.getLoginUrl()}?` + qs.stringify({
                   message: err.message,

--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -74,6 +74,14 @@
 // (see above for concerns). You should bear in mind that this option is not as
 // secure as requiring confirmation via email with `passwordReset.
 //
+// `throttle`
+//
+// If the `throttle` option is set to `{ attempts: 3, per: 1, lockout: 10 }` for
+// this module then no more than three failed attempts per minute are permitted
+// for the same account, after which the user is locked out for 10 minutes. If
+// `throttle` exists, `per` defaults to 1 minute, `lockout` also defaults
+// to 1 minute, and `attempts` must be specified.
+//
 // ## Notable properties of apos.modules['apostrophe-login']
 //
 // `passport`
@@ -294,7 +302,7 @@ module.exports = {
             return callback(null, false);
           }, 1000);
         }
-        return self.apos.users.verifyPassword(user, password, function(err) {
+        return self.verifyPassword(user, password, function(err) {
           if (err) {
             // Slow down and keep 'em hanging to make brute force attacks less easy
             return setTimeout(function () {
@@ -304,6 +312,114 @@ module.exports = {
           return self.checkIfActive(user, callback);
         });
       });
+    };
+
+    // Verify the given password by checking it against the
+    // hash in the safe. The callback is invoked with an error
+    // on failure, otherwise with `null`.
+    //
+    // `user` is an `apostrophe-user` doc. If `options.throttle` is set to
+    // `{ attempts: 3, per: 1, lockout: 10 }` for this module then no more than three failed
+    // attempts per minute are permitted for the same account, after which the user is locked out
+    // for 10 minutes. If `options.throttle` exists, `per` defaults to
+    // 1 minute, `lockout` also defaults to 1 minute, and `attempts` must
+    // be specified.
+
+    self.verifyPassword = function(user, password, callback) {
+      let { attempts, per = 1, lockout = 1 } = self.options.throttle || {};
+      const safe = self.apos.users.safe;
+
+      // Implementation is an async function, but the interface is a legacy callback.
+      // Never return a promise so no one gets the wrong idea
+      Promise.try(body).then(function() {
+        callback(null);
+        return null;
+      }).catch(function(err) {
+        return callback(err);
+      });
+
+      async function body(callback) {
+        await throttleAttempts();
+        await attempt();
+      }
+
+      async function throttleAttempts() {
+        if (self.options.throttle) {
+          if (!attempts) {
+            throw new Error('If the throttle option is set for apostrophe-login, then the attempts subproperty is required.');
+          }
+          const userSafe = await safe.findOne({
+            _id: user._id
+          });
+          const lockoutSince = getLockoutSince();
+          if (userSafe.lockout && (userSafe.lockout >= lockoutSince)) {
+            throw 'throttle';
+          }
+        }
+      }
+
+      async function attempt() {
+        const verify = Promise.promisify(self.apos.users.verifyPassword);
+        try {
+          await verify(user, password);
+        } catch (e) {
+          await addAttempt();
+          await lockoutIfNeeded();
+          await cleanUpAttempts();
+          throw e;
+        }
+      }
+
+      async function addAttempt() {
+        if (!self.options.throttle) {
+          return;
+        }
+        return safe.update({
+          _id: user._id
+        }, {
+          $push: {
+            attempts: new Date()
+          }
+        });
+      }
+
+      async function lockoutIfNeeded() {
+        const userSafe = await safe.findOne({
+          _id: user._id
+        });
+        const perSince = getPerSince();
+        if (userSafe.attempts && userSafe.attempts.filter(attempt => (attempt >= perSince)).length >= attempts) {
+          await safe.update({
+            _id: user._id
+          }, {
+            $set: {
+              lockout: new Date()
+            }
+          });
+        }
+      }
+
+      async function cleanUpAttempts() {
+        const perSince = getPerSince();
+        await safe.update({
+          _id: user._id
+        }, {
+          $pull: {
+            attempts: {
+              $lt: perSince
+            }
+          }
+        });
+      }
+
+      function getPerSince() {
+        return new Date(Date.now() - per * 60 * 1000);
+      }
+
+      function getLockoutSince() {
+        return new Date(Date.now() - lockout * 60 * 1000);
+      }
+
     };
 
     self.verifyTotp = function(user, done) {
@@ -684,7 +800,7 @@ module.exports = {
           });
 
           function verify(callback) {
-            return self.apos.users.verifyPassword(req.user, existingPassword, callback);
+            return self.verifyPassword(req.user, existingPassword, callback);
           }
 
           function reset(callback) {

--- a/lib/modules/apostrophe-users/index.js
+++ b/lib/modules/apostrophe-users/index.js
@@ -456,9 +456,12 @@ module.exports = {
     };
 
     // Verify the given password by checking it against the
-    // hash in the safe. `user` is an `apostrophe-user` doc.
+    // hash in the safe. `user` is an `apostrophe-user` doc. This
+    // method is responsible for the actual implementation of password
+    // hash checks, not throttling. For a throttled interface,
+    // use apos.login.verifyPassword.
 
-    self.verifyPassword = function(user, password, callback) {
+    self.verifyPassword = async (user, password, callback) => {
       return self.verifySecret(user, 'password', password, callback);
     };
 

--- a/test/docs.js
+++ b/test/docs.js
@@ -335,7 +335,7 @@ describe('Docs', function() {
       slug: 'one',
       published: true,
       type: 'test-person',
-      firstName: 'Harry',
+      firstName: 'Lilith',
       lastName: 'Gerber',
       age: 29,
       alive: true

--- a/test/express-anon-csrf.js
+++ b/test/express-anon-csrf.js
@@ -174,12 +174,12 @@ describe('Express', function() {
     var user = apos.users.newInstance();
     assert(user);
 
-    user.firstName = 'Harry';
-    user.lastName = 'Putter';
-    user.title = 'Harry Putter';
-    user.username = 'HarryPutter';
-    user.password = 'crookshanks';
-    user.email = 'hputter@aol.com';
+    user.firstName = 'Lilith';
+    user.lastName = 'Lyapo';
+    user.title = 'Lilith Lyapo';
+    user.username = 'LilithLyapo';
+    user.password = 'nikanj';
+    user.email = 'hlyapo@example.com';
 
     assert(user.type === 'apostrophe-user');
     assert(apos.users.insert);
@@ -192,7 +192,7 @@ describe('Express', function() {
   it('should be able to login a user', function(done) {
     sessionShouldBeEmpty = false;
     return request.post('http://localhost:7900/login', {
-      form: { username: 'HarryPutter', password: 'crookshanks' },
+      form: { username: 'LilithLyapo', password: 'nikanj' },
       followAllRedirects: true,
       jar: jar
     }, function(err, response, body) {

--- a/test/login-throttle.js
+++ b/test/login-throttle.js
@@ -41,9 +41,9 @@ describe('Login', function() {
         },
         'apostrophe-login': {
           throttle: {
-            attempts: 3,
-            per: 0.25,
-            lockout: 0.25
+            allowedAttempts: 3,
+            perMinutes: 0.25,
+            lockoutMinutes: 0.25
           }
         }
       },
@@ -66,12 +66,12 @@ describe('Login', function() {
     const user = apos.users.newInstance();
     assert(user);
 
-    user.firstName = 'Harry';
-    user.lastName = 'Putter';
-    user.title = 'Harry Putter';
-    user.username = 'HarryPutter';
-    user.password = 'crookshanks';
-    user.email = 'hputter@aol.com';
+    user.firstName = 'Lilith';
+    user.lastName = 'Lyapo';
+    user.title = 'Lilith Lyapo';
+    user.username = 'LilithLyapo';
+    user.password = 'nikanj';
+    user.email = 'hlyapo@example.com';
     user.groupIds = [ apos.users.options.groups[1]._id ];
 
     assert(user.type === 'apostrophe-user');
@@ -85,16 +85,16 @@ describe('Login', function() {
   it('should be able to verify a login', async function() {
     const req = apos.tasks.getReq();
     const user = await apos.users.find(req, {
-      username: 'HarryPutter'
+      username: 'LilithLyapo'
     }).toObject();
     const verify = Promise.promisify(apos.login.verifyPassword);
-    await verify(user, 'crookshanks');
+    await verify(user, 'nikanj');
   });
 
   it('third failure in a row should cause a lockout', async function() {
     const req = apos.tasks.getReq();
     const user = await apos.users.find(req, {
-      username: 'HarryPutter'
+      username: 'LilithLyapo'
     }).toObject();
     const verify = Promise.promisify(apos.login.verifyPassword);
     try {
@@ -129,7 +129,7 @@ describe('Login', function() {
     }
     // still throttled even if the password is good
     try {
-      await verify(user, 'crookshanks');
+      await verify(user, 'nikanj');
       assert(false);
     } catch (e) {
       assert(e);
@@ -140,12 +140,12 @@ describe('Login', function() {
   it('should succeed after suitable pause', async function() {
     const req = apos.tasks.getReq();
     const user = await apos.users.find(req, {
-      username: 'HarryPutter'
+      username: 'LilithLyapo'
     }).toObject();
     const verify = Promise.promisify(apos.login.verifyPassword);
     this.timeout(60000);
     await Promise.delay(16000);
-    await verify(user, 'crookshanks');
+    await verify(user, 'nikanj');
   });
 
 });

--- a/test/login-throttle.js
+++ b/test/login-throttle.js
@@ -55,9 +55,6 @@ describe('Login', function() {
         // return callback(null);
       },
       afterListen: function(err) {
-        if (err) {
-          console.error('* * * caught error ', err);
-        }
         assert(!err);
         done();
       }
@@ -105,23 +102,16 @@ describe('Login', function() {
       assert(false);
     } catch (e) {
       assert(e);
-      assert.notEqual(e, 'throttle');
+      assert.notEqual(e.message, 'throttle');
     }
     try {
       await verify(user, 'bad');
       assert(false);
     } catch (e) {
       assert(e);
-      assert.notEqual(e, 'throttle');
+      assert.notEqual(e.message, 'throttle');
     }
-    try {
-      await verify(user, 'bad');
-      assert(false);
-    } catch (e) {
-      assert(e);
-      assert.notEqual(e, 'throttle');
-    }
-    // fourth attempt is throttled
+    // third attempt triggers lockout
     try {
       await verify(user, 'bad');
       assert(false);
@@ -129,7 +119,15 @@ describe('Login', function() {
       assert(e);
       assert.equal(e.message, 'throttle');
     }
-    // ... even if the password is good
+    // fourth attempt is throttled (by lockout)
+    try {
+      await verify(user, 'bad');
+      assert(false);
+    } catch (e) {
+      assert(e);
+      assert.equal(e.message, 'throttle');
+    }
+    // still throttled even if the password is good
     try {
       await verify(user, 'crookshanks');
       assert(false);

--- a/test/login-throttle.js
+++ b/test/login-throttle.js
@@ -1,0 +1,153 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert');
+const Promise = require('bluebird');
+
+let apos;
+
+describe('Login', function() {
+
+  this.timeout(20000);
+
+  after(function(done) {
+    return t.destroy(apos, done);
+  });
+
+  // EXISTENCE
+
+  it('should initialize', function(done) {
+    apos = require('../index.js')({
+      root: module,
+      shortName: 'test',
+      modules: {
+        'apostrophe-express': {
+          secret: 'xxx',
+          port: 7901,
+          csrf: false
+        },
+        'apostrophe-users': {
+          groups: [
+            {
+              title: 'guest',
+              permissions: ['guest']
+            },
+            {
+              title: 'admin',
+              permissions: ['admin']
+            }
+          ],
+          disableInactiveAccounts: {
+            inactivityDuration: 0
+          }
+        },
+        'apostrophe-login': {
+          throttle: {
+            attempts: 3,
+            per: 0.25,
+            lockout: 0.25
+          }
+        }
+      },
+      afterInit: function(callback) {
+        assert(apos.modules['apostrophe-login']);
+        apos.argv._ = [];
+        assert(apos.users.safe.remove);
+        return apos.users.safe.remove({}, callback);
+        // return callback(null);
+      },
+      afterListen: function(err) {
+        if (err) {
+          console.error('* * * caught error ', err);
+        }
+        assert(!err);
+        done();
+      }
+    });
+  });
+
+  it('should be able to insert test user', function(done) {
+    assert(apos.users.newInstance);
+    const user = apos.users.newInstance();
+    assert(user);
+
+    user.firstName = 'Harry';
+    user.lastName = 'Putter';
+    user.title = 'Harry Putter';
+    user.username = 'HarryPutter';
+    user.password = 'crookshanks';
+    user.email = 'hputter@aol.com';
+    user.groupIds = [ apos.users.options.groups[1]._id ];
+
+    assert(user.type === 'apostrophe-user');
+    assert(apos.users.insert);
+    apos.users.insert(apos.tasks.getReq(), user, function(err) {
+      assert(!err);
+      done();
+    });
+  });
+
+  it('should be able to verify a login', async function() {
+    const req = apos.tasks.getReq();
+    const user = await apos.users.find(req, {
+      username: 'HarryPutter'
+    }).toObject();
+    const verify = Promise.promisify(apos.login.verifyPassword);
+    await verify(user, 'crookshanks');
+  });
+
+  it('third failure in a row should cause a lockout', async function() {
+    const req = apos.tasks.getReq();
+    const user = await apos.users.find(req, {
+      username: 'HarryPutter'
+    }).toObject();
+    const verify = Promise.promisify(apos.login.verifyPassword);
+    try {
+      await verify(user, 'bad');
+      assert(false);
+    } catch (e) {
+      assert(e);
+      assert.notEqual(e, 'throttle');
+    }
+    try {
+      await verify(user, 'bad');
+      assert(false);
+    } catch (e) {
+      assert(e);
+      assert.notEqual(e, 'throttle');
+    }
+    try {
+      await verify(user, 'bad');
+      assert(false);
+    } catch (e) {
+      assert(e);
+      assert.notEqual(e, 'throttle');
+    }
+    // fourth attempt is throttled
+    try {
+      await verify(user, 'bad');
+      assert(false);
+    } catch (e) {
+      assert(e);
+      assert.equal(e.message, 'throttle');
+    }
+    // ... even if the password is good
+    try {
+      await verify(user, 'crookshanks');
+      assert(false);
+    } catch (e) {
+      assert(e);
+      assert.equal(e.message, 'throttle');
+    }
+  });
+
+  it('should succeed after suitable pause', async function() {
+    const req = apos.tasks.getReq();
+    const user = await apos.users.find(req, {
+      username: 'HarryPutter'
+    }).toObject();
+    const verify = Promise.promisify(apos.login.verifyPassword);
+    this.timeout(60000);
+    await Promise.delay(16000);
+    await verify(user, 'crookshanks');
+  });
+
+});

--- a/test/login.js
+++ b/test/login.js
@@ -64,12 +64,12 @@ describe('Login', function() {
     var user = apos.users.newInstance();
     assert(user);
 
-    user.firstName = 'Harry';
-    user.lastName = 'Putter';
-    user.title = 'Harry Putter';
-    user.username = 'HarryPutter';
-    user.password = 'crookshanks';
-    user.email = 'hputter@aol.com';
+    user.firstName = 'Lilith';
+    user.lastName = 'Lyapo';
+    user.title = 'Lilith Lyapo';
+    user.username = 'LilithLyapo';
+    user.password = 'nikanj';
+    user.email = 'hlyapo@example.com';
     user.groupIds = [ apos.users.options.groups[1]._id ];
 
     assert(user.type === 'apostrophe-user');
@@ -101,7 +101,7 @@ describe('Login', function() {
   it('should be able to login a user', function(done) {
     // otherwise logins are not remembered in a session
     return request.post('http://localhost:7901/login', {
-      form: { username: 'HarryPutter', password: 'crookshanks' },
+      form: { username: 'LilithLyapo', password: 'nikanj' },
       followAllRedirects: true,
       jar: loginLogoutJar
     }, function(err, response, body) {
@@ -117,7 +117,7 @@ describe('Login', function() {
   it('should be able to login a user with their email', function(done) {
     // otherwise logins are not remembered in a session
     return request.post('http://localhost:7901/login', {
-      form: { username: 'hputter@aol.com', password: 'crookshanks' },
+      form: { username: 'hlyapo@example.com', password: 'nikanj' },
       followAllRedirects: true,
       jar: loginEmailLogoutJar
     }, function(err, response, body) {
@@ -167,7 +167,7 @@ describe('Login', function() {
     user.lastName = 'Test';
     user.title = 'Random Test';
     user.username = 'random-test';
-    user.password = 'crookshanks';
+    user.password = 'nikanj';
     user.email = 'randomtest@aol.com';
     user.lastLogin = new Date();
     user.groupIds = [ apos.users.options.groups[0]._id ]; // guest group
@@ -175,7 +175,7 @@ describe('Login', function() {
     apos.users.insert(apos.tasks.getReq(), user, function(err) {
       assert(!err);
       return request.post('http://localhost:7901/login', {
-        form: { username: 'random-test', password: 'crookshanks' },
+        form: { username: 'random-test', password: 'nikanj' },
         followAllRedirects: true,
         jar: loginLogoutJar
       }, function(err, response, body) {
@@ -194,7 +194,7 @@ describe('Login', function() {
     user.lastName = 'Test';
     user.title = 'Admin Test';
     user.username = 'admin-test';
-    user.password = 'crookshanks';
+    user.password = 'nikanj';
     user.email = 'admintest@aol.com';
     user.lastLogin = new Date();
     user.groupIds = [ apos.users.options.groups[1]._id ]; // admin group
@@ -202,7 +202,7 @@ describe('Login', function() {
     apos.users.insert(apos.tasks.getReq(), user, function(err) {
       assert(!err);
       return request.post('http://localhost:7901/login', {
-        form: { username: 'admin-test', password: 'crookshanks' },
+        form: { username: 'admin-test', password: 'nikanj' },
         followAllRedirects: true,
         jar: loginLogoutJar
       }, function(err, response, body) {
@@ -257,7 +257,7 @@ describe('Login', function() {
         user.lastName = 'Test';
         user.title = 'Random Test';
         user.username = 'random-test';
-        user.password = 'crookshanks';
+        user.password = 'nikanj';
         user.email = 'randomtest@aol.com';
         user.lastLogin = lastLogin.setDate(lastLogin.getDate() - 3); // last login was 3 days ago
         user.groupIds = [ apos2.users.options.groups[0]._id ]; // guest group
@@ -265,7 +265,7 @@ describe('Login', function() {
         apos2.users.insert(apos2.tasks.getReq(), user, function(err) {
           assert(!err);
           return request.post('http://localhost:7902/login', {
-            form: { username: 'random-test', password: 'crookshanks' },
+            form: { username: 'random-test', password: 'nikanj' },
             followAllRedirects: true,
             jar: loginLogoutJar
           }, function(err, response, body) {


### PR DESCRIPTION
In addition to the unit test coverage, you can test it with this configuration:

```
    'apostrophe-login': {
      throttle: {
        attempts: 3,
        per: 1,
        lockout: 1
      }
    },
```

Now three invalid login attempts in one minute for the same account will lock you out for one minute, even if your credentials for the fourth attempt are correct. The issue is disclosed to the user so they know why they still can't get in. As discussed this feature was implemented with an async function and it's ever so much more readable as a result, but since for bc it must have a callback based interface, I plumbed it carefully to avoid returning any promises that might generate warnings or confuse developers.