### PR TITLE
Make selected Boolean darker

### DIFF
--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputBoolean.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputBoolean.vue
@@ -126,7 +126,7 @@ export default {
     }
 
     .apos-boolean__input:checked + & {
-      background-color: var(--a-base-10);
+      background-color: var(--a-base-8);
 
       .apos-boolean__icon {
         color: var(--a-success);


### PR DESCRIPTION
--a-base-10 for a selected Boolean option is indistinguishable from the background (--a-background-primary). The only other marker is a small dot, which is either grey (unselected) or red/green. 

People who struggle to distinguish shades of red/green often also find it difficult to distinguish these colours from greys, and so may find it difficult to understand which option is selected.

Making the background of the selected Boolean option darker makes it clear which option is selected.