### PR TITLE
Replaces page mgr console err w/ notification

### DIFF
--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -194,7 +194,11 @@ export default {
           body
         });
       } catch (error) {
-        console.error('Page tree update error:', error);
+        await apos.notify('An error occurred while updating the page tree.', {
+          type: 'danger',
+          icon: 'alert-circle-icon',
+          dismiss: true
+        });
       }
 
       await this.getPages();


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-644, "Followup: use apos.notify on a page tree movement error"