### PR TITLE
pattern option for string fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## 2.110.0 (2020-07-29)
 
 * Security: added support for throttling login attempts. If you set the `throttle` option of `apostrophe-login` to `{ allowedAttempts: 3, perMinutes: 1, lockoutMinutes: 1 }`, a user will be locked out and unable to try again for 1 minute after three failed login attempts in 1 minute. Thanks to Michelin for making this work possible via [Apostrophe Enterprise Support](https://apostrophecms.org/support/enterprise-support).
+* Schemas: you may now set a regular expression to be used to validate any `string` schema field by setting the `pattern` property of the schema field. **Please note
+that `pattern` must be a string,** not a regular expression literal. Otherwise it
+will only be validated on the server side, causing confusion for the user when it
+is not reported on the browser side. You may also set `patternErrorMessage` to
+provide a clear explanation to the user when their input does not match. When
+setting `pattern` as a string always remember to escape the `\` character properly
+(you will often need two `\` characters, for instance `\\w`). To avoid Denial of Service attacks, take care to avoid [evil regular expressions](https://en.wikipedia.org/wiki/ReDoS).
 
 ## 2.109.0 (2020-07-15)
 

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -1141,10 +1141,13 @@ module.exports = {
             object[name] = object[name].substr(0, field.max);
           }
           // If field is required but empty (and client side didn't catch that)
-          // This is new and until now if JS client side failed, then it would
-          // allow the save with empty values -Lars
           if (field.required && ((data[name] == null) || !data[name].toString().length)) {
             return callback('required');
+          }
+          if (field.pattern) {
+            if (!object[name].match(field.pattern)) {
+              return callback('pattern');
+            }
           }
           return setImmediate(callback);
         },

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -1157,15 +1157,22 @@ apos.define('apostrophe-schemas', {
         err = self.error(field, 'required');
         return setImmediate(_.partial(callback, err));
       }
-      if (data[name] && field.max && (data[name].length > field.max)) {
+      if (data[name].length && field.max && (data[name].length > field.max)) {
         err = self.error(field, 'max');
         err.message = 'Maximum of ' + field.max + ' characters';
         return setImmediate(_.partial(callback, err));
       }
-      if (data[name] && field.min && (data[name].length < field.min)) {
+      if (data[name].length && field.min && (data[name].length < field.min)) {
         err = self.error(field, 'min');
         err.message = 'Minimum of ' + field.min + ' characters';
         return setImmediate(_.partial(callback, err));
+      }
+      if (data[name].length && field.pattern) {
+        if (!data[name].match(new RegExp(field.pattern))) {
+          err = self.error(field, 'pattern');
+          err.message = field.patternErrorMessage || 'Incorrect input';
+          return setImmediate(_.partial(callback, err));
+        }
       }
       return setImmediate(callback);
     }


### PR DESCRIPTION
DCAD needs the ability to restrict characters in usernames in apostrophe-signup. I was about to make it complicated and realized we are missing this simple option in apostrophe-schemas. Simpler to fix it there.

I named the option `pattern` rather than `regExp` because it will be familiar to HTML5 developers. However I do not use the `pattern` attribute in the actual input field because we are not always performing an HTML5 submit event, so there is no context for it to perform validation in; instead I do a simple match of the regular expression in the browser-side `convert` code. The end result is nicely consistent with the rest of our functionality and still very little code.