### PR TITLE
3/versions select

### DIFF
--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocHistory.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocHistory.vue
@@ -15,7 +15,7 @@
         <template #bodyMain>
           <AposTree
             :rows="rows" :headers="headers"
-            :icons="icons" :hide-header="true"
+            :icons="icons" :options="treeOptions"
           />
         </template>
       </AposModalBody>
@@ -60,6 +60,9 @@ export default {
             labelIcon: 'account-box'
           }
         ]
+      },
+      treeOptions: {
+        hideHeader: true
       }
     };
   },

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocHistory.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocHistory.vue
@@ -4,10 +4,16 @@
     @esc="cancel" @no-modal="$emit('safe-close')"
     @inactive="modal.active = false" @show-modal="modal.showModal = true"
   >
+    <template #secondaryControls>
+      <AposButton
+        type="default" label="Exit"
+        @click="cancel"
+      />
+    </template>
     <template #primaryControls>
       <AposButton
-        type="default" label="Finished"
-        @click="cancel"
+        type="primary" :label="restoreLabel"
+        @click="restore" :disabled="latestVersion === selected[0]"
       />
     </template>
     <template #main>
@@ -48,6 +54,7 @@ export default {
         showModal: false
       },
       versions: [],
+      latestVersion: '',
       selected: [],
       options: {
         columns: [
@@ -89,12 +96,17 @@ export default {
       });
 
       return rows;
+    },
+    restoreLabel() {
+      return this.latestVersion === this.selected[0] ? 'Current version' : 'Restore';
     }
   },
   async mounted() {
     this.modal.active = true;
 
     await this.getVersions();
+    this.selected = [ this.versions[0]._id ];
+    this.latestVersion = this.versions[0]._id;
   },
   methods: {
     async getVersions () {
@@ -112,6 +124,11 @@ export default {
       if (docVersions) {
         this.versions = docVersions;
       }
+    },
+    restore() {
+      // TEMP: This will hit a POST or PATCH route in UI integration.
+      // After a confirmation step, this should also trigger `cancel`.
+      console.info(`Restore version ${this.selected[0]} for doc ${this.doc._id}`);
     },
     openEditor(event) {
       console.info('OPEN DOC TO EDIT', event);

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocHistory.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocHistory.vue
@@ -65,7 +65,8 @@ export default {
       },
       treeOptions: {
         hideHeader: true,
-        selectable: true
+        selectable: true,
+        startCollapsed: true
       }
     };
   },

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocHistory.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocHistory.vue
@@ -16,6 +16,7 @@
           <AposTree
             :rows="rows" :headers="headers"
             :icons="icons" :options="treeOptions"
+            v-model="selected"
           />
         </template>
       </AposModalBody>
@@ -47,6 +48,7 @@ export default {
         showModal: false
       },
       versions: [],
+      selected: [],
       options: {
         columns: [
           {
@@ -62,7 +64,8 @@ export default {
         ]
       },
       treeOptions: {
-        hideHeader: true
+        hideHeader: true,
+        selectable: true
       }
     };
   },

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.stories.js
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.stories.js
@@ -1,8 +1,8 @@
 export default {
-  title: 'Pages Organize'
+  title: 'Pages Manager'
 };
 
-export const pagesOrganize = () => {
+export const pagesManager = () => {
   return {
     methods: {
       toggleActive: function () {

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -23,8 +23,8 @@
           <AposTree
             :rows="rows"
             :headers="headers" :icons="icons"
-            :draggable="true" :selectable="true"
             v-model="checked"
+            :options="treeOptions"
             @update="update" @busy="setBusy"
             @edit="openEditor"
           />
@@ -81,6 +81,10 @@ export default {
             type: 'link'
           }
         ]
+      },
+      treeOptions: {
+        bulkSelect: true,
+        draggable: true
       }
     };
   },

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTree.stories.js
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTree.stories.js
@@ -31,8 +31,10 @@ export const Tree = () => ({
       :headers="data.headers"
       :icons="data.icons"
       :rows="data.rows"
-      :draggable="data.draggable"
-      :selectable="data.selectable"
+      :options="{
+        draggable: true,
+        bulkSelect: true
+      }"
       v-model="checked"
       @update="update" @busy="setBusy"
     />
@@ -40,7 +42,7 @@ export const Tree = () => ({
 });
 
 let draggable = false;
-let selectable = false;
+let bulkSelect = false;
 
 function getData () {
   const rows = generateRows(randomNumber());
@@ -78,7 +80,7 @@ function getData () {
     },
     rows,
     draggable,
-    selectable
+    bulkSelect
   };
 }
 
@@ -117,7 +119,7 @@ function generateRow(maxDepth = 5) {
 
   if (randomBoolean(0.3)) {
     draggable = true;
-    selectable = true;
+    bulkSelect = true;
     for (let i = 0; i < randomNumber(); i++) {
       if (maxDepth > i) {
         const child = generateRow(i);

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
@@ -59,6 +59,13 @@ export default {
         return null;
       }
     },
+    // Active options include:
+    // - hideHeader: The tree header row will be visibly hidden.
+    // - selectable: Rows can be individually selected one-at-a-time. Used
+    //   for version history selection.
+    // - bulkSelect: Rows can be bulk selected using checkboxes. Both this
+    //   and `selectable` use the same `checked` array.
+    // - draggable: Rows can be moved around within the tree.
     options: {
       type: Object,
       default () {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
@@ -7,7 +7,7 @@
     />
     <AposTreeHeader
       :headers="headers" :icons="icons"
-      :col-widths="colWidths" :hidden="hideHeader"
+      :col-widths="colWidths" :hidden="options.hideHeader"
     />
     <AposTreeRows
       v-model="checkedProxy"
@@ -21,8 +21,7 @@
       @update="update"
       @edit="$emit('edit', $event)"
       list-id="root"
-      :draggable="draggable"
-      :selectable="selectable"
+      :options="options"
       :tree-id="treeId"
     />
   </div>
@@ -43,10 +42,6 @@ export default {
       type: Array,
       required: true
     },
-    hideHeader: {
-      type: Boolean,
-      default: false
-    },
     icons: {
       type: Object,
       default() {
@@ -64,13 +59,11 @@ export default {
         return null;
       }
     },
-    draggable: {
-      type: Boolean,
-      default: false
-    },
-    selectable: {
-      type: Boolean,
-      default: false
+    options: {
+      type: Object,
+      default () {
+        return {};
+      }
     }
   },
   emits: [ 'busy', 'update', 'change', 'edit' ],

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeHeader.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeHeader.vue
@@ -63,7 +63,6 @@ export default {
       if (this.spacerOnly) {
         // Give this a moment to make sure we have the final widths.
         this.$nextTick(() => {
-          console.info(this.headers);
           this.calculateWidths();
         });
       }

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -14,8 +14,11 @@
       v-for="row in myRows" :key="row._id"
       :data-row-id="row._id" data-apos-tree-row
       :class="getRowClasses(row)"
+      :aria-role="options.selectable ? 'button' : null"
+      :tabindex="options.selectable ? 0 : null"
       v-on="options.selectable ? {
-        'click': selectRow
+        'click': selectRow,
+        'keydown': keydownRow
       } : {}"
     >
       <div class="apos-tree__row-data">
@@ -214,6 +217,11 @@ export default {
         rowList.style.maxHeight = 0;
         toggle.setAttribute('aria-expanded', false);
         rowList.classList.add('is-collapsed');
+      }
+    },
+    keydownRow(event) {
+      if (event.keyCode === 32) {
+        this.selectRow(event);
       }
     },
     selectRow(event) {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -199,10 +199,12 @@ export default {
       this.$emit('update', event);
       this.setHeights();
     },
-    toggleSection(event) {
-      const row = event.target.closest('[data-apos-tree-row]');
+    toggleSection(event, data) {
+      const row = (data && data.row) ||
+        event.target.closest('[data-apos-tree-row]');
       const rowList = row.querySelector('[data-apos-branch-height]');
-      const toggle = event.target.closest('[data-apos-tree-toggle]');
+      const toggle = (data && data.toggle) ||
+        event.target.closest('[data-apos-tree-toggle]');
 
       if (toggle.getAttribute('aria-expanded') !== 'true') {
         rowList.style.maxHeight = rowList.getAttribute('data-apos-branch-height');
@@ -218,11 +220,21 @@ export default {
       const buttonParent = event.target.closest('[data-apos-tree-toggle]');
 
       if (buttonParent) {
+        // If we've clicked on the toggle, don't select the row.
         return;
       }
 
       const row = event.target.closest('[data-row-id]');
       this.$emit('change', [ row.dataset.rowId ]);
+
+      // Expand a row when the full parent row is selected.
+      const toggle = row.querySelector('[data-apos-tree-toggle]');
+      if (toggle && toggle.getAttribute('aria-expanded') !== 'true') {
+        this.toggleSection(null, {
+          row,
+          toggle
+        });
+      }
     },
     getRowClasses(row) {
       return [

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -19,10 +19,11 @@
       } : {}"
     >
       <div class="apos-tree__row-data">
+        <!-- {{ options.startCollapsed }} -->
         <button
           v-if="row.children && row.children.length > 0"
           class="apos-tree__row__toggle" data-apos-tree-toggle
-          aria-label="Toggle section"
+          aria-label="Toggle section" :aria-expanded="!options.startCollapsed"
           @click="toggleSection($event)"
         >
           <chevron-down-icon :size="16" class="apos-tree__row__toggle-icon" />
@@ -80,6 +81,10 @@
         :list-id="row._id"
         :tree-id="treeId"
         :options="options"
+        :class="{ 'is-collapsed': options.startCollapsed }"
+        :style="{
+          'max-height': options.startCollapsed ? '0' : null
+        }"
         @busy="$emit('busy', $event)"
         @update="$emit('update', $event)"
         @edit="$emit('edit', $event)"
@@ -199,7 +204,7 @@ export default {
       const rowList = row.querySelector('[data-apos-branch-height]');
       const toggle = event.target.closest('[data-apos-tree-toggle]');
 
-      if (rowList && rowList.style.maxHeight === '0px') {
+      if (toggle.getAttribute('aria-expanded') !== 'true') {
         rowList.style.maxHeight = rowList.getAttribute('data-apos-branch-height');
         toggle.setAttribute('aria-expanded', true);
         rowList.classList.remove('is-collapsed');
@@ -278,9 +283,10 @@ export default {
 
   .apos-tree__row__toggle-icon {
     transition: transform 0.3s ease;
+    transform: rotate(-90deg) translateY(0.25em);
 
-    [aria-expanded=false] > & {
-      transform: rotate(-90deg) translateY(0.25em);
+    [aria-expanded=true] > & {
+      transform: none;
     }
   }
   .apos-tree__row__handle {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -220,7 +220,8 @@ export default {
       }
     },
     keydownRow(event) {
-      if (event.keyCode === 32) {
+      if (event.key === ' ') {
+        event.preventDefault();
         this.selectRow(event);
       }
     },

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -7,7 +7,7 @@
     @start="startDrag"
     @end="endDrag"
     :data-list-id="listId"
-    :disabled="!draggable"
+    :disabled="!options.draggable"
     handle=".apos-tree__row__handle"
   >
     <li
@@ -38,12 +38,12 @@
           @click="col.action ? $emit(col.action, row._id) : null"
         >
           <drag-icon
-            v-if="draggable && index === 0" class="apos-tree__row__handle"
+            v-if="options.draggable && index === 0" class="apos-tree__row__handle"
             :size="20"
             :fill-color="null"
           />
           <AposCheckbox
-            v-if="selectable && index === 0"
+            v-if="options.bulkSelect && index === 0"
             class="apos-tree__row__checkbox"
             tabindex="-1"
             :field="{
@@ -78,8 +78,7 @@
         :nested="nested"
         :list-id="row._id"
         :tree-id="treeId"
-        :draggable="draggable"
-        :selectable="selectable"
+        :options="options"
         @busy="$emit('busy', $event)"
         @update="$emit('update', $event)"
         @edit="$emit('edit', $event)"
@@ -138,13 +137,11 @@ export default {
       type: Boolean,
       required: true
     },
-    draggable: {
-      type: Boolean,
-      required: true
-    },
-    selectable: {
-      type: Boolean,
-      default: false
+    options: {
+      type: Object,
+      default () {
+        return {};
+      }
     },
     listId: {
       type: String,

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -11,11 +11,12 @@
     handle=".apos-tree__row__handle"
   >
     <li
-      class="apos-tree__row"
-      :class="{ 'apos-tree__row--parent': row.children && row.children.length > 0 }"
-      data-apos-tree-row
       v-for="row in myRows" :key="row._id"
-      :data-row-id="row._id"
+      :data-row-id="row._id" data-apos-tree-row
+      :class="getRowClasses(row)"
+      v-on="options.selectable ? {
+        'click': selectRow
+      } : {}"
     >
       <div class="apos-tree__row-data">
         <button
@@ -208,6 +209,26 @@ export default {
         row.classList.add('is-collapsed');
       }
     },
+    selectRow(event) {
+      let rowId;
+      if (event.target.dataset.rowId) {
+        rowId = event.target.dataset.rowId;
+      } else {
+        const row = event.target.closest('[data-row-id]');
+        rowId = row.dataset.rowId;
+      }
+      this.$emit('change', [ rowId ]);
+    },
+    getRowClasses(row) {
+      return [
+        'apos-tree__row',
+        {
+          'apos-tree__row--parent': row.children && row.children.length > 0,
+          'apos-tree__row--selectable': this.options.selectable,
+          'apos-tree__row--selected': this.options.selectable && this.checked[0] === row._id
+        }
+      ];
+    },
     getCellClasses(col, row) {
       const classes = [ 'apos-tree__cell' ];
       classes.push(`apos-tree__cell--${col.name}`);
@@ -243,6 +264,15 @@ export default {
 
     .apos-tree__row.is-collapsed & {
       overflow-y: auto;
+    }
+  }
+
+  .apos-tree__row--selectable {
+    cursor: pointer;
+  }
+  .apos-tree__row-data {
+    .apos-tree__row--selected > & {
+      background-color: var(--a-base-9);
     }
   }
 

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -21,7 +21,7 @@
       <div class="apos-tree__row-data">
         <button
           v-if="row.children && row.children.length > 0"
-          class="apos-tree__row__toggle"
+          class="apos-tree__row__toggle" data-apos-tree-toggle
           aria-label="Toggle section"
           @click="toggleSection($event)"
         >
@@ -166,9 +166,6 @@ export default {
       set(val) {
         this.$emit('change', val);
       }
-    },
-    isOpen() {
-      return true;
     }
   },
   mounted() {
@@ -200,24 +197,27 @@ export default {
     toggleSection(event) {
       const row = event.target.closest('[data-apos-tree-row]');
       const rowList = row.querySelector('[data-apos-branch-height]');
+      const toggle = event.target.closest('[data-apos-tree-toggle]');
 
       if (rowList && rowList.style.maxHeight === '0px') {
         rowList.style.maxHeight = rowList.getAttribute('data-apos-branch-height');
-        row.classList.remove('is-collapsed');
+        toggle.setAttribute('aria-expanded', true);
+        rowList.classList.remove('is-collapsed');
       } else if (rowList) {
         rowList.style.maxHeight = 0;
-        row.classList.add('is-collapsed');
+        toggle.setAttribute('aria-expanded', false);
+        rowList.classList.add('is-collapsed');
       }
     },
     selectRow(event) {
-      let rowId;
-      if (event.target.dataset.rowId) {
-        rowId = event.target.dataset.rowId;
-      } else {
-        const row = event.target.closest('[data-row-id]');
-        rowId = row.dataset.rowId;
+      const buttonParent = event.target.closest('[data-apos-tree-toggle]');
+
+      if (buttonParent) {
+        return;
       }
-      this.$emit('change', [ rowId ]);
+
+      const row = event.target.closest('[data-row-id]');
+      this.$emit('change', [ row.dataset.rowId ]);
     },
     getRowClasses(row) {
       return [
@@ -262,7 +262,7 @@ export default {
   .apos-tree__list {
     transition: max-height 0.3s ease;
 
-    .apos-tree__row.is-collapsed & {
+    &.is-collapsed {
       overflow-y: auto;
     }
   }
@@ -279,7 +279,7 @@ export default {
   .apos-tree__row__toggle-icon {
     transition: transform 0.3s ease;
 
-    .apos-tree__row.is-collapsed & {
+    [aria-expanded=false] > & {
       transform: rotate(-90deg) translateY(0.25em);
     }
   }


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-347, "Page History: As a user, I can select a row by clicking on it, expanding the row." This does not include UI to actually restore the version. After clicking a row, the `selected` property on `AposDocHistory` will have the ID of the selected row in it.