### PR TITLE
block click events on widgets until they are focused with their controls revealed

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -76,6 +76,14 @@
           @down="$emit('down', i);"
         />
       </div>
+      <!--
+        Note: we will not need this guard layer when we implement widget controls outside of the widget DOM
+        because we will be drawing and fitting a new layer ontop of the widget, which we can use to proxy event handling.
+      -->
+      <div
+        class="apos-area-widget-guard"
+        :class="{'is-disabled': focused}"
+      />
       <!-- Still used for contextual editing components -->
       <component
         v-if="isContextual && !foreign"
@@ -322,7 +330,6 @@ export default {
     }
   },
   methods: {
-
     // Focus parent, useful for obtrusive UI
     focusParent() {
       // Something above us asked the focused widget to try and focus its parent
@@ -440,6 +447,18 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+  .apos-area-widget-guard {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  .apos-area-widget-guard.is-disabled {
+    pointer-events: none;
+  }
+
   .apos-area-widget-wrapper {
     position: relative;
   }


### PR DESCRIPTION
https://apostrophecms.atlassian.net/jira/software/projects/A30U/boards/4?selectedIssue=A30U-904

From the Jira ticket:

> We’re implementing this proxy focus behavior at the `<AposAreaWidget />` level, not specifically on videos. Most widgets will not seem different, but largely interactive content will have its mouse events blocked until it is full ‘focused’ in the Apostrophe sense.

> As noted, this will be implemented slightly differently when we move widget controls out of the immediate widget DOM
