### PR TITLE
pass correctly named event

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -55,7 +55,7 @@
         @close="$emit('close', widget)"
         :is="widgetEditorComponent(widget.type)"
         :value="widget"
-        @update="$emit('update', widget);"
+        @update="$emit('update', $event)"
         :options="options.widgets[widget.type]"
         :type="widget.type"
         :doc-id="docId"


### PR DESCRIPTION
this broke during inline event emit refactor .. it worked prior because we were passing it to a method and calling `$event` "widget"