### PR TITLE
adds New Piece UI to relationship modal

### DIFF
--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -29,9 +29,7 @@
                 </span>
                 {{ modalTitle }}
               </h2>
-              <div
-                class="apos-modal__controls--primary" v-if="hasPrimaryControls"
-              >
+              <div class="apos-modal__controls--primary" v-if="hasPrimaryControls">
                 <slot name="primaryControls" />
               </div>
             </div>
@@ -362,9 +360,18 @@ export default {
     background-color: var(--a-white);
   }
 
+  .apos-modal__controls--primary,
+  .apos-modal__controls--secondary {
+    display: flex;
+    align-items: center;
+  }
+
   .apos-modal__controls--primary {
+    justify-content: flex-end;
     flex-grow: 1;
-    text-align: right;
+  }
+  .apos-modal__controls--primary /deep/ > * {
+    margin-left: 7.5px;
   }
 
   .apos-modal__heading {

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -370,7 +370,7 @@ export default {
     justify-content: flex-end;
     flex-grow: 1;
   }
-  .apos-modal__controls--primary /deep/ > * {
+  .apos-modal__controls--primary /deep/ > .apos-button {
     margin-left: 7.5px;
   }
 

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
@@ -4,23 +4,33 @@
     @esc="cancel" @no-modal="$emit('safe-close')"
     @inactive="modal.active = false" @show-modal="modal.showModal = true"
   >
-    <template v-if="relationshipField" #primaryControls>
+    <template #secondaryControls>
       <AposButton
+        v-if="relationshipField"
         type="default" label="Cancel"
         @click="cancel"
       />
       <AposButton
+        v-else
+        type="default" label="Finished"
+        @click="cancel"
+      />
+    </template>
+    <template #primaryControls>
+      <AposContextMenu
+        v-if="relationshipField"
+        :button="relationshipMore.button"
+        :menu="relationshipMore.menu"
+        @item-clicked="relationshipMoreMenuHandler"
+      />
+      <AposButton
+        v-if="relationshipField"
         :label="`Save`" type="primary"
         :disabled="relationshipErrors === 'min'"
         @click="saveRelationship"
       />
-    </template>
-    <template v-else #primaryControls>
       <AposButton
-        type="default" label="Finished"
-        @click="cancel"
-      />
-      <AposButton
+        v-else
         :label="`New ${ options.label }`" type="primary"
         @click="editing = true"
       />
@@ -102,7 +112,16 @@ export default {
       editing: false,
       editingDocId: '',
       queryExtras: {},
-      holdQueries: false
+      holdQueries: false,
+      relationshipMore: {
+        button: {
+          label: 'More operations',
+          iconOnly: true,
+          icon: 'dots-vertical-icon',
+          type: 'outline'
+        },
+        menu: []
+      }
     };
   },
   computed: {
@@ -155,6 +174,11 @@ export default {
     // Get the data. This will be more complex in actuality.
     this.modal.active = true;
     this.getPieces();
+    // Add computed singular label to context menu
+    this.relationshipMore.menu.unshift({
+      action: 'new',
+      label: `New ${this.moduleLabels.singular}`
+    });
   },
   methods: {
     // TEMP From Manager Mixin:
@@ -164,6 +188,14 @@ export default {
     // generateUi
     // generateIcons
     // generateCheckboxes
+    relationshipMoreMenuHandler(action) {
+      if (action === 'new') {
+        this.new();
+      }
+    },
+    new() {
+      this.editing = true;
+    },
     async finishSaved() {
       await this.getPieces();
     },

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
@@ -19,10 +19,10 @@
     <template #primaryControls>
       <!-- TODO Make sure this gets positioned correctly after Vue3/teleport -->
       <AposContextMenu
-        v-if="relationshipField"
-        :button="relationshipMore.button"
-        :menu="relationshipMore.menu"
-        @item-clicked="relationshipMoreMenuHandler"
+        v-if="moreMenu.menu.length"
+        :button="moreMenu.button"
+        :menu="moreMenu.menu"
+        @item-clicked="moreMenuHandler"
       />
       <AposButton
         v-if="relationshipField"
@@ -114,7 +114,7 @@ export default {
       editingDocId: '',
       queryExtras: {},
       holdQueries: false,
-      relationshipMore: {
+      moreMenu: {
         button: {
           label: 'More operations',
           iconOnly: true,
@@ -175,11 +175,13 @@ export default {
     // Get the data. This will be more complex in actuality.
     this.modal.active = true;
     this.getPieces();
-    // Add computed singular label to context menu
-    this.relationshipMore.menu.unshift({
-      action: 'new',
-      label: `New ${this.moduleLabels.singular}`
-    });
+    if (this.relationshipField) {
+      // Add computed singular label to context menu
+      this.moreMenu.menu.unshift({
+        action: 'new',
+        label: `New ${this.moduleLabels.singular}`
+      });
+    }
   },
   methods: {
     // TEMP From Manager Mixin:
@@ -189,7 +191,7 @@ export default {
     // generateUi
     // generateIcons
     // generateCheckboxes
-    relationshipMoreMenuHandler(action) {
+    moreMenuHandler(action) {
       if (action === 'new') {
         this.new();
       }

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
@@ -17,6 +17,7 @@
       />
     </template>
     <template #primaryControls>
+      <!-- TODO Make sure this gets positioned correctly after Vue3/teleport -->
       <AposContextMenu
         v-if="relationshipField"
         :button="relationshipMore.button"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
@@ -147,12 +147,11 @@ export default {
   position: relative;
   overflow: hidden;
   padding: 10px 20px;
-  // TODO: Uncomment this once style loading is resolved.
-  // font-size: map-get($font-sizes, modal);
-  letter-spacing: 0.75px;
   border: 1px solid var(--a-base-5);
-  border-radius: var(--a-border-radius);
   color: var(--a-text-primary);
+  font-size: map-get($font-sizes, button);
+  letter-spacing: 0.75px;
+  border-radius: var(--a-border-radius);
   background-color: var(--a-base-9);
   transition: all 0.2s ease;
   &:hover {
@@ -449,6 +448,7 @@ export default {
   display: inline-flex;
   margin-right: 5px;
   align-items: center;
+  max-height: 13px;
 }
 
 .apos-button--danger-on-hover:hover {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="apos-context-menu">
+  <div class="apos-context-menu" ref="container">
     <slot name="prebutton" />
     <v-popover
       @hide="hide"
@@ -10,6 +10,7 @@
       :open="isOpen"
       :delay="{ show: 0, hide: 0 }"
       popover-class="apos-popover"
+      :container="container"
     >
       <!-- TODO refactor buttons to take a single config obj -->
       <AposButton
@@ -94,7 +95,8 @@ export default {
   data() {
     return {
       isOpen: false,
-      position: ''
+      position: '',
+      container: null
     };
   },
   computed: {
@@ -131,6 +133,9 @@ export default {
     buttonState() {
       return this.open ? [ 'active' ] : null;
     }
+  },
+  mounted() {
+    this.container = this.$refs.container;
   },
   methods: {
     show() {

--- a/modules/@apostrophecms/ui/ui/apos/scss/mixins/_theme_mixins.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/mixins/_theme_mixins.scss
@@ -18,6 +18,7 @@ $font-weights: (
 );
 
 $font-sizes: (
+  button: 12px,
   default: 12px,
   meta: 10px,
   input-label: 14px,


### PR DESCRIPTION
Satisfies https://apostrophecms.atlassian.net/jira/software/projects/A30U/boards/4?selectedIssue=A30U-455

![Nast](http://g.recordit.co/cAb9YLPYvp.gif)

#### Uh oh! That context menu isn't in the right place?
As modals get nested v-tooltip starts to misplace them, I've confirmed placing it higher up works as expected.
Not spending too much time wrestling them now but we need to make sure they get sorted after vue3/teleport