### PR TITLE
CKEDITOR: When only one style is available, make it default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.113.4 (2020-12-22)
+* When a `styles` config with a single object is passed to an `apostrophe-rich-text` widget, use that as the defualt style.
+
 ## 2.113.3 (2021-01-13)
 * Fixes image manager double-scroll bar bug.
 

--- a/lib/modules/apostrophe-rich-text-widgets/public/js/editor.js
+++ b/lib/modules/apostrophe-rich-text-widgets/public/js/editor.js
@@ -36,20 +36,23 @@ apos.define('apostrophe-rich-text-widgets-editor', {
       self.toolbar = self.options.toolbar || [];
 
       if (!self.defaultStyle) {
+        var defaultStyle;
+
         if (self.options.defaultElement) {
-          // eslint-disable-next-line new-cap
-          self.defaultStyle = new CKEDITOR.style({
-            element: self.options.defaultElement
-          });
+          defaultStyle = { element: self.options.defaultElement };
         } else if (self.styles.length) {
-          var defaultStyle = _.find(self.styles, {
+          defaultStyle = _.find(self.styles, {
             name: self.options.defaultStyle
           });
 
-          if (defaultStyle) {
-            // eslint-disable-next-line new-cap
-            self.defaultStyle = new CKEDITOR.style(defaultStyle);
+          if (!defaultStyle && self.styles.length === 1) {
+            defaultStyle = self.styles[0];
           }
+        }
+
+        if (defaultStyle) {
+          // eslint-disable-next-line new-cap
+          self.defaultStyle = new CKEDITOR.style(defaultStyle);
         }
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "2.113.3",
+  "version": "2.113.4",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The current handling of `defaultStyle` for `apostrophe-rich-text-widgets` isn't really documented, but works as follows:
- firstly, look for a `defaultElement` option and create a new `CKEDITOR.style` from that if available
- secondly, look for a `defaultStyle` option and look up the corresponding `style` object if available

I think a logical third option to add would be:
- if a `styles` option is available and contains a single style object, use it as the `defaultStyle`

This PR makes it so!

Sorry for not opening an issue first, this is sort of a drive by contribution in the middle of other work.