### PR TITLE
fixed duplicates, i18n, string substitution, replaced apply with ES2020 syntax

### DIFF
--- a/modules/@apostrophecms/notification/index.js
+++ b/modules/@apostrophecms/notification/index.js
@@ -16,7 +16,7 @@
 // Until it times out the request will keep making MongoDB queries to
 // see if any new notifications are available (long polling).
 
-const Promise = require('bluebird');
+const delay = require('bluebird').delay;
 
 module.exports = {
   options: {
@@ -280,7 +280,7 @@ module.exports = {
               seenIds
             });
             if (!notifications.length && !dismissed.length) {
-              await Promise.delay(self.options.queryInterval || 1000);
+              await delay(self.options.queryInterval || 1000);
               return attempt();
             }
 

--- a/modules/@apostrophecms/notification/ui/apos/apps/ApostropheNotification.js
+++ b/modules/@apostrophecms/notification/ui/apos/apps/ApostropheNotification.js
@@ -56,8 +56,7 @@ export default function() {
             message,
             strings,
             type: options.type,
-            dismiss: options.dismiss,
-            id: options.id
+            dismiss: options.dismiss
           }
         });
       };


### PR DESCRIPTION
The string substitution thing doesn't even work in 2.x I think? 😆 Well, it works properly now in 3.x...