### PR TITLE
Use right manager for widgets when storing relationship ids

### DIFF
--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1814,7 +1814,7 @@ module.exports = {
           }
           forSchema(manager.schema, doc);
         } else if (doc.metaType === 'widget') {
-          const manager = self.apos.doc.getManager(doc.type);
+          const manager = self.apos.area.getWidgetManager(doc.type);
           if (!manager) {
             return;
           }


### PR DESCRIPTION
The handler that handles translating a relationship array of docs into its idsStorage property at the last minute before saving was consulting the wrong kind of manager for the case of a relationship that resides in a widget.

BTW, what you see here is the method that handles that translation. It gets hooked up to a `beforeSave` promise event handler. This means that nobody else ever has to deal with idsStorage, as long as they are using apostrophe model APIs to save the doc.