### PR TITLE
Fixes login event handler and checks for existing user

### DIFF
--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -57,11 +57,14 @@ module.exports = {
   },
   handlers(self, options) {
     return {
-      apostrophe: {
-        modulesReady() {
+      'apostrophe:modulesReady': {
+        addSecret() {
           // So this property is hashed and the hash kept in the safe,
           // rather than ever being stored literally
           self.apos.user.addSecret('passwordReset');
+        },
+        async checkForUser () {
+          await self.checkForUserAndAlert();
         }
       }
     };
@@ -335,8 +338,16 @@ module.exports = {
             }
           } : {})
         };
-      }
+      },
 
+      async checkForUserAndAlert() {
+        const adminReq = self.apos.task.getReq();
+        const user = await self.apos.user.find(adminReq, {}).limit(1).toObject();
+
+        if (!user) {
+          self.apos.util.warn('⚠️  There are no users created for this installation of ApostropheCMS yet.');
+        }
+      }
     };
   },
 


### PR DESCRIPTION
resolves: https://apostrophecms.atlassian.net/browse/A30U-418, "At start up, check if there is a user"

This looks like it might have had an outdated event handler syntax. It didn't seem to be triggering in the login module.