### PR TITLE
annotate attachments server side when editing areas just like we do i…

### DIFF
--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -136,6 +136,12 @@ module.exports = {
         });
         // Guarantee that `items` at least exists
         area.items = area.items || [];
+        const canEdit = area._edit && (options.edit !== false);
+        if (canEdit) {
+          // Ease of access to image URLs. When not editing we
+          // just use the helpers
+          self.apos.attachment.all(area, { annotate: true });
+        }
         return self.render(req, 'area', {
           // TODO filter area to exclude big relationship objects, but
           // not so sloppy this time please

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -76,29 +76,6 @@ export default {
       return apos.modules[this.field.withType].components.managerModal;
     }
   },
-  async mounted() {
-    this.validateAndEmit();
-
-    // Check if this is joined to an image.
-    if (this.field.withType === '@apostrophecms/image' && this.value.data && this.value.data.length > 0) {
-      // If it is, go get the URLs and populate them on `value`.
-      let i = 0;
-      for (const image of this.value.data) {
-        if (image.attachment._urls) {
-          // If it was updated during this page session we'll already have it.
-          return;
-        }
-
-        const action = apos.modules['@apostrophecms/image'].action;
-        const imgData = await apos.http.get(`${action}/${image._id}`, {
-          busy: true
-        });
-
-        this.value.data.splice(i, 1, imgData);
-        i++;
-      }
-    }
-  },
   methods: {
     validate(value) {
       if (this.field.required && !value.length) {


### PR DESCRIPTION
…n REST responses, avoids overhead of more REST calls. Also, do not validateAndEmit when first mounting a relationship input, we do not do that for other inputs and it makes it look like an error has already occurred when you have not had a chance to pick anything