### PR TITLE
Adds success and error notifications to media editor

### DIFF
--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -61,6 +61,7 @@
           <AposMediaManagerEditor
             v-show="editing"
             :media="editing" :selected="selected"
+            :module-labels="moduleLabels"
             @back="updateEditing(null)" @saved="updateMedia"
           />
           <AposMediaManagerSelections
@@ -112,6 +113,15 @@ export default {
   computed: {
     options() {
       return window.apos.modules[this.moduleName];
+    },
+    moduleLabels() {
+      if (!this.options) {
+        return null;
+      }
+      return {
+        label: this.options.label,
+        pluralLabel: this.options.pluralLabel
+      };
     },
     selected() {
       return this.media.filter(item => this.checked.includes(item._id));

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -62,6 +62,15 @@ export default {
       default() {
         return [];
       }
+    },
+    moduleLabels: {
+      type: Object,
+      default() {
+        return {
+          label: 'Image',
+          pluralLabel: 'Images'
+        };
+      }
     }
   },
   emits: [ 'saved', 'back' ],
@@ -124,8 +133,22 @@ export default {
           busy: true,
           body: this.doc.data
         });
-      } finally {
+
+        await apos.notify(`${this.moduleLabels.label} Saved`, {
+          type: 'success',
+          dismiss: true
+        });
+
         this.$emit('saved');
+      } catch (err) {
+        console.error('Error saving image', err);
+
+        await apos.notify(`Error Saving ${this.moduleLabels.label}`, {
+          type: 'danger',
+          icon: 'alert-circle-icon',
+          dismiss: true
+        });
+      } finally {
         apos.bus.$emit('busy', false);
       }
     },


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-466, "Media Library: Users should receive a notification that their work is saved."

To test, upload an image and look for the success notification.