### PR TITLE
previously we were just hanging on LESS errors at startup, resulting …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.111.4 (2020-09-23)
 
 * The `View File` button now accesses the original version of an image, not a scaled version. This was always the intention, but 2.x defaults to the `full` size and we initially missed it. Thanks to Quentin Mouraret for this contribution.
+* LESS compilation errors during `apostrophe:generation` are now reported properly, resulting in a clean process exit. Previously they resulted in a hung process.
 
 ## 2.111.3 (2020-08-26)
 

--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -1363,8 +1363,7 @@ module.exports = {
 
       return less.render(fs.readFileSync(src, 'utf8'), lessOptions, function(err, css) {
         if (err) {
-          self.apos.utils.error('LESS CSS ERROR:');
-          self.apos.utils.error(err);
+          return callback(err);
         }
         css = css.css;
         if ((self.isGenerationTask && self.simpleBundle) || self.apos.argv['sync-to-uploadfs']) {


### PR DESCRIPTION
…in confused devs, piled up processes on servers, etc. Exit clean

I verified that I still get to see the LESS error at exit.

It was meee I don't know why