### PR TITLE
3/swap tags

### DIFF
--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
@@ -79,7 +79,9 @@ export default {
 
       // If in a relationship input context, keep `checkedDocs` in sync with
       // `checked`, first removing from `checkedDocs` if no longer in `checked`
-      this.checkedDocs.filter(doc => this.checked.includes(doc._id));
+      this.checkedDocs = this.checkedDocs.filter(doc => {
+        return this.checked.includes(doc._id);
+      });
       // then adding to `checkedDocs` if not there yet. These should be in
       // `items`.
       // TODO: Once we have the option to select all docs of a type even if not

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -152,6 +152,11 @@ export default {
         this.searchList = [];
       }, 200);
     },
+    watchValue () {
+      this.error = this.value.error;
+      // Ensure the internal state is an array.
+      this.next = Array.isArray(this.value.data) ? this.value.data : [];
+    },
     openRelationshipEditor (item) {
       this.relationshipSchema = this.field.schema;
       this.clickedItem = item;

--- a/modules/@apostrophecms/schema/ui/apos/mixins/AposInputMixin.js
+++ b/modules/@apostrophecms/schema/ui/apos/mixins/AposInputMixin.js
@@ -1,5 +1,7 @@
 export default {
   props: {
+    // The value passed in from the parent component through the v-model
+    // directive.
     value: {
       type: Object,
       required: true
@@ -76,6 +78,8 @@ export default {
         this.watchValue();
       }
     },
+    // `next` is the internal state of the input's value, which is eventually
+    // emitted with the 'input' event.
     next: {
       deep: true,
       handler (value) {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "less": "^3.12.0",
     "less-middleware": "^3.0.1",
     "lodash": "^4.17.19",
+    "lodash.isequal": "^4.5.0",
     "lorem-ipsum": "^2.0.3",
     "minimatch": "^3.0.4",
     "mkdirp": "^0.5.5",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "less": "^3.12.0",
     "less-middleware": "^3.0.1",
     "lodash": "^4.17.19",
-    "lodash.isequal": "^4.5.0",
     "lorem-ipsum": "^2.0.3",
     "minimatch": "^3.0.4",
     "mkdirp": "^0.5.5",


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-546, "When switching images in the media library (and thus the media editor), the tag field does not update visually," and a bit more.

After a few rounds of work on it, the relationship input was reinventing a lot of things that the input mixin already did for it. That's the majority of the changes in the input component. We also needed to make sure `next` is an empty array, not `undefined` when there's no `value.data`. That was part of the issue with switching the selected image in the media manager.

I noticed that the `AposDocsManagerMixin.js` wasn't assigning `checkedDocs` to the filtered version of itself (that's my mistake) so you couldn't remove items from the selected relationships in the chooser. Fixed.

TESTING:
- The relationship input should work as it did before, with the addition that you can now remove items from the chooser.
- If you have a few images in the media library, some with tags and (importantly) some with no tags, clicking among them to switch which is in the editor should upload all fields, including the image tag <== that wasn't working before.