### PR TITLE
3/replace img

### DIFF
--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -294,7 +294,7 @@ module.exports = {
         if (correctedExtensions) {
           let message = req.__('File type was not accepted.');
           if (correctedExtensions.length) {
-            message += ` ${req.__('Acceptable extensions:')} ${correctedExtensions.join(', ')}`;
+            message += ` ${req.__('Allowed extensions:')} ${correctedExtensions.join(', ')}`;
           }
           throw self.apos.error('invalid', message);
         }

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -35,7 +35,7 @@
             @click="allowReplace = true"
           />
         </li>
-        <li class="apos-media-editor__link" v-if="activeMedia.attachment._urls">
+        <li class="apos-media-editor__link" v-if="activeMedia.attachment && activeMedia.attachment._urls">
           <AposButton
             type="quiet" label="View"
             @click="viewMedia"

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -35,7 +35,7 @@
             @click="allowReplace = true"
           />
         </li>
-        <li class="apos-media-editor__link">
+        <li class="apos-media-editor__link" v-if="activeMedia.attachment._urls">
           <AposButton
             type="quiet" label="View"
             @click="viewMedia"

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -1,22 +1,22 @@
 <template>
-  <div class="apos-media-manager-editor">
-    <div class="apos-media-manager-editor__inner" v-if="activeMedia">
-      <div class="apos-media-manager-editor__thumb-wrapper">
+  <div class="apos-media-editor">
+    <div class="apos-media-editor__inner" v-if="activeMedia">
+      <div class="apos-media-editor__thumb-wrapper">
         <img
           v-if="activeMedia.attachment"
-          class="apos-media-manager-editor__thumb"
+          class="apos-media-editor__thumb"
           :src="activeMedia.attachment._urls['one-third']" :alt="activeMedia.description"
         >
       </div>
-      <ul class="apos-media-manager-editor__details">
-        <li class="apos-media-manager-editor__detail" v-if="createdDate">
+      <ul class="apos-media-editor__details">
+        <li class="apos-media-editor__detail" v-if="createdDate">
           Uploaded: {{ createdDate }}
         </li>
-        <li class="apos-media-manager-editor__detail" v-if="fileSize">
+        <li class="apos-media-editor__detail" v-if="fileSize">
           File Size: {{ fileSize }}
         </li>
         <li
-          class="apos-media-manager-editor__detail"
+          class="apos-media-editor__detail"
           v-if="activeMedia.attachment && activeMedia.attachment.width"
         >
           Dimensions: {{ activeMedia.attachment.width }} 𝗑
@@ -36,15 +36,15 @@
     </div>
     <AposModalLip :refresh="lipKey">
       <div
-        class="apos-media-manager-editor__lip"
+        class="apos-media-editor__lip"
       >
         <AposButton
           @click="cancel"
-          class="apos-media-manager-editor__back" type="outline"
+          class="apos-media-editor__back" type="outline"
           label="Cancel"
         />
         <AposButton
-          @click="save" class="apos-media-manager-editor__save"
+          @click="save" class="apos-media-editor__save"
           :disabled="doc.hasErrors"
           label="Save" type="primary"
         />
@@ -263,13 +263,13 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .apos-media-manager-editor {
+  .apos-media-editor {
     position: relative;
     height: 100%;
     padding: 20px;
   }
 
-  .apos-media-manager-editor__thumb-wrapper {
+  .apos-media-editor__thumb-wrapper {
     display: flex;
     justify-content: center;
     align-items: center;
@@ -277,16 +277,16 @@ export default {
     border: 1px solid var(--a-base-7);
     margin-bottom: 20px;
   }
-  .apos-media-manager-editor__thumb {
+  .apos-media-editor__thumb {
     max-width: 100%;
     max-height: 100%;
   }
 
-  .apos-media-manager-editor /deep/ .apos-field {
+  .apos-media-editor /deep/ .apos-field {
     margin-bottom: 20px;
   }
 
-  .apos-media-manager-editor__details {
+  .apos-media-editor__details {
     @include apos-list-reset();
     color: var(--a-base-4);
     font-size: map-get($font-sizes, default);
@@ -294,11 +294,11 @@ export default {
     margin-bottom: 20px;
   }
 
-  .apos-media-manager-editor__controls {
+  .apos-media-editor__controls {
     margin-bottom: 20px;
   }
 
-  .apos-media-manager-editor__lip {
+  .apos-media-editor__lip {
     display: flex;
     justify-content: space-between;
   }

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaUploader.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaUploader.vue
@@ -105,8 +105,6 @@ export default {
 
       // When complete, refresh the image grid, with the new images at top.
       this.$emit('upload-complete', imageIds);
-
-      // TODO: Else if uploading multiple images, show them as a set of selected images for editing.
     },
     createPlaceholder(file) {
       const img = new Image();

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputAttachment.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputAttachment.vue
@@ -24,7 +24,7 @@
             <template v-else>
               <paperclip-icon :size="14" class="apos-attachment-icon" />
               {{ messages.primary }}&nbsp;
-              <span class="apos-attachment-highlight">
+              <span class="apos-attachment-highlight" v-if="messages.highlighted">
                 {{ messages.highlighted }}
               </span>
             </template>
@@ -157,7 +157,6 @@ export default {
   .apos-attachment-dropzone {
     @include apos-button-reset();
     display: block;
-    width: 100%;
     margin: 10px 0;
     padding: 20px;
     border: 2px dashed var(--a-base-8);
@@ -189,6 +188,7 @@ export default {
 
   .apos-attachment-instructions {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: center;
     pointer-events: none;

--- a/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
@@ -3,7 +3,10 @@
 -->
 <template>
   <div class="apos-schema">
-    <div v-for="field in schema" :key="field.name">
+    <div
+      v-for="field in schema" :key="field.name"
+      :data-apos-field="field.name"
+    >
       <component
         v-show="displayComponent(field.name)"
         v-model="fieldState[field.name]"


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-396, "As a user, I can replace an image in the schema preview," and https://apostrophecms.atlassian.net/browse/A30U-404, "As a user, I can view an image in the schema preview"

To test, jump on into the media library and open an image in the editor. Click "View" to open that image in a new tab to download. Then click "Replace" to view the attachment input. You can clear that, then upload a new file. You can try a non-image and it should be safely rejected with a warning.