### PR TITLE
adding a widget was throwing an error per A30U-583 and leaving the context menu on the page

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
@@ -5,6 +5,7 @@
       v-bind="extendedContextMenuOptions"
       @open="menuOpen"
       @close="menuClose"
+      v-slot="contextMenu"
     >
       <ul class="apos-area-menu__wrapper">
         <li
@@ -58,6 +59,7 @@
                     :tabbable="itemIndex === active"
                     @up="switchItem(`child-${itemIndex}-${childIndex - 1}`, -1)"
                     @down="switchItem(`child-${itemIndex}-${childIndex + 1}`, 1)"
+                    :hideMenu="contextMenu.hide"
                   />
                 </li>
               </ul>
@@ -69,6 +71,7 @@
             :item="item"
             @up="switchItem(`item-${itemIndex - 1}`, -1)"
             @down="switchItem(`item-${itemIndex + 1}`, 1)"
+            :hideMenu="contextMenu.hide"
           />
         </li>
       </ul>
@@ -178,7 +181,7 @@ export default {
     },
     add(name) {
       if (this.widgetIsContextual(name)) {
-        return this.insert({
+        this.insert({
           _id: cuid(),
           type: name,
           ...this.contextualWidgetDefaultData(name)

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaMenuItem.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaMenuItem.vue
@@ -27,6 +27,13 @@ export default {
     tabbable: {
       type: Boolean,
       default: true
+    },
+    hideMenu: {
+      // Usually not preferred in Vue, but in the case of communication
+      // with a slot parent it is the best option:
+      // https://github.com/vuejs/vue/issues/4332
+      type: Function,
+      required: true
     }
   },
   emits: [ 'click', 'up', 'down' ],
@@ -42,8 +49,7 @@ export default {
   methods: {
     click() {
       this.$emit('click');
-      // triggering the `AposContextMenu`'s `hide` method since slots cannot emit events
-      this.$parent.hide();
+      this.hideMenu();
     }
   }
 };

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -27,7 +27,7 @@
           :menu="menu"
           @item-clicked="menuItemClicked"
         >
-          <slot />
+          <slot :hide="hide" />
         </AposContextMenuDialog>
       </template>
     </v-popover>


### PR DESCRIPTION
I know passing a function as a prop is generally not preferred in node but since emitting events from slot to parent is forbidden it is the most frequently cited (and thumbsed-up) solution to this problem, see discussion:

https://github.com/vuejs/vue/issues/4332