### PR TITLE
Eliminate inline script tags (script tags with no src)

### DIFF
--- a/modules/@apostrophecms/template/index.js
+++ b/modules/@apostrophecms/template/index.js
@@ -587,8 +587,6 @@ module.exports = {
       // * `query` (`req.query`)
       // * `permissions` (`req.user._permissions`)
       // * `refreshing` (true if we are refreshing the content area of the page without reloading)
-      // * `js.globalCalls` (javascript markup to insert all global pushed javascript calls)
-      // * `js.reqCalls` (javascript markup to insert all req-specific pushed javascript calls)
       //
       // async function.
 

--- a/modules/@apostrophecms/template/views/refreshLayout.html
+++ b/modules/@apostrophecms/template/views/refreshLayout.html
@@ -1,8 +1,3 @@
 {% block beforeMain %}{% endblock %}
 {% block main %}{% endblock %}
 {% block afterMain %}{% endblock %}
-<script type="text/javascript">
-  {# globalCalls already will have happened at initial page load, but we should #}
-  {# make the request-specific calls #}
-  {{ data.js.reqCalls }}
-</script>


### PR DESCRIPTION
got it all except for wrappers unavoidable for infogram and wufoo embeds, if you do not like inline javascript you can not use those.

This is necessary because some recent security scanners consider all script tags without a src to be forbidden, as they can generally be avoided and they pose an XSS risk.
