### PR TITLE
Removes the transition for the sake of nesting

### DIFF
--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -310,9 +310,6 @@ export default {
     &.is-dragging {
       opacity: 0.5;
     }
-    &.apos-flip-list-move {
-      transition: transform 0.4s;
-    }
   }
   .apos-tree__list {
     transition: max-height 0.3s ease;

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -7,90 +7,86 @@
     @start="startDrag"
     @end="endDrag"
   >
-    <transition-group name="apos-flip-list">
-      <li
-        v-for="row in myRows" :key="row._id"
-        :data-row-id="row._id" data-apos-tree-row
-        :class="getRowClasses(row)"
-        :aria-role="options.selectable ? 'button' : null"
-        :tabindex="options.selectable ? 0 : null"
-        v-on="options.selectable ? {
-          'click': selectRow,
-          'keydown': keydownRow
-        } : {}"
-      >
-        <div class="apos-tree__row-data">
-          <!-- {{ options.startCollapsed }} -->
-          <button
-            v-if="row.children && row.children.length > 0"
-            class="apos-tree__row__toggle" data-apos-tree-toggle
-            aria-label="Toggle section" :aria-expanded="!options.startCollapsed"
-            @click="toggleSection($event)"
-          >
-            <chevron-down-icon :size="16" class="apos-tree__row__toggle-icon" />
-          </button>
+    <li
+      v-for="row in myRows" :key="row._id"
+      :data-row-id="row._id" data-apos-tree-row
+      :class="getRowClasses(row)"
+      :aria-role="options.selectable ? 'button' : null"
+      :tabindex="options.selectable ? 0 : null"
+      v-on="options.selectable ? {
+        'click': selectRow,
+        'keydown': keydownRow
+      } : {}"
+    >
+      <div class="apos-tree__row-data">
+        <button
+          v-if="row.children && row.children.length > 0"
+          class="apos-tree__row__toggle" data-apos-tree-toggle
+          aria-label="Toggle section" :aria-expanded="!options.startCollapsed"
+          @click="toggleSection($event)"
+        >
+          <chevron-down-icon :size="16" class="apos-tree__row__toggle-icon" />
+        </button>
+        <component
+          v-for="(col, index) in headers"
+          :key="`${col.name}-${index}`"
+          :is="col.type === 'link' ? 'a' : col.type === 'button' ? 'button' : 'span'"
+          :href="col.type === 'link' ? row[col.name] : false"
+          :target="col.type === 'link' ? '_blank' : false"
+          :class="getCellClasses(col, row)"
+          :data-col="col.name"
+          :style="getCellStyles(col.name, index)"
+          @click="col.action ? $emit(col.action, row._id) : null"
+        >
+          <drag-icon
+            v-if="options.draggable && index === 0" class="apos-tree__row__handle"
+            :size="20"
+            :fill-color="null"
+          />
+          <AposCheckbox
+            v-if="options.bulkSelect && index === 0"
+            class="apos-tree__row__checkbox"
+            tabindex="-1"
+            :field="{
+              name: row._id,
+              hideLabel: true,
+              label: `Toggle selection of ${row.title}`,
+              disableFocus: true
+            }"
+            :choice="{ value: row._id }"
+            v-model="checkedProxy"
+          />
           <component
-            v-for="(col, index) in headers"
-            :key="`${col.name}-${index}`"
-            :is="col.type === 'link' ? 'a' : col.type === 'button' ? 'button' : 'span'"
-            :href="col.type === 'link' ? row[col.name] : false"
-            :target="col.type === 'link' ? '_blank' : false"
-            :class="getCellClasses(col, row)"
-            :data-col="col.name"
-            :style="getCellStyles(col.name, index)"
-            @click="col.action ? $emit(col.action, row._id) : null"
-          >
-            <drag-icon
-              v-if="options.draggable && index === 0" class="apos-tree__row__handle"
-              :size="20"
-              :fill-color="null"
-            />
-            <AposCheckbox
-              v-if="options.bulkSelect && index === 0"
-              class="apos-tree__row__checkbox"
-              tabindex="-1"
-              :field="{
-                name: row._id,
-                hideLabel: true,
-                label: `Toggle selection of ${row.title}`,
-                disableFocus: true
-              }"
-              :choice="{ value: row._id }"
-              v-model="checkedProxy"
-            />
-            <component
-              v-if="col.icon" :is="icons[col.icon]"
-              class="apos-tree__cell__icon"
-            />
-            <span v-show="!col.iconOnly">
-              {{ row[col.name] }}
-            </span>
-          </component>
-        </div>
-        <AposTreeRows
-          v-if="row.children"
-          data-apos-branch-height
-          ref="tree-branches"
-          :rows="row.children"
-          :headers="headers"
-          :icons="icons"
-          :col-widths="colWidths"
-          :level="level + 1"
-          :nested="nested"
-          :list-id="row._id"
-          :tree-id="treeId"
-          :options="options"
-          :class="{ 'is-collapsed': options.startCollapsed }"
-          :style="{
-            'max-height': options.startCollapsed ? '0' : null
-          }"
-          @busy="$emit('busy', $event)"
-          @update="$emit('update', $event)"
-          @edit="$emit('edit', $event)"
-          v-model="checkedProxy"
-        />
-      </li>
-    </transition-group>
+            v-if="col.icon" :is="icons[col.icon]"
+            class="apos-tree__cell__icon"
+          />
+          <span v-show="!col.iconOnly">
+            {{ row[col.name] }}
+          </span>
+        </component>
+      </div>
+      <AposTreeRows
+        data-apos-branch-height
+        ref="tree-branches"
+        :rows="row.children"
+        :headers="headers"
+        :icons="icons"
+        :col-widths="colWidths"
+        :level="level + 1"
+        :nested="nested"
+        :list-id="row._id"
+        :tree-id="treeId"
+        :options="options"
+        :class="{ 'is-collapsed': options.startCollapsed }"
+        :style="{
+          'max-height': options.startCollapsed ? '0' : null
+        }"
+        @busy="$emit('busy', $event)"
+        @update="$emit('update', $event)"
+        @edit="$emit('edit', $event)"
+        v-model="checkedProxy"
+      />
+    </li>
   </VueDraggable>
 </template>
 


### PR DESCRIPTION
Needs the designer blessing.

Our transition group put a `span` in between the draggable component and the target list. This looks to have got in the way when the list was empty. No one is happy, the sign if a good compromise.