### PR TITLE
Replaces pseudo arrows in docs with unicode arrows

### DIFF
--- a/lib/modules/apostrophe-browser-utils/public/js/always.js
+++ b/lib/modules/apostrophe-browser-utils/public/js/always.js
@@ -101,9 +101,9 @@ apos.define('apostrophe-browser-utils', {
     //
     // Examples:
     //
-    // apos.eventName('aposChange', 'blog') ---> aposChangeBlog
-    // apos.eventName('aposChangeEvents') ---> aposChangeEvents
-    // apos.eventName('apos-jump-gleefully') ---> aposJumpGleefully
+    // apos.eventName('aposChange', 'blog') → aposChangeBlog
+    // apos.eventName('aposChangeEvents') → aposChangeEvents
+    // apos.eventName('apos-jump-gleefully') → aposJumpGleefully
     //
     // It doesn't matter how many arguments you pass. Each new argument
     // is treated as a word boundary.


### PR DESCRIPTION
Documentation minor improvement. Another docs edit that never got PR'd.