### PR TITLE
3/doc more menu

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -153,6 +153,7 @@
                 }
               })"
             />
+            <AposDocMoreMenu :options="moduleOptions" /> <!-- beefy and shared context menu-->
             <AposButton
               class="apos-admin-bar__context-button"
               label="Preview" :tooltip="{

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -153,7 +153,9 @@
                 }
               })"
             />
-            <AposDocMoreMenu :options="moduleOptions" /> <!-- beefy and shared context menu-->
+            <AposDocMoreMenu
+              :doc-id="moduleOptions.contextId"
+            />
             <AposButton
               class="apos-admin-bar__context-button"
               label="Preview" :tooltip="{

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarUser.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarUser.vue
@@ -4,7 +4,6 @@
     :button="button"
     :menu="menu"
     menu-placement="bottom-end"
-    :menu-offset="2"
     @item-clicked="emitEvent"
   >
     <template #prebutton>

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -12,6 +12,9 @@
       />
     </template>
     <template #primaryControls>
+      <AposDocMoreMenu
+        :doc-id="docId"
+      />
       <AposButton
         type="primary" label="Save"
         :disabled="docOtherFields.hasErrors || docUtilityFields.hasErrors"

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
@@ -1,0 +1,76 @@
+<template>
+  <AposContextMenu
+    v-if="options.contextId"
+    class="apos-admin-bar__context-button"
+    :menu="menu"
+    menu-placement="bottom-end"
+    :button="{
+      tooltip: { content: 'More Options', placement: 'bottom' },
+      label: 'More Options',
+      icon: 'dots-vertical-icon',
+      iconOnly: true,
+      type: 'subtle',
+      modifiers: ['small', 'no-motion']
+    }"
+    @item-clicked="emitEvent"
+  >
+    <ul class="apos-context-menu__items" v-if="menu">
+      <AposContextMenuItem
+        v-for="item in menu"
+        :key="item.action"
+        :menu-item="item"
+        @clicked="menuItemClicked"
+        :open="isOpen"
+      />
+    </ul>
+  </AposContextMenu>
+</template>
+
+<script>
+
+export default {
+  name: 'AposDocMoreMenu',
+  props: {
+    options: {
+      type: Object,
+      required: true
+    }
+  },
+  emits: [ 'admin-menu-click' ],
+  data() {
+    return {
+      menu: [
+        {
+          label: 'Share Draft',
+          action: 'share'
+        },
+        {
+          label: 'Save Draft',
+          action: 'save'
+        },
+        {
+          label: 'Duplicate Document',
+          action: 'duplicate'
+        },
+        {
+          label: 'Version History',
+          action: 'versions'
+        },
+        {
+          label: 'Revert to Last Published',
+          action: 'revertToLastPublished',
+          modifiers: [ 'danger' ]
+        }
+      ]
+    };
+  },
+  methods: {
+    menuHandler(action) {
+      console.log(`do ${action}`);
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
@@ -1,9 +1,9 @@
 <template>
   <AposContextMenu
-    v-if="options.contextId"
     class="apos-admin-bar__context-button"
     :menu="menu"
     menu-placement="bottom-end"
+    @item-clicked="menuHandler"
     :button="{
       tooltip: { content: 'More Options', placement: 'bottom' },
       label: 'More Options',
@@ -12,18 +12,7 @@
       type: 'subtle',
       modifiers: ['small', 'no-motion']
     }"
-    @item-clicked="emitEvent"
-  >
-    <ul class="apos-context-menu__items" v-if="menu">
-      <AposContextMenuItem
-        v-for="item in menu"
-        :key="item.action"
-        :menu-item="item"
-        @clicked="menuItemClicked"
-        :open="isOpen"
-      />
-    </ul>
-  </AposContextMenu>
+  />
 </template>
 
 <script>
@@ -31,14 +20,15 @@
 export default {
   name: 'AposDocMoreMenu',
   props: {
-    options: {
-      type: Object,
+    docId: {
+      type: String,
       required: true
     }
   },
-  emits: [ 'admin-menu-click' ],
+  emits: [ 'admin-menu-click', 'close' ],
   data() {
     return {
+      isOpen: false,
       menu: [
         {
           label: 'Share Draft',
@@ -65,8 +55,28 @@ export default {
     };
   },
   methods: {
+    async duplicate() {
+      console.log('TODO: stub for Duplicate action');
+    },
+    async save() {
+      console.log('TODO: stub for Save Draft action');
+    },
+    async share() {
+      console.log('TODO: stub for Share Draft action');
+    },
+    async revertToLastPublished() {
+      console.log('TODO: stub for revertToLastPublished action');
+    },
+    async versions() {
+      await apos.modal.execute('AposDocVersions', {
+        options: { foo: 'bar' },
+        doc: {
+          _id: this.docId
+        }
+      });
+    },
     menuHandler(action) {
-      console.log(`do ${action}`);
+      this[action]();
     }
   }
 };

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
@@ -25,7 +25,6 @@ export default {
       required: true
     }
   },
-  emits: [ 'admin-menu-click', 'close' ],
   data() {
     return {
       isOpen: false,
@@ -35,16 +34,8 @@ export default {
           action: 'share'
         },
         {
-          label: 'Save Draft',
-          action: 'save'
-        },
-        {
           label: 'Duplicate Document',
           action: 'duplicate'
-        },
-        {
-          label: 'Version History',
-          action: 'versions'
         },
         {
           label: 'Revert to Last Published',
@@ -58,24 +49,13 @@ export default {
     async duplicate() {
       console.log('TODO: stub for Duplicate action');
     },
-    async save() {
-      console.log('TODO: stub for Save Draft action');
-    },
     async share() {
       console.log('TODO: stub for Share Draft action');
     },
     async revertToLastPublished() {
       console.log('TODO: stub for revertToLastPublished action');
     },
-    async versions() {
-      await apos.modal.execute('AposDocVersions', {
-        options: { foo: 'bar' },
-        doc: {
-          _id: this.docId
-        }
-      });
-    },
-    menuHandler(action) {
+    async menuHandler(action) {
       this[action]();
     }
   }

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -6,6 +6,7 @@
       @show="show"
       :offset="menuOffset"
       trigger="manual"
+      :placement="menuPlacement"
       :open="isOpen"
       :delay="{ show: 0, hide: 0 }"
       popover-class="apos-popover"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuItem.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuItem.vue
@@ -2,6 +2,7 @@
   <li class="apos-context-menu__item">
     <button
       class="apos-context-menu__button"
+      :class="modifiers"
       @click="click"
       :tabindex="tabindex"
     >
@@ -24,6 +25,15 @@ export default {
   computed: {
     tabindex() {
       return this.open ? '0' : '-1';
+    },
+    modifiers() {
+      const classes = [];
+      if (this.menuItem.modifiers) {
+        this.menuItem.modifiers.forEach(modifier => {
+          classes.push(`apos-context-menu__button--${modifier}`);
+        });
+      }
+      return classes.join(' ');
     }
   },
   methods: {
@@ -54,6 +64,16 @@ export default {
     }
     &:active {
       color: var(--a-base-1);
+    }
+
+    &--danger {
+      color: var(--a-danger);
+      &:hover {
+        color: var(--a-danger-button-hover);
+      }
+      &:focus, &:active {
+        color: var(--a-danger-button-active);
+      }
     }
   }
 </style>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
@@ -10,6 +10,7 @@
       :col-widths="colWidths" :hidden="options.hideHeader"
     />
     <AposTreeRows
+      v-if="myItems"
       v-model="checkedProxy"
       :rows="myItems"
       :headers="headers"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
@@ -10,7 +10,6 @@
       :col-widths="colWidths" :hidden="options.hideHeader"
     />
     <AposTreeRows
-      v-if="myItems"
       v-model="checkedProxy"
       :rows="myItems"
       :headers="headers"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -134,7 +134,9 @@ export default {
     },
     rows: {
       type: Array,
-      required: true
+      default() {
+        return [];
+      }
     },
     checked: {
       type: Array,


### PR DESCRIPTION
kicks off https://apostrophecms.atlassian.net/browse/A30U-731?atlOrigin=eyJpIjoiMDM2ODNiYzE0YzE4NDNmYzgzYzE3YzU2MDYyNDNkN2MiLCJwIjoiaiJ9
- requires follow up tickets for all functionality ([871](https://apostrophecms.atlassian.net/browse/A30U-871), [872](https://apostrophecms.atlassian.net/browse/A30U-872), [873](https://apostrophecms.atlassian.net/browse/A30U-873),)
- Currently the new component comes ready to roll out the whole menu but maybe this should be provided by the parent context 