### PR TITLE
when destroying an apos object we must close down the template file m…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.111.5 (2020-10-07)
+
+* Clean up `fs.watch` calls from the nunjucks loader properly when destroying an `apos` object, so that the process can close and/or memory be recovered.
+
 ## 2.111.4 (2020-09-23)
 
 * The `View File` button now accesses the original version of an image, not a scaled version. This was always the intention, but 2.x defaults to the `full` size and we initially missed it. Thanks to Quentin Mouraret for this contribution.

--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -862,6 +862,15 @@ module.exports = {
       });
     };
 
+    self.on('apostrophe:destroy', 'cleanUpLoaders', function() {
+      for (const env of Object.values(self.envs)) {
+        const loader = env.loaders[0];
+        if (loader.destroy) {
+          loader.destroy();
+        }
+      }
+    });
+
   }
 
 };

--- a/lib/modules/apostrophe-templates/lib/nunjucksLoader.js
+++ b/lib/modules/apostrophe-templates/lib/nunjucksLoader.js
@@ -19,7 +19,7 @@ module.exports = function(moduleName, searchPaths, noWatch, templates, options) 
   var extensions = options.extensions || [ 'njk', 'html' ];
   self.moduleName = moduleName;
   self.templates = templates;
-
+  self.watches = [];
   self.init = function(searchPaths, noWatch) {
     self.pathsToNames = {};
     if (searchPaths) {
@@ -33,11 +33,11 @@ module.exports = function(moduleName, searchPaths, noWatch, templates, options) 
       _.each(self.searchPaths, function(p) {
         if (fs.existsSync(p)) {
           try {
-            fs.watch(p, { persistent: false, recursive: true }, function(event, filename) {
+            self.watches.push(fs.watch(p, { persistent: false, recursive: true }, function(event, filename) {
               // Just blow the whole cache if anything is modified. Much simpler,
               // avoids several false negatives, and works well for a CMS in dev. -Tom
               self.cache = {};
-            });
+            }));
           } catch (e) {
             if (!self.firstWatchFailure) {
               // Don't crash in broken environments like the Linux subsystem for Windows
@@ -142,6 +142,12 @@ module.exports = function(moduleName, searchPaths, noWatch, templates, options) 
       _.each(self.listeners[name], function(listener) {
         listener.apply(null, args);
       });
+    }
+  };
+
+  self.destroy = function() {
+    for (const watch of self.watches) {
+      watch.close();
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "2.111.4",
+  "version": "2.111.5",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
…odification watchers, otherwise the process cannot exit

This impacts TH and other clients