### PR TITLE
Shiny new recursion guard system with an effective "stack trace" and no false positives

### DIFF
--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -60,7 +60,7 @@ module.exports = {
           async function load() {
             // Hint to call nested widget loaders as if it were a doc
             widget._virtual = true;
-            return manager.load(req, [ widget ]);
+            return manager.loadIfSuitable(req, [ widget ]);
           }
           async function render() {
             return self.renderWidget(req, type, widget, options);
@@ -426,7 +426,7 @@ module.exports = {
             self.warnMissingWidgetType(type);
             continue;
           }
-          await manager.load(req, req.deferredWidgets[type]);
+          await manager.loadIfSuitable(req, req.deferredWidgets[type]);
         }
       },
       // Returns true if the named area in the given `doc` is empty.

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1191,7 +1191,6 @@ module.exports = {
               return;
             }
             const req = query.req;
-            req.areasLoadedFor = req.areasLoadedFor || {};
 
             const widgetsByType = {};
 
@@ -1204,21 +1203,6 @@ module.exports = {
                 });
               });
               if (areasInfo.length) {
-                // Simple guard against infinite recursion:
-                // we won't load areas for the same doc more than five times
-                // per page request.
-                //
-                // We run this guard only if areas actually exist so we're
-                // not unfairly triggered by docs loaded with a restricted
-                // projection.
-                if (!_.has(req.areasLoadedFor, doc._id)) {
-                  req.areasLoadedFor[doc._id] = 0;
-                }
-                if (req.areasLoadedFor[doc._id] >= 5) {
-                  self.apos.util.warn('WARNING: reached maximum area loader recursion level. Doc _id is ' + doc._id + '. Are you using projections for all relationships?');
-                  return;
-                }
-                req.areasLoadedFor[doc._id]++;
                 for (const info of areasInfo) {
                   const area = info.area;
                   const dotPath = info.dotPath;
@@ -1270,7 +1254,7 @@ module.exports = {
               if (!(manager && manager.load)) {
                 continue;
               }
-              await manager.load(req, widgetsByType[type]);
+              await manager.loadIfSuitable(req, widgetsByType[type]);
             }
           }
         },

--- a/modules/@apostrophecms/express/index.js
+++ b/modules/@apostrophecms/express/index.js
@@ -195,10 +195,12 @@ module.exports = {
 
   middleware(self, options) {
     return {
-      createData(req, res, next) {
+      createDataAndGuards(req, res, next) {
         if (!req.data) {
           req.data = {};
         }
+        req.aposNeverLoad = {};
+        req.aposStack = [];
         return next();
       },
       sessions: expressSession(self.getSessionOptions()),

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1689,10 +1689,11 @@ module.exports = {
                 _.extend(options.hints, _relationship.hints);
                 _.extend(options.hints, _relationship.hintsByType[type]);
               }
-              // Allow options to the getter to be specified in the schema,
-              // notably editable: true
-
-              await self.fieldTypes[_relationship.type].relate(req, _relationship, _objects, options);
+              await apos.util.recursionGuard(req, `${_relationship.type}:${_relationship.withType}`, () => {
+                // Allow options to the getter to be specified in the schema,
+                // notably editable: true
+                return self.fieldTypes[_relationship.type].relate(req, _relationship, _objects, options);
+              });
               _.each(_objects, function (object) {
                 if (object[subname]) {
                   if (Array.isArray(object[subname])) {
@@ -1737,7 +1738,9 @@ module.exports = {
 
           // Allow options to the getter to be specified in the schema,
           // notably editable: true
-          await self.fieldTypes[relationship.type].relate(req, relationship, _objects, options);
+          await apos.util.recursionGuard(req, `${relationship.type}:${relationship.withType}`, () => {
+            return self.fieldTypes[relationship.type].relate(req, relationship, _objects, options);
+          });
         }
 
         function findObjectsInArrays(objects, arrays) {

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1689,7 +1689,7 @@ module.exports = {
                 _.extend(options.hints, _relationship.hints);
                 _.extend(options.hints, _relationship.hintsByType[type]);
               }
-              await apos.util.recursionGuard(req, `${_relationship.type}:${_relationship.withType}`, () => {
+              await self.apos.util.recursionGuard(req, `${_relationship.type}:${_relationship.withType}`, () => {
                 // Allow options to the getter to be specified in the schema,
                 // notably editable: true
                 return self.fieldTypes[_relationship.type].relate(req, _relationship, _objects, options);
@@ -1738,7 +1738,7 @@ module.exports = {
 
           // Allow options to the getter to be specified in the schema,
           // notably editable: true
-          await apos.util.recursionGuard(req, `${relationship.type}:${relationship.withType}`, () => {
+          await self.apos.util.recursionGuard(req, `${relationship.type}:${relationship.withType}`, () => {
             return self.fieldTypes[relationship.type].relate(req, relationship, _objects, options);
           });
         }

--- a/modules/@apostrophecms/task/index.js
+++ b/modules/@apostrophecms/task/index.js
@@ -250,7 +250,9 @@ module.exports = {
             return { Host: 'you-need-to-set-baseUrl-in-app-js.com' }[propName];
           },
           query: {},
-          url: '/'
+          url: '/',
+          aposNeverLoad: {},
+          aposStack: []
         };
         _.extend(req, properties || {});
         self.apos.modules['@apostrophecms/express'].addAbsoluteUrlsToReq(req);

--- a/modules/@apostrophecms/template/lib/custom-tags/component.js
+++ b/modules/@apostrophecms/template/lib/custom-tags/component.js
@@ -39,7 +39,7 @@ module.exports = function(self, options) {
       if (!(module.components && module.components[componentName])) {
         throw new Error(`{% component %} was invoked with the name of a component that does not exist.\nModule name: ${moduleName} Component name: ${componentName}`);
       }
-      const result = await apos.util.recursionGuard(req, `component:${moduleName}:${componentName}`, async () => {
+      const result = await self.apos.util.recursionGuard(req, `component:${moduleName}:${componentName}`, async () => {
         const input = await module.components[componentName](req, data);
         return module.render(req, componentName, input);
       }) || {};

--- a/modules/@apostrophecms/template/lib/custom-tags/component.js
+++ b/modules/@apostrophecms/template/lib/custom-tags/component.js
@@ -42,7 +42,7 @@ module.exports = function(self, options) {
       const result = await self.apos.util.recursionGuard(req, `component:${moduleName}:${componentName}`, async () => {
         const input = await module.components[componentName](req, data);
         return module.render(req, componentName, input);
-      }) || {};
+      });
       if (result === undefined) {
         // Recursion guard stopped it, nunjucks expects a string
         return '';

--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -29,7 +29,14 @@ const Promise = require('bluebird');
 const util = require('util');
 
 module.exports = {
-  options: { alias: 'util' },
+  options: {
+    alias: 'util',
+    // No more than 50 combined levels deep in:
+    // * relationship fetches
+    // * widget loaders
+    // * async components
+    stackLimit: 50
+  },
   init(self, options) {
     // An id for this particular Apostrophe instance that should be
     // unique even in a multiple server environment.
@@ -723,6 +730,22 @@ module.exports = {
         }
         p = path[i];
         o[p] = v;
+      },
+      // Pushes the given label onto `req.aposStack` before awaiting the given function; then pops the label off the stack
+      // and returns the result of the function. If the stack limit is reached, a warning which includes the stack itself
+      // is printed to assist in debugging, and the return value is `undefined`. Code that calls this function should be
+      // prepared not to crash if `undefined` is returned.
+
+      async recursionGuard(req, label, fn) {
+        req.aposStack.push(label);
+        if (req.aposStack.length === self.options.stackLimit) {
+          self.apos.util.warn(`WARNING: reached the maximum depth of Apostrophe's asynchronous stack.\nThis is usually because widget loaders, async components, and/or relationships\nare causing an infinite loop.\n\nPlease review the stack to find the problem:\n\n${req.aposStack.join('\n')}\n\nSuggested fixes:\n\n* For each relationship, set "areas: false" or configure a projection with\n"project".\n* Use the "neverLoad" option in your widget modules to block them from loading\nparticular widget types recursively.\n* Do not use "neverLoadSelf: false" for any widget type unless you can\nguarantee it will never cause an infinite loop.\n* Make sure your async components do not call themselves recursively in a way that will never terminate.\n\n`);
+          req.aposStack.pop();
+          return;
+        }
+        const result = await fn();
+        req.aposStack.pop();
+        return result;
       }
     };
   },
@@ -1037,25 +1060,7 @@ module.exports = {
           result = _.merge(result, arguments[i]);
         }
         return result;
-      },
-
-      // Pushes the given label onto `req.aposStack` before awaiting the given function; then pops the label off the stack
-      // and returns the result of the function. If the stack limit is reached, a warning which includes the stack itself
-      // is printed to assist in debugging, and the return value is `undefined`. Code that calls this function should be
-      // prepared not to crash if `undefined` is returned.
-
-      async recursionGuard(req, label, fn) {
-        req.aposStack.push(label);
-        if (req.aposStack.length === self.apos.util.stackLimit) {
-          self.apos.util.warn(`WARNING: reached the maximum depth of Apostrophe's asynchronous stack.\nThis is usually because widget loaders, async components, and/or relationships are\ncausing an infinite loop.\nPlease review the stack to find the problem:\n${req.aposStackStack.join('\n')}\nSuggested fixes:\n\n* For each relationship, set "areas: false" or configure a projection with\n"project".\n* Use the "neverLoad" option in your widget modules to block them from loading\nparticular widget types recursively.\n* Do not use "neverLoadSelf: false" for any widget type unless you can\nguarantee it will never cause an infinite loop.\n* Make sure your async components do not call themselves recursively in a way that will never terminate.\n\n`);
-          req.aposStack.pop();
-          return;
-        }
-        const result = await fn();
-        req.aposStack.pop();
-        return result;
       }
-
     };
   }
 };

--- a/modules/@apostrophecms/widget-type/index.js
+++ b/modules/@apostrophecms/widget-type/index.js
@@ -217,7 +217,6 @@ module.exports = {
           req.scene = self.options.scene;
         }
         if (req.aposNeverLoad[self.name]) {
-          console.log(`nested load of ${self.name} blocked by neverLoad/neverLoadSelf`);
           return;
         }
         const pushing = self.neverLoad.filter(type => !req.aposNeverLoad[type]);

--- a/modules/@apostrophecms/widget-type/index.js
+++ b/modules/@apostrophecms/widget-type/index.js
@@ -45,17 +45,17 @@
 //
 // ### `neverLoadSelf`
 //
-// If true, this widget's load method will never recursively load
-// another widget of the same type. This option defaults to `true`.
+// If true, this widget's `load` method will never recursively invoke
+// itself for the same widget type. This option defaults to `true`.
 // If you set it to `false`, be aware that you are responsible
 // for ensuring that the situation does not lead to an infinite loop.
 //
 // ### `neverLoad`
 //
-// If set to an array of widget type names, the specified widget types
-// will never be recursively loaded by this module's `load` method.
-// By default this option is empty. See also `neverLoadSelf`, which
-// defaults to `true`, resolving most performance problems.
+// If set to an array of widget type names, the load methods of the
+// specified widget types will never be recursively invoked by this module's
+// `load` method. By default this option is empty. See also `neverLoadSelf`,
+// which defaults to `true`, resolving most performance problems.
 //
 // ### `scene`
 //

--- a/modules/@apostrophecms/widget-type/index.js
+++ b/modules/@apostrophecms/widget-type/index.js
@@ -43,6 +43,20 @@
 // 100% of the permanent properties of the widget in this way.**
 // This is needed for the editing experience.
 //
+// ### `neverLoadSelf`
+//
+// If true, this widget's load method will never recursively load
+// another widget of the same type. This option defaults to `true`.
+// If you set it to `false`, be aware that you are responsible
+// for ensuring that the situation does not lead to an infinite loop.
+//
+// ### `neverLoad`
+//
+// If set to an array of widget type names, the specified widget types
+// will never be recursively loaded by this module's `load` method.
+// By default this option is empty. See also `neverLoadSelf`, which
+// defaults to `true`, resolving most performance problems.
+//
 // ### `scene`
 //
 // If your widget wishes to use Apostrophe features like schemas
@@ -112,7 +126,8 @@ const _ = require('lodash');
 module.exports = {
   cascades: [ 'fields' ],
   options: {
-    playerData: false
+    playerData: false,
+    neverLoadSelf: true
   },
   init(self, options) {
 
@@ -133,6 +148,17 @@ module.exports = {
 
     self.apos.task.add(self.__meta.name, 'list', 'Run this task to list all widgets of this type in the project.\n' + 'Useful for testing.\n', self.list);
 
+    // To avoid infinite loops and/or bad performance, the load method of
+    // this widget type will never invoke itself recursively unless
+    // the `loadSelf` option of the module is explicitly set to `true`.
+    // In addition the `neverLoad` option can be set to provide additional
+    // widget types that are not to be loaded in a nested way beneath this one
+
+    self.neverLoad = [ ...self.options.neverLoad || [] ];
+    if (self.options.neverLoadSelf) {
+      self.neverLoad.push(self.name);
+      self.neverLoad = [ ...new Set(self.neverLoad) ];
+    }
   },
   methods(self, options) {
     return {
@@ -169,24 +195,58 @@ module.exports = {
         });
       },
 
-      // Perform relationships and any other necessary async
-      // actions for our type of widget. Note that
-      // an array of widgets is handled in a single call
-      // as you can usually optimize this.
-      //
-      // Override this to perform custom relationships not
-      // specified by your schema, talk to APIs, etc.
+      // Load relationships and carry out any other necessary async
+      // actions for our type of widget, as long as it is
+      // not forbidden due to the `neverLoad` option or the
+      // `neverLoadSelf` option (which defaults to `true`).
       //
       // Also implements the `scene` convenience option
       // for upgrading assets delivered to the browser
-      // to the full set of `user` assets.
+      // to the full set of `user` assets (TODO: are we
+      // removing this in A3?)
+      //
+      // If you are looking to add custom loader behavior for
+      // your widget type, don't extend this method, extend
+      // the `load` method which just does the loading work.
+      // `loadIfSuitable` is responsible for invoking that method
+      // only after checking for recursion issues. Those guards
+      // should apply to your code too.
 
-      async load(req, widgets) {
+      async loadIfSuitable(req, widgets) {
         if (self.options.scene) {
           req.scene = self.options.scene;
         }
-        await self.apos.schema.relate(req, self.schema, widgets, undefined);
+        if (req.aposNeverLoad[self.name]) {
+          console.log(`nested load of ${self.name} blocked by neverLoad/neverLoadSelf`);
+          return;
+        }
+        const pushing = self.neverLoad.filter(type => !req.aposNeverLoad[type]);
+        for (const type of pushing) {
+          req.aposNeverLoad[type] = true;
+        }
+        await apos.util.recursionGuard(req, `widget:${self.name}`, async () => {
+          return self.load(req, widgets);
+        });
+        for (const type of pushing) {
+          // Faster than the delete keyword
+          req.aposNeverLoad[type] = false;
+        }
+      },
 
+      // Perform relationships and any other necessary async
+      // actions for our type of widget.
+      //
+      // Override this to perform custom actions not
+      // specified by your schema, talk to APIs, etc. when a widget
+      // is present.
+      //
+      // Note that an array of widgets is handled in a single call
+      // as you can sometimes optimize for that case.
+      // Do not assume there is only one. If you can't optimize it,
+      // that's OK, just loop over them and handle every one.
+
+      async load(req, widgets) {
+        await self.apos.schema.relate(req, self.schema, widgets, undefined);
         // If this is a virtual widget (a widget being edited or previewed in the
         // editor), any nested areas, etc. inside it haven't already been loaded as
         // part of loading a doc. Do that now by creating a query and then feeding
@@ -203,9 +263,8 @@ module.exports = {
         // Shut off relationships because we already did them and the query would try to do them
         // again based on `type`, which isn't really a doc type.
         const query = self.apos.doc.find(req).relationships(false);
-
         // Call .after with our own results
-        return query.after(widgets);
+        await query.after(widgets);
       },
 
       // Sanitize the widget. Invoked when the user has edited a widget on the

--- a/modules/@apostrophecms/widget-type/index.js
+++ b/modules/@apostrophecms/widget-type/index.js
@@ -224,7 +224,7 @@ module.exports = {
         for (const type of pushing) {
           req.aposNeverLoad[type] = true;
         }
-        await apos.util.recursionGuard(req, `widget:${self.name}`, async () => {
+        await self.apos.util.recursionGuard(req, `widget:${self.name}`, async () => {
           return self.load(req, widgets);
         });
         for (const type of pushing) {

--- a/test/modules/recursion-test-page/index.js
+++ b/test/modules/recursion-test-page/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+  components(self, options) {
+    return {
+      test(req, data) {
+        return data;
+      }
+    };
+  }
+};

--- a/test/modules/recursion-test-page/views/page.html
+++ b/test/modules/recursion-test-page/views/page.html
@@ -1,0 +1,3 @@
+<h3>Sing to me, Oh Muse.</h3>
+
+{% component "recursion-test-page:test" with { depth: 0 } %}

--- a/test/modules/recursion-test-page/views/test.html
+++ b/test/modules/recursion-test-page/views/test.html
@@ -1,0 +1,2 @@
+At depth {{ data.depth }}
+{% component "recursion-test-page:test" with { depth: data.depth + 1 } %}

--- a/test/recursionGuard.js
+++ b/test/recursionGuard.js
@@ -1,0 +1,51 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert');
+
+describe('Utils', function() {
+
+  this.timeout(t.timeout);
+
+  let apos;
+
+  after(() => {
+    return t.destroy(apos);
+  });
+
+  it('should exist on the apos.util object', async () => {
+    apos = await t.create({
+      root: module
+    });
+    assert(apos.util.recursionGuard);
+  });
+
+  it('should create a stack as it goes and stop without executing depth 50', async () => {
+    let depth = 0;
+    let depth49First = true;
+    const req = apos.task.getReq();
+    const result = await load();
+    // Guarded functions not directly blocked by the depth rule should
+    // return their own result
+    assert(result === 'result');
+    assert(depth === 49);
+    assert(!req.aposStack.length);
+    async function load() {
+      return apos.util.recursionGuard(req, 'test', async () => {
+        depth++;
+        assert(req.aposStack);
+        assert(req.aposStack.length === depth);
+        const nestedResult = await load();
+        // Careful, "depth" stays at 49 as we return up the stack
+        if ((depth === 49) && (depth49First === true)) {
+          // Guarded functions directly blocked by the depth rule
+          // should return undefined
+          assert(nestedResult === undefined);
+          depth49First = false;
+        } else {
+          // Other invocations should return the result of the inner function
+          assert(nestedResult === 'result');
+        }
+        return 'result';
+      });
+    }
+  });
+});

--- a/test/recursionGuard.js
+++ b/test/recursionGuard.js
@@ -2,7 +2,7 @@ const t = require('../test-lib/test.js');
 const assert = require('assert');
 const cuid = require('cuid');
 
-describe('Utils', function() {
+describe('Recursion Guard', function() {
 
   this.timeout(t.timeout);
 

--- a/test/recursionGuard.js
+++ b/test/recursionGuard.js
@@ -1,5 +1,6 @@
 const t = require('../test-lib/test.js');
 const assert = require('assert');
+const cuid = require('cuid');
 
 describe('Utils', function() {
 
@@ -13,7 +14,111 @@ describe('Utils', function() {
 
   it('should exist on the apos.util object', async () => {
     apos = await t.create({
-      root: module
+      root: module,
+      modules: {
+        product: {
+          options: {
+            alias: 'product'
+          },
+          extend: '@apostrophecms/piece-type',
+          fields: {
+            add: {
+              _articles: {
+                type: 'relationshipReverse',
+                withType: 'article'
+              }
+            }
+          }
+        },
+        article: {
+          options: {
+            alias: 'article'
+          },
+          extend: '@apostrophecms/piece-type',
+          fields: {
+            add: {
+              _products: {
+                type: 'relationship',
+                withType: 'product'
+              },
+              main: {
+                type: 'area',
+                widgets: {
+                  article: {}
+                }
+              }
+            }
+          }
+        },
+        'article-widget': {
+          extend: '@apostrophecms/widget-type',
+          options: {
+            label: 'Article'
+          },
+          fields: {
+            add: {
+              _articles: {
+                type: 'relationship',
+                withType: 'article'
+              }
+            }
+          }
+        },
+        'scary-article-widget': {
+          extend: '@apostrophecms/widget-type',
+          options: {
+            label: 'Scary Article',
+            neverLoadSelf: false
+          },
+          fields: {
+            add: {
+              _articles: {
+                type: 'relationship',
+                withType: 'article'
+              }
+            }
+          }
+        },
+        'product-widget': {
+          extend: '@apostrophecms/widget-type',
+          options: {
+            label: 'Product'
+          },
+          fields: {
+            add: {
+              _products: {
+                type: 'relationship',
+                withType: 'product'
+              }
+            }
+          }
+        },
+        '@apostrophecms/page': {
+          options: {
+            park: [
+              {
+                slug: '/recursion-test-page',
+                type: 'recursion-test-page',
+                title: 'Recursion Test Page',
+                parkedId: 'recursion-test-page'
+              }
+            ],
+            types: [
+              {
+                name: '@apostrophecms/home-page',
+                label: 'Home'
+              },
+              {
+                name: 'recursion-test-page',
+                label: 'Recursion Test Page'
+              }
+            ]
+          }
+        },
+        'recursion-test-page': {
+          extend: '@apostrophecms/page-type'
+        }
+      }
     });
     assert(apos.util.recursionGuard);
   });
@@ -22,7 +127,14 @@ describe('Utils', function() {
     let depth = 0;
     let depth49First = true;
     const req = apos.task.getReq();
+    let warnings = '';
+    // Capture output of util.warn so we can verify there was a warning
+    apos.util.warn = function(...args) {
+      warnings += args.join('\n');
+    };
     const result = await load();
+    assert(warnings.match(/review the stack to find the problem/));
+    assert(warnings.match(/test/));
     // Guarded functions not directly blocked by the depth rule should
     // return their own result
     assert(result === 'result');
@@ -47,5 +159,103 @@ describe('Utils', function() {
         return 'result';
       });
     }
+  });
+
+  it('should immediately stop runaway self-references among widgets by default', async () => {
+    const req = apos.task.getReq();
+    const product = await apos.product.insert(req, {
+      title: 'Test Product'
+    });
+    const selfRefId = cuid();
+    await apos.article.insert(req, {
+      _id: selfRefId,
+      title: 'Self Referential Article',
+      main: {
+        metaType: 'area',
+        _id: cuid(),
+        items: [
+          {
+            metaType: 'widget',
+            type: 'article',
+            articlesIds: [ selfRefId ]
+          },
+          {
+            metaType: 'widget',
+            type: 'product',
+            productsIds: [ product._id ]
+          }
+        ]
+      }
+    });
+    const article = await apos.article.find(req, {
+      _id: selfRefId
+    }).toObject();
+    assert(article);
+    // Sanity check that we didn't kill all widget loaders: check
+    // the product widget
+    assert(article.main.items[1]._products[0]);
+    // Now dig into the recursive article widget
+    assert(article.main.items[0]);
+    // We do go down one level, because it's not recursing within the
+    // widget loader yet on the first go
+    assert(article.main.items[0]._articles);
+    assert(article.main.items[0]._articles[0]);
+    // However there should be no second go!
+    assert(article.main.items[0]._articles[0].main);
+    assert(article.main.items[0]._articles[0].main.items[0]);
+    assert(!article.main.items[0]._articles[0].main.items[0]._articles);
+  });
+
+  it('should eventually stop runaway self-references among widgets that use neverLoadSelf: false', async () => {
+    const req = apos.task.getReq();
+    const selfRefId = cuid();
+    await apos.article.insert(req, {
+      _id: selfRefId,
+      title: 'Very Self Referential Article',
+      main: {
+        metaType: 'area',
+        _id: cuid(),
+        items: [
+          {
+            metaType: 'widget',
+            type: 'scary-article',
+            articlesIds: [ selfRefId ]
+          }
+        ]
+      }
+    });
+    let warnings = '';
+    // Capture output of util.warn so we can verify there was a warning
+    apos.util.warn = function(...args) {
+      warnings += args.join('\n');
+    };
+    const article = await apos.article.find(req, {
+      _id: selfRefId
+    }).toObject();
+    // Verify the stack shown in the warning references the right bits
+    assert(warnings.match(/widget:scary-article/));
+    assert(warnings.match(/relationship:article/));
+    // If we get this far we successfully stopped the recursion at some depth
+    assert(article);
+    // ... But verify some recursion did take place
+    assert(article.main.items[0]);
+    assert(article.main.items[0]._articles[0]);
+    assert(article.main.items[0]._articles[0].main.items[0]._articles[0]);
+  });
+
+  it('should eventually stop runaway self-references in async components', async () => {
+    let warnings = '';
+    // Capture output of util.warn so we can verify there was a warning
+    apos.util.warn = function(...args) {
+      warnings += args.join('\n');
+    };
+    const html = await apos.http.get('/recursion-test-page');
+    assert(warnings.match(/component:recursion-test-page:test/));
+    // If we got this far the recursion was eventually stopped
+    assert(html.match(/Sing to me, Oh Muse\./));
+    assert(html.match(/At depth 0/));
+    assert(html.match(/At depth 48/));
+    assert(!html.match(/At depth 49/));
+    assert(!html.match(/Object/));
   });
 });


### PR DESCRIPTION
Previous discussion:

Resolves #2406 

* By popular demand, this is "option 1d," plus a much better error message if the problem does still occur.
* A widget type will never recursively load itself unless this is explicitly turned on by the developer. This stops most cases of runaway recursion immediately.
* A widget type can also be configured not to recursively load specific other widget types.
* Relationships, widgets *and* async components now all contribute to a combined "apostrophe async stack trace" showing the relationship loaders, widget loaders and async components that were nested at that point in time.
* We limit this stack depth to 50 by default. That limit can be configured.
* If the limit is reached the stack trace is printed with helpful suggestions and recursion stops there.

This eliminates many false positives with the old system, which was based on loading the same document 5 times during a request, which can happen for legitimate reasons. The new system explicitly detects recursion.

Feeling good about it.