### PR TITLE
we used to compute the height because we knew apostrophe was putting …

### DIFF
--- a/modules/@apostrophecms/util/ui/public/video.js
+++ b/modules/@apostrophecms/util/ui/public/video.js
@@ -52,6 +52,7 @@ apos.util.widgetPlayers['@apostrophecms/video'] = {
         // If oembed results include width and height we can get the
         // video aspect ratio right
         if (result.width && result.height) {
+          inner.style.width = '100%';
           inner.style.height = ((result.height / result.width) * inner.offsetWidth) + 'px';
         } else {
           // No, so assume the oembed HTML code is responsive.


### PR DESCRIPTION
…a style on the inner element via a class. But the right way is to assign both the width and the height on that inner element in the player, so we do not hardcode the requirement that it be an iframe

This allows the project level developer to worry only about what overall width they want for the widget, and not what's inside it, which is none of their concern ideally because of oembed.