### PR TITLE
adds secondary slot to field base that lets modals escape error css

### DIFF
--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -22,15 +22,6 @@
             type="input"
             @click="chooser=true"
           />
-          <AposPiecesManager
-            v-if="chooser"
-            :module-name="field.withType"
-            :initially-selected-items="items"
-            :field="field"
-            :relationship="true"
-            @updated="updated"
-            @safe-close="chooser=false"
-          />
         </div>
         <AposSlatList
           v-if="items.length"
@@ -44,7 +35,17 @@
           :selected-items="items"
         />
       </div>
-
+    </template>
+    <template #secondary>
+      <AposPiecesManager
+        v-if="chooser"
+        :module-name="field.withType"
+        :initially-selected-items="items"
+        :field="field"
+        :relationship="true"
+        @updated="updated"
+        @safe-close="chooser=false"
+      />
       <AposRelationshipEditor
         v-if="relationshipSchema"
         :schema="relationshipSchema"

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputWrapper.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputWrapper.vue
@@ -1,35 +1,39 @@
 <template>
-  <component :is="wrapEl" :class="classList">
-    <!-- TODO i18n -->
-    <component
-      v-if="field.label" :class="{'apos-sr-only': field.hideLabel }"
-      class="apos-field-label"
-      :is="labelEl" :for="uid"
-    >
-      {{ field.label }}
-      <span v-if="field.required" class="apos-field-required">
-        *
-      </span>
+  <div class="apos-field__outer">
+    <component :is="wrapEl" :class="classList">
+      <!-- TODO i18n -->
+      <component
+        v-if="field.label" :class="{'apos-sr-only': field.hideLabel }"
+        class="apos-field-label"
+        :is="labelEl" :for="uid"
+      >
+        {{ field.label }}
+        <span v-if="field.required" class="apos-field-required">
+          *
+        </span>
+      </component>
+      <!-- TODO i18n -->
+      <p v-if="field.help" class="apos-field-help">
+        {{ field.help }}
+      </p>
+      <div v-if="field.min || field.max" class="apos-field-limit">
+        <span v-if="field.type === 'relationship'">{{ items.length }} selected</span>
+        <span v-if="field.min">
+          min: {{ field.min }}
+        </span>
+        <span v-if="field.max">
+          max: {{ field.max }}
+        </span>
+      </div>
+      <slot name="body" />
+      <!-- TODO i18n -->
+      <div v-if="errorMessage" class="apos-field-error">
+        {{ errorMessage }}
+      </div>
     </component>
-    <!-- TODO i18n -->
-    <p v-if="field.help" class="apos-field-help">
-      {{ field.help }}
-    </p>
-    <div v-if="field.min || field.max" class="apos-field-limit">
-      <span v-if="field.type === 'relationship'">{{ items.length }} selected</span>
-      <span v-if="field.min">
-        min: {{ field.min }}
-      </span>
-      <span v-if="field.max">
-        max: {{ field.max }}
-      </span>
-    </div>
-    <slot name="body" />
-    <!-- TODO i18n -->
-    <div v-if="errorMessage" class="apos-field-error">
-      {{ errorMessage }}
-    </div>
-  </component>
+    <!-- CSS Escape hatch for additional interfaces like relatipnship managers -->
+    <slot name="secondary" />
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
Fields like Relationships bring their own modals with them, this enhancement allows those modals to live outside the field's own validation status, preventing leaky css on inputs inside additional modals

solving https://apostrophecms.atlassian.net/jira/software/projects/A30U/boards/4?selectedIssue=A30U-454