### PR TITLE
fix wide plus, round admin New, fix FF and safari link dialog, adminb…

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -32,7 +32,8 @@
                 label: 'New item',
                 iconOnly: true,
                 icon: 'plus-icon',
-                type: 'primary'
+                type: 'primary',
+                modifiers: ['round', 'no-motion']
               }"
             />
           </li>
@@ -129,6 +130,11 @@ $menu-v-space: 25px;
 $admin-bar-h-pad: 20px;
 $admin-bar-border: 1px solid var(--a-base-9);
 
+.apos-admin-bar-wrapper {
+  z-index: $z-index-manager-toolbar;
+  position: relative;
+}
+
 .apos-admin-bar {
   z-index: $z-index-default;
   position: fixed;
@@ -162,7 +168,6 @@ $admin-bar-border: 1px solid var(--a-base-9);
   height: 32px;
 }
 
-.apos-admin-bar__create /deep/ .apos-context-menu__btn,
 .apos-admin-bar__sub /deep/ .apos-context-menu__btn,
 .apos-admin-bar__btn.apos-button,
 .apos-admin-bar__btn {

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -131,7 +131,7 @@ $admin-bar-h-pad: 20px;
 $admin-bar-border: 1px solid var(--a-base-9);
 
 .apos-admin-bar-wrapper {
-  z-index: $z-index-manager-toolbar;
+  z-index: $z-index-admin-bar;
   position: relative;
 }
 

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -136,7 +136,6 @@ $admin-bar-border: 1px solid var(--a-base-9);
 }
 
 .apos-admin-bar {
-  z-index: $z-index-default;
   position: fixed;
   top: 0;
   right: 0;

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/ApostropheTiptapLink.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/ApostropheTiptapLink.vue
@@ -15,7 +15,6 @@
       <div
         class="apos-link-control__dialog"
         :class="{
-          'is-ready': menu.isActive,
           'is-triggered': active,
           'has-selection': hasSelection
         }"
@@ -33,15 +32,18 @@
             <AposSchema
               :schema="schema"
               v-model="value"
+              :modifiers="formModifiers"
             />
             <footer class="apos-link-control__footer">
               <AposButton
                 type="default" label="Cancel"
                 @click="close"
+                :modifiers="formModifiers"
               />
               <AposButton
                 type="primary" label="Save"
                 @click="save"
+                :modifiers="formModifiers"
               />
             </footer>
           </form>
@@ -85,6 +87,7 @@ export default {
       value: {
         data: {}
       },
+      formModifiers: [ 'small' ],
       schema: [
         {
           name: 'href',
@@ -185,7 +188,7 @@ export default {
     pointer-events: none;
   }
 
-  .apos-link-control__dialog.is-triggered.has-selection.is-ready {
+  .apos-link-control__dialog.is-triggered.has-selection {
     opacity: 1;
     pointer-events: auto;
   }

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSelect.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSelect.vue
@@ -1,7 +1,9 @@
 <template>
   <AposInputWrapper
-    :field="field" :error="error"
+    :field="field"
+    :error="error"
     :uid="uid"
+    :modifiers="modifiers"
   >
     <template #body>
       <div class="apos-input-wrapper">

--- a/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
@@ -101,7 +101,7 @@ export default {
       }
 
       if (this.iconOnly) {
-        modifiers.push('apos-button--icon');
+        modifiers.push('apos-button--icon-only');
       }
 
       if (this.state && this.state.length) {
@@ -422,7 +422,7 @@ export default {
   }
 }
 
-.apos-button--icon {
+.apos-button--icon-only {
   padding: 10px;
   .apos-button__icon {
     margin-right: 0;
@@ -448,6 +448,9 @@ export default {
   display: inline-flex;
   margin-right: 5px;
   align-items: center;
+}
+
+.apos-button:not(.apos-button--icon-only) .apos-button__icon {
   max-height: 13px;
 }
 

--- a/modules/@apostrophecms/ui/ui/apos/scss/mixins/_zindex.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/mixins/_zindex.scss
@@ -4,6 +4,7 @@ $z-index-default: 1;
 $z-index-model-popup: 1;
 $z-index-manager-display: 2;
 $z-index-manager-toolbar: 3;
+$z-index-admin-bar: 3;
 $z-index-modal-bg: 1000;
 $z-index-modal-inner: 1001;
 $z-index-notifications: 1003;


### PR DESCRIPTION
various quality of life improvements
- admin bar now remains on top of focused area editors (z-index)
- empty Add Content buttons no longer weird wide
- FF and Safari link dialog now works for rich text
- admin bar + button now round
- more explicit icon-only button modifier class
- aposinputselect now applies modifiers
- begin removing extra theme classes to child apps
- make link dialog small inputs