### PR TITLE
fix the bug that broke keyboard focus when editing a nested rich text…

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -140,17 +140,10 @@ export default {
   mounted() {
     if (this.docId) {
       this.areaUpdatedHandler = (area) => {
-        let patched = false;
         for (const item of this.next) {
           if (this.patchSubobject(item, area)) {
-            patched = true;
             break;
           }
-        }
-        if (patched) {
-          // Make sure our knowledge of the change is reflected
-          // everywhere via a refresh
-          this.next = this.next.slice();
         }
       };
       apos.bus.$on('area-updated', this.areaUpdatedHandler);
@@ -161,8 +154,8 @@ export default {
   beforeDestroy() {
     if (this.areaUpdatedHandler) {
       apos.bus.$off('area-updated', this.areaUpdatedHandler);
-      apos.bus.$on('widget-hover', this.updateWidgetHovered);
-      apos.bus.$on('widget-focus', this.updateWidgetFocused);
+      apos.bus.$off('widget-hover', this.updateWidgetHovered);
+      apos.bus.$off('widget-focus', this.updateWidgetFocused);
     }
   },
   methods: {
@@ -305,11 +298,8 @@ export default {
     // its _id matches that of a sub-object of `object`. If found,
     // replace that sub-object with `subObject` and return `true`.
     patchSubobject(object, subObject) {
-      let key;
-      let val;
       let result;
-      for (key in object) {
-        val = object[key];
+      for (const [ key, val ] of Object.entries(object)) {
         if (val && typeof val === 'object') {
           if (val._id === subObject._id) {
             object[key] = subObject;

--- a/modules/@apostrophecms/html-widget/index.js
+++ b/modules/@apostrophecms/html-widget/index.js
@@ -17,44 +17,40 @@ module.exports = {
       }
     }
   },
-  methods(self, options) {
+  components(self, options) {
     return {
-      components(self, options) {
-        return {
-          render(req, data) {
-            // Be understanding of the panic that is probably going on in a user's mind as
-            // they try to remember how to use safe mode. -Tom
-            const safeModeVariations = [
-              'safemode',
-              'safeMode',
-              'safe_mode',
-              'safe-mode',
-              'safe mode'
-            ];
-            if (req.xhr) {
-              return {
-                render: false
-              };
+      render(req, data) {
+        // Be understanding of the panic that is probably going on in a user's mind as
+        // they try to remember how to use safe mode. -Tom
+        const safeModeVariations = [
+          'safemode',
+          'safeMode',
+          'safe_mode',
+          'safe-mode',
+          'safe mode'
+        ];
+        if (req.xhr) {
+          return {
+            render: false
+          };
+        }
+        if (req.query) {
+          let safe = false;
+          for (const variation of safeModeVariations) {
+            if (Object.keys(req.query).includes(variation)) {
+              safe = true;
+              break;
             }
-            if (req.query) {
-              let safe = false;
-              for (const variation of safeModeVariations) {
-                if (Object.keys(req.query).includes(variation)) {
-                  safe = true;
-                  break;
-                }
-              }
-              if (safe) {
-                return {
-                  render: 'safeMode'
-                };
-              }
-            }
+          }
+          if (safe) {
             return {
-              render: true,
-              code: data.code
+              render: 'safeMode'
             };
           }
+        }
+        return {
+          render: true,
+          code: data.code
         };
       }
     };

--- a/modules/@apostrophecms/html-widget/views/render.html
+++ b/modules/@apostrophecms/html-widget/views/render.html
@@ -1,6 +1,6 @@
 {%- if data.render == 'safeMode' -%}
   Running in safe mode, not showing raw HTML.
-{%- else if data.render -%}
+{%- elif data.render -%}
   {{ data.code | safe }}
 {% else %}
   Refresh the page to view raw HTML.

--- a/modules/@apostrophecms/html-widget/views/widget.html
+++ b/modules/@apostrophecms/html-widget/views/widget.html
@@ -1,3 +1,3 @@
 <div data-raw-html>
-  {% component '@apostrophecms/html-widgets:render' with data.widget %}
+  {% component '@apostrophecms/html-widget:render' with data.widget %}
 </div>

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/ApostropheRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/ApostropheRichTextWidgetEditor.vue
@@ -114,7 +114,8 @@ export default {
       const content = this.editor.getHTML();
       const widget = this.widgetInfo.data;
       widget.content = content;
-      this.$emit('update', widget);
+      // ... removes need for deep watching in parent
+      this.$emit('update', { ...widget });
     },
     command(name, options) {
       this.commands[name](options);

--- a/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
@@ -177,7 +177,8 @@ export default {
       });
 
       if (changeFound) {
-        this.$emit('input', this.next);
+        // ... removes need for deep watch at parent level
+        this.$emit('input', { ...this.next });
       }
     },
     findRealChange(oldData, newData) {

--- a/modules/@apostrophecms/widget-type/ui/apos/mixins/ApostropheWidgetMixin.js
+++ b/modules/@apostrophecms/widget-type/ui/apos/mixins/ApostropheWidgetMixin.js
@@ -7,7 +7,6 @@ export default {
   },
   watch: {
     value: {
-      deep: true,
       handler() {
         this.renderContent();
       }


### PR DESCRIPTION
… widget. In the process, reduced our dependency on deep watching. Also fixed: raw HTML widgets, and a bug where area event handlers were never removed.

You may note that we're not setting `this.next` to a new array anymore when a change propagates from a widget nested within. That's deliberate, the nested widget has already updated itself and so all that code was doing was causing an unnecessary performance hit and the loss of keyboard focus due to a complete rebuild of all nested areas.

In theory there is a scenario where the same area appears on the page twice, and it would be nice if the one you're not editing also reflected your edits. I experimented in that direction but encountered a fairly gnarly Vue bug that we don't need to be wranglin' right now, so I went with a simple fix that doesn't move the goalposts.