### PR TITLE
3/new page from tree

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="apos-admin-bar-wrapper">
-    <div class="apos-admin-bar-spacer" ref="spacer"></div>
+    <div class="apos-admin-bar-spacer" ref="spacer" />
     <nav class="apos-admin-bar" ref="adminBar">
       <div class="apos-admin-bar__row">
         <AposLogo class="apos-admin-bar__logo" />
         <ul class="apos-admin-bar__items">
           <li
-            v-for="(item, index) in menuItems" :key="item.name"
+            v-for="(item) in menuItems" :key="item.name"
             class="apos-admin-bar__item"
           >
             <component

--- a/modules/@apostrophecms/asset/lib/webpack.config.js
+++ b/modules/@apostrophecms/asset/lib/webpack.config.js
@@ -38,6 +38,7 @@ module.exports = ({ importFile, modulesDir }, apos) => {
       extensions: [ '*', '.js', '.vue', '.json' ],
       alias: {
         'apostrophe/vue$': 'vue/dist/vue.esm.js',
+        vue$: 'vue/dist/vue.esm.js',
         // resolve apostrophe modules
         Modules: path.resolve(modulesDir)
       },

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -173,7 +173,7 @@ export default {
       return tabs;
     },
     modalTitle () {
-      return `Edit ${this.moduleOptions.label}`;
+      return `Edit ${this.moduleOptions.label || ''}`;
     },
     currentFields: function() {
       if (this.currentTab) {

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -256,7 +256,7 @@ export default {
           return;
         }
 
-        this.doc.data = {
+        const body = {
           ...this.doc.data,
           ...this.docUtilityFields.data,
           ...this.docOtherFields.data
@@ -269,11 +269,16 @@ export default {
         } else {
           route = this.moduleAction;
           requestMethod = apos.http.post;
+
+          if (this.moduleName === '@apostrophecms/page') {
+            body._targetId = apos.page.page._id;
+            body._position = 'lastChild';
+          }
         }
 
         await requestMethod(route, {
           busy: true,
-          body: this.doc.data
+          body
         });
         this.$emit('saved');
         this.modal.showModal = false;

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -325,19 +325,13 @@ export default {
       this.schemaOtherFields = [];
 
       this.schema.forEach(field => {
-        let schemaFields;
-        let docFields;
-
         if (field.group.name === 'utility') {
-          docFields = this.docUtilityFields;
-          schemaFields = this.schemaUtilityFields;
+          this.docUtilityFields.data[field.name] = this.doc.data[field.name] || field.def;
+          this.schemaUtilityFields.push(field);
         } else {
-          docFields = this.docOtherFields;
-          schemaFields = this.schemaOtherFields;
+          this.docOtherFields.data[field.name] = this.doc.data[field.name] || field.def;
+          this.schemaOtherFields.push(field);
         }
-
-        schemaFields.push(field);
-        docFields.data[field.name] = this.doc.data[field.name] || field.def;
       });
       this.splittingDoc = false;
     }

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -300,11 +300,13 @@ export default {
 
         return newDoc;
       } catch (error) {
-        await apos.notify('Error while creating a new, empty item. Please check configured content types.', {
+        await apos.notify('Error while creating new, empty content.', {
           type: 'danger',
           icon: 'alert-circle-icon',
           dismiss: true
         });
+
+        console.error(`Error while creating new, empty content. Review your configuration for ${this.docType} (including \`type\` options in \`@apostrophecms/page\` if it's a page type).`);
 
         this.cancel();
       }

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -331,10 +331,10 @@ export default {
 
       this.schema.forEach(field => {
         if (field.group.name === 'utility') {
-          this.docUtilityFields.data[field.name] = this.doc.data[field.name] || field.def;
+          this.docUtilityFields.data[field.name] = this.doc.data[field.name];
           this.schemaUtilityFields.push(field);
         } else {
-          this.docOtherFields.data[field.name] = this.doc.data[field.name] || field.def;
+          this.docOtherFields.data[field.name] = this.doc.data[field.name];
           this.schemaOtherFields.push(field);
         }
       });

--- a/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
+++ b/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
@@ -1,4 +1,6 @@
 import Vue from 'apostrophe/vue';
+import PortalVue from 'portal-vue';
+Vue.use(PortalVue);
 
 export default function() {
   return new Vue({
@@ -8,7 +10,6 @@ export default function() {
         return window.apos;
       }
     },
-    // apos.modal.components.the, apos.modal.modals
     template: '<component :is="apos.modal.components.the" :modals="apos.modal.modals" />'
   });
 };

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -296,8 +296,8 @@ export default {
     display: block;
     background-color: var(--a-overlay);
 
-    .apos-modal__inner & {
-      // A nested modal doesn't need an overlay.
+    .apos-modal + .apos-modal & {
+      // A second modal doesn't need an overlay.
       display: none;
     }
 

--- a/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
@@ -1,10 +1,13 @@
 <template>
   <div id="apos-modals">
-    <component
-      v-for="modal in activeModals" :key="modal.itemName"
-      :is="modal.componentName" :module-name="modal.itemName"
-      @safe-close="setIsActive(modal.itemName, false)"
-    />
+    <portal to="modal-target">
+      <component
+        v-for="modal in activeModals" :key="modal.itemName"
+        :is="modal.componentName" :module-name="modal.itemName"
+        @safe-close="setIsActive(modal.itemName, false)"
+      />
+    </portal>
+    <portal-target name="modal-target" multiple />
   </div>
 </template>
 

--- a/modules/@apostrophecms/page-type/index.js
+++ b/modules/@apostrophecms/page-type/index.js
@@ -31,14 +31,19 @@ module.exports = {
         },
         orphan: {
           type: 'boolean',
-          label: 'Hide in Navigation'
+          label: 'Hide in Navigation',
+          def: false
         }
       },
       remove: [ 'trash' ],
       group: {
-        meta: {
-          label: 'Meta',
-          fields: [ 'title', 'slug', 'type', 'published', 'orphan' ]
+        utility: {
+          fields: [
+            'published',
+            'slug',
+            'type',
+            'orphan'
+          ]
         }
       }
     };

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -85,6 +85,7 @@ module.exports = {
     self.finalizeControls();
     self.addPermissions();
     self.addToAdminBar();
+    self.addManagerModal();
     self.enableBrowserData();
     await self.createIndexes();
   },
@@ -430,12 +431,21 @@ database.`);
         });
       },
       getBrowserData(req) {
-        const options = _.pick(self, 'action', 'schema', 'types');
-        _.assign(options, _.pick(self.options, 'batchOperations'));
+        const browserOptions = _.pick(self, 'action', 'schema', 'types');
+        _.assign(browserOptions, _.pick(self.options, 'batchOperations'));
+
+        _.defaults(browserOptions, {
+          components: {}
+        });
+        _.defaults(browserOptions.components, {
+          insertModal: 'AposDocEditor',
+          managerModal: 'AposPagesManager'
+        });
+
         if (req.data.bestPage) {
-          options.page = self.pruneCurrentPageForBrowser(req.data.bestPage);
+          browserOptions.page = self.pruneCurrentPageForBrowser(req.data.bestPage);
         }
-        return options;
+        return browserOptions;
       },
       // Returns a cursor that finds pages the current user can edit
       // in a batch operation, including unpublished and trashed pages.
@@ -1719,6 +1729,13 @@ database.`);
       },
       addToAdminBar() {
         self.apos.adminBar.add(self.__meta.name, 'Pages', 'edit-@apostrophecms/page');
+      },
+      addManagerModal() {
+        self.apos.modal.add(
+          self.__meta.name,
+          self.getComponentName('managerModal', 'AposPagesManager'),
+          { moduleName: self.__meta.name }
+        );
       },
       // Returns the effective base URL for the given request.
       // If Apostrophe's top-level `baseUrl` option is set, it is returned,

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -4,10 +4,17 @@
     @esc="cancel" @no-modal="$emit('safe-close')"
     @inactive="modal.active = false" @show-modal="modal.showModal = true"
   >
-    <template #primaryControls>
+    <template #secondaryControls>
       <AposButton
         type="default" label="Finished"
         @click="cancel"
+      />
+    </template>
+    <template #primaryControls>
+      <AposButton
+        type="primary"
+        label="New Page"
+        @click="editing = true"
       />
     </template>
     <template #main>
@@ -34,6 +41,13 @@
           />
         </template>
       </AposModalBody>
+      <!-- The pieces editor modal. -->
+      <component
+        v-if="editing"
+        :is="moduleOptions.components.insertModal"
+        :module-name="moduleName" :doc-id="editingDocId"
+        @saved="finishSaved" @safe-close="closeEditor"
+      />
     </template>
   </AposModal>
 </template>
@@ -49,6 +63,7 @@ export default {
   emits: [ 'trash', 'search', 'safe-close' ],
   data() {
     return {
+      moduleName: '@apostrophecms/page',
       modal: {
         active: false,
         type: 'slide',
@@ -89,10 +104,15 @@ export default {
       treeOptions: {
         bulkSelect: true,
         draggable: true
-      }
+      },
+      editing: false,
+      editingDocId: ''
     };
   },
   computed: {
+    moduleOptions() {
+      return window.apos.modules[this.moduleName];
+    },
     items() {
       const items = [];
       if (!this.pages || !this.headers.length) {
@@ -165,6 +185,13 @@ export default {
           page.children.forEach(formatPage);
         }
       }
+    },
+    async finishSaved() {
+      await this.getPages();
+    },
+    closeEditor() {
+      this.editing = false;
+      this.editingDocId = '';
     },
     update(obj) {
       // We'll hit a route here to update the docs.

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -145,7 +145,7 @@ export default {
             all: 1
           }
         }
-      )).results;
+      ));
 
       formatPage(pageTree);
 

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -42,12 +42,14 @@
         </template>
       </AposModalBody>
       <!-- The pieces editor modal. -->
-      <component
-        v-if="editing"
-        :is="moduleOptions.components.insertModal"
-        :module-name="moduleName" :doc-id="editingDocId"
-        @saved="finishSaved" @safe-close="closeEditor"
-      />
+      <portal to="modal-target">
+        <component
+          v-if="editing"
+          :is="moduleOptions.components.insertModal"
+          :module-name="moduleName" :doc-id="editingDocId"
+          @saved="finishSaved" @safe-close="closeEditor"
+        />
+      </portal>
     </template>
   </AposModal>
 </template>

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -680,9 +680,7 @@ module.exports = {
           components: {}
         });
         _.defaults(browserOptions.components, {
-          filters: 'ApostrophePiecesFilters',
-          list: 'ApostrophePiecesList',
-          pager: 'ApostrophePager',
+          filters: 'ApostrophePiecesFilters', // TODO: Remove component and this.
           insertModal: 'AposDocEditor',
           managerModal: 'AposPiecesManager'
         });

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
@@ -66,13 +66,15 @@
         </template>
       </AposModalBody>
       <!-- The pieces editor modal. -->
-      <component
-        v-if="editing"
-        :is="options.components.insertModal"
-        :module-name="moduleName" :doc-id="editingDocId"
-        :filter-values="filterValues"
-        @saved="finishSaved" @safe-close="closeEditor"
-      />
+      <portal to="modal-target">
+        <component
+          v-if="editing"
+          :is="options.components.insertModal"
+          :module-name="moduleName" :doc-id="editingDocId"
+          :filter-values="filterValues"
+          @saved="finishSaved" @safe-close="closeEditor"
+        />
+      </portal>
     </template>
   </AposModal>
 </template>

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -39,15 +39,17 @@
       </div>
     </template>
     <template #secondary>
-      <component
-        :is="chooserComponent"
-        v-if="choosing"
-        :module-name="field.withType"
-        :chosen="next"
-        :relationship-field="field"
-        @chose="updateSelected"
-        @safe-close="choosing=false"
-      />
+      <portal to="modal-target">
+        <component
+          :is="chooserComponent"
+          v-if="choosing"
+          :module-name="field.withType"
+          :chosen="next"
+          :relationship-field="field"
+          @chose="updateSelected"
+          @safe-close="choosing=false"
+        />
+      </portal>
       <AposRelationshipEditor
         v-if="relationshipSchema"
         :schema="relationshipSchema"

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
@@ -83,7 +83,14 @@ export default {
   watch: {
     followingValue(newValue, oldValue) {
       if (this.compatible(oldValue, this.next)) {
-        this.next = this.slugify(newValue);
+        // If this is a page slug, we only replace the last section of the slug.
+        if (this.field.page) {
+          const parts = this.next.match(/[^/]+/g);
+          parts.pop();
+          this.next = `/${parts.join('/')}${this.slugify(newValue)}`;
+        } else {
+          this.next = this.slugify(newValue);
+        }
       }
     }
   },
@@ -132,8 +139,8 @@ export default {
       if ((typeof title) !== 'string') {
         title = '';
       }
-      if (this.page) {
-        const matches = slug.match(/[^\/]+$/);
+      if (this.field.page) {
+        const matches = slug.match(/[^/]+$/);
         slug = matches[0] || '';
       }
       return ((title === '') && (slug === `${this.prefix}none`)) || this.slugify(title) === this.slugify(slug);

--- a/modules/@apostrophecms/storybook/template/public/mocks.js
+++ b/modules/@apostrophecms/storybook/template/public/mocks.js
@@ -544,8 +544,8 @@
     },
     [`/api/v1/product/${grape._id}`]: grape,
     [`/api/v1/product/${strawberry._id}`]: strawberry,
-    '/api/v1/@apostrophecms/page?all=1': {
-      results: {
+    '/api/v1/@apostrophecms/page?all=1':
+      {
         title: 'Home',
         slug: '/',
         _id: 'ckd4y2m7j00074k9kbrxs0bat',
@@ -586,7 +586,6 @@
         published: true,
         updatedAt: '2020-07-27T20:09:06.031Z'
       }
-    }
   };
 
   apos.http.postResponses = {};

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "passport-local": "^1.0.0",
     "path-to-regexp": "^1.8.0",
     "performance-now": "^2.1.0",
+    "portal-vue": "^2.1.7",
     "postcss-import": "^12.0.1",
     "postcss-loader": "^3.0.0",
     "postcss-prefixer": "^2.1.2",


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-130: "As a user I can create a subpage of the current page"

This lets you create a new page from the page manager, making it the child of the current page. Also an update to the slug-follow mechanism in there for pages.

A demo site branch is in PR to add another page option: https://github.com/apostrophecms/a3-demo/pull/25

Look here to avoid the portal commit: https://github.com/apostrophecms/apostrophe/pull/2458/files/1071e7f4508a58f0262ab7660ec5140fde5b00b3..0592564d48533efb47ec2d1684b6b00f691e2c27