### PR TITLE
an http request for /modules/apostrophe-images-widgets (a folder that…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.111.2 (2020-09-19)
+
+* Fixed a conflict between `express.static` and apostrophe's automatic removal of trailing slashes from possible page URLs. Apostrophe's intent in using `express.static` is only to deliver static assets. So we have made that intent clear by disabling the `redirect` option of `express.static`, which attempts to add a trailing slash whenever a folder exists on disk by that name, resulting in an infinite redirect loop.
+
 ## 2.111.1 (2020-08-17)
 
 * Fixed an incompatibility between apostrophe-workflow and MongoDB 4.4. Prior to version 4.4, MongoDB allowed a projection to contain both a parent property and one of its children, for instance `workflowLastCommitted` and `workflowLastCommitted.at`. Beginning with version 4.4 this causes an error, breaking the list view of pieces when workflow is present. For backwards compatibility, version 2.111.1 of Apostrophe now checks all projections coming from Apostrophe's cursors for this issue and removes the projection for the sub-property on the fly. This does not cause any compatibility issues of its own because projecting the parent always gives you the sub-property anyway.

--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -48,7 +48,9 @@
 //
 // Pass options to the [express.static](https://expressjs.com/en/4x/api.html#express.static)
 // middleware, such as `Cache-Control` and more. If no options are defined,
-// the default options from the middleware will be used. Please note you might want
+// the default options from the middleware will be used, except for `index` and `redirect` which are set to `false` to avoid redirect loops caused by Apostrophe's automatic removal of trailing slashes from page slugs.
+//
+// Please note you might want
 // to define different options depending on your environment. You could for example
 // set `max-age` only for production to ensure fresh files during development.
 // Example:
@@ -1623,9 +1625,13 @@ module.exports = {
         // this property won't be set
         middleware.push(self.lessMiddleware);
       }
+      var staticOptions = self.options.static || {};
+      _.defaults(staticOptions, {
+        redirect: false
+      });
       middleware.push(self.apos.express.static(
         self.apos.rootDir + '/public',
-        self.options.static || {}
+        staticOptions
       ));
       self.expressMiddleware = {
         // Run really early, before all of the stuff apostrophe-express normally

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "2.111.1",
+  "version": "2.111.2",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
… physically exists) should generate a 404, not an infinite redirect loop