### PR TITLE
Enable index correctly, avoid deprecation warning at startup

### DIFF
--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -388,7 +388,7 @@ module.exports = {
 
       async enableBearerTokens() {
         self.bearerTokens = self.apos.db.collection('aposBearerTokens');
-        await self.bearerTokens.ensureIndex({ expires: 1 }, { expireAfterSeconds: 0 });
+        await self.bearerTokens.enableIndex({ expires: 1 }, { expireAfterSeconds: 0 });
       }
     };
   },

--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -388,7 +388,7 @@ module.exports = {
 
       async enableBearerTokens() {
         self.bearerTokens = self.apos.db.collection('aposBearerTokens');
-        await self.bearerTokens.enableIndex({ expires: 1 }, { expireAfterSeconds: 0 });
+        await self.bearerTokens.createIndex({ expires: 1 }, { expireAfterSeconds: 0 });
       }
     };
   },


### PR DESCRIPTION
This method used to be called ensureIndex, that still works but throws a warning, just using the modern name.