### PR TITLE
String field checks if value is a string for required

### DIFF
--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputString.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputString.vue
@@ -116,7 +116,7 @@ export default {
         value = '';
       }
       if (this.field.required) {
-        if (!value.length) {
+        if (typeof value === 'string' && !value.length) {
           return 'required';
         }
       }


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-865, "Float/integer "string" fields with existing value trigger `required` error".

If a field is an integer or float type and has an existing value, that'll be a number, which doesn't have a `length`. But if you do any edits to that value, it'll become a string, so our existing check works at that point. We're also already checking for `null` values, so this update seems like the right move.