### PR TITLE
Open newly uploaded image in media editor

### DIFF
--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -163,9 +163,14 @@ export default {
         dimensions
       });
     },
-    async completeUploading () {
+    async completeUploading (imgId) {
       this.uploading = false;
       await this.getMedia();
+
+      if (imgId) {
+        this.checked = [ imgId ];
+        this.updateEditing(imgId);
+      }
     },
     clearSelected() {
       this.checked = [];

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -119,6 +119,10 @@ export default {
   },
   watch: {
     checked (newVal) {
+      if (this.editing && newVal.includes(this.editing._id)) {
+        return;
+      }
+
       if (newVal.length > 1 || newVal.length === 0) {
         this.editing = null;
       }
@@ -168,8 +172,12 @@ export default {
       await this.getMedia();
 
       if (imgId) {
-        this.checked = [ imgId ];
-        this.updateEditing(imgId);
+        this.checked.push(imgId);
+
+        // If we're currently editing one, don't interrupt that by replacing it.
+        if (!this.editing) {
+          this.updateEditing(imgId);
+        }
       }
     },
     clearSelected() {

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
@@ -181,10 +181,10 @@ export default {
 
       // TODO: While the upload is working, set an uploading animation.
       this.createPlaceholder(file);
-      await this.insertImage(file, emptyDoc);
+      const image = await this.insertImage(file, emptyDoc);
 
       // When complete, refresh the image grid, with the new images at top.
-      this.$emit('upload-complete');
+      this.$emit('upload-complete', image._id);
 
       // TODO: If uploading one image, when complete, load up the edit schema in the right rail.
       // TODO: Else if uploading multiple images, show them as a set of selected images for editing.
@@ -259,15 +259,17 @@ export default {
       });
 
       try {
-        await apos.http.post(this.moduleOptions.action, {
+        const imgPiece = await apos.http.post(this.moduleOptions.action, {
           body: imageData
         });
         await apos.notify('Upload Successful', {
           type: 'success',
           dismiss: true
         });
+        return imgPiece;
       } catch (error) {
         await this.notifyErrors(error, 'Upload Error');
+        return {};
       }
     },
     async notifyErrors(error, fallback) {


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-425, "As a user, when done uploading a single image in the media manager, I can view and edit image piece properties in the right rail"

To test, upload an image to the media editor. It should open in the right rail editor. Then check a few items and upload an image. The checked items should become un-checked and the new one should be checked and in the editor.