### PR TITLE
Register icons

### DIFF
--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -125,10 +125,14 @@ module.exports = {
         const field = self.apos.schema.getFieldById(area._fieldId);
         const options = field.options;
         _.each(options.widgets, function (options, name) {
-          choices.push({
-            name: name,
-            label: options.addLabel || (self.widgetManagers[name] && self.widgetManagers[name].label) || '*ERROR*'
-          });
+          const manager = self.widgetManagers[name];
+          if (manager) {
+            choices.push({
+              name: name,
+              icon: manager.options.icon,
+              label: options.addLabel || manager.label || `No label for ${name}`
+            });
+          }
         });
         // Guarantee that `items` at least exists
         area.items = area.items || [];

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -28,72 +28,111 @@ module.exports = {
   },
 
   init(self, options) {
-
     self.restartId = self.apos.util.generateId();
-
-    self.addTask('build', 'Build Apostrophe frontend javascript master import files', async function (apos, argv) {
-      const buildDir = `${apos.rootDir}/apos-build`;
-      const modulesDir = `${buildDir}/modules`;
-      const bundleDir = `${apos.rootDir}/public/apos-frontend`;
-
-      // Don't clutter up with previous builds.
-      await fs.remove(buildDir);
-      await fs.mkdir(buildDir);
-      await fs.mkdir(modulesDir);
-      await fs.remove(bundleDir);
-      await fs.mkdir(bundleDir);
-      await moduleOverrides();
-      buildPublicBundle();
-      await buildAposBundle();
-      merge();
-      if (process.env.APOS_BUNDLE_ANALYZER) {
-        return new Promise((resolve, reject) => {
-          // Intentionally never resolve it, so the task never exits
-          // and the UI stays up
-        });
+    self.iconMap = {
+      ...globalIcons
+    };
+    self.addTask('build', 'Build Apostrophe frontend javascript master import files', self.buildTask);
+  },
+  middleware(self, options) {
+    return {
+      serveStaticAssets: {
+        before: '@apostrophecms/express',
+        middleware: self.apos.express.static(self.apos.rootDir + '/public', self.options.static || {})
       }
+    };
+  },
+  methods(self, options) {
+    return {
+      scriptsHelper(when) {
+        // TODO we still need an asset generation identifier
+        const bundle = (when === 'apos') ? '<script src="/apos-frontend/apos-bundle.js"></script>' : '<script src="/apos-frontend/public-bundle.js"></script>';
+        return self.apos.template.safe(`
+${bundle}
+`);
+      },
+      shouldRefreshOnRestart() {
+        return options.refreshOnRestart && (process.env.NODE_ENV !== 'production');
+      },
+      // Register an icon as a Vue component for use in the Apostrophe admin
+      // interface. This is suitable for use with the `icon` option of the
+      // `@apostrophecms/widget-type` module.
+      //
+      // `registerAs` should be a hyphenated name like `chevron-down-icon`
+      // and will be registered as a Vue component so your frontend logic does not
+      // have to separately import it. `importFrom` should be the name
+      // of a Vue component file, without the `.vue` extension, as found in
+      // the `vue-material-design-icons` npm package, like `ChevronDown`.
+      //
+      // Alternatively, you may import an icon as a Vue component from any npm
+      // module if you precede `importFrom` with a `~`. In the latter case a `.vue`
+      // extension is not automatically added.
+      addIcon(registerAs, importFrom) {
+        self.iconMap[registerAs] = importFrom;
+      },
+      async buildTask(apos, argv) {
+        const buildDir = `${apos.rootDir}/apos-build`;
+        const modulesDir = `${buildDir}/modules`;
+        const bundleDir = `${apos.rootDir}/public/apos-frontend`;
 
-      async function moduleOverrides() {
-        let names = {};
-        const directories = {};
-        for (const name of Object.keys(self.apos.modules)) {
-          const ancestorDirectories = [];
-          for (const entry of self.apos.modules[name].__meta.chain) {
-            const effectiveName = entry.name.replace(/^my-/, '');
-            names[effectiveName] = true;
-            ancestorDirectories.push(entry.dirname);
-            directories[effectiveName] = directories[effectiveName] || [];
-            for (const dir of ancestorDirectories) {
-              if (!directories[effectiveName].includes(dir)) {
-                directories[effectiveName].push(dir);
+        // Don't clutter up with previous builds.
+        await fs.remove(buildDir);
+        await fs.mkdir(buildDir);
+        await fs.mkdir(modulesDir);
+        await fs.remove(bundleDir);
+        await fs.mkdir(bundleDir);
+        await moduleOverrides();
+        buildPublicBundle();
+        await buildAposBundle();
+        merge();
+        if (process.env.APOS_BUNDLE_ANALYZER) {
+          return new Promise((resolve, reject) => {
+            // Intentionally never resolve it, so the task never exits
+            // and the UI stays up
+          });
+        }
+
+        async function moduleOverrides() {
+          let names = {};
+          const directories = {};
+          for (const name of Object.keys(self.apos.modules)) {
+            const ancestorDirectories = [];
+            for (const entry of self.apos.modules[name].__meta.chain) {
+              const effectiveName = entry.name.replace(/^my-/, '');
+              names[effectiveName] = true;
+              ancestorDirectories.push(entry.dirname);
+              directories[effectiveName] = directories[effectiveName] || [];
+              for (const dir of ancestorDirectories) {
+                if (!directories[effectiveName].includes(dir)) {
+                  directories[effectiveName].push(dir);
+                }
+              }
+            }
+          }
+          names = Object.keys(names);
+          for (const name of names) {
+            const moduleDir = `${modulesDir}/${name}`;
+            for (const dir of directories[name]) {
+              const srcDir = `${dir}/ui/apos`;
+              if (fs.existsSync(srcDir)) {
+                await fs.copy(srcDir, moduleDir);
               }
             }
           }
         }
-        names = Object.keys(names);
-        for (const name of names) {
-          const moduleDir = `${modulesDir}/${name}`;
-          for (const dir of directories[name]) {
-            const srcDir = `${dir}/ui/apos`;
-            if (fs.existsSync(srcDir)) {
-              await fs.copy(srcDir, moduleDir);
-            }
-          }
-        }
-      }
 
-      function buildPublicBundle() {
-        // We do not use an import file here because import is not
-        // an ES5 feature and it is contrary to the spirit of ES5 code
-        // to force-fit that type of code. We do not mandate ES6 in
-        // "public" code (loaded for logged-out users who might have
-        // old browsers).
-        //
-        // Of course, developers can push an "public" asset that is
-        // the output of an ES6 pipeline.
-        const publicImports = getImports('public', '*.js', { });
-        fs.writeFileSync(`${apos.rootDir}/public/apos-frontend/public-bundle.js`,
-          `
+        function buildPublicBundle() {
+          // We do not use an import file here because import is not
+          // an ES5 feature and it is contrary to the spirit of ES5 code
+          // to force-fit that type of code. We do not mandate ES6 in
+          // "public" code (loaded for logged-out users who might have
+          // old browsers).
+          //
+          // Of course, developers can push an "public" asset that is
+          // the output of an ES6 pipeline.
+          const publicImports = getImports('public', '*.js', { });
+          fs.writeFileSync(`${apos.rootDir}/public/apos-frontend/public-bundle.js`,
+            `
 (function() {
   window.apos = window.apos || {};
   var data = document.body && document.body.getAttribute('data-apos');
@@ -102,20 +141,20 @@ module.exports = {
     document.body.removeAttribute('data-apos');
   }
 })();
-` +
-        publicImports.paths.map(path => {
-          return fs.readFileSync(path);
-        }).join('\n')); // TODO: use webpack just to minify at the end.
-      }
+  ` +
+          publicImports.paths.map(path => {
+            return fs.readFileSync(path);
+          }).join('\n')); // TODO: use webpack just to minify at the end.
+        }
 
-      async function buildAposBundle() {
-        const iconImports = getIcons();
-        const componentImports = getImports('apos/components', '*.vue', { registerComponents: true });
-        const tiptapExtensionImports = getImports('apos/tiptap-extensions', '*.js', { registerTiptapExtensions: true });
-        const appImports = getImports('apos/apps', '*.js', { invokeApps: true });
-        const importFile = `${buildDir}/import.js`;
+        async function buildAposBundle() {
+          const iconImports = getIcons();
+          const componentImports = getImports('apos/components', '*.vue', { registerComponents: true });
+          const tiptapExtensionImports = getImports('apos/tiptap-extensions', '*.js', { registerTiptapExtensions: true });
+          const appImports = getImports('apos/apps', '*.js', { invokeApps: true });
+          const importFile = `${buildDir}/import.js`;
 
-        fs.writeFileSync(importFile, `
+          fs.writeFileSync(importFile, `
 import 'Modules/@apostrophecms/ui/scss/global/import-all.scss';
 import Vue from 'apostrophe/vue';
 if (window.apos.modules) {
@@ -137,113 +176,94 @@ ${tiptapExtensionImports.registerCode}
 setImmediate(() => {
 ${appImports.invokeCode}
 });
-        `);
+          `);
 
-        fs.writeFileSync(`${buildDir}/imports.json`, JSON.stringify({
-          icons: iconImports,
-          components: componentImports,
-          tiptapExtensions: tiptapExtensionImports,
-          apps: appImports
-        }));
+          fs.writeFileSync(`${buildDir}/imports.json`, JSON.stringify({
+            icons: iconImports,
+            components: componentImports,
+            tiptapExtensions: tiptapExtensionImports,
+            apps: appImports
+          }));
 
-        await Promise.promisify(webpack)(require('./lib/webpack.config')(
-          {
-            importFile,
-            modulesDir
-          },
-          apos
-        ));
-      }
-
-      function getIcons() {
-        // Load global vue icon components.
-        const output = {
-          importCode: '',
-          registerCode: ''
-        };
-
-        if (globalIcons) {
-          for (const icon in globalIcons) {
-            output.importCode += `import ${globalIcons[icon]}Icon from 'vue-material-design-icons/${globalIcons[icon]}.vue';\n`;
-
-            output.registerCode += `Vue.component('${icon}', ${globalIcons[icon]}Icon);\n`;
-          }
+          await Promise.promisify(webpack)(require('./lib/webpack.config')(
+            {
+              importFile,
+              modulesDir
+            },
+            apos
+          ));
         }
 
-        return output;
-      }
+        function getIcons() {
+          // Load global vue icon components.
+          const output = {
+            importCode: '',
+            registerCode: ''
+          };
 
-      function merge() {
-        fs.writeFileSync(`${apos.rootDir}/public/apos-frontend/apos-bundle.js`, fs.readFileSync(`${apos.rootDir}/public/apos-frontend/public-bundle.js`) + fs.readFileSync(`${apos.rootDir}/public/apos-frontend/apos-only-bundle.js`));
-      }
-
-      function getImports(folder, pattern, options) {
-        let components = [];
-        const seen = {};
-        _.each(self.apos.modules, function (module, name) {
-          _.each(module.__meta.chain, function (entry) {
-            if (seen[entry.dirname]) {
-              return;
+          for (const [ registerAs, importFrom ] of Object.entries(self.iconMap)) {
+            if (importFrom.substring(0, 1) === '~') {
+              output.importCode += `import ${importFrom}Icon from '${importFrom.substring(1)}';\n`;
+            } else {
+              output.importCode += `import ${importFrom}Icon from 'vue-material-design-icons/${importFrom}.vue';\n`;
             }
-            components = components.concat(glob.sync(`${entry.dirname}/ui/${folder}/${pattern}`));
-            seen[entry.dirname] = true;
-          });
-        });
-        const output = {
-          importCode: '',
-          registerCode: '',
-          invokeCode: '',
-          paths: []
-        };
-
-        components.forEach(component => {
-          const jsFilename = JSON.stringify(component);
-          const name = require('path').basename(component).replace(/\.\w+/, '');
-          const jsName = JSON.stringify(name);
-          output.paths.push(component);
-          const importCode = `
-          import ${name} from ${jsFilename};
-          `;
-          output.importCode += `${importCode}\n`;
-
-          if (options.registerComponents) {
-            output.registerCode += `Vue.component(${jsName}, ${name});\n`;
+            output.registerCode += `Vue.component('${registerAs}', ${importFrom}Icon);\n`;
           }
 
-          if (options.registerTiptapExtensions) {
-            output.registerCode += `
+          return output;
+        }
+
+        function merge() {
+          fs.writeFileSync(`${apos.rootDir}/public/apos-frontend/apos-bundle.js`, fs.readFileSync(`${apos.rootDir}/public/apos-frontend/public-bundle.js`) + fs.readFileSync(`${apos.rootDir}/public/apos-frontend/apos-only-bundle.js`));
+        }
+
+        function getImports(folder, pattern, options) {
+          let components = [];
+          const seen = {};
+          _.each(self.apos.modules, function (module, name) {
+            _.each(module.__meta.chain, function (entry) {
+              if (seen[entry.dirname]) {
+                return;
+              }
+              components = components.concat(glob.sync(`${entry.dirname}/ui/${folder}/${pattern}`));
+              seen[entry.dirname] = true;
+            });
+          });
+          const output = {
+            importCode: '',
+            registerCode: '',
+            invokeCode: '',
+            paths: []
+          };
+
+          components.forEach(component => {
+            const jsFilename = JSON.stringify(component);
+            const name = require('path').basename(component).replace(/\.\w+/, '');
+            const jsName = JSON.stringify(name);
+            output.paths.push(component);
+            const importCode = `
+            import ${name} from ${jsFilename};
+            `;
+            output.importCode += `${importCode}\n`;
+
+            if (options.registerComponents) {
+              output.registerCode += `Vue.component(${jsName}, ${name});\n`;
+            }
+
+            if (options.registerTiptapExtensions) {
+              output.registerCode += `
 apos.tiptapExtensions = apos.tiptapExtensions || [];
 apos.tiptapExtensions.push(${name});
-`;
-          }
-          if (options.invokeApps) {
-            output.invokeCode += `${name}();\n`;
-          }
-        });
-        return output;
+  `;
+            }
+            if (options.invokeApps) {
+              output.invokeCode += `${name}();\n`;
+            }
+          });
+          return output;
+        }
       }
-    });
-  },
-  middleware(self, options) {
-    return {
-      serveStaticAssets: {
-        before: '@apostrophecms/express',
-        middleware: self.apos.express.static(self.apos.rootDir + '/public', self.options.static || {})
-      }
-    };
-  },
-  methods(self, options) {
-    return {
-      scriptsHelper(when) {
-        // TODO we still need an asset generation identifier
-        const bundle = (when === 'apos') ? '<script src="/apos-frontend/apos-bundle.js"></script>' : '<script src="/apos-frontend/public-bundle.js"></script>';
-        return self.apos.template.safe(`
-${bundle}
-`);
-      },
-      shouldRefreshOnRestart() {
-        return options.refreshOnRestart && (process.env.NODE_ENV !== 'production');
-      }
+
     };
   },
   helpers(self, options) {

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -8,6 +8,7 @@ const jsDiff = require('diff');
 module.exports = {
   extend: '@apostrophecms/widget-type',
   options: {
+    icon: 'format-text-icon',
     label: 'Rich Text',
     contextual: true,
     defaultData: { content: '' },
@@ -124,6 +125,9 @@ module.exports = {
       ...options.minimumDefaultOptions,
       ...options.defaultOptions
     };
+  },
+  init(self, optins) {
+    self.apos.asset.addIcon('format-text-icon', 'FormatText');
   },
   methods(self, options) {
     return {


### PR DESCRIPTION
I added the ability to register material design icons from any module. I also thew in the ability to register an icon to be imported from somewhere else, by starting the `importFrom` argument with a `~`, for symmetry with the way you escape the normal import rules and get to "real" webpack imports in SASS.

This PR includes an example: the rich text widget now registers an appropriate icon.

I have verified that the icon appears in the "add widget" dropdown (plumbing for this mostly existed already but needed a little lashing-together).