### PR TITLE
Lower default height for tabs in array selection

### DIFF
--- a/lib/modules/apostrophe-modal/public/css/components/modal-tabs.less
+++ b/lib/modules/apostrophe-modal/public/css/components/modal-tabs.less
@@ -5,7 +5,7 @@
     position: fixed;
     top: 0;
     float: left;
-    height: 100%;
+    height: calc(100% - 61px);
     width: 25%;
     background-color: @apos-light;
     // If tab number exceeds viewport allow scroll


### PR DESCRIPTION
When selecting entries from an pieces array the last entry is not visible when the browser window is only a few pixels smaller than the last entry. Here the last entry can be selected, but the entry itself is not visible. To fix this issue i lowered the height by 61px (default size of one array entry) so that the scroll bars appear in time.

Before no scrollbar is visible an it is not clear that there is another element to select:
![before](https://user-images.githubusercontent.com/3825952/90518642-590b1100-e167-11ea-9438-70770bc99f57.png)
After my fix the scrollbars appear sooner, therefore the user can scroll down to the last entry:
![after](https://user-images.githubusercontent.com/3825952/90518639-58727a80-e167-11ea-8346-2fba67a06792.png)


