### PR TITLE
3/admin button space

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -779,7 +779,7 @@ function depth(el) {
   display: flex;
   align-items: center;
   height: 30px;
-  padding: 5px 20px;
+  padding: 10px 20px;
   border-bottom: 1px solid var(--a-base-9);
 }
 
@@ -852,9 +852,6 @@ function depth(el) {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  /deep/ .apos-button--subtle { // optical consistency
-    padding: 9px;
-  }
 }
 
 .apos-admin-bar__control-set {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
@@ -327,7 +327,7 @@ export default {
   }
 
   .apos-button--subtle {
-    padding: 10px;
+    padding: 11px 10px; // extra pixel keeps them aligned with border'd buttons
     color: var(--a-text-primary);
     &:hover,
     &:focus,


### PR DESCRIPTION
satisfies https://apostrophecms.atlassian.net/jira/software/projects/A30U/boards/4?selectedIssue=A30U-915

- keeps `subtle` buttons as tall as their unsubtle counterparts
- add a bit of vertical padding to admin bar rows