### PR TITLE
Uses focusout instead of immediately validating inputs

### DIFF
--- a/modules/@apostrophecms/schema/ui/apos/mixins/AposInputMixin.js
+++ b/modules/@apostrophecms/schema/ui/apos/mixins/AposInputMixin.js
@@ -32,7 +32,10 @@ export default {
     };
   },
   mounted () {
-    this.validateAndEmit();
+    this.$el.addEventListener('focusout', this.validateAndEmit);
+  },
+  destroyed () {
+    this.$el.removeEventListener('focusout', this.validateAndEmit);
   },
   computed: {
     options () {


### PR DESCRIPTION
Resolves the immediate error on input fields: https://apostrophecms.atlassian.net/browse/A30U-331