### PR TITLE
ensure knobs work in storybook

### DIFF
--- a/lib/modules/@apostrophecms/schemas/src/apos/components/AposInputString.stories.js
+++ b/lib/modules/@apostrophecms/schemas/src/apos/components/AposInputString.stories.js
@@ -1,4 +1,5 @@
 import {
+  withKnobs,
   select,
   optionsKnob as options,
   boolean
@@ -7,7 +8,8 @@ import {
 import AposInputString from './AposInputString.vue';
 
 export default {
-  title: 'Inputs (String)'
+  title: 'Inputs (String)',
+  decorators: [withKnobs]
 };
 
 export const stringInputs = () => {

--- a/lib/modules/@apostrophecms/storybook/template/.storybook/main.tmpl.js
+++ b/lib/modules/@apostrophecms/storybook/template/.storybook/main.tmpl.js
@@ -1,7 +1,7 @@
 module.exports = {
   stories: "STORIES",
   addons: [
-    '@storybook/addon-knobs',
+    '@storybook/addon-knobs/register',
     '@storybook/addon-a11y/register',
     '@storybook/addon-contexts/register',
     {


### PR DESCRIPTION
Updated the knobs addon, the `knobStore` state object was empty without knobs being "registered". This looked like a pretty much direct copy from the `apostrophe-storybook` repo so not totally sure why it just "worked" there. 

Also, re-added the decorators to the `AposInputString` so those should also work now too.