### PR TITLE
simple joins

### DIFF
--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -255,8 +255,8 @@ module.exports = {
   handlers(self, options) {
     return {
       beforeSave: {
-        async joinsToStorage(req, doc) {
-          self.apos.schema.joinsToStorage(doc);
+        async prepareJoinsForStorage(req, doc) {
+          self.apos.schema.prepareJoinsForStorage(req, doc);
         }
       },
       afterSave: {

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -254,6 +254,11 @@ module.exports = {
   },
   handlers(self, options) {
     return {
+      beforeSave: {
+        async joinsToStorage(req, doc) {
+          self.apos.schema.joinsToStorage(doc);
+        }
+      },
       afterSave: {
         async emitAfterTrashOrAfterRescue(req, doc) {
           if (doc.trash && (!doc.aposWasTrash)) {

--- a/modules/@apostrophecms/schema/lib/joinr.js
+++ b/modules/@apostrophecms/schema/lib/joinr.js
@@ -186,7 +186,7 @@ const joinr = module.exports = {
             if (relationshipsField) {
               const relationships = joinr._get(item, relationshipsField) || {};
               item[objectsField].push({
-                ...item,
+                ...othersById[id],
                 _relationship: relationships[id] || {}
               });
             } else {

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -560,9 +560,9 @@ describe('Pieces', function() {
       },
       jar
     });
-    const articleId = response._id;
-    assert(articleId);
-
+    const article = response;
+    assert(article);
+    assert(article.title === 'First Article');
     response = await apos.http.post('/api/v1/products', {
       body: {
         title: 'Product Key Product With Join',
@@ -577,12 +577,12 @@ describe('Pieces', function() {
             }
           ]
         },
-        articlesIds: [articleId]
+        _articles: [ article ]
       },
       jar
     });
     assert(response._id);
-    assert(response.articlesIds[0] === articleId);
+    assert(response.articlesIds[0] === article._id);
     joinedProductId = response._id;
   });
 
@@ -654,8 +654,9 @@ describe('Pieces', function() {
         name: 'join-article'
       }
     });
-    const articleId = response._id;
-    assert(articleId);
+    const article = response;
+    assert(article);
+    assert(article.title === 'Join Article');
 
     response = await apos.http.post('/api/v1/products', {
       jar,
@@ -679,13 +680,15 @@ describe('Pieces', function() {
     assert(product._id);
     response = await apos.http.patch(`/api/v1/products/${product._id}`, {
       body: {
-        articlesIds: [ articleId ]
+        _articles: [ article ]
       },
       jar
     });
     assert(response.title === 'Initially No Join Value');
     assert(response.articlesIds);
-    assert(response.articlesIds[0] === articleId);
+    assert(response.articlesIds[0] === article._id);
+    assert(response._articles);
+    assert(response._articles[0]._id === article._id);
   });
 
   it('can log out to destroy a session', async () => {


### PR DESCRIPTION
The model layer of apostrophe now expects you to just pass an array of docs to be joined as a property with the name of the join field. For instance, `_products` can be set by literally passing in an array of product pieces. Same thing you get back later when you fetch the doc. Same thing you probably just got from find() and were hoping to painlessly join with. Intuitive.

Transition to the idsField and relationshipsField is handled at a lower level in a promise event handler. Thus both front and backend developers no longer have to think about them at all, and the REST APIs also automatically work in this simple and intuitive way.

This is NOT a way to *create new docs* of the type you're joining with, or update the joined docs themselves. You should still do that separately.  For updating the join all Apostrophe really cares about is the _id property of each joined doc, and the _relationship property if appropriate. Supporting updates would be a performance & race conditions nightmare, have lousy error handling, etc.

This is still a draft because I need to add tests that cover the relationship feature, and update all existing tests to work this way. However `npx mocha test/pieces` passes at the moment, notably including a bunch of RESTful tests of joins (not with relationships though).

I'm mindful of the proposal to rename `relationship` to `fields`, etc., and I'm in favor of it, but for purposes of this PR, one thing at a time.