### PR TITLE
Updates pager to allow flexible number of intermediate pgs

### DIFF
--- a/modules/@apostrophecms/pager/index.js
+++ b/modules/@apostrophecms/pager/index.js
@@ -9,14 +9,38 @@ module.exports = {
       // Just a little too much math to be comfortable in pure Nunjucks
       pageRange: function (options) {
         const pages = [];
-        let fromPage = options.page - 2;
+        let fromPage = options.page - (Math.floor(options.shown / 2));
+
+        if (fromPage > options.total - options.shown) {
+          fromPage = options.total - options.shown;
+        }
+
         if (fromPage < 2) {
           fromPage = 2;
         }
-        for (let page = fromPage; page < fromPage + options.shown; page++) {
-          pages.push(page);
+
+        for (let pg = fromPage; pg < fromPage + options.shown; pg++) {
+          if (pg < options.total) {
+            pages.push(pg);
+          }
         }
         return pages;
+      },
+      showHeadGap: function (options) {
+        if (options.shown % 2 === 0) {
+          return ((options.page - (Math.floor(options.shown / 2))) > 2)
+            && options.page > (options.shown - Math.floor(options.shown / 2));
+        } else {
+          return ((options.page - (Math.floor(options.shown / 2))) > 2)
+            && (options.page >= (options.shown - Math.floor(options.shown / 2)));
+        }
+      },
+      showTailGap(options) {
+        if (options.shown % 2 === 0) {
+          return options.page < (options.total - (options.shown - 2));
+        } else {
+          return options.page <= (options.total - (options.shown - 2));
+        }
       }
     };
   }

--- a/modules/@apostrophecms/pager/index.js
+++ b/modules/@apostrophecms/pager/index.js
@@ -37,9 +37,11 @@ module.exports = {
       },
       showTailGap(options) {
         if (options.shown % 2 === 0) {
-          return options.page < (options.total - (options.shown - 2));
+          return (options.page < (options.total - (options.shown - 2)))
+            && (total > (shown + 2));
         } else {
-          return options.page <= (options.total - (options.shown - 2));
+          return (options.page <= (options.total - (options.shown - 2)))
+            && (total > (shown + 2));
         }
       }
     };

--- a/modules/@apostrophecms/pager/index.js
+++ b/modules/@apostrophecms/pager/index.js
@@ -28,20 +28,20 @@ module.exports = {
       },
       showHeadGap: function (options) {
         if (options.shown % 2 === 0) {
-          return ((options.page - (Math.floor(options.shown / 2))) > 2)
-            && options.page > (options.shown - Math.floor(options.shown / 2));
+          return ((options.page - (Math.floor(options.shown / 2))) > 2) &&
+            options.page > (options.shown - Math.floor(options.shown / 2));
         } else {
-          return ((options.page - (Math.floor(options.shown / 2))) > 2)
-            && (options.page >= (options.shown - Math.floor(options.shown / 2)));
+          return ((options.page - (Math.floor(options.shown / 2))) > 2) &&
+            (options.page >= (options.shown - Math.floor(options.shown / 2)));
         }
       },
       showTailGap(options) {
         if (options.shown % 2 === 0) {
-          return (options.page < (options.total - (options.shown - 2)))
-            && (total > (shown + 2));
+          return (options.page < (options.total - (options.shown - 2))) &&
+            (options.total > (options.shown + 2));
         } else {
-          return (options.page <= (options.total - (options.shown - 2)))
-            && (total > (shown + 2));
+          return (options.page <= (options.total - (options.shown - 2))) &&
+            (options.total > (options.shown + 2));
         }
       }
     };

--- a/modules/@apostrophecms/pager/views/macros.html
+++ b/modules/@apostrophecms/pager/views/macros.html
@@ -11,19 +11,19 @@
     {% set gapClass = pagerClass + '__gap' if pagerClass else '' %}
     <div class="{{ pagerClass if pagerClass }}">
       {{ pagerPage(1, options, pagerClass, url) }}
-      {% if options.page > 4 %}
+      {% if apos.pager.showHeadGap(options) %}
         <span class="{{ gapClass }}">&hellip;</span>
       {% endif %}
 
       {% for page in apos.pager.pageRange({
         page: options.page,
         total: options.total,
-        shown: 5
+        shown: options.shown or 5
       }) %}
         {{ pagerPageInner(page, options, pagerClass, url) }}
       {% endfor %}
 
-      {% if options.page < (options.total - 3) %}
+      {% if apos.pager.showTailGap(options) %}
         <span class="{{ gapClass }}">&hellip;</span>
       {% endif %}
       {{ pagerPage(options.total, options, pagerClass, url) }}


### PR DESCRIPTION
Updates the pager macro to end the tyranny of the 5-item intermediary range. A `shown` option can be included in the macro to change the number of items in the middle of the pager.

See a test PoC for this: https://codepen.io/alexbea/pen/NWRRPyV?editors=0012, changing the variables at the top of the JS section.