### PR TITLE
widget groups (hierarchy for the Add Widget menu)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
-## 2.110.1 (2020-08-12)
+## 2.111.0 (2020-08-12)
+
+* By popular request, "Add Widget" dropdown menus are better organized now, with support for categories of widgets. You can configure this optional feature like so:
+
+```
+apos.area(data.page, 'areaNameHere', {
+  widgets: { ... you must configure your widgets as usual ... }
+  widgetGroups: {
+    'Content': [ 'apostrophe-rich-text', 'apostrophe-images' ],
+    'Layout': [ 'one-column', 'two-column' ]
+  }
+}
+```
+
+Every widget type you specify for `widgetGroups` must still be configured in `widgets`.
+
+If `widgetGroups` is not present the "add widget" dropdown menu will appear as it always did.
 
 * Removes the `aposBody` template macro, which was unused.
 

--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -54,6 +54,40 @@
       &:hover { opacity: 1; }
     }
   }
+  .apos-widget-group {
+    max-height: ~"calc(1em + 40px)";
+    position: relative;
+    // So we can click the whole thing as a toggle
+    width: 100%;
+    ul {
+      display: none;
+    }
+    overflow: hidden;
+    .apos-widget-group-toggle::after {
+      display: block;
+      position: absolute;
+      right: 20px;
+      content: '►';
+    }
+    &.apos-widget-group--open {
+      ul {
+        display: block;
+        margin-top: 1em;
+        li {
+          padding: 15px;
+          &:hover {
+            background-color: @apos-mid;
+          }
+        }
+      }
+      max-height: none;
+      .apos-widget-group-toggle::after {
+        display: block;
+        float: right;
+        content: '▲';
+      }
+    }
+  }
 }
 
 // disable menu interactions while some windows are open
@@ -210,6 +244,9 @@
     margin-right: auto;
     max-width: 200px;
     .apos-rounded;
+    &.apos-widget-groups {
+      max-width: 300px;
+    }
   }
 }
 

--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -59,33 +59,36 @@
     position: relative;
     // So we can click the whole thing as a toggle
     width: 100%;
-    ul {
-      display: none;
-    }
     overflow: hidden;
-    .apos-widget-group-toggle::after {
-      display: block;
-      position: absolute;
-      right: 20px;
-      content: '►';
-    }
     &.apos-widget-group--open {
-      ul {
-        display: block;
-        margin-top: 1em;
-        li {
-          padding: 15px;
-          &:hover {
-            background-color: @apos-mid;
-          }
-        }
-      }
       max-height: none;
-      .apos-widget-group-toggle::after {
-        display: block;
-        float: right;
-        content: '▲';
-      }
+    }
+  }
+  .apos-widget-group-widgets {
+    display: none;
+  }
+  .apos-widget-group--open .apos-widget-group-widgets {
+    display: block;
+    margin-top: 1em;
+  }
+  .apos-widget-group-toggle::after {
+    display: block;
+    position: absolute;
+    right: 20px;
+    font-size: 10px;
+    margin-top: 2px;
+    content: '►';
+  }
+  .apos-widget-group--open .apos-widget-group-toggle::after {
+    content: '▼';
+  }
+  .apos-widget-group-widget {
+    padding: 5px 10px;
+    font-size: 10px;
+    font-size: 80%;
+    line-height: 80%;
+    &:hover {
+      background-color: @apos-mid;
     }
   }
 }

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -251,7 +251,7 @@ apos.define('apostrophe-areas-editor', {
       // It is now OK to show this again without worrying about
       // menu interactions being suppressed due to stacking order issues. -Tom
       $('.apos-context-menu-container').removeClass('apos-content-menu-active');
-      self.$el.find('.apos-widget-group--open').removeClass('apos-widget-group--open');
+      self.$el.find('[data-apos-widget-group]').removeClass('apos-widget-group--open');
       self.enableAreaControls();
     };
 

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -251,6 +251,7 @@ apos.define('apostrophe-areas-editor', {
       // It is now OK to show this again without worrying about
       // menu interactions being suppressed due to stacking order issues. -Tom
       $('.apos-context-menu-container').removeClass('apos-content-menu-active');
+      self.$el.find('.apos-widget-group--open').removeClass('apos-widget-group--open');
       self.enableAreaControls();
     };
 

--- a/lib/modules/apostrophe-areas/public/js/user.js
+++ b/lib/modules/apostrophe-areas/public/js/user.js
@@ -406,7 +406,7 @@ apos.define('apostrophe-areas', {
     };
 
     self.enableWidgetGroups = function() {
-      $('body').on('click', '.apos-widget-group', function() {
+      $('body').on('click', '[data-apos-widget-group]', function() {
         $(this).toggleClass('apos-widget-group--open');
         return false;
       });

--- a/lib/modules/apostrophe-areas/public/js/user.js
+++ b/lib/modules/apostrophe-areas/public/js/user.js
@@ -17,6 +17,7 @@ apos.define('apostrophe-areas', {
       self.enhanceAddContent();
       self.enhanceControlsHover();
       self.enableUnload();
+      self.enableWidgetGroups();
       // the enhance event already happened while
       // we were waiting for our templates, so call
       // this ourselves
@@ -401,6 +402,13 @@ apos.define('apostrophe-areas', {
           // message appears instead, but we must set it
           return 'You may have unsaved changes. Are you sure?';
         }
+      });
+    };
+
+    self.enableWidgetGroups = function() {
+      $('body').on('click', '.apos-widget-group', function() {
+        $(this).toggleClass('apos-widget-group--open');
+        return false;
       });
     };
 

--- a/lib/modules/apostrophe-areas/views/areaControls.html
+++ b/lib/modules/apostrophe-areas/views/areaControls.html
@@ -4,17 +4,34 @@
       <div class="apos-button apos-button--major apos-button--circular apos-button--in-context" data-apos-add-content>
         <i class="fa fa-plus"></i>
       </div>
-      <ul class="apos-dropdown-items" data-apos-dropdown-items>
-        {%- for name, options in data.options.widgets -%}
-          {%- if data.widgetManagers[name] -%}
-            {%- if not options.readOnly -%}
-              <li class="apos-dropdown-item" data-apos-add-item="{{ name }}">{{ options.addLabel or __ns('apostrophe', data.widgetManagers[name].label) }}</li>
-            {% endif %}
-          {%- else -%}
-            {{ apos.log("Your area contains a widget of type " + name + " but there is no manager for that type. Maybe you forgot to configure the " + name + "-widgets module?") }}
-          {%- endif -%}
-        {%- endfor -%}
-      </ul>
+      {%- if data.options.widgetGroups -%}
+        <ul class="apos-dropdown-items apos-widget-groups" data-apos-dropdown-items>
+          {%- for label, widgets in data.options.widgetGroups -%}
+            <li class="apos-dropdown-item apos-widget-group" data-apos-widget-group>
+              <span class="apos-widget-group-toggle"></span>
+              {{ __ns('apostrophe', label) }}
+              <ul>
+                {%- for name in widgets -%}
+                  {%- set options = data.options.widgets[name] -%}
+                  <li class="apos-widget-group-widget" data-apos-add-item="{{ name }}">{{ options.addLabel or __ns('apostrophe', data.widgetManagers[name].label) }}</li>
+                {%- endfor -%}
+              </ul>
+            </li>
+          {%- endfor -%}
+        </ul>
+      {%- else -%}
+        <ul class="apos-dropdown-items" data-apos-dropdown-items>
+          {%- for name, options in data.options.widgets -%}
+            {%- if data.widgetManagers[name] -%}
+              {%- if not options.readOnly -%}
+                <li class="apos-dropdown-item" data-apos-add-item="{{ name }}">{{ options.addLabel or __ns('apostrophe', data.widgetManagers[name].label) }}</li>
+              {% endif %}
+            {%- else -%}
+              {{ apos.log("Your area contains a widget of type " + name + " but there is no manager for that type. Maybe you forgot to configure the " + name + "-widgets module?") }}
+            {%- endif -%}
+          {%- endfor -%}
+        </ul>
+      {%- endif -%}
     </div>
     <div class="apos-area-divider"></div>
   </div>

--- a/lib/modules/apostrophe-areas/views/areaControls.html
+++ b/lib/modules/apostrophe-areas/views/areaControls.html
@@ -10,7 +10,7 @@
             <li class="apos-dropdown-item apos-widget-group" data-apos-widget-group>
               <span class="apos-widget-group-toggle"></span>
               {{ __ns('apostrophe', label) }}
-              <ul>
+              <ul class="apos-widget-group-widgets">
                 {%- for name in widgets -%}
                   {%- set options = data.options.widgets[name] -%}
                   <li class="apos-widget-group-widget" data-apos-add-item="{{ name }}">{{ options.addLabel or __ns('apostrophe', data.widgetManagers[name].label) }}</li>

--- a/lib/modules/apostrophe-areas/views/areaControls.html
+++ b/lib/modules/apostrophe-areas/views/areaControls.html
@@ -5,7 +5,7 @@
         <i class="fa fa-plus"></i>
       </div>
       {%- if data.options.widgetGroups -%}
-        <ul class="apos-dropdown-items apos-widget-groups" data-apos-dropdown-items>
+        <ul class="apos-dropdown-items apos-widget-groups">
           {%- for label, widgets in data.options.widgetGroups -%}
             <li class="apos-dropdown-item apos-widget-group" data-apos-widget-group>
               <span class="apos-widget-group-toggle"></span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "2.110.1",
+  "version": "2.111.0",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Developers use it like this:

```
      {{ apos.area(data.page, 'body', {
        widgets: { ... configure like always },
        widgetGroups: {
          'Basic': [ 'apostrophe-rich-text', 'image', 'slideshow', 'apostrophe-video', 'logo-mask' ],
          'Layout': [ 'columns' ],
          'Content': [ 'link', 'artworks', 'locations', 'content', 'articles', 'events', 'random-met-artwork' ]
        }
      }) }}
```

I did it this way because it avoids opening a can of worms in the zillion lines of code that think they know how `options.widgets` is structured. Feels like a good way to retrofit this feature, which is very late in the game for A2, yet coming up in a pressing way for clients and needed enough that we kinda fake it in our own demo 😆 

If you don't use `widgetGroups` your widget menu behaves normally.

I forgot to demo it, but you can click the group's label to toggle it closed again.

![a2-widget-groups](https://user-images.githubusercontent.com/32125/89743840-25e4c580-da75-11ea-8e4a-2c470bec6b86.gif)
