### PR TITLE
3/exit confirm

### DIFF
--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -357,6 +357,7 @@ export default {
       // TODO stub
       this.$emit('search', query);
     },
+    // Override the `cancel` method in `AposModalParentMixin`.
     cancel() {
       if (this.editsInProgress && !this.discardConfirmed) {
         // If the modal is a manager with an open editor, close the editor and

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -87,6 +87,7 @@
             :media="editing" :selected="selected"
             :module-labels="moduleLabels"
             @back="updateEditing(null)" @saved="updateMedia"
+            @edited="editsInProgress = $event"
           />
           <AposMediaManagerSelections
             :items="selected"
@@ -95,6 +96,15 @@
           />
         </div>
       </AposModalRail>
+      <portal to="modal-target">
+        <AposModalConfirm
+          v-if="confirmingDiscard"
+          :confirm-content="confirmContent"
+          :callback-name="confirmCallback"
+          @confirm="discardChanges"
+          @safe-close="confirmingDiscard = false"
+        />
+      </portal>
     </template>
   </AposModal>
 </template>
@@ -126,12 +136,21 @@ export default {
         showModal: false
       },
       editing: undefined,
+      editingOnDeck: undefined,
+      editsInProgress: false,
       uploading: false,
       lastSelected: null,
       emptyDisplay: {
         title: 'No Media Found',
         message: 'Uploaded media will appear here',
         emoji: '🖼'
+      },
+      confirmingDiscard: false,
+      discardConfirmed: false,
+      confirmContent: {
+        heading: 'Unsaved Changes',
+        description: 'Do you want to discard changes to the active image?',
+        affirmativeLabel: 'Discard Changes'
       }
     };
   },
@@ -251,7 +270,20 @@ export default {
       this.editing = undefined;
     },
     updateEditing(id) {
-      this.editing = this.items.find(item => item._id === id);
+      if (this.editsInProgress && !this.discardConfirmed) {
+        // If the modal is a manager with an open editor, close the editor and
+        // keep the manager open.
+        this.confirmingDiscard = true;
+        this.confirmCallback = 'updateEditing';
+        this.editingOnDeck = this.items.find(item => item._id === id);
+      } else if (!id && this.editingOnDeck) {
+        this.editing = this.editingOnDeck;
+        this.editingOnDeck = undefined;
+        this.editsInProgress = false;
+      } else {
+        this.editing = this.items.find(item => item._id === id);
+        this.editsInProgress = false;
+      }
     },
 
     // select setters
@@ -324,8 +356,35 @@ export default {
     search(query) {
       // TODO stub
       this.$emit('search', query);
-    }
+    },
+    cancel() {
+      if (this.editsInProgress && !this.discardConfirmed) {
+        // If the modal is a manager with an open editor, close the editor and
+        // keep the manager open.
+        this.confirmingDiscard = true;
+        this.confirmCallback = 'cancel';
+        return;
+      }
+      this.modal.showModal = false;
+    },
+    cancelEditor() {
+      this.editing = undefined;
+      this.editsInProgress = false;
+    },
+    async discardChanges (callbackName) {
+      this.discardConfirmed = true;
 
+      if (callbackName) {
+        this[callbackName]();
+      }
+
+      this.discardConfirmed = false;
+      this.confirmingDiscard = false;
+
+      await apos.notify(`${this.moduleLabels.label} changes discarded`, {
+        dismiss: true
+      });
+    }
   }
 };
 </script>

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -230,15 +230,6 @@ export default {
     border: 1px solid var(--a-base-4);
     color: var(--a-text-primary);
 
-    .apos-modal__inner {
-      // A nested modal should not have additional spacing around the modal.
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      border-width: 0;
-    }
-
     .apos-modal--slide & {
       position: fixed;
       transition: transform 0.15s ease;

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalConfirm.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalConfirm.vue
@@ -99,16 +99,13 @@ export default {
 }
 
 /deep/ .apos-modal__inner {
-  &,
-  .apos-modal__inner .apos-confirm & {
-    top: auto;
-    right: auto;
-    bottom: auto;
-    left: auto;
-    width: 420px;
-    height: auto;
-    text-align: center;
-  }
+  top: auto;
+  right: auto;
+  bottom: auto;
+  left: auto;
+  width: 420px;
+  height: auto;
+  text-align: center;
 }
 
 /deep/ .apos-modal__overlay {

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalConfirm.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalConfirm.vue
@@ -53,6 +53,10 @@ export default {
     confirmContent: {
       type: Object,
       required: true
+    },
+    callbackName: {
+      type: String,
+      default: ''
     }
   },
   emits: [ 'safe-close', 'confirm' ],
@@ -75,7 +79,7 @@ export default {
   methods: {
     confirm() {
       this.modal.showModal = false;
-      this.$emit('confirm');
+      this.$emit('confirm', this.callbackName);
     }
   }
 };
@@ -83,9 +87,7 @@ export default {
 
 <style lang="scss" scoped>
 .apos-confirm {
-  // Repeat modal z-index here since this typically lives inside a modal.
-  // TODO: Remove z-index once using Vue 3 Teleport.
-  z-index: $z-index-modal-bg;
+  z-index: $z-index-modal-inner;
   position: fixed;
   top: 0;
   right: 0;
@@ -110,7 +112,7 @@ export default {
 }
 
 /deep/ .apos-modal__overlay {
-  .apos-modal__inner .apos-confirm & {
+  .apos-modal + .apos-confirm & {
     display: block;
   }
 }


### PR DESCRIPTION
Unifies the media manager/editor confirmation step for pending edits (https://apostrophecms.atlassian.net/browse/A30U-576). The confirmation now belongs to the manager component in all cases, with the editor simply letting the manager know that edits have been made. The manager checks on that before closing the editor, swapping active media in the editor, or closing itself.