### PR TITLE
Fixes bug preventing area widget controls in editor modal

### DIFF
--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArea.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArea.vue
@@ -6,6 +6,7 @@
     <template #body>
       <div class="apos-input-wrapper">
         <Component
+          :doc-id="docId"
           :is="editorComponent"
           :options="field.options"
           :items="next.items"


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-706, "Areas in modals's controls are being masked by the inner column of the modal, need to be accessible"

I tested this with the old canvas era style where the controls float outside the area and it works. This was the issue, not that the controls were visually hidden.