### PR TITLE
autopublish images and files

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -569,8 +569,12 @@ export default {
         window.sessionStorage.setItem('aposStateChangeSeen', '{}');
         if (mode === 'published') {
           window.sessionStorage.setItem('aposEditMode', JSON.stringify(false));
+          this.editMode = false;
         }
         this.draftMode = mode;
+        this.moduleOptions.context = doc;
+        // Changes the ending from :published to :draft, etc.
+        this.moduleOptions.contextId = doc._id;
         this.refreshOrReload(doc._url);
       } catch (e) {
         if (e.status === 404) {

--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -862,7 +862,12 @@ module.exports = {
         if (options.deleted) {
           commands.push([
             { _id: { $in: ids } },
-            { $pull: { docIds: doc._id, trashDocIds: doc._id } }
+            {
+              $pull: {
+                docIds: doc._id,
+                trashDocIds: doc._id
+              }
+            }
           ]);
         } else if (!doc.trash) {
           commands.push([

--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -955,10 +955,10 @@ module.exports = {
           const attachments = await self.db.find({
             utilized: true,
             'docIds.0': { $exists: 0 },
-            'trashIds.0': { $exists: 0 }
+            'trashDocIds.0': { $exists: 0 }
           }).toArray();
           for (const attachment of attachments) {
-            await alterOne(attachment, 'enable');
+            await alterOne(attachment, 'remove');
           }
         }
         async function alterOne(attachment, action) {

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -129,6 +129,14 @@ module.exports = {
             });
             return self.emit('afterRescue', req, doc);
           }
+        },
+        async autopublish(req, doc, options) {
+          if (!self.options.autopublish) {
+            return;
+          }
+          if (doc.aposLocale.includes(':draft')) {
+            return self.publish(req, doc, options);
+          }
         }
       },
       afterTrash: {

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -197,7 +197,7 @@ module.exports = {
         }
       },
       '@apostrophecms/doc-type:afterDelete': {
-                // If deleting draft also delete published,
+        // If deleting draft also delete published,
         // and vice versa. (Note that when the user
         // "discards the draft" of a previously published
         // document it is not really deleted, it is reset

--- a/modules/@apostrophecms/file/index.js
+++ b/modules/@apostrophecms/file/index.js
@@ -15,7 +15,8 @@ module.exports = {
     alias: 'file',
     quickCreate: false,
     insertViaUpload: true,
-    slugPrefix: 'file-'
+    slugPrefix: 'file-',
+    autopublish: true
   },
   fields: {
     add: {

--- a/modules/@apostrophecms/image/index.js
+++ b/modules/@apostrophecms/image/index.js
@@ -20,7 +20,8 @@ module.exports = {
     quickCreate: false,
     insertViaUpload: true,
     searchable: false,
-    slugPrefix: 'image-'
+    slugPrefix: 'image-',
+    autopublish: true
   },
   fields: {
     add: {

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -1081,7 +1081,6 @@ database.`);
       // "page."
       async getTarget(req, targetId, position) {
         const criteria = self.getIdCriteria(targetId);
-        console.log(criteria);
         const target = await self.find(req, criteria).permission(false).trash(null).areas(false).ancestors(_.assign({
           depth: 1,
           trash: null,

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -364,7 +364,7 @@ module.exports = {
         });
         return self.delete(req, page);
       },
-        // Patch some properties of the page.
+      // Patch some properties of the page.
       //
       // You may pass `_targetId` and `_position` to move the page within the tree. `_position`
       // may be `before`, `after` or `inside`. To move a page into or out of the trash, set


### PR DESCRIPTION
This turns out to be a very simple solution to an otherwise sticky problem.

Images and files can still be localized when we get around to building i18n UI, since locales are still in play. They just don't need to be published. And other types can be given the `autopublish: true` option as needed.