### PR TITLE
3/busy media

### DIFF
--- a/modules/@apostrophecms/busy/ui/apos/components/TheAposBusy.vue
+++ b/modules/@apostrophecms/busy/ui/apos/components/TheAposBusy.vue
@@ -9,15 +9,25 @@ export default {
   name: 'TheAposBusy',
   data() {
     return {
-      busy: false
+      busy: false,
+      busyCount: 0
     };
   },
   mounted() {
     apos.bus.$on('apos-busy', state => {
-      // TODO: Eventually add a counter to track if busy state was enabled
-      // multiple times, to require clearing it an equal number of times.
-      // Possibly add a check for `state.name === 'busy'` again.
-      this.busy = state.active;
+      // TODO: Possibly add a check for `state.name === 'busy'` again if other
+      // busy contexts are added.
+      if (state.active === false && this.busyCount >= 0) {
+        this.busyCount--;
+      }
+
+      if (this.busyCount === 0) {
+        this.busy = state.active;
+      }
+
+      if (state.active === true) {
+        this.busyCount++;
+      }
     });
   }
 };

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaUploader.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaUploader.vue
@@ -93,6 +93,7 @@ export default {
         const fileCount = files.length;
 
         const emptyDoc = await apos.http.post(this.action, {
+          busy: true,
           body: {
             _newInstance: true
           }
@@ -160,6 +161,7 @@ export default {
 
       // Make an async request to upload the image.
       const attachment = await apos.http.post('/api/v1/@apostrophecms/attachment/upload', {
+        busy: true,
         body: formData
       });
 
@@ -170,6 +172,7 @@ export default {
 
       try {
         const imgPiece = await apos.http.post(this.action, {
+          busy: true,
           body: imageData
         });
 

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaUploader.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaUploader.vue
@@ -82,6 +82,11 @@ export default {
     },
     async uploadMedia (event) {
       try {
+        apos.bus.$emit('apos-busy', {
+          name: 'busy',
+          active: true
+        });
+
         if (this.disabled) {
           return;
         }
@@ -136,6 +141,10 @@ export default {
         // When complete, refresh the image grid, with the new images at top.
         this.$emit('upload-complete', imageIds);
       } finally {
+        apos.bus.$emit('apos-busy', {
+          name: 'busy',
+          active: false
+        });
         this.$refs.upload.value = '';
       }
     },


### PR DESCRIPTION
The media manager upload is the primary long-running busy operation we have, but as it was the busy state would simply flip on and off. I added a general event for it and implemented a counter.