### PR TITLE
handle field types with no ui (reverse relationships) properly

### DIFF
--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -141,7 +141,7 @@ export default {
       return (window.apos.modules[this.moduleName] || {}).action;
     },
     schema() {
-      return this.moduleOptions.schema || [];
+      return (this.moduleOptions.schema || []).filter(field => apos.schema.components.fields[field.type]);
     },
     groups() {
       const groupSet = {};

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -135,10 +135,7 @@ export default {
       return window.apos.modules[this.activeMedia.type] || {};
     },
     schema() {
-      if (this.moduleOptions.schema) {
-        return this.moduleOptions.schema;
-      }
-      return [];
+      return (this.moduleOptions.schema || []).filter(field => apos.schema.components.fields[field.type]);
     },
     fileSize() {
       if (

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -894,6 +894,7 @@ module.exports = {
 
     self.addFieldType({
       name: 'relationshipReverse',
+      vueComponent: false,
       relate: async function (req, field, objects, options) {
         return self.relationshipDriver(req, joinr.byArrayReverse, true, objects, field.idsStorage, field.fieldsStorage, field.name, options);
       },
@@ -2337,7 +2338,13 @@ module.exports = {
         const browserOptions = _super(req);
         const fields = {};
         for (const name in self.fieldTypes) {
-          fields[name] = self.fieldTypes[name].vueComponent || 'AposInput' + self.apos.util.capitalizeFirst(name);
+          let component = self.fieldTypes[name].vueComponent;
+          // If explicitly false, it intentionally has no UI at all
+          if (component !== false) {
+            // Otherwise fall back to the standard naming pattern if not otherwise specified
+            component = component || 'AposInput' + self.apos.util.capitalizeFirst(name);
+          }
+          fields[name] = component;
         }
 
         browserOptions.components = { fields: fields };

--- a/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
@@ -62,7 +62,7 @@
                 <div class="apos-array-item__body">
                   <AposSchema
                     v-if="currentId"
-                    :schema="field.schema"
+                    :schema="schema"
                     :trigger-validation="triggerValidation"
                     :utility-rail="false"
                     :following-values="followingValues()"
@@ -145,7 +145,7 @@ export default {
     },
     schema() {
       // For AposDocEditorMixin
-      return this.field.schema;
+      return (this.field.schema || []).filter(field => apos.schema.components.fields[field.type]);
     },
     countLabel() {
       return `${this.next.length} Added`;
@@ -276,7 +276,7 @@ export default {
     isModified() {
       if (this.currentId) {
         const currentIndex = this.next.findIndex(item => item._id === this.currentId);
-        if (detectDocChange(this.field.schema, this.next[currentIndex], this.currentDoc.data)) {
+        if (detectDocChange(this.schema, this.next[currentIndex], this.currentDoc.data)) {
           return true;
         }
       }
@@ -287,7 +287,7 @@ export default {
         if (this.next[i]._id !== this.original[i]._id) {
           return true;
         }
-        if (detectDocChange(this.field.schema, this.next[i], this.original[i])) {
+        if (detectDocChange(this.schema, this.next[i], this.original[i])) {
           return true;
         }
       }
@@ -325,7 +325,7 @@ export default {
     },
     newInstance() {
       const instance = {};
-      for (const field of this.field.schema) {
+      for (const field of this.schema) {
         if (field.def !== undefined) {
           instance[field.name] = klona(field.def);
         }
@@ -336,7 +336,7 @@ export default {
       let candidate;
       if (this.field.titleField) {
         candidate = get(item, this.field.titleField);
-      } else if (this.field.schema.find(field => field.name === 'title') && (item.title !== undefined)) {
+      } else if (this.schema.find(field => field.name === 'title') && (item.title !== undefined)) {
         candidate = item.title;
       }
       if ((candidate == null) || candidate === '') {

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -109,7 +109,7 @@ export default {
       }
     },
     schema() {
-      return this.moduleOptions.schema;
+      return (this.moduleOptions.schema || []).filter(field => apos.schema.components.fields[field.type]);
     }
   },
   async mounted() {


### PR DESCRIPTION
We've been seeing errors that boil down to the fact that `relationshipReverse` fields have no UI.

That's intentional but our frontend needed to know how to deal with it. Now the schemas are filtered appropriately and we don't get console errors and empty tabs.

(The possibility of making relationshipReverse an editable field type has lots of ins and outs and pros and cons and wouldn't be in-scope right now, this PR is just about un-breaking things.)