### PR TITLE
Displays file size, created date, and dimensions for images

### DIFF
--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -10,7 +10,7 @@
       </div>
       <ul class="apos-media-manager-editor__details">
         <li class="apos-media-manager-editor__detail" v-if="createdDate">
-          {{ createdDate }}
+          Uploaded: {{ createdDate }}
         </li>
         <li
           class="apos-media-manager-editor__detail"
@@ -55,6 +55,8 @@
 import AposHelpers from 'Modules/@apostrophecms/ui/mixins/AposHelpersMixin';
 import klona from 'klona';
 import dayjs from 'dayjs';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
+dayjs.extend(advancedFormat);
 
 export default {
   mixins: [ AposHelpers ],
@@ -136,10 +138,10 @@ export default {
       }
     },
     createdDate() {
-      if (!this.media.createdAt) {
+      if (!this.media.attachment || !this.media.attachment.createdAt) {
         return '';
       }
-      return dayjs(this.media.createdAt).format('MMM D, YYYY');
+      return dayjs(this.media.attachment.createdAt).format('MMM Do, YYYY');
     }
   },
   watch: {

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -9,14 +9,21 @@
         >
       </div>
       <ul class="apos-media-manager-editor__details">
-        <li class="apos-media-manager-editor__detail">
-          {{ media.uploadedAt }}
+        <li class="apos-media-manager-editor__detail" v-if="createdDate">
+          {{ createdDate }}
         </li>
-        <li class="apos-media-manager-editor__detail">
-          File Size: {{ media.fileSize }}
+        <li
+          class="apos-media-manager-editor__detail"
+          v-if="media.attachment && media.attachment.length && media.attachment.length.size"
+        >
+          File Size: {{ fileSize }}
         </li>
-        <li class="apos-media-manager-editor__detail">
-          {{ media.dim }}
+        <li
+          class="apos-media-manager-editor__detail"
+          v-if="media.attachment && media.attachment.width"
+        >
+          Dimensions: {{ media.attachment.width }} 𝗑
+          {{ media.attachment.height }}
         </li>
       </ul>
       <AposSchema
@@ -47,6 +54,7 @@
 <script>
 import AposHelpers from 'Modules/@apostrophecms/ui/mixins/AposHelpersMixin';
 import klona from 'klona';
+import dayjs from 'dayjs';
 
 export default {
   mixins: [ AposHelpers ],
@@ -110,6 +118,28 @@ export default {
         });
       }
       return [];
+    },
+    fileSize() {
+      if (
+        !this.media.attachment || !this.media.attachment.length ||
+        !this.media.attachment.length.size
+      ) {
+        return '';
+      }
+
+      const size = this.media.attachment.length.size;
+
+      if (size >= 1000000) {
+        return `${(size / 1000000).toFixed(2)}MB`;
+      } else {
+        return `${Math.round(size / 1000)}KB`;
+      }
+    },
+    createdDate() {
+      if (!this.media.createdAt) {
+        return '';
+      }
+      return dayjs(this.media.createdAt).format('MMM D, YYYY');
     }
   },
   watch: {

--- a/modules/@apostrophecms/storybook/template/public/lib/mock-images.js
+++ b/modules/@apostrophecms/storybook/template/public/lib/mock-images.js
@@ -100,7 +100,7 @@
           length: {
             size: 345000
           },
-          wdith: dim[0],
+          width: dim[0],
           height: dim[1]
         },
         title,

--- a/modules/@apostrophecms/storybook/template/public/lib/mock-images.js
+++ b/modules/@apostrophecms/storybook/template/public/lib/mock-images.js
@@ -96,14 +96,17 @@
           _urls: {
             'one-sixth': imgUrl,
             'one-third': imgUrl
-          }
+          },
+          length: {
+            size: 345000
+          },
+          wdith: dim[0],
+          height: dim[1]
         },
         title,
         alt,
         credit,
-        uploadedAt: 'Uploaded: March 6th, 2018',
-        fileSize: '345KB',
-        dim: `${dim[0]} x ${dim[1]}`,
+        createdAt: '2019-05-12T19:17:57.075Z',
         creditUrl,
         slug: `${title.replace(/\s/g, '-').toLowerCase()}-${_id}`,
         tags: tags.tags


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-430

Displays the uploaded image size, created date (for the image piece) and dimensions in the editor view:
<img width="251" alt="Screen Shot 2020-09-29 at 3 01 48 PM" src="https://user-images.githubusercontent.com/1155984/94609685-bf09ae80-0264-11eb-99f6-b15374e914a7.png">
<img width="256" alt="Screen Shot 2020-09-29 at 3 01 53 PM" src="https://user-images.githubusercontent.com/1155984/94609688-c03adb80-0264-11eb-8ce7-a1473a2cd0e5.png">
