### PR TITLE
Updates CircleCI cache naming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,14 +8,14 @@ jobs:
       - checkout
       - run:
           name: update-npm
-          command: 'sudo npm install -g npm'
+          command: "sudo npm install -g npm"
       - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          key: dependency-cache-{{ .Branch }}-{{ checksum "package-lock.json" }}
       - run:
           name: install-npm-wee
           command: npm install
       - save_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          key: dependency-cache-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:
             - ./node_modules
       - run:


### PR DESCRIPTION
The CircleCI cache will now be fresh for every branch, in addition to every version of the `package.json` file.