### PR TITLE
1. Fix the bug where players do not run when switching modes. 2. Fix …

### DIFF
--- a/modules/@apostrophecms/util/ui/public/1-util.js
+++ b/modules/@apostrophecms/util/ui/public/1-util.js
@@ -139,7 +139,10 @@
 
   apos.util.onReadyAndRefresh = function(fn) {
     onReady(fn);
-    apos.bus && apos.bus.$on('refreshed', fn);
+    // Allow Apostrophe to create the bus first
+    setTimeout(function() {
+      apos.bus && apos.bus.$on('refreshed', fn);
+    }, 0);
     function onReady(fn) {
       if (document.readyState !== 'loading') {
         setTimeout(fn, 0);


### PR DESCRIPTION
…the bug where sometimes all widgets are "foreign" until you refresh the page. 3. Fix the bug where "undo publish" can erroneously switch the button to "Publish" or unlock the "Unpublish" functionality if the doc was born as a parked page. 4. Removed unnecessary logic after unpublish, we know we are setting lastPublishedAt to null.