### PR TITLE
edit mode toggle, "publish changes" button, auto refresh of main content area on edits, gear icon is contextual to the context page or piece, "context bar" is roughed in (really roughed in)

### DIFF
--- a/modules/@apostrophecms/admin-bar/index.js
+++ b/modules/@apostrophecms/admin-bar/index.js
@@ -266,7 +266,7 @@ module.exports = {
             slug: context.slug
           },
           // Simplifies frontend logic
-          contextId: context._id,
+          contextId: context && context._id,
           contextEditorName
         };
       }

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -191,7 +191,6 @@ export default {
       }
     },
     emitEvent: function (name) {
-      console.log(name);
       apos.bus.$emit('admin-menu-click', name);
     },
     async save() {

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -136,7 +136,7 @@ module.exports = {
         });
         // Guarantee that `items` at least exists
         area.items = area.items || [];
-        const canEdit = area._edit && (options.edit !== false);
+        const canEdit = area._edit && (options.edit !== false) && req.query['apos-edit'];
         if (canEdit) {
           // Ease of access to image URLs. When not editing we
           // just use the helpers

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -149,7 +149,8 @@ module.exports = {
           field,
           options,
           choices,
-          context
+          context,
+          canEdit
         });
       },
       // Sanitize an input array of items intended to become

--- a/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
+++ b/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
@@ -6,6 +6,9 @@ export default function() {
   window.apos.bus.$on('widget-rendered', function() {
     createAreaApps();
   });
+  window.apos.bus.$on('refreshed', function() {
+    createAreaApps();
+  });
 
   function createAreaApps() {
     const els = document.querySelectorAll('[data-apos-area-newly-editable]');

--- a/modules/@apostrophecms/area/views/area.html
+++ b/modules/@apostrophecms/area/views/area.html
@@ -1,10 +1,9 @@
 {# area needs its own copy of the widget options as #}
 {# JSON, for adding new widgets #}
-{%- set canEdit = data.area._edit and data.options.edit != false -%}
 {%- set isSingleton = data.options.limit == 1 and data.options.type -%}
 
-<div class="apos-area" {%- if canEdit %} data-test data-apos-area-newly-editable data-doc-id='{{ data.area._docId | jsonAttribute({ single: true }) }}' data-field-id='{{ data.field._id | jsonAttribute({ single: true }) }}' data-options='{{ apos.util.omit(data.options, 'area') | jsonAttribute({ single: true }) }}' data='{{ data.area | jsonAttribute({ single: true }) }}' data-choices='{{ data.choices | jsonAttribute({ single: true }) }}'{% endif %}>
-  {%- if not canEdit -%}
+<div class="apos-area" {%- if data.canEdit %} data-test data-apos-area-newly-editable data-doc-id='{{ data.area._docId | jsonAttribute({ single: true }) }}' data-field-id='{{ data.field._id | jsonAttribute({ single: true }) }}' data-options='{{ apos.util.omit(data.options, 'area') | jsonAttribute({ single: true }) }}' data='{{ data.area | jsonAttribute({ single: true }) }}' data-choices='{{ data.choices | jsonAttribute({ single: true }) }}'{% endif %}>
+  {%- if not data.canEdit -%}
     {%- for item in data.area.items -%}
       {%- set widgetOptions = data.options.widgets[item.type] or {} -%}
       {% widget item, widgetOptions %}

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -284,6 +284,7 @@ export default {
             busy: true,
             body
           });
+          apos.bus.$emit('content-changed', doc);
         } catch (e) {
           await this.handleSaveError(e, {
             fallback: 'An error occurred saving the document.'

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -217,11 +217,11 @@ export default {
         }
 
         try {
-          await apos.http.put(route, {
+          const doc = await apos.http.put(route, {
             busy: true,
             body: this.docFields.data
           });
-
+          apos.bus.$emit('content-changed', doc);
           this.original = klona(this.docFields.data);
           this.$emit('modified', false);
           this.$emit('saved');

--- a/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
+++ b/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
@@ -28,19 +28,4 @@ export default function() {
   });
   apos.modal.execute = theAposModals.execute;
   apos.confirm = theAposModals.confirm;
-  apos.bus.$on('content-changed', async () => {
-    const content = await apos.http.get(window.location.href, {
-      headers: {
-        'Cache-Control': 'no-cache'
-      },
-      qs: {
-        ...apos.http.parseQuery(window.location.search),
-        'apos-refresh': '1'
-      }
-    });
-    const refreshable = document.querySelector('[data-apos-refreshable]');
-    if (refreshable) {
-      refreshable.innerHTML = content;
-    }
-  });
 };

--- a/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
+++ b/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
@@ -28,4 +28,16 @@ export default function() {
   });
   apos.modal.execute = theAposModals.execute;
   apos.confirm = theAposModals.confirm;
+  apos.bus.$on('content-changed', async () => {
+    const content = await apos.http.get(window.location.href, {
+      headers: {
+        'Cache-Control': 'no-cache',
+        'Apostrophe-Refresh': 'true'
+      }
+    });
+    const refreshable = document.querySelector('[data-apos-refreshable]');
+    if (refreshable) {
+      refreshable.innerHTML = content;
+    }
+  });
 };

--- a/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
+++ b/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
@@ -31,8 +31,11 @@ export default function() {
   apos.bus.$on('content-changed', async () => {
     const content = await apos.http.get(window.location.href, {
       headers: {
-        'Cache-Control': 'no-cache',
-        'Apostrophe-Refresh': 'true'
+        'Cache-Control': 'no-cache'
+      },
+      qs: {
+        ...apos.http.parseQuery(window.location.search),
+        'apos-refresh': '1'
       }
     });
     const refreshable = document.querySelector('[data-apos-refreshable]');

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -333,21 +333,14 @@ module.exports = {
       //
       // Note the lack of quotes.
       //
-      // Under the following conditions, `refreshLayout.html`
-      // is used in place of `outerLayout.html`:
-      //
-      // `req.xhr` is true (always set on AJAX requests by jQuery)
-      // `req.query.xhr` is set to simulate an AJAX request
-      // `req.decorate` is false
-      // `req.query.apos_refresh` is true
+      // If `req.headers['apostrophe-refresh']` is `'true'`,
+      // `refreshLayout.html` is used in place of `outerLayout.html`.
       //
       // These default properties are provided on
       // the `data` object in nunjucks:
       //
       // `data.user` (req.user)
       // `data.query` (req.query)
-      // `data.calls` (javascript markup to insert all global and
-      //   request-specific calls pushed by server-side code)
       //
       // This method is async in 3.x and must be awaited.
 
@@ -378,13 +371,8 @@ module.exports = {
       //
       // Note the lack of quotes.
       //
-      // Under the following conditions, `refreshLayout.html`
-      // is used in place of `outerLayout.html`:
-      //
-      // `req.xhr` is true (always set on AJAX requests by jQuery)
-      // `req.query.xhr` is set to simulate an AJAX request
-      // `req.decorate` is false
-      // `req.query.apos_refresh` is true
+      // If `req.headers['apostrophe-refresh']` is `'true'`,
+      // `refreshLayout.html` is used in place of `outerLayout.html`.
       //
       // These default properties are provided on
       // the `data` object in nunjucks:

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -333,7 +333,7 @@ module.exports = {
       //
       // Note the lack of quotes.
       //
-      // If `req.headers['apostrophe-refresh']` is `'true'`,
+      // If `req.query.apos-refresh` is `'1'`,
       // `refreshLayout.html` is used in place of `outerLayout.html`.
       //
       // These default properties are provided on
@@ -371,7 +371,7 @@ module.exports = {
       //
       // Note the lack of quotes.
       //
-      // If `req.headers['apostrophe-refresh']` is `'true'`,
+      // If `req.query.apos-refresh` is `'1'`,
       // `refreshLayout.html` is used in place of `outerLayout.html`.
       //
       // These default properties are provided on

--- a/modules/@apostrophecms/template/index.js
+++ b/modules/@apostrophecms/template/index.js
@@ -570,13 +570,8 @@ module.exports = {
       //
       // Note the lack of quotes.
       //
-      // Under **any** of the following conditions, "refreshLayout.html"
-      // is used in place of "outerLayout.html":
-      //
-      // * `req.xhr` is true (always set on AJAX requests by jQuery)
-      // * `req.query.xhr` is set to simulate an AJAX request
-      // * `req.decorate` is false
-      // * `req.query.apos_refresh` is true
+      // If `req.headers['apostrophe-refresh']` is `'true'`,
+      // `refreshLayout.html` is used in place of `outerLayout.html`.
       //
       // These default properties are also provided on the `data` object
       // visible in Nunjucks:
@@ -628,30 +623,22 @@ module.exports = {
         // Waits for DOMready to give other
         // things maximum opportunity to happen.
 
-        const decorate = !(req.query.apos_refresh || req.query.xhr || req.xhr || req.decorate === false);
+        const decorate = (req.headers['apostrophe-refresh'] !== 'true');
 
         // data.url will be the original requested page URL, for use in building
         // relative links, adding or removing query parameters, etc. If this is a
         // refresh request, we remove that so that frontend templates don't build
         // URLs that also refresh
 
-        let dataUrl = req.url;
-
-        const parsed = new URL(req.absoluteUrl);
-        if (parsed.query && parsed.searchParams.get('apos_refresh')) {
-          parsed.searchParams.remove('apos_refresh');
-          dataUrl = parsed.toString();
-        }
-
         const args = {
           outerLayout: decorate ? '@apostrophecms/template:outerLayout.html' : '@apostrophecms/template:refreshLayout.html',
           permissions: req.user && (req.user._permissions || {}),
           scene,
-          refreshing: req.query && !!req.query.apos_refresh,
+          refreshing: !decorate,
           // Make the query available to templates for easy access to
           // filter settings etc.
           query: req.query,
-          url: dataUrl
+          url: req.url
         };
 
         _.extend(args, data);

--- a/modules/@apostrophecms/template/index.js
+++ b/modules/@apostrophecms/template/index.js
@@ -570,7 +570,7 @@ module.exports = {
       //
       // Note the lack of quotes.
       //
-      // If `req.headers['apostrophe-refresh']` is `'true'`,
+      // If `req.query.apos-refresh` is `'1'`,
       // `refreshLayout.html` is used in place of `outerLayout.html`.
       //
       // These default properties are also provided on the `data` object
@@ -623,7 +623,7 @@ module.exports = {
         // Waits for DOMready to give other
         // things maximum opportunity to happen.
 
-        const decorate = (req.headers['apostrophe-refresh'] !== 'true');
+        const decorate = (req.query['apos-refresh'] !== '1');
 
         // data.url will be the original requested page URL, for use in building
         // relative links, adding or removing query parameters, etc. If this is a

--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -392,7 +392,7 @@ module.exports = {
       // `req.query.xhr` is set to emulate it) and Apostrophe's
       // main content area refresh mechanism is not in play.
       isAjaxRequest(req) {
-        return (req.xhr || req.query.xhr) && (req.headers['apostrophe-refresh'] !== 'true');
+        return (req.xhr || req.query.xhr) && (req.query['apos-refresh'] !== '1');
       },
       // Sort the given array of strings in place, comparing strings in a case-insensitive way.
       insensitiveSort(strings) {

--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -389,10 +389,10 @@ module.exports = {
         return items;
       },
       // Return true if `req` is an AJAX request (`req.xhr` is set, or
-      // `req.query.xhr` is set to emulate it, or `req.query.apos_refresh` has
-      // been set by Apostrophe's content refresh mechanism).
+      // `req.query.xhr` is set to emulate it) and Apostrophe's
+      // main content area refresh mechanism is not in play.
       isAjaxRequest(req) {
-        return (req.xhr || req.query.xhr) && !req.query.apos_refresh;
+        return (req.xhr || req.query.xhr) && (req.headers['apostrophe-refresh'] !== 'true');
       },
       // Sort the given array of strings in place, comparing strings in a case-insensitive way.
       insensitiveSort(strings) {

--- a/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
+++ b/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
@@ -34,7 +34,7 @@ export default {
   methods: {
     async renderContent() {
       try {
-        this.rendered = await apos.http.post(`${apos.area.action}/render-widget`, {
+        this.rendered = await apos.http.post(`${apos.area.action}/render-widget?apos-edit=1`, {
           busy: true,
           body: {
             _docId: this.docId,


### PR DESCRIPTION
* Functioning edit mode toggle, remembered in session storage so it persists for the lifetime of the current tab
* Main content area refreshes when pieces and page settings change, this mechanism is also used in the implementation of edit mode
* Page always renders normally ("preview") unless apos-edit=1 is present in the query string
* parseQuery method to complement addQueryToUrl, did it this way because we want apos-edit and apos-refresh to be query parameters (because "custom headers should not change the response body") and because we'll want to be able to fully parse filters with nested objects/arrays from the query before too long (thinking ahead to how we'll address what used to be called data-apos-ajax and other things). This implementation understands everything addQueryToUrl can stringify and is much smaller than comparable implementations, might be worth releasing this pair as a module
* Gear icon is contextual to the right context document
* "Save" became "Publish Changes" as that is what it does until we have drafts
