### PR TITLE
3/update tree

### DIFF
--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -1005,10 +1005,9 @@ database.`);
       async getTargetIdAndPosition(req, pageId, targetId, position) {
         targetId = self.apos.launder.id(targetId);
 
-        const validPositions = [ 'firstChild', 'lastChild', 'before', 'after' ];
         position = self.apos.launder.string(position);
 
-        if (validPositions.includes(position) || isNaN(parseInt(position))) {
+        if (isNaN(parseInt(position))) {
           // Return an already-valid position or a potentially invalid, but
           // non-numeric position to be evaluated in `self.move`.
           return {

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -160,7 +160,10 @@ module.exports = {
             _.each(nodes, function(node) {
               node._children = prune(node._children || []);
               if (node.good) {
-                newNodes.push(_.pick(node, 'title', 'slug', '_id', 'type', 'metaType', '_url', '_children', 'published'));
+                newNodes.push(_.pick(node,
+                  'title', 'slug', 'path', '_id', 'type', 'metaType', '_url',
+                  '_children', 'published', 'parked'
+                ));
               }
             });
             return newNodes;
@@ -897,6 +900,10 @@ database.`);
               } else {
                 rank = 0;
               }
+            } else if (!isNaN(parseInt(position))) {
+              parent = target;
+              rank = parseInt(position);
+              return;
             } else {
               throw new Error('no such position option');
             }

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -214,8 +214,13 @@ module.exports = {
       // This call is atomic with respect to other REST write operations on pages.
       async post(req) {
         self.publicApiCheck(req);
-        const targetId = self.apos.launder.id(req.body._targetId);
-        const position = self.apos.launder.string(req.body._position) || 'lastChild';
+        req.body._position = req.body._position || 'lastChild';
+
+        const {
+          targetId,
+          position
+        } = await self.getTargetIdAndPosition(req, null, req.body._targetId, req.body._position);
+
         const copyingId = self.apos.launder.id(req.body._copyingId);
         const input = _.omit(req.body, '_targetId', '_position', '_copyingId');
         if (typeof (input) !== 'object') {
@@ -505,7 +510,7 @@ database.`);
           }
           let parent;
           if ((position === 'before') || (position === 'after')) {
-            parent = await self.findOneForEditing(req, {
+            parent = await self.findForEditing(req, {
               path: self.getParentPath(target)
             }).children({
               depth: 1,

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -1007,7 +1007,7 @@ database.`);
 
         position = self.apos.launder.string(position);
 
-        if (isNaN(parseInt(position))) {
+        if (isNaN(parseInt(position)) || parseInt(position) < 0) {
           // Return an already-valid position or a potentially invalid, but
           // non-numeric position to be evaluated in `self.move`.
           return {
@@ -1031,16 +1031,19 @@ database.`);
           position = 'firstChild';
         } else if (childIndex > -1 && position >= (target._children.length - 1)) {
           position = 'lastChild';
+        } else if (childIndex === -1 && position >= (target._children.length)) {
+          position = 'lastChild';
+        } else if (childIndex === position) {
+          // If they're trying to put a page in the position it already has,
+          // allow them to proceed nonetheless.
+          targetId = target._children[position - 1]._id;
+          position = 'after';
+        } else if (childIndex > -1 && childIndex < position) {
+          targetId = target._children[position]._id;
+          position = 'after';
         } else {
-          if (childIndex === -1 && position >= (target._children.length)) {
-            position = 'lastChild';
-          } else if (childIndex > -1 && childIndex < position) {
-            targetId = target._children[position]._id;
-            position = 'after';
-          } else {
-            targetId = target._children[position]._id;
-            position = 'before';
-          }
+          targetId = target._children[position]._id;
+          position = 'before';
         }
 
         return {

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -444,12 +444,10 @@ database.`);
           await self.update(req, page);
 
           if (input._targetId) {
-            console.info('🧧', input._targetId, input._position);
             const {
               targetId,
               position
             } = await self.getTargetIdAndPosition(req, page._id, input._targetId, input._position);
-            console.info('💺', targetId, position);
 
             await self.move(req, page._id, targetId, position);
           }
@@ -1029,7 +1027,7 @@ database.`);
         const childIndex = target._children.findIndex(child => {
           return child._id === pageId;
         });
-        console.info('📗 STARTING>>>', childIndex);
+
         if (position === 0 || target._children.length === 0) {
           position = 'firstChild';
         } else if (childIndex > -1 && position >= (target._children.length - 1)) {
@@ -1046,7 +1044,6 @@ database.`);
           }
         }
 
-        console.info('GOT IT');
         return {
           targetId,
           position

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -131,6 +131,7 @@ export default {
           data[column.name] = page[column.name];
           data._id = page._id;
           data.children = page.children;
+          data.parked = page.parked;
         });
         items.push(data);
       });

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -114,7 +114,7 @@ export default {
   },
   computed: {
     moduleOptions() {
-      return window.apos.modules[this.moduleName];
+      return apos.page;
     },
     items() {
       const items = [];
@@ -178,7 +178,9 @@ export default {
         page.published = page.published ? 'Published' : 'Unpublished';
         self.pagesFlat.push({
           title: page.title,
-          id: page._id
+          id: page._id,
+          path: page.path,
+          parked: page.parked
         });
 
         page.children = page._children;
@@ -196,9 +198,23 @@ export default {
       this.editing = false;
       this.editingDocId = '';
     },
-    update(obj) {
-      // We'll hit a route here to update the docs.
-      console.info('CHANGED ROW:', obj);
+    async update(page) {
+      const body = {
+        _targetId: page.endContext,
+        _position: page.endIndex
+      };
+
+      const route = `${this.moduleOptions.action}/${page.changedId}`;
+      try {
+        await apos.http.patch(route, {
+          busy: true,
+          body
+        });
+      } catch (error) {
+        console.error('Page tree update error:', error);
+      }
+
+      await this.getPages();
     },
     setBusy(val) {
       apos.bus.$emit('busy', val);

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
@@ -33,7 +33,7 @@ import cuid from 'cuid';
 
 export default {
   name: 'AposTree',
-    model: {
+  model: {
     prop: 'checked',
     event: 'change'
   },
@@ -184,11 +184,11 @@ export default {
         // The ID of the item that moved.
         changedId: event.item.dataset.rowId,
         // The ID of the original parent, or 'root' if top-level.
-        startContext: event.from.dataset.listId,
+        startContext: event.from.dataset.listRow,
         // The index of the moved item within its original context.
         startIndex: event.oldIndex,
         // The ID of the new parent, or 'root' if top-level.
-        endContext: event.to.dataset.listId,
+        endContext: event.to.dataset.listRow,
         // The index of the moved item within its new context.
         endIndex: event.newIndex
       });

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -38,8 +38,10 @@
           :style="getCellStyles(col.name, index)"
           @click="col.action ? $emit(col.action, row._id) : null"
         >
+          <!-- TODO: Make this v-if cleaner -->
           <drag-icon
-            v-if="options.draggable && index === 0 && !row.parked" class="apos-tree__row__handle"
+            v-if="options.draggable && index === 0 && !row.parked && row._url !== '/'"
+            class="apos-tree__row__handle"
             :size="20"
             :fill-color="null"
           />
@@ -261,7 +263,7 @@ export default {
       return [
         'apos-tree__row',
         {
-          'is-parked': !!row.parked,
+          'is-parked': !!row.parked || row._url === '/',
           'apos-tree__row--parent': row.children && row.children.length > 0,
           'apos-tree__row--selectable': this.options.selectable,
           'apos-tree__row--selected': this.options.selectable && this.checked[0] === row._id

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -38,9 +38,8 @@
           :style="getCellStyles(col.name, index)"
           @click="col.action ? $emit(col.action, row._id) : null"
         >
-          <!-- TODO: Make this v-if cleaner -->
           <drag-icon
-            v-if="options.draggable && index === 0 && !row.parked && row._url !== '/'"
+            v-if="options.draggable && index === 0 && !row.parked"
             class="apos-tree__row__handle"
             :size="20"
             :fill-color="null"
@@ -263,7 +262,7 @@ export default {
       return [
         'apos-tree__row',
         {
-          'is-parked': !!row.parked || row._url === '/',
+          'is-parked': !!row.parked,
           'apos-tree__row--parent': row.children && row.children.length > 0,
           'apos-tree__row--selectable': this.options.selectable,
           'apos-tree__row--selected': this.options.selectable && this.checked[0] === row._id

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -39,7 +39,7 @@
           @click="col.action ? $emit(col.action, row._id) : null"
         >
           <drag-icon
-            v-if="options.draggable && index === 0" class="apos-tree__row__handle"
+            v-if="options.draggable && index === 0 && !row.parked" class="apos-tree__row__handle"
             :size="20"
             :fill-color="null"
           />
@@ -67,6 +67,7 @@
       </div>
       <AposTreeRows
         data-apos-branch-height
+        :data-list-row="row._id"
         ref="tree-branches"
         :rows="row.children"
         :headers="headers"
@@ -177,7 +178,8 @@ export default {
         dataListId: this.listId,
         disabled: !this.options.draggable,
         handle: '.apos-tree__row__handle',
-        ghostClass: 'is-dragging'
+        ghostClass: 'is-dragging',
+        filter: '.is-parked'
       };
     }
   },
@@ -259,6 +261,7 @@ export default {
       return [
         'apos-tree__row',
         {
+          'is-parked': !!row.parked,
           'apos-tree__row--parent': row.children && row.children.length > 0,
           'apos-tree__row--selectable': this.options.selectable,
           'apos-tree__row--selected': this.options.selectable && this.checked[0] === row._id

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -243,7 +243,7 @@ export default {
         return;
       }
 
-      const row = event.target.closest('[data-row-id]');
+      const row = event.target.closest('[data-apos-tree-row]');
       this.$emit('change', [ row.dataset.rowId ]);
 
       // Expand a row when the full parent row is selected.

--- a/test/pages-rest.js
+++ b/test/pages-rest.js
@@ -402,7 +402,45 @@ describe('Pages REST', function() {
     // Is the rank correct?
     assert(page.rank > sibling.rank);
   });
+
+  it('allows positioning a page at its existing location (lastChild) using numerical position', async function() {
+    const page = await apos.http.patch('/api/v1/@apostrophecms/page/neighbor', {
+      body: {
+        _targetId: 'parent',
+        _position: 4
+      },
+      jar
+    });
+
+    // `sibling` was previously the last child of `parent`.
+    const sibling = await apos.http.get('/api/v1/@apostrophecms/page/sibling', { jar });
+
+    // Is the new path correct?
+    assert.strictEqual(page.path, `${homeId}/parent/neighbor`);
+    // Is the rank correct?
+    assert(page.rank > sibling.rank);
+  });
   it('is able to move root/parent/child/grandchild to the next-to-last position under `parent`', async function() {
+    const page = await apos.http.patch('/api/v1/@apostrophecms/page/grandchild', {
+      body: {
+        _targetId: 'parent',
+        _position: 4
+      },
+      jar
+    });
+
+    // `sibling` was previously the next-to-last child of `parent`.
+    const sibling = await apos.http.get('/api/v1/@apostrophecms/page/sibling', { jar });
+    const neighbor = await apos.http.get('/api/v1/@apostrophecms/page/neighbor', { jar });
+
+    // Is the new path correct?
+    assert.strictEqual(page.path, `${homeId}/parent/grandchild`);
+    // Is the rank correct?
+    assert(page.rank > sibling.rank);
+    assert(page.rank < neighbor.rank);
+  });
+
+  it('allows positioning a page at its existing location (4 of 5) using numerical position', async function() {
     const page = await apos.http.patch('/api/v1/@apostrophecms/page/grandchild', {
       body: {
         _targetId: 'parent',

--- a/test/pages-rest.js
+++ b/test/pages-rest.js
@@ -385,12 +385,7 @@ describe('Pages REST', function() {
     assert(page.rank < sibling.rank);
   });
 
-  async function logKids() {
-    const page = await apos.http.get('/api/v1/@apostrophecms/page/parent', { jar });
-    console.info(page._children.map(c => c._id));
-  }
   it('is able to move root/neighbor as the last child of /root/parent using numerical position', async function() {
-    console.info('🚸');
     const page = await apos.http.patch('/api/v1/@apostrophecms/page/neighbor', {
       body: {
         _targetId: 'parent',
@@ -401,7 +396,6 @@ describe('Pages REST', function() {
 
     // `sibling` was previously the last child of `parent`.
     const sibling = await apos.http.get('/api/v1/@apostrophecms/page/sibling', { jar });
-    await logKids(); // TEMP
 
     // Is the new path correct?
     assert.strictEqual(page.path, `${homeId}/parent/neighbor`);
@@ -409,7 +403,6 @@ describe('Pages REST', function() {
     assert(page.rank > sibling.rank);
   });
   it('is able to move root/parent/child/grandchild to the next-to-last position under `parent`', async function() {
-    console.info('🚸');
     const page = await apos.http.patch('/api/v1/@apostrophecms/page/grandchild', {
       body: {
         _targetId: 'parent',
@@ -421,8 +414,6 @@ describe('Pages REST', function() {
     // `sibling` was previously the next-to-last child of `parent`.
     const sibling = await apos.http.get('/api/v1/@apostrophecms/page/sibling', { jar });
     const neighbor = await apos.http.get('/api/v1/@apostrophecms/page/neighbor', { jar });
-
-    await logKids(); // TEMP
 
     // Is the new path correct?
     assert.strictEqual(page.path, `${homeId}/parent/grandchild`);

--- a/test/pages-rest.js
+++ b/test/pages-rest.js
@@ -217,6 +217,29 @@ describe('Pages REST', function() {
     assert.strictEqual(page.level, 1);
   });
 
+  it('is able to make a subpage of the homepage at index `1` with numerical _position', async function() {
+    const body = {
+      slug: '/second-new',
+      published: true,
+      type: 'test-page',
+      title: 'Second New',
+      _targetId: '_home',
+      _position: '1'
+    };
+
+    const page = await apos.http.post('/api/v1/@apostrophecms/page', {
+      body,
+      jar
+    });
+
+    assert(page);
+    assert(page.title === 'Second New');
+    // Is the path generally correct?
+    assert.strictEqual(page.path, `${homeId}/${page._id}`);
+    assert.strictEqual(page.level, 1);
+    assert.strictEqual(page.rank, 1);
+  });
+
   let newPageId;
   it('is able to make a subpage of /parent with _position and _targetId', async function() {
 


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-135, "As a user I can reorganize (drag and drop) pages in the tree." A couple of page API bugs fixed in there as well.

Drag UI removed for parked pages in the page tree.