### PR TITLE
Fixes for various bugs with media selection

### DIFF
--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -27,7 +27,7 @@
       <AposButton
         type="primary"
         :label="`Select ${moduleLabels.pluralLabel || ''}`"
-        :disabled="relationshipErrors === 'min'"
+        :disabled="relationshipErrors"
         @click="saveRelationship"
       />
     </template>
@@ -69,8 +69,9 @@
             @upload-started="uploading = true"
             @upload-complete="completeUploading"
             @create-placeholder="createPlaceholder"
+            :max-reached="maxReached()"
             :options="{
-              disableUnchecked: relationshipErrors === 'max',
+              disableUnchecked: maxReached(),
               hideCheckboxes: !relationshipField
             }"
           />
@@ -171,9 +172,11 @@ export default {
     }
   },
   watch: {
-    checked (newVal) {
+    checked (newVal, oldVal) {
       if (newVal.length > 1 || newVal.length === 0) {
-        this.editing = undefined;
+        if (!this.updateEditing(null)) {
+          this.checked = oldVal;
+        }
       }
     }
   },
@@ -260,7 +263,10 @@ export default {
       this.editing = undefined;
     },
     async updateEditing(id) {
-      if (this.isModified()) {
+      // We only care about the current doc for this prompt,
+      // we are not in danger of discarding a selection when
+      // we switch images
+      if (this.editing && this.modified) {
         const discard = await apos.confirm({
           heading: this.cancelHeading,
           description: this.cancelDescription,
@@ -268,10 +274,11 @@ export default {
           affirmativeLabel: this.cancelAffirmativeLabel
         });
         if (!discard) {
-          return;
+          return false;
         }
       }
       this.editing = this.items.find(item => item._id === id);
+      return true;
     },
     // select setters
     select(id) {
@@ -280,7 +287,6 @@ export default {
       } else {
         this.checked = [ id ];
       }
-
       this.updateEditing(id);
       this.lastSelected = id;
     },

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
@@ -2,6 +2,7 @@
   <div class="apos-media-manager-display">
     <div class="apos-media-manager-display__grid">
       <AposMediaUploader
+        :disabled="maxReached"
         :action="moduleOptions.action"
         @upload-started="$emit('upload-started')"
         @upload-complete="$emit('upload-complete', $event)"
@@ -79,6 +80,10 @@ export default {
     event: 'change'
   },
   props: {
+    maxReached: {
+      type: Boolean,
+      default: false
+    },
     checked: {
       type: [ Array, Boolean ],
       default: false

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
@@ -38,7 +38,7 @@ export default {
         return 'min';
       }
 
-      if (this.relationshipField.max && this.checked.length >= this.relationshipField.max) {
+      if (this.relationshipField.max && this.checked.length > this.relationshipField.max) {
         return 'max';
       }
 
@@ -88,6 +88,14 @@ export default {
     }
   },
   methods: {
+    // It would have been nice for this to be computed, however
+    // AposMediaManagerDisplay does not re-render when it is
+    // a computed prop rather than a method call in the template.
+    maxReached() {
+      // Reaching max and exceeding it are different things
+      const result = this.relationshipField.max && this.checked.length >= this.relationshipField.max;
+      return result;
+    },
     selectAll() {
       if (!this.checked.length) {
         this.items.forEach((item) => {

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
@@ -54,7 +54,7 @@
             @page-change="updatePage"
             @filter="filter"
             :options="{
-              disableUnchecked: relationshipErrors === 'max',
+              disableUnchecked: maxReached(),
               hideSelectAll: !relationshipField
             }"
           />
@@ -67,7 +67,7 @@
             v-model="checked"
             @open="edit"
             :options="{
-              disableUnchecked: relationshipErrors === 'max',
+              disableUnchecked: maxReached(),
               hideCheckboxes: !relationshipField
             }"
           />


### PR DESCRIPTION
* Disable uploads when max is reached. TODO: the button's appearance should change. I messed around with CSS filter but couldn't see an easy way to get a good PoC of this in place. I have opened a separate ticket to properly design this state. For now we just have the functional disabling.
* When switching images in the inline editor, the confirmation prompt should only appear if the editor is modified, the selection is not relevant to that prompt.
* Don't let the media manager save a selection with any relationship errors. Not just min.
* Fix the max error so it is not an "error" if you're just *at* the maximum. Provide a separate `maxReached` mechanism for the cases where that was important. I wanted this to be "computed" but the child components didn't respond to its changes that way, so it's a method.
* If an image is being edited and the user deselects it, confirm before clearing the editor. If they cancel, re-select the item.
* Allow the user to upload the same file twice in a row in the media manager. Note: this wasn't about avoiding duplicates, it was a browser behavior ("same file? I'm not going to emit an event") that provided zero feedback and made it feel broken in a test that users are likely to conduct during evaluation. I was confused myself.
