### PR TITLE
3/bar fixes

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -41,7 +41,7 @@
         :user="user" :avatar-url="userAvatar"
       />
     </div>
-    <div class="apos-admin-bar__row">
+    <div class="apos-admin-bar__row apos-admin-bar__row--utils">
       <AposButton
         type="default" label="Page Settings"
         icon="cog-icon" class="apos-admin-bar__btn"
@@ -117,6 +117,7 @@ $menu-item-height: $menu-row-height - (2 * $menu-v-pad);
 $menu-h-space: 16px;
 $menu-v-space: 25px;
 $admin-bar-h-pad: 20px;
+$admin-bar-border: 1px solid var(--a-base-9);
 
 body {
   margin-top: $menu-row-height * 2;
@@ -136,7 +137,7 @@ body {
   align-items: center;
   height: $menu-row-height;
   padding: 0 $admin-bar-h-pad 0 0;
-  border-bottom: 1px solid var(--a-base-9);
+  border-bottom: $admin-bar-border;
 }
 
 .apos-admin-bar__items {
@@ -219,8 +220,19 @@ body {
   top: calc(100% + 5px);
 }
 
-.apos-admin-bar__dropdown-items .apos-admin-bar__btn {
-  padding: 25px;
+.apos-admin-bar__btn {
+  .apos-admin-bar__row--utils & {
+    border-right: $admin-bar-border;
+
+    &:hover,
+    &:focus {
+      border-width: 1px;
+    }
+  }
+
+  .apos-admin-bar__dropdown-items & {
+    padding: 25px;
+  }
 }
 
 .apos-admin-bar__dropdown-items {

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -111,9 +111,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-$menu-row-height: 68px;
+$menu-row-height: 50px;
 $menu-v-pad: 18px;
-$menu-item-height: $menu-row-height - (2 * $menu-v-pad);
 $menu-h-space: 16px;
 $menu-v-space: 25px;
 $admin-bar-h-pad: 20px;
@@ -152,7 +151,7 @@ body {
 
 .apos-admin-bar__logo {
   display: inline-block;
-  height: $menu-item-height;
+  height: 32px;
 }
 
 .apos-admin-bar__create /deep/ .apos-context-menu__btn,

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -123,6 +123,7 @@ body {
 }
 
 .apos-admin-bar {
+  z-index: $z-index-default;
   position: fixed;
   top: 0;
   right: 0;

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -189,8 +189,6 @@ $admin-bar-border: 1px solid var(--a-base-9);
 }
 
 .apos-admin-bar__sub /deep/ .apos-context-menu__btn {
-  padding-left: 20px;
-  padding-right: 20px;
   border-radius: 0;
 }
 
@@ -226,6 +224,8 @@ $admin-bar-border: 1px solid var(--a-base-9);
 
 .apos-admin-bar__btn {
   .apos-admin-bar__row--utils & {
+    padding-left: $admin-bar-h-pad;
+    padding-right: $admin-bar-h-pad;
     border-right: $admin-bar-border;
 
     &:hover,

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -246,7 +246,7 @@ body {
   // Adjust button padding and svg size to have a large plus icon while keeping
   // the button size the same.
   /deep/ .apos-context-menu__btn {
-    padding: 5px;
+    padding: 4px;
   }
 
   /deep/ .apos-context-menu__popup {

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -84,17 +84,15 @@ export default {
     }
   },
   mounted() {
-    this.menuItems = [
-      ...this.items.map(item => {
-        if (item.items) {
-          item.items.forEach(subitem => {
-            // The context menu needs an `action` property to emit.
-            subitem.action = subitem.name;
-          });
-        }
-        return item;
-      })
-    ];
+    this.menuItems = this.items.map(item => {
+      if (item.items) {
+        item.items.forEach(subitem => {
+          // The context menu needs an `action` property to emit.
+          subitem.action = subitem.name;
+        });
+      }
+      return item;
+    });
     // TODO: This will need to be an async call to get pieces as well as the
     // new page route.
     this.createMenu = [

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -84,7 +84,17 @@ export default {
     }
   },
   mounted() {
-    this.menuItems = [ ...this.items ];
+    this.menuItems = [
+      ...this.items.map(item => {
+        if (item.items) {
+          item.items.forEach(subitem => {
+            // The context menu needs an `action` property to emit.
+            subitem.action = subitem.name;
+          });
+        }
+        return item;
+      })
+    ];
     // TODO: This will need to be an async call to get pieces as well as the
     // new page route.
     this.createMenu = [
@@ -117,10 +127,6 @@ $menu-h-space: 16px;
 $menu-v-space: 25px;
 $admin-bar-h-pad: 20px;
 $admin-bar-border: 1px solid var(--a-base-9);
-
-body {
-  margin-top: $menu-row-height * 2;
-}
 
 .apos-admin-bar {
   z-index: $z-index-default;

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarUser.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarUser.vue
@@ -18,7 +18,7 @@
 import AposHelpers from 'Modules/@apostrophecms/ui/mixins/AposHelpersMixin';
 
 export default {
-  mixins: [AposHelpers],
+  mixins: [ AposHelpers ],
   props: {
     user: {
       type: Object,
@@ -29,7 +29,7 @@ export default {
       default: ''
     }
   },
-  emits: ['input'],
+  emits: [ 'input' ],
   data() {
     return {
       menu: [
@@ -51,7 +51,7 @@ export default {
       return {
         label: this.user.label || '',
         icon: 'chevron-down-icon',
-        modifiers: ['icon-right'],
+        modifiers: [ 'icon-right' ],
         type: 'quiet'
       };
     }

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuItem.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuItem.vue
@@ -20,6 +20,7 @@ export default {
     },
     open: Boolean
   },
+  emits: [ 'clicked' ],
   computed: {
     tabindex() {
       return this.open ? '0' : '-1';


### PR DESCRIPTION
Resolves bug notes from https://apostrophecms.atlassian.net/browse/A30U-379:

- The height of the buttons in Figma is 52px, with the border being centered (for a total of 54 visual px)
  - **Note**: In Figma the whole set of admin rows are 102px. I got to 50px height by subtracting the border heights.
- The right borders are missing on both buttons