### PR TITLE
No default widget class names. If the class name option is set though…

### DIFF
--- a/modules/@apostrophecms/html-widget/index.js
+++ b/modules/@apostrophecms/html-widget/index.js
@@ -8,7 +8,7 @@ module.exports = {
   extend: '@apostrophecms/widget-type',
   options: {
     label: 'Raw HTML',
-    className: 'apos-raw-html-widget'
+    className: false
   },
   fields: {
     add: {

--- a/modules/@apostrophecms/image-widget/index.js
+++ b/modules/@apostrophecms/image-widget/index.js
@@ -2,7 +2,7 @@ module.exports = {
   extend: '@apostrophecms/widget-type',
   options: {
     label: 'Image',
-    className: 'apos-image-widget'
+    className: false
   },
   fields: {
     add: {

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -12,7 +12,7 @@ module.exports = {
     label: 'Rich Text',
     contextual: true,
     defaultData: { content: '' },
-    className: 'apos-rich-text-widget',
+    className: false,
     minimumDefaultOptions: {
       toolbar: [
         'styles',

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -27,7 +27,7 @@
       </AposContextMenuDialog>
     </component>
     <div class="apos-rich-text-editor__editor">
-      <editor-content :editor="editor" />
+      <editor-content :editor="editor" :class="moduleOptions.className" />
     </div>
   </div>
 </template>

--- a/modules/@apostrophecms/video-widget/index.js
+++ b/modules/@apostrophecms/video-widget/index.js
@@ -13,7 +13,7 @@ module.exports = {
   extend: '@apostrophecms/widget-type',
   options: {
     label: 'Video',
-    className: 'apos-video-widget'
+    className: false
   },
   fields: {
     add: {

--- a/modules/@apostrophecms/widget-type/index.js
+++ b/modules/@apostrophecms/widget-type/index.js
@@ -359,7 +359,8 @@ module.exports = {
           action: self.action,
           schema: schema,
           contextual: self.options.contextual,
-          skipInitialModal: self.options.skipInitialModal
+          skipInitialModal: self.options.skipInitialModal,
+          className: self.options.className
         });
         return result;
       }


### PR DESCRIPTION
…, make sure it is wrapped around the contextual rich text editor's content too. (At present no other widgets are contextually edited.)