### PR TITLE
3/fix relation input

### DIFF
--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -17,6 +17,7 @@
             tabindex="0"
           >
           <AposButton
+            class="apos-input-relationship__button"
             :label="browseLabel"
             :modifiers="['small']"
             type="input"
@@ -33,6 +34,7 @@
           />
         </div>
         <AposSlatList
+          class="apos-input-relationship__items"
           v-if="items.length"
           @update="updated"
           @item-clicked="openRelationshipEditor"
@@ -190,13 +192,23 @@ export default {
 
 <style lang="scss" scoped>
   .apos-input-relationship__input-wrapper {
-    display: flex;
-    align-items: center;
-    margin-bottom: 10px;
+    position: relative;
+
+    .apos-input-relationship__button {
+      position: absolute;
+      top: 5px;
+      right: 5px;
+      padding: ($input-padding - 5px) $input-padding;
+      font-size: map-get($font-sizes, input);
+
+      &:hover:not([disabled]),
+      &:focus:not([disabled]) {
+        transform: none;
+      }
+    }
   }
 
-  .apos-button {
-    position: absolute;
-    right: 7.5px;
+  .apos-input-relationship__items {
+    margin-top: 10px;
   }
 </style>

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -209,6 +209,7 @@ export default {
   }
 
   .apos-input-relationship__items {
+    max-width: 220px;
     margin-top: 10px;
   }
 </style>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlatList.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlatList.vue
@@ -40,7 +40,9 @@
       </transition-group>
     </draggable>
 
-    <div class="apos-slat-status">{{ message }}</div>
+    <div class="apos-slat-status">
+      {{ message }}
+    </div>
   </div>
 </template>
 
@@ -77,9 +79,6 @@ export default {
       message: null
     };
   },
-  mounted() {
-    this.updateMessage();
-  },
   computed: {
     items() {
       return this.initialItems;
@@ -108,6 +107,9 @@ export default {
     items() {
       this.updateMessage();
     }
+  },
+  mounted() {
+    this.updateMessage();
   },
   methods: {
     engage(id) {
@@ -191,13 +193,14 @@ export default {
     max-width: $input-max-width * 0.75;
   }
 
-  .apos-modal__rail .apos-slat-list {
-    padding: 16px;
-  }
-
-  .apos-modal__rail .apos-slat-list /deep/ .apos-slat {
-    margin-bottom: 8px;
-  }
+  // TODO: Factor this positioning into pieces manager refactor. - AB
+  // .apos-modal__rail .apos-slat-list {
+  //   padding: 16px;
+  // }
+  // TODO: Factor this positioning into pieces manager refactor. - AB
+  // .apos-modal__rail .apos-slat-list /deep/ .apos-slat {
+  //   margin-bottom: 8px;
+  // }
 
   .apos-slat-status {
     text-align: center;


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-395, "As a user, I can tag a single image through the schema," by making the relationship field fully styled.

I commented out some styles that were set too broadly. I didn't fix them fully because the fix will need to come when the pieces manager is refactored to split it apart from the relationships manager.

To test, click to edit an image in the media library. Or look at the relationship input field in the storybook.