### PR TITLE
In the presence of middleware, we should still call the wrapper function for this type of route properly

### DIFF
--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -161,7 +161,7 @@ module.exports = {
               }
               return self.insert(req, file);
             } finally {
-              for (const file of (req.files || {})) {
+              for (const file of (req.files || [])) {
                 try {
                   fs.unlinkSync(file.path);
                 } catch (e) {

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -59,7 +59,7 @@ module.exports = {
             if (Array.isArray(route)) {
               let routeFn = route[route.length - 1];
               if (self.routeWrappers[section]) {
-                routeFn = self.routeWrappers[section](routeFn);
+                routeFn = self.routeWrappers[section](name, routeFn);
                 route[route.length - 1] = routeFn;
               }
               self.apos.app[method](url, function(req, res) {


### PR DESCRIPTION
I was calling it without the method name, resulting in the error Bea saw.

I can now get to a polite 404 when I send a bogus file upload attempt, due to the nonexistence of req.files, which makes sense (throwing an "invalid" error could be more appropriate perhaps).

Also fixed a tiny bug in the `finally` cleanup code.