### PR TITLE
undo/redo: only the current context doc should be considered part of the basis

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -335,7 +335,7 @@ export default {
           // "@ notation" PATCH feature. Sort the areas by DOM depth
           // to ensure parents patch before children
           this.original = {};
-          const els = Array.from(document.querySelectorAll('[data-apos-area-newly-editable]'));
+          const els = Array.from(document.querySelectorAll('[data-apos-area-newly-editable]')).filter(el => el.getAttribute('data-doc-id') === this.moduleOptions.contextId);
           els.sort((a, b) => {
             const da = depth(a);
             const db = depth(b);


### PR DESCRIPTION
Fixes A30U-808
