### PR TITLE
area edits now save properly in piece modals, including nested areas,…

### DIFF
--- a/modules/@apostrophecms/area/lib/custom-tags/area.js
+++ b/modules/@apostrophecms/area/lib/custom-tags/area.js
@@ -90,7 +90,7 @@ module.exports = function(self, options) {
 In Apostrophe 3.x areas must be part of the schema for each page or piece type.`);
       }
       area._fieldId = field._id;
-      area._docId = doc._docId || doc._id;
+      area._docId = doc._docId || ((doc.metaType === 'doc') ? doc._id : null);
       area._edit = doc._edit;
 
       const content = await self.apos.area.renderArea(req, area, context);

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -156,7 +156,6 @@ export default {
         this.$emit('changed', {
           items: this.next
         });
-      } else {
         // For the benefit of all other area editors on-page
         // which may have this one as a sub-area in some way, and
         // mistakenly think they know its contents have not changed
@@ -168,27 +167,16 @@ export default {
     }
   },
   mounted() {
-    if (this.docId) {
-      this.areaUpdatedHandler = (area) => {
-        for (const item of this.next) {
-          if (this.patchSubobject(item, area)) {
-            break;
-          }
-        }
-      };
-      apos.bus.$on('area-updated', this.areaUpdatedHandler);
-      apos.bus.$on('widget-hover', this.updateWidgetHovered);
-      apos.bus.$on('widget-focus', this.updateWidgetFocused);
-      this.bindEventListeners();
-    }
+    apos.bus.$on('area-updated', this.areaUpdatedHandler);
+    apos.bus.$on('widget-hover', this.updateWidgetHovered);
+    apos.bus.$on('widget-focus', this.updateWidgetFocused);
+    this.bindEventListeners();
   },
   beforeDestroy() {
-    if (this.areaUpdatedHandler) {
-      apos.bus.$off('area-updated', this.areaUpdatedHandler);
-      apos.bus.$off('widget-hover', this.updateWidgetHovered);
-      apos.bus.$off('widget-focus', this.updateWidgetFocused);
-      this.unbindEventListeners();
-    }
+    apos.bus.$off('area-updated', this.areaUpdatedHandler);
+    apos.bus.$off('widget-hover', this.updateWidgetHovered);
+    apos.bus.$off('widget-focus', this.updateWidgetFocused);
+    this.unbindEventListeners();
   },
   methods: {
     bindEventListeners() {
@@ -197,7 +185,13 @@ export default {
     unbindEventListeners() {
       window.removeEventListener('keydown', this.focusParentEvent);
     },
-
+    areaUpdatedHandler(area) {
+      for (const item of this.next) {
+        if (this.patchSubobject(item, area)) {
+          break;
+        }
+      }
+    },
     focusParentEvent(event) {
       if (event.metaKey && event.keyCode === 8) {
         // meta + backspace

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -56,7 +56,6 @@
         <AposWidgetControls
           :first="i === 0"
           :last="i === next.length - 1"
-          :item="widget"
           :options="{ contextual: isContextual }"
           @up="$emit('up', i);"
           @remove="$emit('remove', i);"

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -1,7 +1,7 @@
 
 <template>
   <div
-    class="apos-area-widget-wrapper" :data-area-widget="widgetId"
+    class="apos-area-widget-wrapper" :data-area-widget="widget._id"
     :data-area-label="widgetLabel"
   >
     <div
@@ -9,7 +9,7 @@
       :class="ui.container"
       @mouseover="mouseover($event)"
       @mouseleave="mouseleave"
-      @click="getFocus($event, widgetId)"
+      @click="getFocus($event, widget._id)"
     >
       <div
         class="apos-area-widget-controls apos-area-widget__label"
@@ -56,6 +56,7 @@
         <AposWidgetControls
           :first="i === 0"
           :last="i === next.length - 1"
+          :item="widget"
           :options="{ contextual: isContextual }"
           @up="$emit('up', i);"
           @remove="$emit('remove', i);"
@@ -223,9 +224,6 @@ export default {
     moduleOptions() {
       return window.apos.area;
     },
-    widgetId() {
-      return cuid();
-    },
     isSuppressed() {
       if (this.focused) {
         return false;
@@ -236,7 +234,7 @@ export default {
       }
 
       if (this.widgetHovered) {
-        return this.widgetHovered !== this.widgetId;
+        return this.widgetHovered !== this.widget._id;
       } else {
         return false;
       }
@@ -266,7 +264,7 @@ export default {
   },
   watch: {
     widgetFocused (newVal) {
-      if (newVal === this.widgetId) {
+      if (newVal === this.widget._id) {
         this.focus();
       } else {
         // reset everything
@@ -299,7 +297,7 @@ export default {
       // If another widget was in focus (because the user clicked the "add"
       // menu, for example), and this widget was created, give the new widget
       // focus.
-      apos.bus.$emit('widget-focus', this.widgetId);
+      apos.bus.$emit('widget-focus', this.widget._id);
     }
   },
   methods: {
@@ -335,7 +333,7 @@ export default {
       this.state.add.bottom.show = true;
       this.state.container.highlight = true;
       this.state.labels.show = true;
-      apos.bus.$emit('widget-hover', this.widgetId);
+      apos.bus.$emit('widget-hover', this.widget._id);
     },
 
     mouseleave() {

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -47,10 +47,6 @@ export default {
       default() {
         return {};
       }
-    },
-    item: {
-      type: Object,
-      default: null
     }
   },
   emits: [ 'remove', 'edit', 'clone', 'up', 'down' ],

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -47,6 +47,10 @@ export default {
       default() {
         return {};
       }
+    },
+    item: {
+      type: Object,
+      default: null
     }
   },
   emits: [ 'remove', 'edit', 'clone', 'up', 'down' ],

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArea.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArea.vue
@@ -5,8 +5,9 @@
   >
     <template #body>
       <div class="apos-input-wrapper">
+        <!-- We do not pass docId here because it is solely for
+          contextual editing as far as the area editor is concerned. -Tom -->
         <Component
-          :doc-id="docId"
           :is="editorComponent"
           :options="field.options"
           :items="next.items"


### PR DESCRIPTION
… without breaking the widget controls within the area. Comprehensive fixes to ensure docId is not passed where it should not be (in a modal) or when the parent is just another widget that also intentionally does not know docId (metatypes to the rescue). Make sure parent areas know about edits to child areas even inside modals, because even inside a modal a nested area does not have AposInputArea as a direct parent, so the normal changed event does not cover that situation.