### PR TITLE
users and other nonlocalized piece types can be edited again

### DIFF
--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -76,16 +76,9 @@ module.exports = {
       },
       // Infer `req.locale` and `req.mode` from `_id` if they were
       // not set already by explicit query parameters. Conversely,
-      // if the parameters were set, rewrite `_id` accordingly.
-      // Returns `_id`, after rewriting if appropriate.
-      //
-      // If `localize` is `true`, or the name of a type that is localized,
-      // the method has its effect as described above. Otherwise it has no effect
-      // and returns `_id` unmodified.
-      inferIdLocaleAndMode(req, _id, localize) {
-        if ((localize === false) || ((localize !== true) && (!self.apos.doc.getManager(localize).isLocalized()))) {
-          return _id;
-        }
+      // if the appropriate query parameters were set, rewrite
+      // `_id` accordingly. Returns `_id`, after rewriting if appropriate.
+      inferIdLocaleAndMode(req, _id) {
         let [ cuid, locale, mode ] = _id.split(':');
         if (locale && mode) {
           if (!req.query['apos-locale']) {

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -78,7 +78,14 @@ module.exports = {
       // not set already by explicit query parameters. Conversely,
       // if the parameters were set, rewrite `_id` accordingly.
       // Returns `_id`, after rewriting if appropriate.
-      inferIdLocaleAndMode(req, _id) {
+      //
+      // If `localize` is `true`, or the name of a type that is localized,
+      // the method has its effect as described above. Otherwise it has no effect
+      // and returns `_id` unmodified.
+      inferIdLocaleAndMode(req, _id, localize) {
+        if ((localize === false) || ((localize !== true) && (!self.apos.doc.getManager(localize).isLocalized()))) {
+          return _id;
+        }
         let [ cuid, locale, mode ] = _id.split(':');
         if (locale && mode) {
           if (!req.query['apos-locale']) {

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -207,7 +207,7 @@ module.exports = {
       // `_home` or `_trash`
       async getOne(req, _id) {
         self.publicApiCheck(req);
-        _id = self.apos.i18n.inferIdLocaleAndMode(req, _id);
+        _id = self.apos.i18n.inferIdLocaleAndMode(req, _id, true);
         const criteria = self.getIdCriteria(_id);
         const result = await self.getRestQuery(req).and(criteria).toObject();
         if (!result) {
@@ -309,7 +309,7 @@ module.exports = {
 
       async put(req, _id) {
         self.publicApiCheck(req);
-        _id = self.apos.i18n.inferIdLocaleAndMode(req, _id);
+        _id = self.apos.i18n.inferIdLocaleAndMode(req, _id, true);
         return self.withLock(req, async () => {
           const page = await self.find(req, { _id }).toObject();
           if (!page) {
@@ -356,7 +356,7 @@ module.exports = {
       // fully deleted, which isn't the same as having references still in the trash.
       async delete(req, _id) {
         self.publicApiCheck(req);
-        _id = self.apos.i18n.inferIdLocaleAndMode(req, _id);
+        _id = self.apos.i18n.inferIdLocaleAndMode(req, _id, true);
         const page = await self.findOneForEditing(req, {
           _id
         });
@@ -377,7 +377,7 @@ module.exports = {
     return {
       post: {
         ':_id/publish': async (req) => {
-          const _id = self.apos.i18n.inferIdLocaleAndMode(req, req.params._id);
+          const _id = self.apos.i18n.inferIdLocaleAndMode(req, req.params._id, true);
           const draft = await self.findOneForEditing({
             ...req,
             mode: 'draft'
@@ -394,7 +394,7 @@ module.exports = {
           return self.publish(req, draft);
         },
         ':_id/revert-draft-to-published': async (req) => {
-          const _id = self.apos.i18n.inferIdLocaleAndMode(req, req.params._id);
+          const _id = self.apos.i18n.inferIdLocaleAndMode(req, req.params._id, true);
           const draft = await self.findOneForEditing({
             ...req,
             mode: 'draft'
@@ -411,7 +411,7 @@ module.exports = {
           return self.revertDraftToPublished(req, draft);
         },
         ':_id/revert-published-to-previous': async (req) => {
-          const _id = self.apos.i18n.inferIdLocaleAndMode(req, req.params._id);
+          const _id = self.apos.i18n.inferIdLocaleAndMode(req, req.params._id, true);
           const published = await self.findOneForEditing({
             ...req,
             mode: 'published'

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -207,7 +207,7 @@ module.exports = {
       // `_home` or `_trash`
       async getOne(req, _id) {
         self.publicApiCheck(req);
-        _id = self.apos.i18n.inferIdLocaleAndMode(req, _id, true);
+        _id = self.inferIdLocaleAndMode(req, _id);
         const criteria = self.getIdCriteria(_id);
         const result = await self.getRestQuery(req).and(criteria).toObject();
         if (!result) {
@@ -309,7 +309,7 @@ module.exports = {
 
       async put(req, _id) {
         self.publicApiCheck(req);
-        _id = self.apos.i18n.inferIdLocaleAndMode(req, _id, true);
+        _id = self.inferIdLocaleAndMode(req, _id);
         return self.withLock(req, async () => {
           const page = await self.find(req, { _id }).toObject();
           if (!page) {
@@ -356,7 +356,7 @@ module.exports = {
       // fully deleted, which isn't the same as having references still in the trash.
       async delete(req, _id) {
         self.publicApiCheck(req);
-        _id = self.apos.i18n.inferIdLocaleAndMode(req, _id, true);
+        _id = self.inferIdLocaleAndMode(req, _id);
         const page = await self.findOneForEditing(req, {
           _id
         });
@@ -377,7 +377,7 @@ module.exports = {
     return {
       post: {
         ':_id/publish': async (req) => {
-          const _id = self.apos.i18n.inferIdLocaleAndMode(req, req.params._id, true);
+          const _id = self.inferIdLocaleAndMode(req, req.params._id);
           const draft = await self.findOneForEditing({
             ...req,
             mode: 'draft'
@@ -394,7 +394,7 @@ module.exports = {
           return self.publish(req, draft);
         },
         ':_id/revert-draft-to-published': async (req) => {
-          const _id = self.apos.i18n.inferIdLocaleAndMode(req, req.params._id, true);
+          const _id = self.inferIdLocaleAndMode(req, req.params._id);
           const draft = await self.findOneForEditing({
             ...req,
             mode: 'draft'
@@ -411,7 +411,7 @@ module.exports = {
           return self.revertDraftToPublished(req, draft);
         },
         ':_id/revert-published-to-previous': async (req) => {
-          const _id = self.apos.i18n.inferIdLocaleAndMode(req, req.params._id, true);
+          const _id = self.inferIdLocaleAndMode(req, req.params._id);
           const published = await self.findOneForEditing({
             ...req,
             mode: 'published'
@@ -2198,6 +2198,15 @@ database.`);
             });
           });
         });
+      },
+      // Infer `req.locale` and `req.mode` from `_id` if they were
+      // not set already by explicit query parameters. Conversely,
+      // if the appropriate query parameters were set, rewrite
+      // `_id` accordingly. Returns `_id`, after rewriting if appropriate.
+      inferIdLocaleAndMode(req, _id) {
+        // For pages we currently always do this. For pieces it's conditional
+        // on whether the type is localized.
+        return self.apos.i18n.inferIdLocaleAndMode(req, _id);
       }
     };
   },

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -182,7 +182,7 @@ module.exports = {
     },
     async getOne(req, _id) {
       self.publicApiCheck(req);
-      _id = self.apos.i18n.inferIdLocaleAndMode(req, _id);
+      _id = self.apos.i18n.inferIdLocaleAndMode(req, _id, self.name);
       const doc = await self.getRestQuery(req).and({ _id }).toObject();
       if (!doc) {
         throw self.apos.error('notfound');
@@ -199,12 +199,12 @@ module.exports = {
     },
     async put(req, _id) {
       self.publicApiCheck(req);
-      _id = self.apos.i18n.inferIdLocaleAndMode(req, _id);
+      _id = self.apos.i18n.inferIdLocaleAndMode(req, _id, self.name);
       return self.convertUpdateAndRefresh(req, req.body, _id);
     },
     async delete(req, _id) {
       self.publicApiCheck(req);
-      _id = self.apos.i18n.inferIdLocaleAndMode(req, _id);
+      _id = self.apos.i18n.inferIdLocaleAndMode(req, _id, self.name);
       const piece = await self.findOneForEditing(req, {
         _id
       });
@@ -212,7 +212,7 @@ module.exports = {
     },
     patch(req, _id) {
       self.publicApiCheck(req);
-      _id = self.apos.i18n.inferIdLocaleAndMode(req, _id);
+      _id = self.apos.i18n.inferIdLocaleAndMode(req, _id, self.name);
       return self.patch(req, _id);
     }
   }),
@@ -220,7 +220,7 @@ module.exports = {
     return {
       post: {
         ':_id/publish': async (req) => {
-          const _id = self.apos.i18n.inferIdLocaleAndMode(req, req.params._id);
+          const _id = self.apos.i18n.inferIdLocaleAndMode(req, req.params._id, self.name);
           const draft = await self.findOneForEditing({
             ...req,
             mode: 'draft'
@@ -237,7 +237,7 @@ module.exports = {
           return self.publish(req, draft);
         },
         ':_id/revert-draft-to-published': async (req) => {
-          const _id = self.apos.i18n.inferIdLocaleAndMode(req, req.params._id);
+          const _id = self.apos.i18n.inferIdLocaleAndMode(req, req.params._id, self.name);
           const draft = await self.findOneForEditing({
             ...req,
             mode: 'draft'
@@ -254,7 +254,7 @@ module.exports = {
           return self.revertDraftToPublished(req, draft);
         },
         ':_id/revert-published-to-previous': async (req) => {
-          const _id = self.apos.i18n.inferIdLocaleAndMode(req, req.params._id);
+          const _id = self.apos.i18n.inferIdLocaleAndMode(req, req.params._id, self.name);
           const published = await self.findOneForEditing({
             ...req,
             mode: 'published'


### PR DESCRIPTION
The method that sometimes infers the locale from the _id was at fault. Need to check whether it's appropriate to the type before doing that.