### PR TITLE
image and file tags autopublish, no need for publishing-related UI. A…

### DIFF
--- a/modules/@apostrophecms/file-tag/index.js
+++ b/modules/@apostrophecms/file-tag/index.js
@@ -2,7 +2,8 @@ module.exports = {
   extend: '@apostrophecms/piece-type',
   options: {
     label: 'File Tag',
-    quickCreate: false
+    quickCreate: false,
+    autopublish: true
   },
   fields: {
     remove: [ 'visibility' ]

--- a/modules/@apostrophecms/image-tag/index.js
+++ b/modules/@apostrophecms/image-tag/index.js
@@ -2,7 +2,8 @@ module.exports = {
   extend: '@apostrophecms/piece-type',
   options: {
     label: 'Image Tag',
-    quickCreate: false
+    quickCreate: false,
+    autopublish: true
   },
   fields: {
     remove: [ 'visibility' ]


### PR DESCRIPTION
…lso, a new image tag becomes visible in the media manager as soon as you save a media item that contains it (note: just making the tag was never enough, we only show media tags that are used for at least one media item somewhere).