### PR TITLE
3/open page

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -45,14 +45,20 @@
       </div>
       <div class="apos-admin-bar__row">
         <AposButton
+          v-if="currentPageId"
           type="default" label="Page Settings"
           icon="cog-icon" class="apos-admin-bar__btn"
-          @click="emitEvent('page-settings')"
+          @click="emitEvent({
+            name: '@apostrophecms/page:editor',
+            props: {
+              docId: currentPageId
+            }
+          })"
         />
         <AposButton
           type="default" label="Page Tree"
           icon="file-tree-icon" class="apos-admin-bar__btn"
-          @click="emitEvent('@apostrophecms/page')"
+          @click="emitEvent('@apostrophecms/page:manager')"
         />
       </div>
     </nav>
@@ -84,6 +90,12 @@ export default {
       // TODO: get the user avatar via an async API call
       // when this.user._id is truthy
       return require('./userData').userAvatar;
+    },
+    currentPageId() {
+      if (apos.page && apos.page.page && apos.page.page._id) {
+        return apos.page.page._id;
+      }
+      return false;
     }
   },
   mounted() {

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -232,6 +232,9 @@ export default {
         apos.bus.$emit('busy', false);
         this.cancel();
       } finally {
+        if (docData.type !== this.docType) {
+          this.docType = docData.type;
+        }
         this.doc.data = docData;
         this.docReady = true;
         this.splitDoc();

--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -328,7 +328,7 @@ module.exports = {
       // Add the logout admin bar item.
 
       addAdminBarItems() {
-        self.apos.adminBar.add(self.__meta.name + '-logout', 'Log Out', null, {
+        self.apos.adminBar.add(`${self.__meta.name}-logout`, 'Log Out', null, {
           last: true
         });
       },

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -85,6 +85,7 @@ module.exports = {
     self.finalizeControls();
     self.addPermissions();
     self.addManagerModal();
+    self.addEditorModal();
     self.enableBrowserData();
     await self.createIndexes();
   },
@@ -1738,8 +1739,15 @@ database.`);
       },
       addManagerModal() {
         self.apos.modal.add(
-          self.__meta.name,
+          `${self.__meta.name}:manager`,
           self.getComponentName('managerModal', 'AposPagesManager'),
+          { moduleName: self.__meta.name }
+        );
+      },
+      addEditorModal() {
+        self.apos.modal.add(
+          `${self.__meta.name}:editor`,
+          self.getComponentName('insertModal', 'AposDocEditor'),
           { moduleName: self.__meta.name }
         );
       },

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -38,7 +38,7 @@
             v-model="checked"
             :options="treeOptions"
             @update="update" @busy="setBusy"
-            @open="openEditor"
+            @edit="openEditor"
           />
         </template>
       </AposModalBody>
@@ -228,8 +228,9 @@ export default {
       // TODO: Trigger a confirmation modal and execute the deletion.
       this.$emit('trash', this.selected);
     },
-    openEditor(page) {
-      console.info('📝 EDIT PAGE', page);
+    openEditor(pageId) {
+      this.editingDocId = pageId;
+      this.editing = true;
     }
   }
 };

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
@@ -19,7 +19,7 @@
       :nested="nested"
       @busy="setBusy"
       @update="update"
-      @open="$emit('open', $event)"
+      @edit="$emit('edit', $event)"
       list-id="root"
       :options="options"
       :tree-id="treeId"
@@ -74,7 +74,7 @@ export default {
       }
     }
   },
-  emits: [ 'busy', 'update', 'change', 'open' ],
+  emits: [ 'busy', 'update', 'change', 'edit' ],
   data() {
     return {
       // Copy the `items` property to mutate with VueDraggable.

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -86,7 +86,7 @@
           }"
           @busy="$emit('busy', $event)"
           @update="$emit('update', $event)"
-          @open="$emit('open', $event)"
+          @edit="$emit('edit', $event)"
           v-model="checkedProxy"
         />
       </li>
@@ -158,9 +158,7 @@ export default {
       required: true
     }
   },
-  // TODO The 'open' event isn't actually currently emitted. Fix during UI
-  // integration.
-  emits: [ 'busy', 'update', 'change', 'open' ],
+  emits: [ 'busy', 'update', 'change', 'edit' ],
   computed: {
     myRows() {
       return this.rows;


### PR DESCRIPTION
Resolves:
- https://apostrophecms.atlassian.net/browse/A30U-132, "As a developer i can edit the settings of an existing page from the page settings button"
- https://apostrophecms.atlassian.net/browse/A30U-137, "As a user I can edit page settings from the reorganize view"

I introduced a way to pass in props directly to `TheAposModals` modals. Also a pattern for a single module to have multiple top level modals. That could be used only in those case or made universal.