### PR TITLE
pre-render widgets on the initial apos-edit=1 request for the page

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
+++ b/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
@@ -23,11 +23,30 @@ export default function() {
     const data = JSON.parse(el.getAttribute('data'));
     const fieldId = el.getAttribute('data-field-id');
     const choices = JSON.parse(el.getAttribute('data-choices'));
+    const renderings = {};
+    const _docId = data._docId;
+
+    for (const widgetEl of el.querySelectorAll('[data-apos-widget]')) {
+      const _id = widgetEl.getAttribute('data-apos-widget');
+      const item = data.items.find(item => _id === item._id);
+      if (item) {
+        renderings[_id] = {
+          html: widgetEl.innerHTML,
+          parameters: {
+            _docId,
+            widget: item,
+            areaFieldId: fieldId,
+            type: item.type
+          }
+        };
+        widgetEl.remove();
+      } else {
+        // Nested widget, none of our business, picked up later
+      }
+    }
     el.removeAttribute('data-apos-area-newly-editable');
 
     const component = window.apos.area.components.editor;
-
-    const _docId = data._docId;
 
     return new Vue({
       el: el,
@@ -38,10 +57,11 @@ export default function() {
           items: data.items,
           choices,
           docId: _docId,
-          fieldId
+          fieldId,
+          renderings
         };
       },
-      template: `<${component} :options="options" :items="items" :choices="choices" :id="$data.id" :docId="$data.docId" :fieldId="fieldId" />`
+      template: `<${component} :options="options" :items="items" :choices="choices" :id="$data.id" :docId="$data.docId" :fieldId="fieldId" :renderings="renderings" />`
     });
 
   }

--- a/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
+++ b/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
@@ -29,6 +29,8 @@ export default function() {
     for (const widgetEl of el.querySelectorAll('[data-apos-widget]')) {
       const _id = widgetEl.getAttribute('data-apos-widget');
       const item = data.items.find(item => _id === item._id);
+      // This will only match our own widgets, leaving the nested matches alone,
+      // another area app will handle them when the time comes
       if (item) {
         renderings[_id] = {
           html: widgetEl.innerHTML,
@@ -40,8 +42,6 @@ export default function() {
           }
         };
         widgetEl.remove();
-      } else {
-        // Nested widget, none of our business, picked up later
       }
     }
     el.removeAttribute('data-apos-area-newly-editable');

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -38,6 +38,7 @@
         :widget-hovered="hoveredWidget"
         :widget-focused="focusedWidget"
         :max-reached="maxReached"
+        :rendering="renderings[widget._id]"
         @up="up"
         @down="down"
         @remove="remove"
@@ -90,6 +91,12 @@ export default {
     choices: {
       type: Array,
       required: true
+    },
+    renderings: {
+      type: Object,
+      default() {
+        return {};
+      }
     }
   },
   emits: [ 'changed' ],

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -73,7 +73,6 @@
         :options="options.widgets[widget.type]"
         :type="widget.type"
         :doc-id="docId"
-        data-apos-widget
       />
       <component
         v-else
@@ -85,7 +84,7 @@
         :value="widget"
         @edit="$emit('edit', i);"
         :doc-id="docId"
-        data-apos-widget
+        :rendering="rendering"
       />
       <div
         class="apos-area-widget-controls apos-area-widget-controls--add apos-area-widget-controls--add--bottom"
@@ -157,6 +156,12 @@ export default {
     },
     maxReached: {
       type: Boolean
+    },
+    rendering: {
+      type: Object,
+      default() {
+        return null;
+      }
     }
   },
   emits: [ 'clone', 'up', 'down', 'remove', 'edit', 'update', 'insert', 'changed' ],

--- a/modules/@apostrophecms/area/views/area.html
+++ b/modules/@apostrophecms/area/views/area.html
@@ -3,10 +3,14 @@
 {%- set isSingleton = data.options.limit == 1 and data.options.type -%}
 
 <div class="apos-area" {%- if data.canEdit %} data-test data-apos-area-newly-editable data-doc-id='{{ data.area._docId | jsonAttribute({ single: true }) }}' data-field-id='{{ data.field._id | jsonAttribute({ single: true }) }}' data-options='{{ apos.util.omit(data.options, 'area') | jsonAttribute({ single: true }) }}' data='{{ data.area | jsonAttribute({ single: true }) }}' data-choices='{{ data.choices | jsonAttribute({ single: true }) }}'{% endif %}>
-  {%- if not data.canEdit -%}
-    {%- for item in data.area.items -%}
-      {%- set widgetOptions = data.options.widgets[item.type] or {} -%}
-      {% widget item, widgetOptions %}
-    {%- endfor -%}
-  {%- endif -%}
+  {%- for item in data.area.items -%}
+    {%- set widgetOptions = data.options.widgets[item.type] or {} -%}
+    {%- if data.canEdit -%}
+      <div data-apos-widget="{{ item._id }}">
+    {%- endif -%}
+    {% widget item, widgetOptions %}
+    {%- if data.canEdit -%}
+      </div>
+    {%- endif -%}
+  {%- endfor -%}
 </div>

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidget.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidget.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- eslint-disable-next-line vue/no-v-html -->
   <div @click="clicked" v-html="rendered" />
 </template>
 

--- a/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
+++ b/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
@@ -1,9 +1,17 @@
+import { isEqual } from 'lodash';
+
 export default {
   props: {
     docId: String,
     type: String,
     areaFieldId: String,
-    value: Object
+    value: Object,
+    rendering: {
+      type: Object,
+      default() {
+        return null;
+      }
+    }
   },
   watch: {
     value: {
@@ -33,16 +41,22 @@ export default {
   },
   methods: {
     async renderContent() {
+      const parameters = {
+        _docId: this.docId,
+        widget: this.value,
+        areaFieldId: this.areaFieldId,
+        type: this.type
+      };
       try {
-        this.rendered = await apos.http.post(`${apos.area.action}/render-widget?apos-edit=1`, {
-          busy: true,
-          body: {
-            _docId: this.docId,
-            widget: this.value,
-            areaFieldId: this.areaFieldId,
-            type: this.type
-          }
-        });
+        if (this.rendering && (isEqual(this.rendering.parameters, parameters))) {
+          this.rendered = this.rendering.html;
+        } else {
+          this.rendered = '...';
+          this.rendered = await apos.http.post(`${apos.area.action}/render-widget?apos-edit=1`, {
+            busy: true,
+            body: parameters
+          });
+        }
         // Wait for reactivity to populate v-html so the
         // AposAreas manager can spot any new area divs
         setImmediate(function() {


### PR DESCRIPTION
Saves a zillion render-widget requests.

Currently if the page request has `apos-edit=1` the server renders areas as just a div with a data attribute and lets Vue call back for renderings of the widgets so it can encapsulate them in components, etc. This is great in principle, slow and visually weird in practice.

So with this PR, in addition to the div with the data attribute, we do render the widgets in a div for each one, with a data attribute containing its _id. The AposAreas app finds these and passes them to the areas as advance renderings, then snips them out of the DOM, allowing Vue to put them back as it sees fit.

Since props don't change but the widgets can be edited, we pass in enough information to figure out if these pre-renderings are still relevant or not; if not we call render-widgets as per normal.