### PR TITLE
3/fix area menu close after add

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
@@ -4,6 +4,7 @@
       :button="buttonOptions"
       v-bind="extendedContextMenuOptions"
       @open="menuOpen"
+      @close="menuClose"
       ref="contextMenu"
     >
       <ul class="apos-area-menu__wrapper">
@@ -102,7 +103,7 @@ export default {
       type: Boolean
     }
   },
-  emits: [ 'menu-open', 'insert' ],
+  emits: [ 'menu-open', 'menu-close', 'insert' ],
   data() {
     return {
       active: 0,
@@ -160,11 +161,14 @@ export default {
     menuOpen(e) {
       this.$emit('menu-open', e);
     },
+    menuClose(e) {
+      this.$emit('menu-close', e);
+    },
     async add(name) {
       // Potential TODO: If we find ourselves manually flipping these bits in other AposContextMenu overrides
       // we should consider refactoring contextmenus to be able to self close when any click takes place within their el
       // as it is often the logical experience (not always, see tag menus and filters)
-      this.$refs.contextMenu.isOpen = !this.$refs.contextMenu.isOpen;
+      this.$refs.contextMenu.isOpen = false;
       if (this.widgetIsContextual(name)) {
         this.insert({
           _id: cuid(),

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
@@ -158,11 +158,11 @@ export default {
     }
   },
   methods: {
-    menuOpen(e) {
-      this.$emit('menu-open', e);
-    },
     menuClose(e) {
       this.$emit('menu-close', e);
+    },
+    menuOpen(e) {
+      this.$emit('menu-open', e);
     },
     async add(name) {
       // Potential TODO: If we find ourselves manually flipping these bits in other AposContextMenu overrides

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
@@ -103,7 +103,7 @@ export default {
       type: Boolean
     }
   },
-  emits: [ 'menu-open', 'menu-close', 'insert' ],
+  emits: [ 'menu-close', 'menu-open', 'insert' ],
   data() {
     return {
       active: 0,

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
@@ -4,7 +4,7 @@
       :button="buttonOptions"
       v-bind="extendedContextMenuOptions"
       @open="menuOpen"
-      @close="menuClose"
+      ref="contextMenu"
     >
       <ul class="apos-area-menu__wrapper">
         <li
@@ -102,7 +102,7 @@ export default {
       type: Boolean
     }
   },
-  emits: [ 'menu-close', 'menu-open', 'insert' ],
+  emits: [ 'menu-open', 'insert' ],
   data() {
     return {
       active: 0,
@@ -157,13 +157,14 @@ export default {
     }
   },
   methods: {
-    menuClose(e) {
-      this.$emit('menu-close', e);
-    },
     menuOpen(e) {
       this.$emit('menu-open', e);
     },
     async add(name) {
+      // Potential TODO: If we find ourselves manually flipping these bits in other AposContextMenu overrides
+      // we should consider refactoring contextmenus to be able to self close when any click takes place within their el
+      // as it is often the logical experience (not always, see tag menus and filters)
+      this.$refs.contextMenu.isOpen = !this.$refs.contextMenu.isOpen;
       if (this.widgetIsContextual(name)) {
         this.insert({
           _id: cuid(),
@@ -180,7 +181,6 @@ export default {
           this.insert(result);
         }
       }
-      this.menuClose();
     },
     widgetEditorComponent(type) {
       return this.moduleOptions.components.widgetEditors[type];

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaMenuItem.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaMenuItem.vue
@@ -48,42 +48,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.apos-tag-list__button {
-  @include apos-button-reset();
-  display: flex;
-  align-items: center;
-  padding: 7.5px 10px;
-  border-radius: 5px;
-  background: transparent;
-  @include apos-transition(all, 0.1s, ease-in-out);
-  &.is-active {
-    background-color: var(--a-primary);
-    color: var(--a-white);
+  .apos-area-menu__item-icon {
+    @include apos-align-icon();
+    margin-right: 10px;
   }
-  &:hover,
-  &:focus {
-    background-color: var(--a-base-8);
-    .apos-tag-list__icon--tag {
-      color: var(--a-base-2);
-    }
-  }
-  &:hover.is-active,
-  &:focus.is-active {
-    background-color: var(--a-primary-button-hover);
-    color: var(--a-white);
-  }
-  &:focus {
-    outline: none;
-    box-shadow: 0 0 5px var(--a-base-6);
-  }
-  &:focus.is-active {
-    box-shadow: 0 0 5px var(--a-primary-button-active);
-  }
-}
-
-.apos-area-menu__item-icon {
-  @include apos-align-icon();
-  margin-right: 10px;
-}
-
 </style>


### PR DESCRIPTION
https://apostrophecms.atlassian.net/jira/software/projects/A30U/boards/4?selectedIssue=A30U-913
- cleans up some unused event listeners
- manually closes context menu when a user adds something to a page/doc

As noted, context menus should really be able to handle this on their own but are currently relying on blurring or using the full `<AposContextMenu/>` implementation, which is being overridden and cherry picked here