### PR TITLE
Errata: display simple string errors properly, file extension restrictions, require user to have a full name, infer min from required for arrays

### DIFF
--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -257,7 +257,8 @@ module.exports = {
           name: self.name,
           partial: self.fieldTypePartial,
           convert: self.convert,
-          index: self.index
+          index: self.index,
+          register: self.register
         });
       },
       async convert(req, field, data, object) {
@@ -308,6 +309,41 @@ module.exports = {
           text: value.title,
           silent: silent
         });
+      },
+      // When the field is registered in the schema,
+      // canonicalize .group and .extensions and .extension
+      // into .accept for convenience, as a comma-separated
+      // list of dotted file extensions suitable to pass to
+      // the "accept" HTML5 attribute, including mapped extensions
+      // like jpeg. If none of these options are set, .accept is
+      // set to an array of all accepted file extensions across
+      // all groups
+      register(field) {
+        let fileGroups = self.fileGroups;
+        if (field.fileGroups) {
+          fileGroups = fileGroups.filter(group => field.fileGroups.includes(group.name));
+        }
+        if (field.fileGroup) {
+          fileGroups = fileGroups.filter(group => group.name === field.fileGroup);
+        }
+        let extensions = [];
+        fileGroups.forEach(group => {
+          extensions = [ ...extensions, ...group.extensions ];
+        });
+        if (field.extensions) {
+          extensions = extensions.filter(extension => field.extensions.includes(extension));
+        }
+        if (field.extension) {
+          extensions = extensions.filter(extension => extension === field.extension);
+        }
+        fileGroups.forEach(group => {
+          for (const [ from, to ] of Object.entries(group.extensionMaps || {})) {
+            if (extensions.includes(to) && (!extensions.includes(from))) {
+              extensions.push(from);
+            }
+          }
+        });
+        field.accept = extensions.map(extension => `.${extension}`).join(',');
       },
       // Checked a given attachment's file extension against the extensions
       // allowed by a particular schema field. If the attachment's file

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -59,6 +59,7 @@
         <template #bodyMain>
           <AposMediaManagerDisplay
             ref="display"
+            :accept="accept"
             :items="items"
             :module-options="options"
             @edit="updateEditing"
@@ -169,6 +170,9 @@ export default {
     },
     selected() {
       return this.items.filter(item => this.checked.includes(item._id));
+    },
+    accept() {
+      return this.options.schema.find(field => field.name === 'attachment').accept;
     }
   },
   watch: {

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
@@ -4,6 +4,7 @@
       <AposMediaUploader
         :disabled="maxReached"
         :action="moduleOptions.action"
+        :accept="accept"
         @upload-started="$emit('upload-started')"
         @upload-complete="$emit('upload-complete', $event)"
         @create-placeholder="$emit('create-placeholder', $event)"
@@ -103,6 +104,11 @@ export default {
       default() {
         return {};
       }
+    },
+    accept: {
+      type: String,
+      required: false,
+      default: null
     }
   },
   emits: [
@@ -123,18 +129,6 @@ export default {
       set(val) {
         this.$emit('change', val);
       }
-    }
-  },
-  mounted() {
-    // Get the acceptable file types, if set.
-    const imageGroup = apos.modules['@apostrophecms/attachment'].fileGroups
-      .find(group => group.name === 'images');
-
-    if (imageGroup && this.$refs['apos-upload-input']) {
-      const acceptTypes = imageGroup.extensions.map(type => `.${type}`)
-        .join(',');
-
-      this.$refs['apos-upload-input'].setAttribute('accept', acceptTypes);
     }
   },
   methods: {

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaUploader.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaUploader.vue
@@ -26,6 +26,7 @@
       type="file" class="apos-sr-only"
       ref="upload"
       @input="uploadMedia"
+      :accept="accept"
       multiple="true"
       :disabled="disabled"
     >
@@ -43,6 +44,11 @@ export default {
     disabled: {
       type: Boolean,
       required: false
+    },
+    accept: {
+      type: String,
+      required: false,
+      default: null
     }
   },
   emits: [

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputAttachment.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputAttachment.vue
@@ -34,6 +34,7 @@
             class="apos-sr-only"
             :disabled="disabled"
             @input="uploadMedia"
+            :accept="field.accept"
           >
         </label>
         <div v-if="next && next._id" class="apos-attachment-files">

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputWrapper.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputWrapper.vue
@@ -112,7 +112,9 @@ export default {
     },
     errorMessage () {
       if (this.error) {
-        if (this.error.message) {
+        if (typeof this.error === 'string') {
+          return this.error;
+        } else if (this.error.message) {
           return this.error.message;
         } else {
           return 'Error';
@@ -133,6 +135,9 @@ export default {
     minLabel() {
       if ((typeof this.field.min) === 'number') {
         return `Min: ${this.field.min}`;
+      } else if (this.field.required && (this.field.type === 'array')) {
+        // For consistency with the array editor's behavior
+        return 'Min: 1';
       } else {
         return false;
       }

--- a/modules/@apostrophecms/user/index.js
+++ b/modules/@apostrophecms/user/index.js
@@ -58,7 +58,8 @@ module.exports = {
         title: {
           type: 'string',
           label: 'Full Name',
-          following: [ 'firstName', 'lastName' ]
+          following: [ 'firstName', 'lastName' ],
+          required: true
         },
         slug: {
           type: 'slug',


### PR DESCRIPTION
* Display simple string errors properly (like browser-side "required") as well as the more complex object errors that come from the server on failed save attempts.
* Users must have a full name (title). Caught this just now: a user with no name can't be edited, so make sure they have one.
* For array inputs, "min: 1" messaging is now inferred from "required: true" if "min" is not otherwise present. This is for consistency with the array editor, where the "*" marker would lack context so I've been treating required as an implicit "min: 1".
* Restrict file extensions properly for all file inputs, including but not limited to the media browser one. Bea had this worked out for the media browser one and I broke it earlier this week. However this led me to really sort it out completely for all attachment fields based on the rather flexible configuration that is permissible server side, baking a canonical "accept" attribute in advance so the browser side code can be simple.