### PR TITLE
V3/observe upload progress

### DIFF
--- a/modules/@apostrophecms/util/ui/public/http.js
+++ b/modules/@apostrophecms/util/ui/public/http.js
@@ -12,7 +12,7 @@
   // `options.body`. See `apos.http.remote` for details.
   // You do NOT have to pass a callback unless you must support IE11
   // and do not want to include a promise polyfill in your build.
- 
+
   apos.http.post = function(url, options, callback) {
     return apos.http.remote('POST', url, options, callback);
   };

--- a/modules/@apostrophecms/util/ui/public/http.js
+++ b/modules/@apostrophecms/util/ui/public/http.js
@@ -69,9 +69,12 @@
   // properties, rather than returning the body directly; the individual `headers` are canonicalized
   // to lowercase names. If there are duplicate headers after canonicalization only the
   // last value is returned. If a header appears multiple times an array is returned for it)
-  // `progress` (may be a function accepting `loaded` and `total` parameters. May never be called. If
-  // called, `loaded` will be the bytes sent or received so far, and `total` will be the total bytes to be
-  // sent or received. If the total is unknown, it will be `null`)
+  // `downloadProgress` (may be a function accepting `received` and `total` parameters. May never be called. If
+  // called, `received` will be the bytes sent so far, and `total` will be the total bytes to be
+  // received. If the total is unknown, it will be `null`)
+  // `uploadProgress` (may be a function accepting `sent` and `total` parameters. May never be called. If
+  // called, `sent` will be the bytes sent so far, and `total` will be the total bytes to be
+  // sent. If the total is unknown, it will be `null`)
   //
   // If the status code is >= 400 an error is thrown. The error object will be
   // similar to a `fullResponse` object, with a `status` property.
@@ -141,7 +144,6 @@
     } else {
       data = options.body;
     }
-    xmlhttp.send(data);
     xmlhttp.addEventListener('load', function() {
       if (options.busy) {
         if (!busyActive[busyName]) {
@@ -200,11 +202,16 @@
     xmlhttp.addEventListener('error', function(evt) {
       return callback(evt);
     });
-    xmlhttp.addEventListener('progress', function(evt) {
-      if (options.progress) {
-        options.progress(evt.loaded, evt.lengthComputable ? evt.total : null);
-      }
-    });
+    if (options.downloadProgress) {
+      xmlhttp.addEventListener('progress', function(evt) {
+        options.downloadProgress(evt.loaded, evt.lengthComputable ? evt.total : null);
+      });
+    }
+    if (xmlhttp.upload && options.uploadProgress) {
+      xmlhttp.upload.addEventListener('progress', function(evt) {
+        options.uploadProgress(evt.loaded, evt.lengthComputable ? evt.total : null);
+      });
+    }
     xmlhttp.addEventListener('loadend', function (evt) {
       if (options.busy) {
         busyActive[busyName]--;
@@ -217,6 +224,7 @@
         }
       }
     });
+    xmlhttp.send(data);
 
     function getHeaders() {
       var headers = xmlhttp.getAllResponseHeaders();

--- a/modules/@apostrophecms/util/ui/public/http.js
+++ b/modules/@apostrophecms/util/ui/public/http.js
@@ -12,6 +12,7 @@
   // `options.body`. See `apos.http.remote` for details.
   // You do NOT have to pass a callback unless you must support IE11
   // and do not want to include a promise polyfill in your build.
+ 
   apos.http.post = function(url, options, callback) {
     return apos.http.remote('POST', url, options, callback);
   };
@@ -67,9 +68,10 @@
   // `fullResponse` (if true, return an object with `status`, `headers` and `body`
   // properties, rather than returning the body directly; the individual `headers` are canonicalized
   // to lowercase names. If there are duplicate headers after canonicalization only the
-  // last value is returned.
-  //
-  // `If a header appears multiple times an array is returned for it)
+  // last value is returned. If a header appears multiple times an array is returned for it)
+  // `progress` (may be a function accepting `loaded` and `total` parameters. May never be called. If
+  // called, `loaded` will be the bytes sent or received so far, and `total` will be the total bytes to be
+  // sent or received. If the total is unknown, it will be `null`)
   //
   // If the status code is >= 400 an error is thrown. The error object will be
   // similar to a `fullResponse` object, with a `status` property.
@@ -198,7 +200,12 @@
     xmlhttp.addEventListener('error', function(evt) {
       return callback(evt);
     });
-    xmlhttp.addEventListener('loadend', function () {
+    xmlhttp.addEventListener('progress', function(evt) {
+      if (options.progress) {
+        options.progress(evt.loaded, evt.lengthComputable ? evt.total : null);
+      }
+    });
+    xmlhttp.addEventListener('loadend', function (evt) {
       if (options.busy) {
         busyActive[busyName]--;
         if (!busyActive[busyName]) {


### PR DESCRIPTION
Filling in the gap in `apos.http.remote` so it becomes possible to code up progress meters for uploads at some point.

I tested successfully by adding two lines of code here in the media manager:

```
        attachment = await apos.http.post('/api/v1/@apostrophecms/attachment/upload', {
          busy: true,
          body: formData,
          downloadProgress(received, total) { console.log(`< ${received} ${total}`); },
          uploadProgress(sent, total) { console.log(`> ${sent} ${total}`); }
        });
```