### PR TITLE
Migration to fix duplicate or missing widget ids

### DIFF
--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -120,7 +120,7 @@ module.exports = {
       ...options.defaultOptions
     };
   },
-  init(self, optins) {
+  init(self, options) {
     self.apos.asset.addIcon('format-text-icon', 'FormatText');
   },
   methods(self, options) {


### PR DESCRIPTION
. I cannot reproduce the issue from scratch anymore (I tested the migration by manually modifying my database).

But it existed on staging in existing content at one point, so others might have this problem with alpha 1 databases and need this migration to have better success in alpha 2.

I don't see a clear point at which the original bug was fixed though. So if we see it creep back in then I will need to know how to reproduce it. Just using the clone button does not reproduce it.