### PR TITLE
Uses cell components for piece manager display

### DIFF
--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -28,17 +28,21 @@ module.exports = {
     return {
       add: {
         title: {
-          label: 'Title'
+          label: 'Title',
+          component: 'AposCellButton'
         },
         updatedAt: {
-          label: 'Edited on'
+          label: 'Edited on',
+          component: 'AposCellDate'
         },
         visibility: {
           label: 'Visibility'
         },
+        // TODO: Update this to identify if there's a piece page for the type.
         ...(self.options.contextual ? {
           _url: {
-            label: 'Link'
+            label: 'Link',
+            component: 'AposCellLink'
           }
         } : {})
       }

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
@@ -162,8 +162,10 @@ export default {
 
         this.headers.forEach(column => {
           data[column.name] = piece[column.name];
-          data._id = piece._id;
         });
+
+        data._id = piece._id;
+
         items.push(data);
       });
 

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManagerDisplay.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManagerDisplay.vue
@@ -52,28 +52,18 @@
           :key="item[header.name]"
           @click="$emit('open',item._id)"
         >
-          <a
-            v-if="header.name === '_url' && item[header.name]"
-            class="apos-table__link"
-            :href="item[header.name]"
-            @click.stop
-          >
-            <link-icon :size="14" />
-          </a>
-          <button
-            v-else-if="header.name === 'title'"
-            @click.stop="$emit('open',item._id)"
-            class="apos-table__cell-field"
-            :class="`apos-table__cell-field--${header.name}`"
-          >
-            {{ item[header.name] }}
-          </button>
-          <p
-            v-else class="apos-table__cell-field"
-            :class="`apos-table__cell-field--${header.name}`"
-          >
-            {{ item[header.name] }}
-          </p>
+          <component
+            v-if="header.component" :is="header.component"
+            :header="header" :item="item"
+          />
+          <AposCellLink
+            v-else-if="header.name === '_url' && item[header.name]"
+            :header="header" :item="item"
+          />
+          <AposCellBasic
+            v-else
+            :header="header" :item="item"
+          />
         </td>
       </tr>
     </tbody>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellBasic.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellBasic.vue
@@ -1,0 +1,24 @@
+<template>
+  <p
+    class="apos-table__cell-field"
+    :class="`apos-table__cell-field--${header.name}`"
+  >
+    {{ item[header.name] }}
+  </p>
+</template>
+
+<script>
+export default {
+  name: 'AposCellBasic',
+  props: {
+    item: {
+      type: Object,
+      required: true
+    },
+    header: {
+      type: Object,
+      required: true
+    }
+  }
+};
+</script>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellButton.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellButton.vue
@@ -1,0 +1,24 @@
+<template>
+  <button
+    class="apos-table__cell-field" type="button"
+    :class="`apos-table__cell-field--${header.name}`"
+  >
+    {{ item[header.name] }}
+  </button>
+</template>
+
+<script>
+export default {
+  name: 'AposCellButton',
+  props: {
+    item: {
+      type: Object,
+      required: true
+    },
+    header: {
+      type: Object,
+      required: true
+    }
+  }
+};
+</script>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellDate.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellDate.vue
@@ -1,0 +1,68 @@
+<template>
+  <p
+    class="apos-table__cell-field"
+    :class="`apos-table__cell-field--${header.name}`"
+  >
+    {{ formattedDate }}
+  </p>
+</template>
+
+<script>
+export default {
+  name: 'AposCellBasic',
+  props: {
+    item: {
+      type: Object,
+      required: true
+    },
+    header: {
+      type: Object,
+      required: true
+    }
+  },
+  computed: {
+    formattedDate () {
+      const value = this.item[this.header.name];
+
+      return this.formatDateColumn(value);
+    }
+  },
+  methods: {
+    formatDateColumn (value) {
+      const d = new Date(value);
+      if (Number.isNaN(d.getDate())) {
+        // We're not sure what this is, but it's not a date.
+        return value;
+      }
+      const month = d.getMonth();
+      const date = d.getDate();
+      const year = d.getFullYear();
+      let hour = d.getHours();
+      const period = hour > 11 ? 'pm' : 'am';
+      if (hour > 12) {
+        hour = hour - 12;
+      } else if (hour === 0) {
+        hour = 12;
+      }
+      const minute = d.getMinutes();
+
+      return `${toTwoChars(month)}/${toTwoChars(date)}/${toTwoChars(year)} at ${hour}:${minute} ${period}`;
+
+      function toTwoChars(num) {
+        num = parseInt(num);
+
+        if (num < 10) {
+          return `0${num.toString()}`;
+        } else if (num > 1000) {
+          // Good as long as we replace this by year 10,000.
+          return toTwoChars(num.toString().slice(2, 4));
+        } else {
+          // If it's more than 12 and less than 1000, the problem isn't here.
+          return num;
+        };
+      }
+    }
+
+  }
+};
+</script>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellLink.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellLink.vue
@@ -1,0 +1,24 @@
+<template>
+  <a
+    :href="item[header.name]"
+    @click.stop
+  >
+    <link-icon :size="14" />
+  </a>
+</template>
+
+<script>
+export default {
+  name: 'AposCellLink',
+  props: {
+    item: {
+      type: Object,
+      required: true
+    },
+    header: {
+      type: Object,
+      required: true
+    }
+  }
+};
+</script>


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-690, "Date columns look bad in the piece manager"

Introduces a manager cell component option to allow project-level introduction of other manager cell formats. This is limited to the piece manager now. It _could_ be introduced in the page manager. That is arguably more fundamental to core (being that there's only one page manager view) and is more finicky with the dragging that I'm holding off on adding it there for now. Plus that's out of scope of this ticket.