### PR TITLE
3/media save alert

### DIFF
--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -114,7 +114,7 @@ export default {
         type: 'overlay',
         showModal: false
       },
-      editing: null,
+      editing: undefined,
       uploading: false,
       lastSelected: null,
       emptyDisplay: {
@@ -152,7 +152,7 @@ export default {
       }
 
       if (newVal.length > 1 || newVal.length === 0) {
-        this.editing = null;
+        this.editing = undefined;
       }
     }
   },
@@ -210,7 +210,7 @@ export default {
     },
     clearSelected() {
       this.checked = [];
-      this.editing = null;
+      this.editing = undefined;
     },
     updateEditing(id) {
       this.editing = this.items.find(item => item._id === id);
@@ -236,7 +236,7 @@ export default {
       }
 
       this.lastSelected = id;
-      this.editing = null;
+      this.editing = undefined;
     },
 
     selectSeries(id) {
@@ -264,13 +264,13 @@ export default {
       });
 
       this.lastSelected = sliced[sliced.length - 1]._id;
-      this.editing = null;
+      this.editing = undefined;
     },
 
     // Toolbar handlers
     selectClick() {
       this.selectAll();
-      this.editing = null;
+      this.editing = undefined;
     },
     async updatePage(num) {
       if (num) {

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -116,8 +116,11 @@ export default {
       deep: true,
       handler(newData, oldData) {
         this.$nextTick(() => {
-          // If the previous state was an empty object, it's not "edited"
-          if (Object.keys(oldData).length > 0) {
+          // If either old or new state are an empty object, it's not "edited"
+          if (
+            Object.keys(oldData).length > 0 &&
+            Object.keys(newData).length > 0
+          ) {
             this.docEdited = true;
           }
         });
@@ -173,6 +176,7 @@ export default {
             body: this.doc.data
           });
 
+          this.docEdited = false;
           this.$emit('saved');
         } catch (err) {
           console.error('Error saving image', err);

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -20,10 +20,13 @@
         </li>
       </ul>
       <AposSchema
+        v-if="doc.data.title !== undefined"
         :schema="schema"
         v-model="doc"
         :modifiers="['small', 'inverted']"
         :trigger-validation="triggerValidation"
+        :doc-id="doc.data._id"
+        @reset="docEdited = false"
       />
     </div>
     <AposModalLip :refresh="lipKey">
@@ -81,6 +84,7 @@ export default {
         data: {},
         hasErrors: false
       },
+      docEdited: false,
       lipKey: '',
       triggerValidation: false
     };
@@ -99,6 +103,17 @@ export default {
     }
   },
   watch: {
+    'doc.data': {
+      deep: true,
+      handler(newData, oldData) {
+        this.$nextTick(() => {
+          // If the previous state was an empty object, it's not "edited"
+          if (Object.keys(oldData).length > 0) {
+            this.docEdited = true;
+          }
+        });
+      }
+    },
     media(newVal) {
       this.doc.data = klona(newVal);
       this.generateLipKey();
@@ -106,6 +121,7 @@ export default {
   },
   mounted() {
     this.generateLipKey();
+    this.docEdited = false;
   },
   methods: {
     save() {

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -49,7 +49,7 @@
       v-if="confirmContent"
       @safe-close="confirmContent = null"
       :confirm-content="confirmContent"
-      @confirm="changeConfirmed = true && updateActiveDoc(media)"
+      @confirm="discardChanges"
     />
   </div>
 </template>
@@ -193,6 +193,14 @@ export default {
     },
     generateLipKey() {
       this.lipKey = this.generateId();
+    },
+    async discardChanges () {
+      this.changeConfirmed = true;
+      this.updateActiveDoc(this.media);
+
+      await apos.notify(`${this.moduleLabels.label} changes discarded`, {
+        dismiss: true
+      });
     }
   }
 };

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -130,8 +130,8 @@ export default {
       ) {
         this.confirmContent = {
           heading: 'Unsaved Changes',
-          description: 'Do you want to abandon changes to the active image?',
-          affirmativeLabel: 'Yes'
+          description: 'Do you want to discard changes to the active image?',
+          affirmativeLabel: 'Discard Changes'
         };
 
         return;

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalConfirm.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalConfirm.vue
@@ -48,14 +48,14 @@
 import AposModalParentMixin from 'Modules/@apostrophecms/modal/mixins/AposModalParentMixin';
 
 export default {
-  mixins: [AposModalParentMixin],
+  mixins: [ AposModalParentMixin ],
   props: {
     confirmContent: {
       type: Object,
       required: true
     }
   },
-  emits: ['safe-close', 'confirm'],
+  emits: [ 'safe-close', 'confirm' ],
   data() {
     return {
       modal: {
@@ -83,6 +83,9 @@ export default {
 
 <style lang="scss" scoped>
 .apos-confirm {
+  // Repeat modal z-index here since this typically lives inside a modal.
+  // TODO: Remove z-index once using Vue 3 Teleport.
+  z-index: $z-index-modal-bg;
   position: fixed;
   top: 0;
   right: 0;
@@ -94,13 +97,22 @@ export default {
 }
 
 /deep/ .apos-modal__inner {
-  top: auto;
-  right: auto;
-  bottom: auto;
-  left: auto;
-  width: 420px;
-  height: auto;
-  text-align: center;
+  &,
+  .apos-modal__inner .apos-confirm & {
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
+    width: 420px;
+    height: auto;
+    text-align: center;
+  }
+}
+
+/deep/ .apos-modal__overlay {
+  .apos-modal__inner .apos-confirm & {
+    display: block;
+  }
 }
 
 /deep/ .apos-modal__body {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
@@ -7,7 +7,7 @@
       <component
         v-show="displayComponent(field.name)"
         v-model="fieldState[field.name]"
-        :followingValue="followingValues[field.name]"
+        :following-value="followingValues[field.name]"
         :is="fieldComponentMap[field.type]"
         :field="fields[field.name].field"
         :status="fields[field.name].status"
@@ -20,6 +20,7 @@
 </template>
 
 <script>
+import isEqual from 'lodash.isequal';
 
 export default {
   name: 'AposSchema',
@@ -59,9 +60,10 @@ export default {
       }
     }
   },
-  emits: [ 'input' ],
+  emits: [ 'input', 'reset' ],
   data() {
     return {
+      schemaReady: false,
       next: {
         hasErrors: false,
         data: {}
@@ -114,6 +116,7 @@ export default {
   },
   methods: {
     populateDocData() {
+      this.schemaReady = false;
       const next = {
         hasErrors: false,
         data: {}
@@ -136,24 +139,51 @@ export default {
       });
       this.next = next;
       this.fieldState = fieldState;
+
+      this.$nextTick(() => {
+        this.schemaReady = true;
+        // Signal that the schema data is ready to be tracked.
+        this.$emit('reset');
+      });
     },
     updateNextAndEmit() {
+      if (!this.schemaReady) {
+        return;
+      }
+
       this.next.hasErrors = false;
+      let changeFound = false;
+
       this.schema.forEach(field => {
         if (this.fieldState[field.name].error) {
           this.next.hasErrors = true;
         }
 
         if (
-          this.fieldState[field.name].data ||
-          this.fieldState[field.name].data !== undefined
+          this.fieldState[field.name].data !== undefined &&
+          this.findRealChange(this.next.data[field.name], this.fieldState[field.name].data)
         ) {
+          changeFound = true;
           this.next.data[field.name] = this.fieldState[field.name].data;
         } else {
           this.next.data[field.name] = this.value.data[field.name];
         }
       });
-      this.$emit('input', this.next);
+
+      if (changeFound) {
+        this.$emit('input', this.next);
+      }
+    },
+    findRealChange(oldData, newData) {
+      if (isEqual(oldData, newData)) {
+        return false;
+      } else if (!oldData && !newData) {
+        return false;
+      } else if (!oldData && Array.isArray(newData) && newData.length === 0) {
+        return false;
+      } else {
+        return true;
+      }
     },
     displayComponent(fieldName) {
       return this.currentFields.length ? this.currentFields.includes(fieldName) : true;

--- a/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
@@ -143,6 +143,9 @@ export default {
       this.next = next;
       this.fieldState = fieldState;
 
+      // Wait until the next tick so the parent editor component is done
+      // updating. This is only really a concern in editors that can swap
+      // the active doc/object without unmounting AposSchema.
       this.$nextTick(() => {
         this.schemaReady = true;
         // Signal that the schema data is ready to be tracked.

--- a/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script>
-import isEqual from 'lodash.isequal';
+import { isEqual } from 'lodash';
 
 export default {
   name: 'AposSchema',

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "less": "^3.12.0",
     "less-middleware": "^3.0.1",
     "lodash": "^4.17.19",
+    "lodash.isequal": "^4.5.0",
     "lorem-ipsum": "^2.0.3",
     "minimatch": "^3.0.4",
     "mkdirp": "^0.5.5",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "less": "^3.12.0",
     "less-middleware": "^3.0.1",
     "lodash": "^4.17.19",
-    "lodash.isequal": "^4.5.0",
     "lorem-ipsum": "^2.0.3",
     "minimatch": "^3.0.4",
     "mkdirp": "^0.5.5",


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-467, "Media Library: Alerts for unsaved changes"

To test, have at least two images in the media library. Open one to edit, change a field value, and then click another image (to make it active in the editor). You should be met with a confirmation alert, allowing you to cancel the change or continue with it.