### PR TITLE
Sets up quick create menu in admin menu

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -37,6 +37,7 @@
                 type: 'primary',
                 modifiers: ['round', 'no-motion']
               }"
+              @item-clicked="emitEvent"
             />
           </li>
         </ul>
@@ -114,20 +115,16 @@ export default {
       }
       return item;
     });
-    // TODO: This will need to be an async call to get pieces as well as the
-    // new page route.
-    this.createMenu = [
-      {
-        label: 'Sandwich',
-        name: 'sandwich-artists',
-        action: 'sandwich-piece'
-      },
-      {
-        label: 'Tree',
-        name: 'trees',
-        action: 'trees-piece'
+
+    Object.values(apos.modules).forEach(module => {
+      if (module.quickCreate && module.schema && module.schema.length > 0) {
+        this.createMenu.push({
+          label: module.label || module.name,
+          name: module.name,
+          action: `${module.name}:editor`
+        });
       }
-    ];
+    });
 
     this.user = require('./userData').user;
   },

--- a/modules/@apostrophecms/global/index.js
+++ b/modules/@apostrophecms/global/index.js
@@ -134,6 +134,7 @@ module.exports = {
         // from the copy the middleware fetched for this specific request,
         // if not fall back to self._id
         browserOptions._id = req.data.global && (req.data.global._id || self._id);
+        browserOptions.quickCreate = false;
         return browserOptions;
       },
       getEditControls(_super, req) {

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -5,7 +5,8 @@ module.exports = {
   cascades: [ 'filters', 'columns', 'batchOperations' ],
   options: {
     manageViews: [ 'list' ],
-    perPage: 10
+    perPage: 10,
+    quickCreate: true
     // By default there is no public REST API, but you can configure a
     // projection to enable one:
     // publicApiProjection: {
@@ -683,7 +684,7 @@ module.exports = {
         browserOptions.contextual = self.contextual;
         browserOptions.batchOperations = self.batchOperations;
         browserOptions.insertViaUpload = self.options.insertViaUpload;
-        browserOptions.quickCreate = true;
+        browserOptions.quickCreate = self.options.quickCreate;
         _.defaults(browserOptions, {
           components: {}
         });

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -683,6 +683,7 @@ module.exports = {
         browserOptions.contextual = self.contextual;
         browserOptions.batchOperations = self.batchOperations;
         browserOptions.insertViaUpload = self.options.insertViaUpload;
+        browserOptions.quickCreate = true;
         _.defaults(browserOptions, {
           components: {}
         });


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-669, populating the quick-create menu with real piece types.

This merges into the global admin menu item branch (#2502) since it uses the piece editor actions set up there.