### PR TITLE
fix storage of group ids so apostrophe works without hardcoded groups

### DIFF
--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1722,6 +1722,7 @@ module.exports = {
               }
               // Allow options to the getter to be specified in the schema,
               // notably editable: true
+
               await self.fieldTypes[_relationship.type].relate(req, _relationship, _objects, options);
               _.each(_objects, function (object) {
                 if (object[subname]) {

--- a/modules/@apostrophecms/user/index.js
+++ b/modules/@apostrophecms/user/index.js
@@ -120,7 +120,7 @@ module.exports = {
               type: 'relationship',
               label: 'Groups',
               idsStorage: 'groupIds',
-              withType: '@apostrophecms/group',
+              withType: '@apostrophecms/group'
             }
           }
         )

--- a/modules/@apostrophecms/user/index.js
+++ b/modules/@apostrophecms/user/index.js
@@ -119,7 +119,8 @@ module.exports = {
             _groups: {
               type: 'relationship',
               label: 'Groups',
-              withType: '@apostrophecms/group'
+              idsStorage: 'groupIds',
+              withType: '@apostrophecms/group',
             }
           }
         )


### PR DESCRIPTION
The configuration was inconsistent leading to problems.