### PR TITLE
Prevents relationship methods when not needed

### DIFF
--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposTableMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposTableMixin.js
@@ -36,7 +36,7 @@ export default {
     }
   },
   methods: {
-    toggleRowCheck(event, id) {
+    toggleRowCheck(id) {
       if (this.checked.includes(id)) {
         this.checked = this.checked.filter(item => item !== id);
         if (this.checkboxes[id]) {
@@ -50,7 +50,7 @@ export default {
     selectAll(event) {
       if (!this.checked.length) {
         this.rows.forEach((row) => {
-          this.toggleRowCheck('checked', row._id);
+          this.toggleRowCheck(row._id);
           this.updateSelectedItems({ target: { id: row._id } });
         });
         return;
@@ -58,7 +58,7 @@ export default {
 
       if (this.checked.length <= this.rows.length) {
         this.checked.forEach((id) => {
-          this.toggleRowCheck('checked', id);
+          this.toggleRowCheck(id);
         });
       }
     },

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -200,14 +200,14 @@ export default {
     selectAll(event) {
       if (!this.checked.length) {
         this.pagesFlat.forEach((row) => {
-          this.toggleRowCheck('checked', row.id);
+          this.toggleRowCheck(row.id);
         });
         return;
       }
 
       if (this.checked.length <= this.pagesFlat.length) {
         this.checked.forEach((id) => {
-          this.toggleRowCheck('checked', id);
+          this.toggleRowCheck(id);
         });
       }
     },

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
@@ -17,7 +17,10 @@
 
     <template v-if="relationship" #leftRail>
       <AposModalRail>
-        <AposSlatList @update="updateSlatList" :initial-items="selectedItems" :field="field" />
+        <AposSlatList
+          @update="updateSlatList"
+          :initial-items="selectedItems" :field="field"
+        />
       </AposModalRail>
     </template>
 
@@ -220,6 +223,12 @@ export default {
       return 'empty';
     }
   },
+  watch: {
+    // NOTE: revisit this during refactoring
+    checked: function() {
+      this.generateUi();
+    }
+  },
   created() {
     this.options.filters.forEach(filter => {
       this.filterValues[filter.name] = filter.def || filter.choices[0].value;
@@ -229,12 +238,6 @@ export default {
     // Get the data. This will be more complex in actuality.
     this.modal.active = true;
     this.getPieces();
-  },
-  watch: {
-    // NOTE: revisit this during refactoring
-    checked: function() {
-      this.generateUi();
-    }
   },
   methods: {
     async finishSaved() {
@@ -316,12 +319,18 @@ export default {
     },
     // NOTE: move this into the new AposRelationshipManager in the refactor
     updateSlatList(items) {
+      if (!this.relationship) {
+        return;
+      }
       this.selectedItems = items;
       this.checked = items.map(item => item._id);
       this.$emit('updated', items);
     },
     // NOTE: move this into the new AposRelationshipManager in the refactor
     updateSelectedItems(event) {
+      if (!this.relationship) {
+        return;
+      }
       if (this.checked.length > this.selectedItems.length) {
         const piece = this.pieces.find(piece => piece._id === event.target.id);
         if (this.field.max) {


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-462. The involvement of `selectedItems` when it was not needed in the pieces manager was mutating `checked` when it shouldn't have been. I also removed an argument from `toggleRowCheck` that wasn't actually used.