### PR TITLE
Allows clicks anywhere on piece manager table row to open piece

### DIFF
--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
@@ -1,6 +1,6 @@
 <template>
   <AposModal
-    :modal="modal" :modal-title="modalTitle" 
+    :modal="modal" :modal-title="modalTitle"
     ref="modal"
     @esc="confirmAndCancel" @no-modal="$emit('safe-close')"
     @inactive="modal.active = false" @show-modal="modal.showModal = true"
@@ -187,13 +187,6 @@ export default {
     this.destroyShortcuts();
   },
   methods: {
-    // TEMP From Manager Mixin:
-    // selectAll
-    // iconSize
-    // sort
-    // generateUi
-    // generateIcons
-    // generateCheckboxes
     moreMenuHandler(action) {
       if (action === 'new') {
         this.new();

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManagerDisplay.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManagerDisplay.vue
@@ -11,7 +11,7 @@
           class="apos-table__header" :key="header.label"
         >
           <component
-            :is="getEl(header)" 
+            :is="getEl(header)"
             class="apos-table__header-label"
           >
             <component
@@ -48,18 +48,21 @@
           />
         </td>
         <td
-          class="apos-table__cell" v-for="header in headers"
+          class="apos-table__cell apos-table__cell--pointer" v-for="header in headers"
           :key="item[header.name]"
+          @click="$emit('open',item._id)"
         >
           <a
-            v-if="header.name === 'url'" class="apos-table__link"
+            v-if="header.name === '_url' && item[header.name]"
+            class="apos-table__link"
             :href="item[header.name]"
+            @click.stop
           >
-            <LinkIcon :size="12" />
+            <link-icon :size="14" />
           </a>
           <button
             v-else-if="header.name === 'title'"
-            @click="$emit('open',item._id)"
+            @click.stop="$emit('open',item._id)"
             class="apos-table__cell-field"
             :class="`apos-table__cell-field--${header.name}`"
           >
@@ -136,3 +139,9 @@ export default {
   }
 };
 </script>
+
+<style lang="scss" scoped>
+  .apos-table__cell--pointer {
+    cursor: pointer;
+  }
+</style>


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-441, "Entire row in (piece) manager windows should click through the primary action of editing the item."