### PR TITLE
color field bugs

### DIFF
--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputColor.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputColor.vue
@@ -105,6 +105,11 @@ export default {
           return 'required';
         }
       }
+
+      if (!value) {
+        return false;
+      }
+
       const color = tinycolor(value);
       return color.isValid() ? false : 'Error';
     }
@@ -116,15 +121,17 @@ export default {
   .apos-color {
     display: flex;
     align-items: center;
-
-    & /deep/ .vc-sketch {
-      padding: 0;
-      box-shadow: none;
-    }
   }
 
   .apos-color__info {
     @include type-base;
     margin-left: 15px;
+  }
+</style>
+
+<style lang="scss">
+  .apos-popover .vc-sketch {
+    padding: 0;
+    box-shadow: none;
   }
 </style>

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputColor.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputColor.vue
@@ -129,6 +129,10 @@ export default {
   }
 </style>
 
+<!--
+  This styleblock is unscoped so that it reaches the color field's implementation
+  of AposContextMenu, which is outside the component's DOM tree
+-->
 <style lang="scss">
   .apos-popover .vc-sketch {
     padding: 0;


### PR DESCRIPTION
- Fixes case where the editor engaged an un-required color picker but didn't select a color and got an erroneous error
- Unscopes `AposContextMenu` styles that now live in a different part of the DOM tree