### PR TITLE
Youtube invalid url fix

### DIFF
--- a/modules/@apostrophecms/oembed/lib/youtube.js
+++ b/modules/@apostrophecms/oembed/lib/youtube.js
@@ -26,6 +26,10 @@ module.exports = function(self, oembetter) {
       response.thumbnail_url = maxResImage;
       return cb(null);
     } catch (e) {
+      if (e.status === 404) {
+        // Nonfatal, just continue to use hqdefault
+        return cb(null);
+      }
       return cb(e);
     }
   });


### PR DESCRIPTION
YouTube videos usually come back from their oembed endpoint with a thumbnail that is not the best available. We change that URL to get the best available, then make sure it exists, and if not, we flunk the embed... which works for most videos, but for a few, that "max" version just doesn't exist.

So I changed the code to gracefully accept that situation and fall back to the original thumbnail, and that fixed the issue with your video.

PLEASE NOTE: when you test this you may still get the error because of the oembed cache of apostrophe, which lasts an hour. You could clear that:

```
mongo a3-demo
(at the mongo prompt:)
db.aposCache.remove({})
```
