### PR TITLE
Don't try to fetch notifications when there is no user; don't fetch notifications redundantly

### DIFF
--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -350,7 +350,15 @@ module.exports = {
 
       getBrowserData(req) {
         return {
-          action: self.action
+          action: self.action,
+          ...(req.user ? {
+            user: {
+              title: req.user.title,
+              _id: req.user._id,
+              username: req.user.username,
+              email: req.user.email
+            }
+          } : {})
         };
       }
 

--- a/modules/@apostrophecms/notification/ui/apos/apps/ApostropheNotification.js
+++ b/modules/@apostrophecms/notification/ui/apos/apps/ApostropheNotification.js
@@ -1,6 +1,11 @@
 import Vue from 'apostrophe/vue';
 
 export default function() {
+  if (!apos.login.user) {
+    // The user scene is being used but no one is logged in
+    // (example: the login page)
+    return;
+  }
   /* eslint-disable no-new */
   return new Vue({
     el: '#apos-notification',

--- a/modules/@apostrophecms/util/ui/public/http.js
+++ b/modules/@apostrophecms/util/ui/public/http.js
@@ -110,7 +110,9 @@
     var data = options.body;
     var keys;
     var i;
-    url = apos.http.addQueryToUrl(url, data);
+    if (options.qs) {
+      url = apos.http.addQueryToUrl(url, options.qs);
+    }
 
     xmlhttp.open(method, url);
     var formData = window.FormData && (data instanceof window.FormData);


### PR DESCRIPTION
Also cc @falkodev, it's not necessary that he be one of the two reviewers but he'll be interested in the fix:

1. The notifications module was trying to fetch notifications because it had no way of knowing no user was logged in. You can now look in `apos.login.user` for a minimal amount of info about the current user. If that object does not exist, there is no logged-in user. (See `apos.user` in 2.x browserland.)

2. The notifications module was displaying duplicates because of a dumb mistake of mine in `apos.http.remote`. This is fixed, `options.qs` now works like it is supposed to.

NOTE: I am not sure exactly how this will play with old notifications that predate Anthony's work. So if you still get redundant notifications, try `db.aposNotifications.remove({})` once before opening a ticket. A migration would be bloat since nobody but us will have that early version of the code.