### PR TITLE
3/tooltips

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/apps/AposAdminBar.js
+++ b/modules/@apostrophecms/admin-bar/ui/apos/apps/AposAdminBar.js
@@ -1,5 +1,8 @@
 import Vue from 'apostrophe/vue';
 import { VTooltip } from 'v-tooltip';
+import tooltipConfig from 'Modules/@apostrophecms/ui/lib/tooltip';
+
+tooltipConfig.updateOptions(VTooltip);
 Vue.directive('tooltip', VTooltip);
 
 export default function() {

--- a/modules/@apostrophecms/admin-bar/ui/apos/apps/AposAdminBar.js
+++ b/modules/@apostrophecms/admin-bar/ui/apos/apps/AposAdminBar.js
@@ -1,4 +1,6 @@
 import Vue from 'apostrophe/vue';
+import { VTooltip } from 'v-tooltip';
+Vue.directive('tooltip', VTooltip);
 
 export default function() {
   // Careful, login page is in user scene but has no admin bar

--- a/modules/@apostrophecms/admin-bar/ui/apos/apps/AposAdminBar.js
+++ b/modules/@apostrophecms/admin-bar/ui/apos/apps/AposAdminBar.js
@@ -1,9 +1,4 @@
-import Vue from 'apostrophe/vue';
-import { VTooltip } from 'v-tooltip';
-import tooltipConfig from 'Modules/@apostrophecms/ui/lib/tooltip';
-
-tooltipConfig.updateOptions(VTooltip);
-Vue.directive('tooltip', VTooltip);
+import Vue from 'Modules/@apostrophecms/ui/lib/vue';
 
 export default function() {
   // Careful, login page is in user scene but has no admin bar

--- a/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
+++ b/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
@@ -1,9 +1,4 @@
-import Vue from 'apostrophe/vue';
-import { VTooltip } from 'v-tooltip';
-import tooltipConfig from 'Modules/@apostrophecms/ui/lib/tooltip';
-
-tooltipConfig.updateOptions(VTooltip);
-Vue.directive('tooltip', VTooltip);
+import Vue from 'Modules/@apostrophecms/ui/lib/vue';
 
 export default function() {
 

--- a/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
+++ b/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
@@ -1,5 +1,8 @@
 import Vue from 'apostrophe/vue';
 import { VTooltip } from 'v-tooltip';
+import tooltipConfig from 'Modules/@apostrophecms/ui/lib/tooltip';
+
+tooltipConfig.updateOptions(VTooltip);
 Vue.directive('tooltip', VTooltip);
 
 export default function() {

--- a/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
+++ b/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
@@ -1,4 +1,6 @@
 import Vue from 'apostrophe/vue';
+import { VTooltip } from 'v-tooltip';
+Vue.directive('tooltip', VTooltip);
 
 export default function() {
 

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -51,8 +51,6 @@
 </template>
 
 <script>
-
-import Vue from 'apostrophe/vue';
 import cuid from 'cuid';
 import klona from 'klona';
 

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -160,7 +160,7 @@ ${bundle}
 
           fs.writeFileSync(importFile, `
 import 'Modules/@apostrophecms/ui/scss/global/import-all.scss';
-import Vue from 'apostrophe/vue';
+import Vue from 'Modules/@apostrophecms/ui/lib/vue';
 if (window.apos.modules) {
   for (const module of Object.values(window.apos.modules)) {
     if (module.alias) {

--- a/modules/@apostrophecms/asset/lib/webpack.config.js
+++ b/modules/@apostrophecms/asset/lib/webpack.config.js
@@ -37,7 +37,6 @@ module.exports = ({ importFile, modulesDir }, apos) => {
     resolve: {
       extensions: [ '*', '.js', '.vue', '.json' ],
       alias: {
-        'apostrophe/vue$': 'vue/dist/vue.esm.js',
         vue$: 'vue/dist/vue.esm.js',
         // resolve apostrophe modules
         Modules: path.resolve(modulesDir)

--- a/modules/@apostrophecms/busy/ui/apos/apps/AposBusy.js
+++ b/modules/@apostrophecms/busy/ui/apos/apps/AposBusy.js
@@ -1,4 +1,4 @@
-import Vue from 'apostrophe/vue';
+import Vue from 'Modules/@apostrophecms/ui/lib/vue';
 
 export default function() {
   return new Vue({

--- a/modules/@apostrophecms/login/ui/apos/apps/AposLogin.js
+++ b/modules/@apostrophecms/login/ui/apos/apps/AposLogin.js
@@ -1,4 +1,4 @@
-import Vue from 'apostrophe/vue';
+import Vue from 'Modules/@apostrophecms/ui/lib/vue';
 
 export default function() {
   const el = document.querySelector('#apos-login');

--- a/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
+++ b/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
@@ -1,8 +1,11 @@
 import Vue from 'apostrophe/vue';
 import PortalVue from 'portal-vue';
 import { VTooltip } from 'v-tooltip';
-Vue.use(PortalVue);
+import tooltipConfig from 'Modules/@apostrophecms/ui/lib/tooltip';
+
+tooltipConfig.updateOptions(VTooltip);
 Vue.directive('tooltip', VTooltip);
+Vue.use(PortalVue);
 
 export default function() {
   const theAposModals = new Vue({

--- a/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
+++ b/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
@@ -1,6 +1,8 @@
 import Vue from 'apostrophe/vue';
 import PortalVue from 'portal-vue';
+import { VTooltip } from 'v-tooltip';
 Vue.use(PortalVue);
+Vue.directive('tooltip', VTooltip);
 
 export default function() {
   const theAposModals = new Vue({

--- a/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
+++ b/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
@@ -1,11 +1,4 @@
-import Vue from 'apostrophe/vue';
-import PortalVue from 'portal-vue';
-import { VTooltip } from 'v-tooltip';
-import tooltipConfig from 'Modules/@apostrophecms/ui/lib/tooltip';
-
-tooltipConfig.updateOptions(VTooltip);
-Vue.directive('tooltip', VTooltip);
-Vue.use(PortalVue);
+import Vue from 'Modules/@apostrophecms/ui/lib/vue';
 
 export default function() {
   const theAposModals = new Vue({

--- a/modules/@apostrophecms/notification/ui/apos/apps/AposNotification.js
+++ b/modules/@apostrophecms/notification/ui/apos/apps/AposNotification.js
@@ -1,4 +1,4 @@
-import Vue from 'apostrophe/vue';
+import Vue from 'Modules/@apostrophecms/ui/lib/vue';
 
 export default function() {
   if (!apos.login.user) {

--- a/modules/@apostrophecms/storybook/template/.storybook/preview.tmpl.js
+++ b/modules/@apostrophecms/storybook/template/.storybook/preview.tmpl.js
@@ -9,6 +9,9 @@
 import 'Modules/@apostrophecms/storybook/scss/storybook.scss';
 
 import Vue from 'apostrophe/vue';
+import { VTooltip } from 'v-tooltip';
+Vue.directive('tooltip', VTooltip);
+
 if (window.apos.modules) {
   for (const module of Object.values(window.apos.modules)) {
     if (module.alias) {

--- a/modules/@apostrophecms/storybook/template/.storybook/preview.tmpl.js
+++ b/modules/@apostrophecms/storybook/template/.storybook/preview.tmpl.js
@@ -10,6 +10,9 @@ import 'Modules/@apostrophecms/storybook/scss/storybook.scss';
 
 import Vue from 'apostrophe/vue';
 import { VTooltip } from 'v-tooltip';
+import tooltipConfig from 'Modules/@apostrophecms/ui/lib/tooltip';
+
+tooltipConfig.updateOptions(VTooltip);
 Vue.directive('tooltip', VTooltip);
 
 if (window.apos.modules) {

--- a/modules/@apostrophecms/storybook/template/.storybook/preview.tmpl.js
+++ b/modules/@apostrophecms/storybook/template/.storybook/preview.tmpl.js
@@ -8,12 +8,7 @@
 
 import 'Modules/@apostrophecms/storybook/scss/storybook.scss';
 
-import Vue from 'apostrophe/vue';
-import { VTooltip } from 'v-tooltip';
-import tooltipConfig from 'Modules/@apostrophecms/ui/lib/tooltip';
-
-tooltipConfig.updateOptions(VTooltip);
-Vue.directive('tooltip', VTooltip);
+import Vue from 'Modules/@apostrophecms/ui/lib/vue';
 
 if (window.apos.modules) {
   for (const module of Object.values(window.apos.modules)) {

--- a/modules/@apostrophecms/storybook/template/.storybook/webpack.js
+++ b/modules/@apostrophecms/storybook/template/.storybook/webpack.js
@@ -45,8 +45,6 @@ module.exports = async (config) => {
     path.resolve(`${process.env.APOS_ROOT}/node_modules`)
   ];
 
-  // find vue like our components do
-  config.resolve.alias['apostrophe/vue$'] = 'vue/dist/vue.esm.js';
   // resolve frontend assets of apostrophe modules as Modules/@apostrophecms/modulename/something
   config.resolve.alias['Modules'] = path.resolve(`${process.env.APOS_ROOT}/apos-build/modules`);
 

--- a/modules/@apostrophecms/ui/ui/apos/components/AposButton.stories.js
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposButton.stories.js
@@ -46,6 +46,9 @@ export const buttons = () => ({
     disabled: {
       default: boolean('Disabled', false)
     },
+    tooltip: {
+      default: boolean('Activate Tooltip (on hover)', false)
+    },
     busy: {
       default: boolean('Busy', false)
     },
@@ -66,8 +69,10 @@ export const buttons = () => ({
         )
     }
   },
+  // Margin added to make room for demonstrating tooltip.
   template: `
     <AposButton
+      style="margin: 100px;"
       :disabled="disabled"
       :label="label"
       :busy="busy"
@@ -75,6 +80,7 @@ export const buttons = () => ({
       :icon="icon"
       :iconOnly="iconOnly"
       v-bind:modifiers="modifiers"
+      :tooltip="tooltip ? 'Duis mollis, est<br />porttitor ligula.' : null"
     />
   `
 });

--- a/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
@@ -8,6 +8,7 @@
     :disabled="isDisabled"
     :type="buttonType"
     :role="role"
+    v-tooltip="tooltip"
   >
     <transition name="fade">
       <AposSpinner :color="spinnerColor" v-if="busy" />
@@ -75,6 +76,10 @@ export default {
     },
     role: {
       type: [ String, Boolean ],
+      default: false
+    },
+    tooltip: {
+      type: [ String, Object, Boolean ],
       default: false
     }
   },

--- a/modules/@apostrophecms/ui/ui/apos/lib/tooltip.js
+++ b/modules/@apostrophecms/ui/ui/apos/lib/tooltip.js
@@ -1,0 +1,13 @@
+export default {
+  updateOptions (tooltipObject) {
+    tooltipObject.options.defaultOffset = '11';
+    tooltipObject.options.defaultPlacement = 'bottom-end';
+    tooltipObject.options.defaultTemplate = `
+      <div class="apos-tooltip" role="tooltip">
+        <div class="apos-tooltip__arrow"></div>
+        <div class="apos-tooltip__inner"></div>
+      </div>`;
+    tooltipObject.options.defaultArrowSelector = '.apos-tooltip__arrow';
+    tooltipObject.options.defaultInnerSelector = '.apos-tooltip__inner';
+  }
+};

--- a/modules/@apostrophecms/ui/ui/apos/lib/vue.js
+++ b/modules/@apostrophecms/ui/ui/apos/lib/vue.js
@@ -1,0 +1,8 @@
+import Vue from 'vue';
+import { VTooltip } from 'v-tooltip';
+import tooltipConfig from './tooltip';
+
+tooltipConfig.updateOptions(VTooltip);
+Vue.directive('tooltip', VTooltip);
+
+export default Vue;

--- a/modules/@apostrophecms/ui/ui/apos/scss/global/_tooltips.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/_tooltips.scss
@@ -1,48 +1,47 @@
-// stylelint-disable
-.tooltip {
-  display: block !important;
-  z-index: 10000;
+// Styles based on the v-tooltip example styles:
+// https://github.com/Akryum/v-tooltip/blob/83615e394c96ca491a4df04b892ae87e833beb97/demo-src/src/App.vue#L179-L303
+.apos-tooltip {
+  z-index: $z-index-notifications;
+  display: block;
 
-  .tooltip-inner {
-    background: black;
-    color: white;
-    border-radius: 16px;
-    padding: 5px 10px 4px;
+  .apos-tooltip__inner {
+    @include type-large;
+    z-index: $z-index-default;
+    position: relative;
+    padding: 16px;
+    border-radius: 5px;
+    border-width: 0;
+    color: var(--a-text-inverted);
+    background: var(--a-background-inverted);
   }
 
-  .tooltip-arrow {
-    width: 0;
-    height: 0;
-    border-style: solid;
+  .apos-tooltip__arrow {
+    z-index: $z-index-base;
     position: absolute;
+    width: 16px;
+    height: 16px;
     margin: 5px;
-    border-color: black;
-    z-index: 1;
+    border-radius: 5px;
+    border-style: solid;
+    background-color: var(--a-background-inverted);
+    transform: rotate(45deg);
   }
 
-  &[x-placement^="top"] {
+  &[x-placement^='top'] {
     margin-bottom: 5px;
 
-    .tooltip-arrow {
-      border-width: 5px 5px 0 5px;
-      border-left-color: transparent !important;
-      border-right-color: transparent !important;
-      border-bottom-color: transparent !important;
-      bottom: -5px;
+    .apos-tooltip__arrow {
+      bottom: -7px;
       left: calc(50% - 5px);
       margin-top: 0;
       margin-bottom: 0;
     }
   }
 
-  &[x-placement^="bottom"] {
+  &[x-placement^='bottom'] {
     margin-top: 5px;
 
-    .tooltip-arrow {
-      border-width: 0 5px 5px 5px;
-      border-left-color: transparent !important;
-      border-right-color: transparent !important;
-      border-top-color: transparent !important;
+    .apos-tooltip__arrow {
       top: -5px;
       left: calc(50% - 5px);
       margin-top: 0;
@@ -50,61 +49,37 @@
     }
   }
 
-  &[x-placement^="right"] {
+  &[x-placement^='right'] {
     margin-left: 5px;
 
-    .tooltip-arrow {
-      border-width: 5px 5px 5px 0;
-      border-left-color: transparent !important;
-      border-top-color: transparent !important;
-      border-bottom-color: transparent !important;
-      left: -5px;
+    .apos-tooltip__arrow {
       top: calc(50% - 5px);
+      left: -5px;
       margin-left: 0;
       margin-right: 0;
     }
   }
 
-  &[x-placement^="left"] {
+  &[x-placement^='left'] {
     margin-right: 5px;
 
-    .tooltip-arrow {
-      border-width: 5px 0 5px 5px;
-      border-top-color: transparent !important;
-      border-right-color: transparent !important;
-      border-bottom-color: transparent !important;
-      right: -5px;
+    .apos-tooltip__arrow {
       top: calc(50% - 5px);
+      right: -5px;
       margin-left: 0;
       margin-right: 0;
-    }
-  }
-
-  &.popover {
-    $color: #f9f9f9;
-
-    .popover-inner {
-      background: $color;
-      color: black;
-      padding: 24px;
-      border-radius: 5px;
-      box-shadow: 0 5px 30px rgba(black, .1);
-    }
-
-    .popover-arrow {
-      border-color: $color;
     }
   }
 
   &[aria-hidden='true'] {
     visibility: hidden;
     opacity: 0;
-    transition: opacity .15s, visibility .15s;
+    transition: opacity 0.15s, visibility 0.15s;
   }
 
   &[aria-hidden='false'] {
     visibility: visible;
     opacity: 1;
-    transition: opacity .15s;
+    transition: opacity 0.15s;
   }
 }

--- a/modules/@apostrophecms/ui/ui/apos/scss/global/_tooltips.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/_tooltips.scss
@@ -1,0 +1,110 @@
+// stylelint-disable
+.tooltip {
+  display: block !important;
+  z-index: 10000;
+
+  .tooltip-inner {
+    background: black;
+    color: white;
+    border-radius: 16px;
+    padding: 5px 10px 4px;
+  }
+
+  .tooltip-arrow {
+    width: 0;
+    height: 0;
+    border-style: solid;
+    position: absolute;
+    margin: 5px;
+    border-color: black;
+    z-index: 1;
+  }
+
+  &[x-placement^="top"] {
+    margin-bottom: 5px;
+
+    .tooltip-arrow {
+      border-width: 5px 5px 0 5px;
+      border-left-color: transparent !important;
+      border-right-color: transparent !important;
+      border-bottom-color: transparent !important;
+      bottom: -5px;
+      left: calc(50% - 5px);
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+
+  &[x-placement^="bottom"] {
+    margin-top: 5px;
+
+    .tooltip-arrow {
+      border-width: 0 5px 5px 5px;
+      border-left-color: transparent !important;
+      border-right-color: transparent !important;
+      border-top-color: transparent !important;
+      top: -5px;
+      left: calc(50% - 5px);
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+
+  &[x-placement^="right"] {
+    margin-left: 5px;
+
+    .tooltip-arrow {
+      border-width: 5px 5px 5px 0;
+      border-left-color: transparent !important;
+      border-top-color: transparent !important;
+      border-bottom-color: transparent !important;
+      left: -5px;
+      top: calc(50% - 5px);
+      margin-left: 0;
+      margin-right: 0;
+    }
+  }
+
+  &[x-placement^="left"] {
+    margin-right: 5px;
+
+    .tooltip-arrow {
+      border-width: 5px 0 5px 5px;
+      border-top-color: transparent !important;
+      border-right-color: transparent !important;
+      border-bottom-color: transparent !important;
+      right: -5px;
+      top: calc(50% - 5px);
+      margin-left: 0;
+      margin-right: 0;
+    }
+  }
+
+  &.popover {
+    $color: #f9f9f9;
+
+    .popover-inner {
+      background: $color;
+      color: black;
+      padding: 24px;
+      border-radius: 5px;
+      box-shadow: 0 5px 30px rgba(black, .1);
+    }
+
+    .popover-arrow {
+      border-color: $color;
+    }
+  }
+
+  &[aria-hidden='true'] {
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity .15s, visibility .15s;
+  }
+
+  &[aria-hidden='false'] {
+    visibility: visible;
+    opacity: 1;
+    transition: opacity .15s;
+  }
+}

--- a/modules/@apostrophecms/ui/ui/apos/scss/global/_tooltips.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/_tooltips.scss
@@ -22,6 +22,7 @@
     height: 16px;
     margin: 5px;
     border-radius: 5px;
+    // Solid border style needed to work with v-tooltip placement.
     border-style: solid;
     background-color: var(--a-background-inverted);
     transform: rotate(45deg);

--- a/modules/@apostrophecms/ui/ui/apos/scss/global/_tooltips.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/_tooltips.scss
@@ -5,7 +5,7 @@
   display: block;
 
   .apos-tooltip__inner {
-    @include type-large;
+    @include type-small;
     z-index: $z-index-default;
     position: relative;
     padding: 16px;

--- a/modules/@apostrophecms/ui/ui/apos/scss/global/import-all.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/import-all.scss
@@ -9,4 +9,5 @@
 @import './_scrollbars';
 @import './_utilities';
 @import './_tables';
+@import './_tooltips';
 @import 'Modules/@apostrophecms/notification/scss/notification';

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "passport-local": "^1.0.0",
     "path-to-regexp": "^1.8.0",
     "performance-now": "^2.1.0",
-    "portal-vue": "^2.1.7",
     "postcss-import": "^12.0.1",
     "postcss-loader": "^3.0.0",
     "postcss-prefixer": "^2.1.2",


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-724, "Implement tooltips"

Currently only implemented for buttons. Adding anywhere else only requires using the `v-tooltip` directive with either a string or [configuration object](https://github.com/Akryum/v-tooltip#object-notation).

![tooltip design example](https://user-images.githubusercontent.com/1155984/98989653-04b9c800-24ef-11eb-88f7-ef8e366c60d5.png)