### PR TITLE
Slats array editor

### DIFF
--- a/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
@@ -136,6 +136,9 @@ export default {
   },
   async mounted() {
     this.modal.active = true;
+    if (this.next.length) {
+      this.select(this.next[0]._id);
+    }
   },
   methods: {
     select(_id) {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
@@ -32,9 +32,10 @@
           </button>
           <AposSlatList
             class="apos-modal-array-items__items"
-            @update="update"
+            @input="update"
             @select="select"
-            :initial-items="next"
+            :selected="currentId"
+            :value="withLabels(next)"
           />
         </div>
       </AposModalRail>
@@ -47,7 +48,7 @@
               <div class="apos-modal-array-item__pane">
                 <div class="apos-array-item__body">
                   <AposSchema
-                    v-if="currentId !== false"
+                    v-if="currentId"
                     :schema="field.schema"
                     :trigger-validation="triggerValidation"
                     :utility-rail="false"
@@ -90,7 +91,7 @@ export default {
   emits: [ 'input', 'safe-close', 'update' ],
   data() {
     return {
-      currentId: false,
+      currentId: null,
       currentDoc: null,
       modal: {
         active: false,
@@ -134,12 +135,10 @@ export default {
     }
   },
   async mounted() {
-    console.log('sanity check');
     this.modal.active = true;
   },
   methods: {
     select(_id) {
-      console.log(`selecting ${_id}`);
       if (this.currentId === _id) {
         return;
       }
@@ -154,10 +153,13 @@ export default {
       });
     },
     update(items) {
-      this.next = items;
+      // Take care to use the same items in order to avoid
+      // losing too much state inside draggable, otherwise
+      // drags fail
+      this.next = items.map(item => this.next.find(_item => item._id === _item._id));
       if (this.currentId) {
         if (!this.next.find(item => item._id === this.currentId)) {
-          this.currentId = false;
+          this.currentId = null;
           this.currentDoc = null;
         }
       }
@@ -255,6 +257,13 @@ export default {
         }
       }
       return candidate;
+    },
+    withLabels(items) {
+      const result = items.map(item => ({
+        ...item,
+        title: this.label(item)
+      }));
+      return result;
     }
   }
 };

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputAttachment.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputAttachment.vue
@@ -38,8 +38,8 @@
         </label>
         <div v-if="next && next._id" class="apos-attachment-files">
           <AposSlatList
-            :initial-items="[ next ]"
-            @update="updated"
+            :value="next ? [ next ] : []"
+            @input="updated"
           />
         </div>
       </div>
@@ -98,7 +98,7 @@ export default {
   methods: {
     watchNext () {
       this.validateAndEmit();
-      this.disabled = typeof this.next === 'object' && this.next._id;
+      this.disabled = !!this.next;
     },
     updated (items) {
       // NOTE: This is limited to a single item.

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -27,9 +27,9 @@
         <AposSlatList
           class="apos-input-relationship__items"
           v-if="next.length"
-          @update="updateSelected"
+          @input="updateSelected"
           @item-clicked="openRelationshipEditor"
-          :initial-items="next"
+          :value="next"
         />
         <AposSearchList
           :list="searchList"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
@@ -7,7 +7,8 @@
       tabindex="0"
       :class="{
         'is-engaged': engaged,
-        'is-only-child': slatCount === 1
+        'is-only-child': slatCount === 1,
+        'is-selected': selected
       }"
       @keydown.prevent.space="toggleEngage"
       @keydown.prevent.enter="toggleEngage"
@@ -90,9 +91,13 @@ export default {
     removable: {
       type: Boolean,
       default: true
+    },
+    selected: {
+      type: Boolean,
+      default: false
     }
   },
-  emits: [ 'engage', 'disengage', 'move', 'remove', 'item-clicked', 'selected' ],
+  emits: [ 'engage', 'disengage', 'move', 'remove', 'item-clicked', 'select' ],
   data() {
     return {
       more: {
@@ -149,7 +154,7 @@ export default {
       this.$emit('remove', this.item, focusNext);
     },
     click(e) {
-      this.$emit('selected', this.item._id);
+      this.$emit('select', this.item._id);
     }
   }
 };
@@ -196,7 +201,8 @@ export default {
   .apos-slat.is-engaged,
   .apos-slat.is-engaged:focus,
   .apos-slat.sortable-chosen:focus,
-  .apos-slat.is-dragging:focus {
+  .apos-slat.is-dragging:focus,
+  .apos-slat.is-selected {
     background-color: var(--a-primary);
     &,
     /deep/ .apos-button {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
@@ -15,6 +15,7 @@
       @keydown.prevent.arrow-down="move(1)"
       @keydown.prevent.arrow-up="move(-1)"
       @keydown.prevent.backspace="remove(true)"
+      @click="click"
       :aria-pressed="engaged"
       role="listitem"
       :aria-labelledby="parent"
@@ -91,7 +92,7 @@ export default {
       default: true
     }
   },
-  emits: [ 'engage', 'disengage', 'move', 'remove', 'item-clicked' ],
+  emits: [ 'engage', 'disengage', 'move', 'remove', 'item-clicked', 'selected' ],
   data() {
     return {
       more: {
@@ -146,6 +147,9 @@ export default {
     },
     remove(focusNext) {
       this.$emit('remove', this.item, focusNext);
+    },
+    click(e) {
+      this.$emit('selected', this.item._id);
     }
   }
 };

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
@@ -202,7 +202,8 @@ export default {
   .apos-slat.is-engaged:focus,
   .apos-slat.sortable-chosen:focus,
   .apos-slat.is-dragging:focus,
-  .apos-slat.is-selected {
+  .apos-slat.is-selected,
+  .apos-slat.is-selected:focus {
     background-color: var(--a-primary);
     &,
     /deep/ .apos-button {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlatList.stories.js
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlatList.stories.js
@@ -40,5 +40,5 @@ export const slatList = () => ({
       initialItems: items
     };
   },
-  template: '<AposSlatList :initialItems="initialItems" />'
+  template: '<AposSlatList :value="initialItems" />'
 });

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlatList.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlatList.vue
@@ -29,6 +29,7 @@
           @remove="remove"
           @engage="engage"
           @disengage="disengage"
+          @select="select"
           @move="move"
           @item-clicked="$emit('item-clicked', item)"
           :key="item._id"
@@ -76,7 +77,7 @@ export default {
       }
     }
   },
-  emits: [ 'update', 'item-clicked' ],
+  emits: [ 'update', 'item-clicked', 'select' ],
   data() {
     return {
       isDragging: false,
@@ -115,6 +116,7 @@ export default {
     }
   },
   mounted() {
+    console.log('sanity check');
     this.updateMessage();
   },
   methods: {
@@ -123,6 +125,9 @@ export default {
     },
     disengage(id) {
       this.engaged = null;
+    },
+    select(id) {
+      this.$emit('select', id);
     },
     remove(item, focusNext) {
       const itemIndex = this.getIndex(item._id);

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlatList.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlatList.vue
@@ -2,7 +2,7 @@
 <template>
   <div ref="root">
     <div v-if="field.min || field.max" class="apos-slat-limit">
-      <span>{{ items.length }} selected</span>
+      <span>{{ next.length }} selected</span>
       <span v-if="field.min">
         min: {{ field.min }}
       </span>
@@ -15,7 +15,7 @@
       class="apos-slat-list"
       tag="ol"
       role="list"
-      :list="items"
+      :list="next"
       :move="onMove"
       v-bind="dragOptions"
       @start="isDragging=true"
@@ -24,7 +24,7 @@
     >
       <transition-group type="transition" name="apos-flip-list">
         <AposSlat
-          v-for="item in items"
+          v-for="item in next"
           class="apos-slat-list__item"
           @remove="remove"
           @engage="engage"
@@ -34,10 +34,11 @@
           @item-clicked="$emit('item-clicked', item)"
           :key="item._id"
           :item="item"
+          :selected="selected === item._id"
           :class="{'apos-slat-list__item--disabled' : !editable}"
           :engaged="engaged === item._id"
           :parent="listId"
-          :slat-count="items.length"
+          :slat-count="next.length"
           :removable="removable"
         />
       </transition-group>
@@ -58,7 +59,7 @@ export default {
     draggable
   },
   props: {
-    initialItems: {
+    value: {
       type: Array,
       required: true
     },
@@ -70,6 +71,10 @@ export default {
       type: Boolean,
       default: true
     },
+    selected: {
+      type: String,
+      default: null
+    },
     field: {
       type: Object,
       default() {
@@ -77,26 +82,24 @@ export default {
       }
     }
   },
-  emits: [ 'update', 'item-clicked', 'select' ],
+  emits: [ 'update', 'item-clicked', 'select', 'input' ],
   data() {
     return {
       isDragging: false,
       delayedDragging: false,
       engaged: null,
-      message: null
+      message: null,
+      next: this.value.slice()
     };
   },
   computed: {
-    items() {
-      return this.initialItems;
-    },
     listId() {
       return `sortableList-${(Math.floor(Math.random() * Math.floor(10000)))}`;
     },
     dragOptions() {
       return {
         animation: 0,
-        disabled: !this.editable || this.items.length <= 1,
+        disabled: !this.editable || this.next.length <= 1,
         ghostClass: 'is-dragging'
       };
     }
@@ -111,12 +114,28 @@ export default {
         this.delayedDragging = false;
       });
     },
-    items() {
-      this.updateMessage();
+    value() {
+      this.next = this.value.slice();
+    },
+    next(newValue, oldValue) {
+      let equal = true;
+      if (newValue.length === this.value.length) {
+        for (let i = 0; (i < newValue.length); i++) {
+          if ((newValue[i]._id !== this.value[i]._id) || (newValue[i].title !== this.value[i].title)) {
+            equal = false;
+            break;
+          }
+        }
+      } else {
+        equal = false;
+      }
+      if (!equal) {
+        this.updateMessage();
+        this.$emit('input', this.next);
+      }
     }
   },
   mounted() {
-    console.log('sanity check');
     this.updateMessage();
   },
   methods: {
@@ -131,27 +150,26 @@ export default {
     },
     remove(item, focusNext) {
       const itemIndex = this.getIndex(item._id);
-      const items = this.items.filter(i => item._id !== i._id);
-      this.$emit('update', items);
-      if (focusNext && items[itemIndex]) {
-        this.focusElement(items[itemIndex]._id);
-        return;
+      this.next = this.next.filter(i => item._id !== i._id);
+      if (focusNext && this.next[itemIndex]) {
+        this.focusElement(this.next[itemIndex]._id);
+      } else if (focusNext && this.next[itemIndex - 1]) {
+        this.focusElement(this.next[itemIndex - 1]._id);
       }
-      if (focusNext && items[itemIndex - 1]) {
-        this.focusElement(items[itemIndex - 1]._id);
-      }
+      this.$emit('update', this.next);
     },
-    move (id, dir) {
+    move(id, dir) {
       const index = this.getIndex(id);
       const target = dir > 0 ? index + 1 : index - 1;
-      if (this.items[target]) {
-        this.items.splice(target, 0, this.items.splice(index, 1)[0]);
+      if (this.next[target]) {
+        this.next.splice(target, 0, this.next.splice(index, 1)[0]);
         this.focusElement(id);
+        return this.$emit('update', this.next);
       }
     },
     getIndex(id) {
       let i = null;
-      this.items.forEach((item, index) => {
+      this.next.forEach((item, index) => {
         if (item._id === id) {
           i = index;
         }


### PR DESCRIPTION
Acceptance of this PR does not mean the whole ticket is done because I'm waiting on Stu's design to deal with things like the add button better, but accepting the PR soon would be good because it fixes issues for both slats and attachments too (slat related).

Now uses slat list Also, refactored slat list to support selection and removed logic that modified props (not permitted in Vue).

Slat list now supports the v-model pattern, although we are currently choosing to pass in "value" and accept the "input" event directly in the three components that use it (that is also what v-model does).