### PR TITLE
foreign areas now work approximately per design by Stu but could use …

### DIFF
--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -27,10 +27,6 @@ module.exports = {
     self.widgetManagers = {};
     self.richTextWidgetTypes = [];
     self.widgetManagers = {};
-    // These are the most frequently used helpers in A2,
-    // so we allow their use without typing .areas first
-    self.addHelperShortcut('area');
-    self.addHelperShortcut('singleton');
     self.enableBrowserData();
   },
   apiRoutes(self, options) {
@@ -558,20 +554,6 @@ module.exports = {
   },
   helpers(self, options) {
     return {
-      // Former 2.x way of inserting singletons. Throws an error in 3.x. See the new {% singleton %} tag.
-      singleton: function (doc, name, type, _options) {
-        throw new Error('3.x migration: you must replace {{ apos.area.singleton(...) }} calls with the new {% singleton doc, name, options %} syntax. Note the lack of parens, and the need for {% rather than {{. Otherwise all syntaxes accepted for apos.singleton work here too.');
-      },
-      // Former 2.x way of inserting areas. Throws an error in 3.x. See the new {% area %} tag.
-      area: function (doc, name, _options) {
-        throw new Error('3.x migration: you must replace {{ apos.area(...) }} calls with the new {% area doc, name, { options... } %} tag. Note the lack of parens, and the need for {% rather than {{. Otherwise all syntaxes that worked for apos.area work here too.');
-      },
-      // Throws an error in 3.x. See the new {% area %} or {% singleton %} tag.
-      // There is also a {% widget %} tag that corresponds directly to this, but
-      // that is usually not what you want.
-      widget: function (widget, options) {
-        throw new Error('3.x migration: you must replace {{ apos.area.widget(...) }} calls with the new {% widget item, options %} syntax. Note the lack of parens, and the need for {% rather than {{.');
-      },
       // Returns the rich text markup of all `@apostrophecms/rich-text` widgets
       // within the provided doc or area, concatenated as a single string. In future this method
       // may improve to return the content of other widgets that consider themselves primarily

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -260,7 +260,12 @@ export default {
             }
           );
           if (doc._url) {
-            window.location.href = doc._url;
+            if (await apos.confirm({
+              heading: 'Open that document in a new tab?',
+              description: 'That content is part of another document. Would you like to edit that document in another tab?'
+            })) {
+              window.open(doc._url);
+            }
           } else {
             apos.bus.$emit('admin-menu-click', {
               itemName: `${doc.type}:editor`,

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -40,6 +40,7 @@
         :class="ui.addTop"
       >
         <AposAreaMenu
+          v-if="!foreign"
           :max-reached="maxReached"
           @insert="$emit('insert', $event);"
           @menu-open="toggleMenuFocus($event, 'top', true)"
@@ -57,6 +58,7 @@
           :first="i === 0"
           :last="i === next.length - 1"
           :options="{ contextual: isContextual }"
+          :foreign="foreign"
           @up="$emit('up', i);"
           @remove="$emit('remove', i);"
           @edit="$emit('edit', i);"
@@ -66,7 +68,7 @@
       </div>
       <!-- Still used for contextual editing components -->
       <component
-        v-if="isContextual"
+        v-if="isContextual && !foreign"
         :is="widgetEditorComponent(widget.type)"
         :value="widget"
         @update="$emit('update', $event)"
@@ -83,6 +85,7 @@
         :id="widget._id"
         :area-field-id="fieldId"
         :value="widget"
+        :foreign="foreign"
         @edit="$emit('edit', i);"
         :doc-id="docId"
         data-apos-widget
@@ -92,6 +95,7 @@
         :class="ui.addBottom"
       >
         <AposAreaMenu
+          v-if="!foreign"
           :max-reached="maxReached"
           @insert="$emit('insert', $event)"
           :context-menu-options="bottomContextMenuOptions"
@@ -192,7 +196,8 @@ export default {
         show: 'apos-show',
         open: 'apos-open',
         focus: 'apos-focus',
-        highlight: 'apos-highlight'
+        highlight: 'apos-highlight',
+        foreign: 'apos-foreign'
       },
       breadcrumbs: {
         $lastEl: null,
@@ -246,6 +251,9 @@ export default {
         addBottom: this.state.add.bottom.focus ? this.classes.focus
           : (this.state.add.bottom.show ? this.classes.show : null)
       };
+      if ((this.state.container.focus || this.state.container.highlight) && this.foreign) {
+        state.container = this.classes.foreign;
+      }
 
       if (this.isSuppressed) {
         this.resetState();
@@ -253,6 +261,10 @@ export default {
       }
 
       return state;
+    },
+    foreign() {
+      // Cast to boolean is necessary to satisfy prop typing
+      return !!(this.docId && (window.apos.adminBar.contextId !== this.docId));
     }
   },
   watch: {
@@ -467,6 +479,13 @@ export default {
     .apos-area-widget-inner &.apos-highlight:before {
       z-index: $z-index-default;
     }
+
+    &.apos-foreign {
+      outline: 1px dashed var(--a-warning);
+      /deep/ .apos-button {
+        background-color: var(--a-warning);
+      }
+    }
   }
 
   .apos-area-widget-inner .apos-area-widget-inner {
@@ -560,8 +579,16 @@ export default {
     background-color: var(--a-primary);
   }
 
+  .apos-foreign .apos-area-widget__breadcrumbs {
+    background-color: var(--a-warning);
+  }
+
   .apos-area-widget-inner .apos-area-widget-inner .apos-area-widget__breadcrumbs {
     background-color: var(--a-secondary);
+  }
+
+  .apos-area-widget-inner .apos-foreign.apos-area-widget-inner .apos-area-widget__breadcrumbs {
+    background-color: var(--a-warning);
   }
 
   .apos-area-widget__breadcrumb,

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -489,6 +489,7 @@ export default {
       outline: 1px dashed var(--a-warning);
       /deep/ .apos-button {
         background-color: var(--a-warning);
+        color: var(--a-white);
       }
     }
   }

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -2,6 +2,7 @@
   <div class="apos-area-modify-controls">
     <AposButtonGroup direction="vertical">
       <AposButton
+        v-if="!foreign"
         v-bind="upButton"
         :disabled="first"
         @click="$emit('up')"
@@ -10,18 +11,21 @@
       <!-- <AposButton v-bind="dragButton" /> -->
       <AposButton
         v-bind="editButton"
-        v-if="!options.contextual"
+        v-if="foreign || !options.contextual"
         @click="$emit('edit')"
       />
       <AposButton
+        v-if="!foreign"
         v-bind="cloneButton"
         @click="$emit('clone')"
       />
       <AposButton
+        v-if="!foreign"
         v-bind="removeButton"
         @click="$emit('remove')"
       />
       <AposButton
+        v-if="!foreign"
         v-bind="downButton"
         :disabled="last"
         @click="$emit('down')"
@@ -47,6 +51,10 @@ export default {
       default() {
         return {};
       }
+    },
+    foreign: {
+      type: Boolean,
+      required: true
     }
   },
   emits: [ 'remove', 'edit', 'clone', 'up', 'down' ],

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -28,9 +28,17 @@ module.exports = {
   },
   restApiRoutes(self, options) {
     return {
+      // GET /api/v1/@apostrophecms/doc/_id supports only the universal query
+      // features, but works for any document type, Simplifies browser-side
+      // logic for redirects to foreign documents; the frontend only has to
+      // know the doc _id.
+      async getOne(req, _id) {
+        return self.find(req, { _id }).toObject();
+      },
+
       // PATCH /api/v1/@apostrophecms/doc/_id works for any document type,
       // at the expense of one extra query to determine what module should
-      // be asked to do the work. Simplifies browse-side logic for
+      // be asked to do the work. Simplifies browser-side logic for
       // on-page editing: the frontend only has to know the doc _id.
       async patch(req, _id) {
         const doc = await self.find(req, { _id }).project({


### PR DESCRIPTION
…some CSS followup. Also, apos.area.isEmpty and similar helpers work now. Necessary casualty: apos.area cannot just be a helper that tells you to use the new {% area %} tag, so we may want to lint that another way at some point