### PR TITLE
3/fix/vanishing branch

### DIFF
--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -37,6 +37,7 @@
 <script>
 import AposModalParentMixin from 'Modules/@apostrophecms/modal/mixins/AposModalParentMixin';
 import AposTableMixin from 'Modules/@apostrophecms/modal/mixins/AposTableMixin';
+import klona from 'klona';
 
 export default {
   name: 'AposPagesManager',
@@ -90,7 +91,9 @@ export default {
         return [];
       }
 
-      this.pages.forEach(page => {
+      const pagesSet = klona(this.pages);
+
+      pagesSet.forEach(page => {
         const data = {};
 
         this.headers.forEach(column => {

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -41,7 +41,7 @@ import AposTableMixin from 'Modules/@apostrophecms/modal/mixins/AposTableMixin';
 export default {
   name: 'AposPagesManager',
   mixins: [ AposModalParentMixin, AposTableMixin ],
-  emits: ['trash', 'search', 'safe-close'],
+  emits: [ 'trash', 'search', 'safe-close' ],
   data() {
     return {
       modal: {
@@ -96,7 +96,7 @@ export default {
         this.headers.forEach(column => {
           data[column.name] = page[column.name];
           data._id = page._id;
-          data.children = page._children;
+          data.children = page.children;
         });
         rows.push(data);
       });
@@ -147,7 +147,7 @@ export default {
 
       formatPage(pageTree);
 
-      this.pages = [pageTree];
+      this.pages = [ pageTree ];
 
       function formatPage(page) {
         page.published = page.published ? 'Published' : 'Unpublished';
@@ -156,8 +156,11 @@ export default {
           id: page._id
         });
 
-        if (Array.isArray(page._children)) {
-          page._children.forEach(formatPage);
+        page.children = page._children;
+        delete page._children;
+
+        if (Array.isArray(page.children)) {
+          page.children.forEach(formatPage);
         }
       }
     },

--- a/modules/@apostrophecms/storybook/template/public/mocks.js
+++ b/modules/@apostrophecms/storybook/template/public/mocks.js
@@ -250,7 +250,7 @@
         'type': '@apostrophecms/home-page',
         'metaType': 'doc',
         '_url': '/',
-        '_children': [{
+        '_children': [ {
           'title': 'Pellentesque Nullam Purus',
           'slug': '/second',
           '_id': 'ckd96fndy0004fo9kbusxz2kf',
@@ -280,7 +280,7 @@
           '_children': [],
           'published': true,
           'updatedAt': '2020-07-30T19:14:15.750Z'
-        }],
+        } ],
         'published': true,
         'updatedAt': '2020-07-27T20:09:06.031Z'
       }

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTree.stories.js
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTree.stories.js
@@ -6,7 +6,7 @@ import { LoremIpsum } from 'lorem-ipsum';
 const data = getData();
 export default {
   title: 'Tree',
-  decorators: [withKnobs]
+  decorators: [ withKnobs ]
 };
 
 export const Tree = () => ({
@@ -155,8 +155,8 @@ function randomDay() {
     'November',
     'December'
   ];
-  const days = [...Array(31).keys()];
-  const years = [2018, 2019, 2020, 2021];
+  const days = [ ...Array(31).keys() ];
+  const years = [ 2018, 2019, 2020, 2021 ];
   return `${weekdays[randomItem(weekdays)]}
     ${months[randomItem(months)]}
     ${days[randomItem(days)]},

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
@@ -32,7 +32,7 @@ import AposHelpers from 'Modules/@apostrophecms/ui/mixins/AposHelpersMixin';
 
 export default {
   name: 'AposTree',
-  mixins: [AposHelpers],
+  mixins: [ AposHelpers ],
   model: {
     prop: 'checked',
     event: 'change'
@@ -68,7 +68,7 @@ export default {
       default: false
     }
   },
-  emits: ['busy', 'update', 'change', 'edit'],
+  emits: [ 'busy', 'update', 'change', 'edit' ],
   data() {
     return {
       // Copy the `data` property to mutate with VueDraggable.
@@ -97,7 +97,7 @@ export default {
         });
       }
 
-      let completeRows = [headers];
+      let completeRows = [ headers ];
       // Add child rows into `completeRows`.
       this.rows.forEach(row => {
         completeRows.push(row);

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
@@ -10,7 +10,7 @@
     />
     <AposTreeRows
       v-model="checkedProxy"
-      :rows="rows"
+      :rows="myRows"
       :headers="headers"
       :icons="icons"
       :col-widths="colWidths"
@@ -71,7 +71,8 @@ export default {
   emits: [ 'busy', 'update', 'change', 'edit' ],
   data() {
     return {
-      // Copy the `data` property to mutate with VueDraggable.
+      // Copy the `rows` property to mutate with VueDraggable.
+      myRows: [],
       nested: false,
       colWidths: null,
       treeId: this.generateId()
@@ -159,6 +160,11 @@ export default {
         finalRow.push(obj);
       });
       return finalRow;
+    }
+  },
+  watch: {
+    rows(array) {
+      this.myRows = array;
     }
   },
   methods: {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -15,7 +15,7 @@
       :class="{ 'apos-tree__row--parent': row.children && row.children.length > 0 }"
       data-apos-tree-row
       v-for="row in myRows" :key="row._id"
-      :data-row-id="row.id"
+      :data-row-id="row._id"
     >
       <div class="apos-tree__row-data">
         <button
@@ -155,7 +155,7 @@ export default {
       required: true
     }
   },
-  emits: ['busy', 'update', 'change', 'edit'],
+  emits: [ 'busy', 'update', 'change', 'edit' ],
   computed: {
     myRows() {
       return this.rows;
@@ -209,7 +209,7 @@ export default {
       }
     },
     getCellClasses(col, row) {
-      const classes = ['apos-tree__cell'];
+      const classes = [ 'apos-tree__cell' ];
       classes.push(`apos-tree__cell--${col.name}`);
 
       if (col.iconOnly) {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -179,7 +179,11 @@ export default {
       if (!this.$refs['tree-branches']) {
         return;
       }
-
+      this.setHeights();
+    });
+  },
+  methods: {
+    setHeights() {
       this.$refs['tree-branches'].forEach(branch => {
         // Add padding to the max-height to avoid needing a `resize`
         // event listener updating values.
@@ -187,14 +191,13 @@ export default {
         branch.$el.setAttribute('data-apos-branch-height', `${height}px`);
         branch.$el.style.maxHeight = `${height}px`;
       });
-    });
-  },
-  methods: {
+    },
     startDrag() {
       this.$emit('busy', true);
     },
     endDrag(event) {
       this.$emit('update', event);
+      this.setHeights();
     },
     toggleSection(event) {
       const row = event.target.closest('[data-apos-tree-row]');

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "i18n": "^0.8.6",
     "import-fresh": "^3.2.1",
     "js-cookie": "^2.2.1",
+    "klona": "^1.1.2",
     "launder": "^1.2.0",
     "less": "^3.12.0",
     "less-middleware": "^3.0.1",


### PR DESCRIPTION
Resolves the problem with an item disappearing when it is place above the home page in the page tree. That's the `klona` part. The rest are other little bugs I discovered in this. 

`<tom-stream-of-consciousness-narrative>`
We don't want a page to be a sibling of the home page in the page tree, do we? No, that would be bad and doesn't make any sense. However, in the ultimate UI integration, the page tree will be refreshed when things are moved. This will likely produce new things to figure out, but quoth Angela Bassett in MI:6, "that's the job." The "updated" event will be triggered, the manager will hear it, and it will it hit a route to update the page tree and refresh things.
`</tom-stream-of-consciousness-narrative>`