### PR TITLE
page level undo/redo support

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -91,6 +91,20 @@
             class="apos-admin-bar__btn"
             @click="save"
           />
+          <AposButton
+            v-if="patches.length"
+            type="default" label="Undo"
+            icon="undo-icon" class="apos-admin-bar__btn"
+            :icon-only="true"
+            @click="undo"
+          />
+          <AposButton
+            v-if="undone.length"
+            type="default" label="Redo"
+            icon="redo-icon" class="apos-admin-bar__btn"
+            :icon-only="true"
+            @click="redo"
+          />
         </span>
       </div>
     </nav>
@@ -116,6 +130,7 @@ export default {
       menuItems: [],
       createMenu: [],
       patches: [],
+      undone: [],
       editMode: window.sessionStorage.getItem('aposEditMode') === 'true'
     };
   },
@@ -162,6 +177,7 @@ export default {
 
     apos.bus.$on('context-edited', patch => {
       this.patches.push(patch);
+      this.undone = [];
     });
 
     window.addEventListener('beforeunload', this.beforeUnload);
@@ -212,24 +228,50 @@ export default {
       this.editMode = false;
       this.refresh();
     },
-    async refresh() {
-      const content = await apos.http.get(window.location.href, {
-        headers: {
-          'Cache-Control': 'no-cache'
-        },
-        qs: {
-          ...apos.http.parseQuery(window.location.search),
-          'apos-refresh': '1',
-          ...(this.editMode ? {
-            'apos-edit': '1'
-          } : {})
-        }
-      });
+    async refresh({ asPatched } = {}) {
+      let content;
+      let url = window.location.href;
+      const qs = {
+        ...apos.http.parseQuery(window.location.search),
+        'apos-refresh': '1',
+        ...(this.editMode ? {
+          'apos-edit': '1'
+        } : {})
+      };
+      url = url.replace(/\?.*$/, '');
+      url = apos.http.addQueryToUrl(url, qs);
+      if (asPatched) {
+        content = await apos.http.post(`${window.apos.doc.action}/get-as-patched`, {
+          body: {
+            url,
+            _id: this.moduleOptions.contextId,
+            type: this.moduleOptions.context.type,
+            patches: asPatched
+          },
+          busy: true
+        });
+      } else {
+        content = await apos.http.get(window.location.href, {
+          qs,
+          headers: {
+            'Cache-Control': 'no-cache'
+          },
+          busy: true
+        });
+      }
       const refreshable = document.querySelector('[data-apos-refreshable]');
       if (refreshable) {
         refreshable.innerHTML = content;
       }
       apos.bus.$emit('refreshed');
+    },
+    async undo() {
+      this.undone.push(this.patches.pop());
+      this.refresh({ asPatched: this.patches });
+    },
+    async redo() {
+      this.patches.push(this.undone.pop());
+      this.refresh({ asPatched: this.patches });
     }
   }
 };

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1485,12 +1485,20 @@ module.exports = {
           return count;
         },
 
-        // Returns an array of documents matching
-        // the query. Not chainable.
+        // Returns an array of documents matching the query. Not chainable.
 
         async toArray() {
           const mongo = await query.toMongo();
           const docs = await query.mongoToArray(mongo);
+          if (query.req.query['apos-as-patched']) {
+            const asPatched = await self.apos.cache.get('as-patched', query.req.query['apos-as-patched']);
+            if (asPatched) {
+              const doc = docs.find(doc => doc._id === asPatched._id);
+              if (doc) {
+                Object.assign(doc, asPatched);
+              }
+            }
+          }
           await query.after(docs);
           return docs;
         },

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -1,4 +1,6 @@
 const _ = require('lodash');
+const cuid = require('cuid');
+
 // This module is responsible for managing all of the documents (apostrophe "docs")
 // in the `aposDocs` mongodb collection.
 //
@@ -79,6 +81,59 @@ module.exports = {
               available: true
             };
           }
+        }
+      }
+    };
+  },
+  routes(self, options) {
+    return {
+      post: {
+        // POST to /@apostrophecms/doc/api/v1/get-as-patched with
+        // the properties `url`, `_id`, `type` and `patches` in order
+        // to fetch the given document, apply the supplied patches
+        // without actually saving them, and then render the given
+        // `url` exactly as if it were a normal GET request for it,
+        // substituting the patched doc for any query that would
+        // otherwise return it. This is useful for re-rendering after
+        // undo/redo, given that we don't actually save edits
+        // on the fly, undo/redo included.
+        async getAsPatched(req, res) {
+          let url = self.apos.launder.string(req.body.url);
+          const _id = self.apos.launder.id(req.body._id);
+          const type = self.apos.launder.string(req.body.type);
+          const patches = Array.isArray(req.body.patches) ? req.body.patches : [];
+          const manager = self.getManager(type);
+          if (!manager) {
+            return self.routeSendError(req, self.apos.error('invalid'));
+          }
+          const query = await manager.find(req, { _id });
+          if (self.apos.instanceOf(manager, '@apostrophecms/page-type')) {
+            query.ancestors(true);
+          }
+          const doc = await query.toObject();
+          if (!doc) {
+            return self.routeSendError(req, self.apos.error('notfound'));
+          }
+          for (const input of patches) {
+            if (self.apos.page.isPage(doc)) {
+              await self.apos.page.applyPatch(req, doc, input);
+            } else {
+              await manager.applyPatch(req, doc, input);
+            }
+          }
+          // As far as applyPatch is concerned, relationships are
+          // real, but as far as mongo is concerned they're not, so
+          // we have to get back to real _ids before we try to substitute
+          // this document in the result of a mongo query
+          manager.prepareRelationshipsForStorage(req, doc);
+          const key = cuid();
+          await self.apos.cache.set('as-patched', key, self.apos.util.clonePermanent(doc), 300);
+          if (url.indexOf('?') !== -1) {
+            url += `&apos-as-patched=${key}`;
+          } else {
+            url += `?apos-as-patched=${key}`;
+          }
+          return res.redirect(url);
         }
       }
     };

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -517,22 +517,23 @@ module.exports = {
           }
           if (Array.isArray(input._patches)) {
             for (const patch of input._patches) {
-              await apply(patch);
+              await self.applyPatch(req, piece, patch);
             }
           } else {
-            await apply(input);
+            await self.applyPatch(req, piece, input);
           }
           await self.update(req, piece);
           return self.findOneForEditing(req, { _id }, { annotate: true });
-          async function apply(input) {
-            self.apos.schema.implementPatchOperators(input, piece);
-            const schema = self.apos.schema.subsetSchemaForPatch(self.allowedSchema(req), input);
-            await self.apos.schema.convert(req, schema, input, piece);
-            await self.emit('afterConvert', req, input, piece);
-          }
         });
       },
-
+      // Apply a single patch to the given piece without saving. An implementation detail of
+      // convertPatchAndRefresh, also used by the undo mechanism to simulate patches.
+      async applyPatch(req, piece, input) {
+        self.apos.schema.implementPatchOperators(input, piece);
+        const schema = self.apos.schema.subsetSchemaForPatch(self.allowedSchema(req), input);
+        await self.apos.schema.convert(req, schema, input, piece);
+        await self.emit('afterConvert', req, input, piece);
+      },
       getCreateControls(req) {
         const controls = _.cloneDeep(self.createControls);
         return controls;


### PR DESCRIPTION
I added undo/redo buttons to the context bar, as I understand the original design to have been.

This undoes and redoes operations on the context document (the only document that we're going to be editing in context soon, remember, that ticket is open but not done). You can only undo back to the last save operation. 

The strategy is to leverage the existing array of pending patches that we are already building in order to "save all at once" rather than "save as you go." Nothing *really* happens in the database until you save, but we need the server's help to re-render the content with the change undone.

In principle we'd handle that with a GET request containing all the patches we do still want to apply in the query string, as a way of doing a "virtual patch" that gives us back the content rendered with all the pending changes we haven't undone. In practice you can't make giant query strings like that. So instead we use a POST API that stashes the patches in Apostrophe's cache and redirects to the URL we really wanted, with a query parameter referencing that cache. Apostrophe's database query APIs then spot any match with that cache entry and use that patched document instead of the real one.

Some followups I will open if this is incremental step is accepted:

* Hold on to the scroll position so that if you undo while way down the page, you don't get scrolled to the top while the content is rebuilding onscreen.
* To improve performance both here and when loading the page as an editor, make optimizations to require fewer separate render-widget requests. Debounce these and send requests for more than one at a time.
* Wrap a "busy" state around that rendering process, both here and when loading the page as an editor, because otherwise it's a lot of flashing going on.

Those last two aren't specific to undo/redo really, you just notice them more with this feature present.

A point for discussion: how many "undo points" typing in the rich text editor could produce. One per character was really inefficient, so I've debounced it. However if you're furiously typing this could mean a whole paragraph is one undo point. Maybe it should create at least one every 5 seconds or so if the text has changed? Google Docs does something like that.