### PR TITLE
3/a30u 733 save button

### DIFF
--- a/modules/@apostrophecms/admin-bar/index.js
+++ b/modules/@apostrophecms/admin-bar/index.js
@@ -243,12 +243,15 @@ module.exports = {
           return false;
         }
         const closeDelay = self.options.closeDelay;
+        const context = req.data.piece || req.data.page;
+        const contextId = context && context._id;
         return {
           items: items,
           components: { the: 'TheAposAdminBar' },
           openOnLoad: !!(typeof self.options.openOnLoad === 'undefined' || self.options.openOnLoad),
           openOnHomepageLoad: !!(typeof self.options.openOnHomepageLoad === 'undefined' || self.options.openOnHomepageLoad),
-          closeDelay: typeof closeDelay === 'number' ? closeDelay : 3000
+          closeDelay: typeof closeDelay === 'number' ? closeDelay : 3000,
+          contextId
         };
       }
     };

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -132,8 +132,18 @@ export default {
     apos.bus.$on('context-edited', patch => {
       this.patches.push(patch);
     });
+
+    window.addEventListener('beforeunload', this.beforeUnload);
   },
   methods: {
+    beforeUnload(e) {
+      if (this.patches.length) {
+        e.preventDefault();
+        // No actual control over the message is possible in modern browsers,
+        // but Chrome requires we set a string here
+        e.returnValue = '';
+      }
+    },
     emitEvent: function (name) {
       apos.bus.$emit('admin-menu-click', name);
     },

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -211,15 +211,12 @@ export default {
       this.focusedWidget = widgetId;
     },
     async up(i) {
-      if (this.docId) {
-        await apos.http.patch(`${apos.doc.action}/${this.docId}`, {
-          busy: true,
-          body: {
-            $move: {
-              [`@${this.id}.items`]: {
-                $item: this.next[i]._id,
-                $before: this.next[i - 1]._id
-              }
+      if (this.docId === window.apos.adminBar.contextId) {
+        apos.bus.$emit('context-edited', {
+          $move: {
+            [`@${this.id}.items`]: {
+              $item: this.next[i]._id,
+              $before: this.next[i - 1]._id
             }
           }
         });
@@ -232,15 +229,12 @@ export default {
       ];
     },
     async down(i) {
-      if (this.docId) {
-        await apos.http.patch(`${apos.doc.action}/${this.docId}`, {
-          busy: true,
-          body: {
-            $move: {
-              [`@${this.id}.items`]: {
-                $item: this.next[i]._id,
-                $after: this.next[i + 1]._id
-              }
+      if (this.docId === window.apos.adminBar.contextId) {
+        apos.bus.$emit('context-edited', {
+          $move: {
+            [`@${this.id}.items`]: {
+              $item: this.next[i]._id,
+              $after: this.next[i + 1]._id
             }
           }
         });
@@ -253,13 +247,10 @@ export default {
       ];
     },
     async remove(i) {
-      if (this.docId) {
-        await apos.http.patch(`${apos.doc.action}/${this.docId}`, {
-          busy: true,
-          body: {
-            $pullAllById: {
-              [`@${this.id}.items`]: [ this.next[i]._id ]
-            }
+      if (this.docId === window.apos.adminBar.contextId) {
+        apos.bus.$emit('context-edited', {
+          $pullAllById: {
+            [`@${this.id}.items`]: [ this.next[i]._id ]
           }
         });
       }
@@ -294,12 +285,9 @@ export default {
       });
     },
     async update(widget) {
-      if (this.docId) {
-        await apos.http.patch(`${apos.doc.action}/${this.docId}`, {
-          busy: 'contextual',
-          body: {
-            [`@${widget._id}`]: widget
-          }
+      if (this.docId === window.apos.adminBar.contextId) {
+        apos.bus.$emit('context-edited', {
+          [`@${widget._id}`]: widget
         });
       }
       const index = this.next.findIndex(w => w._id === widget._id);
@@ -350,13 +338,10 @@ export default {
       if (e.index < this.next.length) {
         push.$before = this.next[e.index]._id;
       }
-      if (this.docId) {
-        await apos.http.patch(`${apos.doc.action}/${this.docId}`, {
-          busy: true,
-          body: {
-            $push: {
-              [`@${this.id}.items`]: push
-            }
+      if (this.docId === window.apos.adminBar.contextId) {
+        apos.bus.$emit('context-edited', {
+          $push: {
+            [`@${this.id}.items`]: push
           }
         });
       }

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -477,8 +477,18 @@ database.`);
               await apply(patch);
             }
           } else {
-            apply(req.body);
+            await apply(req.body);
           }
+          await self.update(req, page);
+
+          if (_targetId) {
+            const result = await self.getTargetIdAndPosition(req, page._id, _targetId, _position);
+            const actualTargetId = result.targetId;
+            const actualPosition = result.position;
+            await self.move(req, page._id, actualTargetId, actualPosition);
+          }
+          return self.findOneForEditing(req, { _id: page._id }, null, { annotate: true });
+
           async function apply(input) {
             const manager = self.apos.doc.getManager(self.apos.launder.string(input.type) || page.type);
             if (!manager) {
@@ -499,17 +509,6 @@ database.`);
               _position = input._position;
             }
           }
-          await self.update(req, page);
-
-          if (_targetId) {
-            const {
-              actualTargetId,
-              actualPosition
-            } = await self.getTargetIdAndPosition(req, page._id, _targetId, _position);
-
-            await self.move(req, page._id, actualTargetId, actualPosition);
-          }
-          return self.findOneForEditing(req, { _id: page._id }, null, { annotate: true });
         });
       },
       getBrowserData(req) {

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -453,38 +453,61 @@ database.`);
       // Implementation of the PATCH route. Factored as a method to allow
       // it to be called from the universal @apostrophecms/doc PATCH route
       // as well.
+      //
+      // If `req.body._patches` is an array of patches to the same document, this method
+      // will iterate over those patches as if each were `req.body`, applying all of them
+      // within a single lock and without redundant network operations. This greatly
+      // improves the performance of saving all changes to a document at once after
+      // accumulating a number of changes in patch form on the front end. This feature
+      // may not be used to patch `_targetId` and `_position`.
       async patch(req, _id) {
         // TODO watch out for _targetId and _position and trash and their implications
         return self.withLock(req, async () => {
           const page = await self.findOneForEditing(req, { _id });
+          let _targetId;
+          let _position;
           if (!page) {
             throw self.apos.error('notfound');
           }
           if (!page._edit) {
             throw self.apos.error('forbidden');
           }
-          const input = req.body;
-          const manager = self.apos.doc.getManager(self.apos.launder.string(input.type) || page.type);
-          if (!manager) {
-            throw self.apos.error('invalid');
+          if (Array.isArray(req.body._patches)) {
+            for (const patch of req.body._patches) {
+              await apply(patch);
+            }
+          } else {
+            apply(req.body);
           }
-          self.apos.schema.implementPatchOperators(input, page);
-          const parentPage = page._ancestors.length && page._ancestors[page._ancestors.length - 1];
-          const schema = self.apos.schema.subsetSchemaForPatch(self.allowedSchema(req, {
-            ...page,
-            type: manager.name
-          }, parentPage), input);
-          await self.apos.schema.convert(req, schema, input, page);
-          await self.emit('afterConvert', req, input, page);
+          async function apply(input) {
+            const manager = self.apos.doc.getManager(self.apos.launder.string(input.type) || page.type);
+            if (!manager) {
+              throw self.apos.error('invalid');
+            }
+            self.apos.schema.implementPatchOperators(input, page);
+            const parentPage = page._ancestors.length && page._ancestors[page._ancestors.length - 1];
+            const schema = self.apos.schema.subsetSchemaForPatch(self.allowedSchema(req, {
+              ...page,
+              type: manager.name
+            }, parentPage), input);
+            await self.apos.schema.convert(req, schema, input, page);
+            await self.emit('afterConvert', req, input, page);
+            // Since patches are applied consecutively, the last move
+            // is the move that matters
+            if (input._targetId) {
+              _targetId = input._targetId;
+              _position = input._position;
+            }
+          }
           await self.update(req, page);
 
-          if (input._targetId) {
+          if (_targetId) {
             const {
-              targetId,
-              position
-            } = await self.getTargetIdAndPosition(req, page._id, input._targetId, input._position);
+              actualTargetId,
+              actualPosition
+            } = await self.getTargetIdAndPosition(req, page._id, _targetId, _position);
 
-            await self.move(req, page._id, targetId, position);
+            await self.move(req, page._id, actualTargetId, actualPosition);
           }
           return self.findOneForEditing(req, { _id: page._id }, null, { annotate: true });
         });


### PR DESCRIPTION
* Your edits do not immediately go live when editing in context on the page.
* The "save" button starts out disabled (these are the current styles for that in our admin bar).
* when you save, it sends up all the patches in a single PATCH operation.
* If you try to close the page prematurely you get the built-in "gee do you want to do that" prompt from the browser. This is not a message that can be adjusted or substituted in modern browsers, we get what we get.
* That message stops appearing if the page has been saved.

We have lots of other pieces that need to come together here, like edit mode itself, but I saw no reason not to start with this.

Something NOT done in this PR: if you try to edit something that's not part of the current "context document" (page or piece that is the best fit for this URL), there is no visual indication yet and the UI is available to you, but it won't save it. There is a separate ticket to address it so the editing UI is not available and you get appropriate affordances to help you figure out where you should go to edit that particular thing. So I'm not worrying about that here, other than making sure I don't send up any patches for the wrong document.