### PR TITLE
TOTP (google auth) by group, if specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.110.0 (2020-07-29)
 
 * Security: added support for throttling login attempts. If you set the `throttle` option of `apostrophe-login` to `{ allowedAttempts: 3, perMinutes: 1, lockoutMinutes: 1 }`, a user will be locked out and unable to try again for 1 minute after three failed login attempts in 1 minute. Thanks to Michelin for making this work possible via [Apostrophe Enterprise Support](https://apostrophecms.org/support/enterprise-support).
+* Security: when requiring Google Authenticator or a similar app for login (TOTP), you may now limit the requirement to certain groups, by passing a setting like `totp: { groups: [ 'admin' ] }` to the `apostrophe-login` module rather than just `totp: true`. You may specify groups by slug or by title (name). In addition, the existing `totp` option has been added to the module documentation.
 
 ## 2.109.0 (2020-07-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.110.0 (2020-07-29)
 
 * Security: added support for throttling login attempts. If you set the `throttle` option of `apostrophe-login` to `{ allowedAttempts: 3, perMinutes: 1, lockoutMinutes: 1 }`, a user will be locked out and unable to try again for 1 minute after three failed login attempts in 1 minute. Thanks to Michelin for making this work possible via [Apostrophe Enterprise Support](https://apostrophecms.org/support/enterprise-support).
-* Security: when requiring Google Authenticator or a similar app for login (TOTP), you may now limit the requirement to certain groups, by passing a setting like `totp: { groups: [ 'admin' ] }` to the `apostrophe-login` module rather than just `totp: true`. You may specify groups by slug or by title (name). In addition, the existing `totp` option has been added to the module documentation.
+* Security: when requiring Google Authenticator or a similar app for login (TOTP), you may now limit the requirement to certain groups, by passing a setting like `totp: { groups: true }` to the `apostrophe-login` module rather than just `totp: true`. Admins may then select which groups actually require TOTP by selecting it when editing the group (look at the permissions tab). In addition, the existing `totp` option has been added to the module documentation.
 
 ## 2.109.0 (2020-07-15)
 

--- a/lib/modules/apostrophe-groups/index.js
+++ b/lib/modules/apostrophe-groups/index.js
@@ -32,25 +32,32 @@ module.exports = {
   // You can't give someone permission to edit groups because that
   // allows them to make themselves an admin. -Tom
   adminOnly: true,
-  addFields: [
-    {
-      type: 'joinByArrayReverse',
-      name: '_users',
-      label: 'Users',
-      idsField: 'groupIds',
-      withType: 'apostrophe-user',
-      ifOnlyOne: true
-    },
-    {
-      type: 'checkboxes',
-      name: 'permissions',
-      label: 'Permissions',
-      // This gets patched at modulesReady time
-      choices: []
-    }
-  ],
 
   beforeConstruct: function(self, options) {
+    options.addFields = [
+      {
+        type: 'joinByArrayReverse',
+        name: '_users',
+        label: 'Users',
+        idsField: 'groupIds',
+        withType: 'apostrophe-user',
+        ifOnlyOne: true
+      },
+      {
+        type: 'checkboxes',
+        name: 'permissions',
+        label: 'Permissions',
+        // This gets patched at modulesReady time
+        choices: []
+      },
+      {
+        type: 'boolean',
+        name: 'totp',
+        label: 'Require TOTP',
+        help: 'When checked, users in this group must use Google Authenticator or a compatible app as a second factor when logging in.'
+      }
+    ].concat(options.addFields || []);
+
     options.removeFields = (options.minimumRemoved || [ 'published' ])
       .concat(options.removeFields || []);
 
@@ -61,7 +68,7 @@ module.exports = {
       {
         name: 'permissions',
         label: 'Permissions',
-        fields: [ 'permissions' ]
+        fields: [ 'permissions', 'totp' ]
       }
     ].concat(options.arrangeFields || []);
   },
@@ -76,6 +83,7 @@ module.exports = {
       self.composeBatchOperations();
       self.setPermissionsChoices();
       self.addToAdminBarIfSuitable();
+      self.removeTotpFromSchemaIfUnsuitable();
     };
 
     self.setPermissionsChoices = function() {
@@ -84,6 +92,12 @@ module.exports = {
         return;
       }
       permissions.choices = self.apos.permissions.getChoices();
+    };
+
+    self.removeTotpFromSchemaIfUnsuitable = function() {
+      if (!(self.apos.login.options.totp && self.apos.login.options.totp.groups)) {
+        self.schema = self.schema.filter(field => field.name !== 'totp');
+      }
     };
 
     self.addToAdminBar = function() {};

--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -90,11 +90,13 @@
 //
 // If this option is set to an object, you may specify sub-options:
 //
-// `totp: { groups: [ 'admin' ] }`
+// `totp: { groups: true }`
 //
-// The `groups` sub-option limits the TOTP requirement to members of those
-// groups only. Other users are not required to use two-factor authentication
-// to log in. Groups may be specified by slug, or by title (name).
+// The `groups` sub-option indicates that TOTP is only required for groups
+// for which it has been activated. This usually only makes sense when the
+// `groups` option for the `apostrophe-user` module is *not* set, allowing
+// administrators to edit the configuration for groups, make new ones, and
+// check the box to require TOTP.
 //
 // ## Notable properties of apos.modules['apostrophe-login']
 //
@@ -546,11 +548,7 @@ module.exports = {
         return false;
       }
       if (self.options.totp.groups) {
-        return !!self.options.totp.groups.find(name => {
-          return (req.user._groups || []).find(group => {
-            return (group.title === name) || (group.slug === name);
-          });
-        });
+        return !!(req.user._groups || []).find(group => group.totp);
       } else {
         return true;
       }

--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -82,6 +82,20 @@
 // `throttle` exists, `allowedAttempts` defaults to 3, `perMinutes` defaults to 1,
 // and `lockoutMinutes` also defaults to 1.
 //
+// `totp`
+//
+// If this option is set to `true`, the user will be required to set up two-factor
+// authentication via Google Authenticator or a compatible app (TOTP) on their
+// next successful login, and all future logins will require the verification code.
+//
+// If this option is set to an object, you may specify sub-options:
+//
+// `totp: { groups: [ 'admin' ] }`
+//
+// The `groups` sub-option limits the TOTP requirement to members of those
+// groups only. Other users are not required to use two-factor authentication
+// to log in. Groups may be specified by slug, or by title (name).
+//
 // ## Notable properties of apos.modules['apostrophe-login']
 //
 // `passport`
@@ -507,6 +521,9 @@ module.exports = {
       if (!req.user) {
         return next();
       }
+      if (!self.totpNeeded(req)) {
+        return next();
+      }
       var safelist = [ '/login-totp', '/setup-totp', '/confirm-totp', '/login', '/logout' ];
       if (_.contains(safelist, req.url)) {
         return next();
@@ -522,6 +539,21 @@ module.exports = {
         }
       }
       return next();
+    };
+
+    self.totpNeeded = function(req) {
+      if (!req.user) {
+        return false;
+      }
+      if (self.options.totp.groups) {
+        return !!self.options.totp.groups.find(name => {
+          return (req.user._groups || []).find(group => {
+            return (group.title === name) || (group.slug === name);
+          });
+        });
+      } else {
+        return true;
+      }
     };
 
     // return the loginUrl option
@@ -1046,7 +1078,7 @@ module.exports = {
     self.afterLogin = function(req, res) {
 
       if (self.options.totp) {
-        if (!req.session.totp) {
+        if ((!req.session.totp) && self.totpNeeded(req)) {
           return res.redirect('/login-totp');
         }
       }


### PR DESCRIPTION
The developer can set `totp: { groups: true }`, and then the TOTP requirement is in place only for groups for which it has been checked off in the backend.

Note that if you are logged in as an admin and you apply this rule to the admin group, the rule is immediately enforced for you, so leaving the manage modal you will discover a TOTP prompt and you won't be able to do anything else until you address it.