### PR TITLE
Relationship editor: toggle not disabled if limit reached

### DIFF
--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
@@ -165,7 +165,7 @@ export default {
       }
     }
   },
-  emits: [ 'trash', 'search', 'safe-close' ],
+  emits: [ 'trash', 'search', 'safe-close', 'updated' ],
   data() {
     return {
       modal: {
@@ -240,6 +240,10 @@ export default {
     // NOTE: revisit this during refactoring
     checked: function() {
       this.generateUi();
+      if (!this.checked.length) {
+        this.selectedItems = [];
+        this.$emit('updated', this.selectedItems);
+      }
     }
   },
   created() {
@@ -251,17 +255,6 @@ export default {
     // Get the data. This will be more complex in actuality.
     this.modal.active = true;
     this.getPieces();
-  },
-  watch: {
-    // NOTE: revisit this during refactoring
-    checked: function() {
-      this.generateUi();
-      if (!this.checked.length) {
-        this.selectedItems = [];
-        this.$emit('updated', this.selectedItems);
-      }
-
-    }
   },
   methods: {
     async finishSaved() {

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
@@ -28,7 +28,6 @@
             :selected-state="selectAllState"
             :total-pages="totalPages" :current-page="currentPage"
             :filters="options.filters" :labels="moduleLabels"
-            :disable-selection="field.max && checked.length >= field.max"
             @select-click="selectAll"
             @trash-click="trashClick"
             @search="search"
@@ -234,6 +233,11 @@ export default {
     // NOTE: revisit this during refactoring
     checked: function() {
       this.generateUi();
+      if (!this.checked.length) {
+        this.selectedItems = [];
+        this.$emit('updated', this.selectedItems);
+      }
+
     }
   },
   methods: {

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManagerToolbar.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManagerToolbar.vue
@@ -3,7 +3,6 @@
     <template #leftControls>
       <AposButton
         label="Select" :icon-only="true"
-        :disabled="disableSelection"
         :icon="checkboxIcon" type="outline"
         @click="$emit('select-click')" :icon-color="iconColor"
       />
@@ -70,10 +69,6 @@ export default {
     labels: {
       type: Object,
       required: true
-    },
-    disableSelection: {
-      type: Boolean,
-      default: false
     }
   },
   emits: [ 'trash-click', 'select-click', 'filter', 'search', 'page-change' ],


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/jira/software/projects/A30U/boards/4?assignee=5ddbce7e47baa50cfd05eed2&selectedIssue=A30U-453

## How to test

- In A3-demo, go to "articles", and click on "Browse products".
- Select 3 products. The toggle to select/unselect all products should still be enabled.
- Unselecting all products should also empty the slat list on the right rail.