### PR TITLE
indexCursor is the 2.x naming convention, call the method indexQuery …

### DIFF
--- a/index.js
+++ b/index.js
@@ -287,7 +287,7 @@ module.exports = async function(options) {
       bundles: [ 'apostrophe' ].concat(self.options.bundles || []),
       localModules: self.localModules,
       defaultBaseClass: '@apostrophecms/module',
-      sections: [ 'helpers', 'handlers', 'routes', 'apiRoutes', 'restApiRoutes', 'renderRoutes', 'htmlRoutes', 'middleware', 'customTags', 'components' ],
+      sections: [ 'helpers', 'handlers', 'routes', 'apiRoutes', 'restApiRoutes', 'renderRoutes', 'middleware', 'customTags', 'components' ],
       unparsedSections: [ 'queries', 'extendQueries' ]
     });
 

--- a/modules/@apostrophecms/piece-page-type/index.js
+++ b/modules/@apostrophecms/piece-page-type/index.js
@@ -79,7 +79,7 @@ module.exports = {
       // `@apostrophecms/piece-type-cursor` in your subclass of
       // `@apostrophecms/piece-type`.
 
-      indexCursor(req) {
+      indexQuery(req) {
         const cursor = self.pieces.find(req, {}).applyBuildersSafely(req.query).perPage(self.perPage);
         self.filterByIndexPage(cursor, req.data.page);
         return cursor;
@@ -104,7 +104,7 @@ module.exports = {
           });
         }
 
-        const cursor = self.indexCursor(req);
+        const cursor = self.indexQuery(req);
 
         await getFilters();
         await totalPieces();
@@ -224,7 +224,7 @@ module.exports = {
           if (!doc) {
             return;
           }
-          const cursor = self.indexCursor(req);
+          const cursor = self.indexQuery(req);
           previous = await cursor.previous(doc).applyBuilders(typeof self.options.previous === 'object' ? self.options.previous : {}).toObject();
         }
 
@@ -235,7 +235,7 @@ module.exports = {
           if (!doc) {
             return;
           }
-          const cursor = self.indexCursor(req);
+          const cursor = self.indexQuery(req);
           next = await cursor.next(doc).applyBuidlers(typeof self.options.next === 'object' ? self.options.next : {}).toObject();
         }
       },


### PR DESCRIPTION
…so we can document it. A more complete sweep for the use of "cursor" internally in this file will be done later. Also removed htmlRoutes section as that is not a thing in A3 (apiRoutes can do the same job).