### PR TITLE
Page picker picks pages passably

### DIFF
--- a/modules/@apostrophecms/admin-bar/index.js
+++ b/modules/@apostrophecms/admin-bar/index.js
@@ -55,27 +55,14 @@ module.exports = {
       // Alternatively, an `href` option may be set to an ordinary URL in
       // `options`. This creates a basic link in the admin menu.
       //
-      // `permission` should be a permission name such as `admin`
-      // (the user must be a full admin) or `edit-@apostrophecms/event`
-      // (the user can create events and edit their own). If
-      // `permission` is null then being logged in is
-      // good enough to see the item. (Securing your backend routes that
-      // respond to user actions is up to you.)
+      // `permission` should be an object with `action` and `type`
+      // properties. This determines visibility of the option, securing
+      // actual actions is a separate concern.
       //
       // You can use the `after` option to specify an admin bar item name
       // this item should appear immediately following.
       //
-      // Usually just one admin bar item per module makes sense, and
-      // the appropriate Vue component name is found via
-      // the `self.componentName()` method of the module.
-      //
-      // For example, the blog module (and every pieces subclass) does this:
-      //
-      // ```
-      // self.apos.adminBar.add(self.componentName('ManagerModal'), self.pluralLabel, 'edit')
-      // ```
-      //
-      // This results in the component name `ApostropheBlogManagerModal`.
+      // Usually just one admin bar item per module makes sense.
       //
       // On the browser side, it is possible to write
       // `apos.bus.$on('admin-menu-click', (name) => { ... })` to catch

--- a/modules/@apostrophecms/global/index.js
+++ b/modules/@apostrophecms/global/index.js
@@ -122,9 +122,8 @@ module.exports = {
       addToAdminBar() {
         if (self.schema.length > 0) {
           self.apos.adminBar.add(
-            `${self.__meta.name}:editor`,
-            self.pluralLabel,
-            'admin-' + self.name,
+            '@apostrophecms/global:singleton-editor',
+            self.label,
             {
               action: 'admin',
               type: self.name
@@ -138,10 +137,8 @@ module.exports = {
     return {
       getBrowserData(_super, req) {
         const browserOptions = _super(req);
-        // For compatibility with the workflow module try to get the _id
-        // from the copy the middleware fetched for this specific request,
-        // if not fall back to self._id
-        browserOptions._id = req.data.global && (req.data.global._id || self._id);
+        // _id of the piece, which is a singleton
+        browserOptions._id = req.data.global && req.data.global._id;
         browserOptions.quickCreate = false;
         return browserOptions;
       },

--- a/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
@@ -33,7 +33,16 @@ export default {
     // property is merged with the props supplied by the server-side configuration.
     apos.bus.$on('admin-menu-click', async (itemName) => {
       let item;
-      if ((typeof itemName) === 'object') {
+      if (itemName === '@apostrophecms/global:singleton-editor') {
+        // Special case: the global doc is a singleton, and we know its
+        // _id in browserland
+        item = {
+          ...apos.modal.modals.find(modal => modal.itemName === '@apostrophecms/global:editor'),
+          props: {
+            docId: apos.modules['@apostrophecms/global']._id
+          }
+        };
+      } else if ((typeof itemName) === 'object') {
         item = {
           ...apos.modal.modals.find(modal => modal.itemName === itemName.itemName),
           ...itemName

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
@@ -84,22 +84,7 @@ export default {
       if (!this.checkedDocs) {
         return;
       }
-
-      // If in a relationship input context, keep `checkedDocs` in sync with
-      // `checked`, first removing from `checkedDocs` if no longer in `checked`
-      this.checkedDocs = this.checkedDocs.filter(doc => {
-        return this.checked.includes(doc._id);
-      });
-      // then adding to `checkedDocs` if not there yet. These should be in
-      // `items`.
-      // TODO: Once we have the option to select all docs of a type even if not
-      // currently visible in the manager this will need to make calls to the
-      // database... maybe better to do that in the relationship input?
-      this.checked.forEach(id => {
-        if (this.checkedDocs.findIndex(doc => doc._id === id) === -1) {
-          this.checkedDocs.push(this.items.find(item => item._id === id));
-        }
-      });
+      this.updateCheckedDocs();
     }
   },
   methods: {
@@ -177,6 +162,29 @@ export default {
           }
         }
       }
+    },
+    // update this.checkedDocs based on this.checked. The default
+    // implementation is suitable for paginated lists. Can be overridden
+    // for other cases.
+    updateCheckedDocs() {
+      // Keep `checkedDocs` in sync with `checked`, first removing from
+      // `checkedDocs` if no longer in `checked`
+      this.checkedDocs = this.checkedDocs.filter(doc => {
+        return this.checked.includes(doc._id);
+      });
+      // then adding to `checkedDocs` if not there yet. These should be in
+      // `items` which is assumed to contain a flat list of items currently
+      // visible.
+      //
+      // TODO: Once we have the option to select all docs of a type even if not
+      // currently visible in the manager this will need to make calls to the
+      // database.
+      this.checked.forEach(id => {
+        if (this.checkedDocs.findIndex(doc => doc._id === id) === -1) {
+          this.checkedDocs.push(this.items.find(item => item._id === id));
+        }
+      });
+
     }
   }
 };

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -89,13 +89,37 @@ module.exports = {
   restApiRoutes(self, options) {
     return {
       // Trees are arranged in a tree, not a list. So this API returns the home page,
-      // with _children populated if ?_children=1 is in the query string. An admin can
+      // with _children populated if ?_children=1 is in the query string. An editor can
       // also get a light version of the entire tree with ?all=1, for use in a
       // drag-and-drop UI.
+      //
+      // If flat=1 is present, the pages are returned as a flat list rather than a tree,
+      // and the `_children` property of each is just an array of `_id`s.
+      //
+      // If ?autocomplete=x is present, then an autocomplete prefix search for pages
+      // matching that string is carried out, and a flat list of pages is returned,
+      // with no `_children`. This is mainly useful to our relationship editor.
+      // The user must have some page editing privileges to use it. The 10 best
+      // matches are returned as an object with a `results` property containing the
+      // array of pages.
+
       async getAll(req) {
         self.publicApiCheck(req);
         const all = self.apos.launder.boolean(req.query.all);
         const flat = self.apos.launder.boolean(req.query.flat);
+        const autocomplete = self.apos.launder.string(req.query.autocomplete);
+
+        if (autocomplete.length) {
+          if (!self.apos.permission.can(req, 'edit', '@apostrophecms/page')) {
+            throw self.apos.error('forbidden');
+          }
+          return {
+            // For consistency with the pieces REST API we
+            // use a results property when returning a flat list
+            results: await self.getRestQuery(req).limit(10).relationships(false).areas(false).toArray()
+          };
+        }
+
         if (all) {
           if (!self.apos.permission.can(req, 'edit', '@apostrophecms/page')) {
             throw self.apos.error('forbidden');
@@ -120,7 +144,11 @@ module.exports = {
           if (flat) {
             const result = [];
             flatten(result, data[0]);
-            return result;
+            return {
+              // For consistency with the pieces REST API we
+              // use a results property when returning a flat list
+              results: result
+            };
           }
           return data[0];
         } else {

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -104,8 +104,7 @@ export default {
       treeOptions: {
         bulkSelect: !!this.relationshipField,
         draggable: true
-      },
-      originalPageTree: null
+      }
     };
   },
   computed: {
@@ -166,22 +165,12 @@ export default {
         }
       ));
 
-      // Clone before it is rewritten in the tree's preferred format.
-      // We need the original for checkedDocs and delivering results
-      // to AposInputRelationship
-      this.originalPageTree = klona(pageTree);
-
       formatPage(pageTree);
 
       this.pages = [ pageTree ];
 
       function formatPage(page) {
-        self.pagesFlat.push({
-          title: page.title,
-          id: page._id,
-          path: page.path,
-          parked: page.parked
-        });
+        self.pagesFlat.push(klona(page));
 
         page.children = page._children;
         delete page._children;
@@ -226,7 +215,7 @@ export default {
     selectAll(event) {
       if (!this.checked.length) {
         this.pagesFlat.forEach((row) => {
-          this.toggleRowCheck(row.id);
+          this.toggleRowCheck(row._id);
         });
         return;
       }
@@ -260,25 +249,7 @@ export default {
       }
     },
     updateCheckedDocs() {
-      this.checkedDocs = this.checked.map(_id => find([ this.originalPageTree ], item => {
-        return item._id === _id;
-      }));
-      // Could be a page tree structure, or just a flat list,
-      // works either way
-      function find(items, fn) {
-        for (const item of items) {
-          const result = fn(item);
-          if (result) {
-            return item;
-          }
-          if (item._children) {
-            const result = find(item._children, fn);
-            if (result) {
-              return result;
-            }
-          }
-        }
-      }
+      this.checkedDocs = this.checked.map(_id => this.pagesFlat.find(page => page._id === _id));
     }
   }
 };


### PR DESCRIPTION
You can pick pages both via autocomplete in the relationship field and via browsing the page tree.

I also fixed a bug in the implementation of the "Global" button so that you can edit the singular, existing global preferences doc now. previously it was trying to make a new one every time.

See corresponding a3-demo PR, which introduces a simple set of footer links via the global doc.
