### PR TITLE
3/theme edit mode

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -54,19 +54,23 @@
         />
       </div>
       <div class="apos-admin-bar__row">
-        <span class="apos-admin-bar__context-spacer" />
-        <span class="apos-admin-bar__context-title">
-          <information-outline-icon
+        <div class="apos-admin-bar__context-spacer" />
+        <div class="apos-admin-bar__context-title">
+          <span
+            v-tooltip="'Page Title'"
             class="apos-admin-bar__context-title__icon"
-            fill-color="var(--a-primary)" :size="16"
-          />
+          >
+            <information-outline-icon
+              fill-color="var(--a-primary)" :size="16"
+            />
+          </span>
           {{ moduleOptions.context.title }}
-        </span>
-        <span class="apos-admin-bar__context-controls">
+        </div>
+        <div class="apos-admin-bar__context-controls">
           <AposButton
             v-if="editMode"
             class="apos-admin-bar__context-button"
-            label="Preview Mode"
+            label="Preview Mode" tooltip="Preview Mode"
             type="outline" :modifiers="['no-motion']"
             icon="eye-icon" :icon-only="true"
             @click="switchToPreviewMode"
@@ -74,7 +78,7 @@
           <AposButton
             v-if="!editMode"
             class="apos-admin-bar__context-button"
-            label="Edit Mode"
+            label="Edit Mode" tooltip="Edit Mode"
             type="outline" :modifiers="['no-motion']"
             icon="pencil-icon" :icon-only="true"
             @click="switchToEditMode"
@@ -82,7 +86,7 @@
           <AposButton
             v-if="moduleOptions.contextId"
             class="apos-admin-bar__context-button"
-            label="Page Settings"
+            label="Page Settings" tooltip="Page Settings"
             type="outline" :modifiers="['no-motion']"
             icon="cog-icon" :icon-only="true"
             @click="emitEvent({
@@ -98,7 +102,7 @@
             class="apos-admin-bar__btn apos-admin-bar__context-button"
             @click="save"
           />
-        </span>
+        </div>
       </div>
     </nav>
   </div>
@@ -289,7 +293,8 @@ $admin-bar-border: 1px solid var(--a-base-9);
 }
 
 .apos-admin-bar__context-title__icon {
-  padding-right: 5px;
+  display: inline-block;
+  margin-right: 5px;
   line-height: 0;
 }
 

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -55,7 +55,10 @@
       <div class="apos-admin-bar__row">
         <span class="apos-admin-bar__context-spacer" />
         <span class="apos-admin-bar__context-title">
-          <information-outline-icon />
+          <information-outline-icon
+            class="apos-admin-bar__context-title__icon"
+            fill-color="var(--a-primary)" :size="16"
+          />
           {{ moduleOptions.context.title }}
         </span>
         <span class="apos-admin-bar__context-controls">
@@ -274,8 +277,16 @@ $admin-bar-border: 1px solid var(--a-base-9);
 }
 
 .apos-admin-bar__context-title {
+  @include type-base;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
   flex: 1;
-  text-align: center;
+}
+
+.apos-admin-bar__context-title__icon {
+  padding-right: 5px;
+  line-height: 0;
 }
 
 .apos-admin-bar__context-controls {

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -306,14 +306,14 @@ $admin-bar-border: 1px solid var(--a-base-9);
 .apos-admin-bar__context-controls {
   display: flex;
   align-items: center;
-  justify-content: end;
+  justify-content: flex-end;
   flex: 1;
 }
 
 .apos-admin-bar__context-button {
   // All but the first.
   .apos-admin-bar__context-controls &:nth-child(n+2) {
-    margin-left: 10px;
+    margin-left: 7.5px;
   }
 }
 

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -9,6 +9,7 @@
             <AposButton
               type="default" label="Page Tree"
               icon="file-tree-icon" class="apos-admin-bar__btn"
+              :modifiers="['no-motion']"
               @click="emitEvent('@apostrophecms/page:manager')"
             />
           </li>
@@ -64,23 +65,26 @@
         <span class="apos-admin-bar__context-controls">
           <AposButton
             v-if="editMode"
-            type="default" label="Preview Mode"
-            icon="eye-icon" class="apos-admin-bar__btn"
-            :icon-only="true"
+            class="apos-admin-bar__context-button"
+            label="Preview Mode"
+            type="outline" :modifiers="['no-motion']"
+            icon="eye-icon" :icon-only="true"
             @click="switchToPreviewMode"
           />
           <AposButton
             v-if="!editMode"
-            type="default" label="Edit Mode"
-            icon="pencil-icon" class="apos-admin-bar__btn"
-            :icon-only="true"
+            class="apos-admin-bar__context-button"
+            label="Edit Mode"
+            type="outline" :modifiers="['no-motion']"
+            icon="pencil-icon" :icon-only="true"
             @click="switchToEditMode"
           />
           <AposButton
             v-if="moduleOptions.contextId"
-            type="default" label="Page Settings"
-            icon="cog-icon" class="apos-admin-bar__btn"
-            :icon-only="true"
+            class="apos-admin-bar__context-button"
+            label="Page Settings"
+            type="outline" :modifiers="['no-motion']"
+            icon="cog-icon" :icon-only="true"
             @click="emitEvent({
               itemName: contextEditorName,
               props: {
@@ -91,7 +95,7 @@
           <AposButton
             type="primary" label="Publish Changes"
             :disabled="!readyToSave"
-            class="apos-admin-bar__btn"
+            class="apos-admin-bar__btn apos-admin-bar__context-button"
             @click="save"
           />
         </span>
@@ -290,8 +294,17 @@ $admin-bar-border: 1px solid var(--a-base-9);
 }
 
 .apos-admin-bar__context-controls {
+  display: flex;
+  align-items: center;
+  justify-content: end;
   flex: 1;
-  text-align: right;
+}
+
+.apos-admin-bar__context-button {
+  // All but the first.
+  .apos-admin-bar__context-controls &:nth-child(n+2) {
+    margin-left: 10px;
+  }
 }
 
 .apos-admin-bar__items {

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -78,16 +78,12 @@
           <AposButton
             v-if="!editMode"
             class="apos-admin-bar__context-button"
-            label="Edit Mode" :tooltip="{
-              content: 'Edit Mode',
-              offset: 0
-            }"
-            type="outline" :modifiers="['no-motion']"
-            icon="pencil-icon" :icon-only="true"
+            label="Edit" icon="pencil-icon"
+            :modifiers="['no-motion']"
             @click="switchToEditMode"
           />
           <AposButton
-            v-if="moduleOptions.contextId"
+            v-if="editMode && moduleOptions.contextId"
             class="apos-admin-bar__context-button"
             label="Page Settings" :tooltip="{
               content: 'Page Settings',
@@ -103,6 +99,7 @@
             })"
           />
           <AposButton
+            v-if="editMode"
             type="primary" label="Publish Changes"
             :disabled="!readyToSave"
             class="apos-admin-bar__btn apos-admin-bar__context-button"

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -57,12 +57,9 @@
         <div class="apos-admin-bar__context-spacer" />
         <div class="apos-admin-bar__context-title">
           <span
-            v-tooltip="'Page Title'"
-            class="apos-admin-bar__context-title__icon"
+            v-tooltip="'Page Title'" class="apos-admin-bar__context-title__icon"
           >
-            <information-outline-icon
-              fill-color="var(--a-primary)" :size="16"
-            />
+            <information-outline-icon fill-color="var(--a-primary)" :size="16" />
           </span>
           {{ moduleOptions.context.title }}
         </div>
@@ -70,7 +67,10 @@
           <AposButton
             v-if="editMode"
             class="apos-admin-bar__context-button"
-            label="Preview Mode" tooltip="Preview Mode"
+            label="Preview Mode" :tooltip="{
+              content: 'Preview Mode',
+              offset: 0
+            }"
             type="outline" :modifiers="['no-motion']"
             icon="eye-icon" :icon-only="true"
             @click="switchToPreviewMode"
@@ -78,7 +78,10 @@
           <AposButton
             v-if="!editMode"
             class="apos-admin-bar__context-button"
-            label="Edit Mode" tooltip="Edit Mode"
+            label="Edit Mode" :tooltip="{
+              content: 'Edit Mode',
+              offset: 0
+            }"
             type="outline" :modifiers="['no-motion']"
             icon="pencil-icon" :icon-only="true"
             @click="switchToEditMode"
@@ -86,7 +89,10 @@
           <AposButton
             v-if="moduleOptions.contextId"
             class="apos-admin-bar__context-button"
-            label="Page Settings" tooltip="Page Settings"
+            label="Page Settings" :tooltip="{
+              content: 'Page Settings',
+              offset: 0
+            }"
             type="outline" :modifiers="['no-motion']"
             icon="cog-icon" :icon-only="true"
             @click="emitEvent({

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -69,7 +69,8 @@
             class="apos-admin-bar__context-button"
             label="Preview Mode" :tooltip="{
               content: 'Preview Mode',
-              offset: 0
+              offset: 0,
+              placement: 'bottom'
             }"
             type="outline" :modifiers="['no-motion']"
             icon="eye-icon" :icon-only="true"
@@ -87,7 +88,8 @@
             class="apos-admin-bar__context-button"
             label="Page Settings" :tooltip="{
               content: 'Page Settings',
-              offset: 0
+              offset: 0,
+              placement: 'bottom'
             }"
             type="outline" :modifiers="['no-motion']"
             icon="cog-icon" :icon-only="true"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
@@ -501,7 +501,6 @@ export default {
       transform: none;
       box-shadow: none;
       outline: none;
-      border-color: transparent;
     }
   }
 

--- a/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
@@ -501,7 +501,7 @@ export default {
       transform: none;
       box-shadow: none;
       outline: none;
-      border: 0;
+      border-color: transparent;
     }
   }
 


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-795, "Style the context bar"

<img width="839" alt="Screen Shot 2020-11-13 at 8 50 55 AM" src="https://user-images.githubusercontent.com/1155984/99299230-8c197b00-2810-11eb-8d6c-a2a5de90b007.png">
<img width="705" alt="Screen Shot 2020-11-13 at 8 50 39 AM" src="https://user-images.githubusercontent.com/1155984/99299232-8cb21180-2810-11eb-83d2-727318a57db6.png">
