### PR TITLE
remove unused form el that can be mistakenly submitted, breaking link UI

### DIFF
--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
@@ -167,7 +167,6 @@ export default {
         delete this.value.data.target;
       }
       this.editor.commands[this.name](this.value.data);
-      console.log('set to false');
       this.active = false;
     },
     keyboardHandler(e) {

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
@@ -34,25 +34,23 @@
             label="Remove Link"
           />
         </div>
-        <form>
-          <AposSchema
-            :schema="schema"
-            v-model="value"
+        <AposSchema
+          :schema="schema"
+          v-model="value"
+          :modifiers="formModifiers"
+        />
+        <footer class="apos-link-control__footer">
+          <AposButton
+            type="default" label="Cancel"
+            @click="close"
             :modifiers="formModifiers"
           />
-          <footer class="apos-link-control__footer">
-            <AposButton
-              type="default" label="Cancel"
-              @click="close"
-              :modifiers="formModifiers"
-            />
-            <AposButton
-              type="primary" label="Save"
-              @click="save"
-              :modifiers="formModifiers"
-            />
-          </footer>
-        </form>
+          <AposButton
+            type="primary" label="Save"
+            @click="save"
+            :modifiers="formModifiers"
+          />
+        </footer>
       </AposContextMenuDialog>
     </div>
   </div>
@@ -169,6 +167,7 @@ export default {
         delete this.value.data.target;
       }
       this.editor.commands[this.name](this.value.data);
+      console.log('set to false');
       this.active = false;
     },
     keyboardHandler(e) {

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
@@ -21,10 +21,6 @@ export default class Link extends Mark {
         target: {
           default: null
         }
-        // // In HTML5, the name attribute is obsolete
-        // id: {
-        //   default: null
-        // }
       },
       inclusive: false,
       parseDOM: [
@@ -32,8 +28,6 @@ export default class Link extends Mark {
           tag: 'a',
           getAttrs: dom => ({
             href: dom.getAttribute('href'),
-            // Fallback for legacy name attributes
-            // id: dom.getAttribute('id') || dom.getAttribute('name'),
             target: dom.getAttribute('target')
           })
         }
@@ -49,8 +43,6 @@ export default class Link extends Mark {
   commands({ type }) {
     return attrs => {
       if (attrs.href) {
-        console.log(type);
-        console.log(attrs);
         return updateMark(type, attrs);
       }
 
@@ -73,7 +65,6 @@ export default class Link extends Mark {
       new Plugin({
         props: {
           handleClick(view, pos) {
-            console.log('do i ever come here');
             const {
               schema, doc, tr
             } = view.state;
@@ -86,7 +77,6 @@ export default class Link extends Mark {
             const $start = doc.resolve(range.from);
             const $end = doc.resolve(range.to);
             const transaction = tr.setSelection(new TextSelection($start, $end));
-            console.log(transaction);
             view.dispatch(transaction);
           }
         }

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
@@ -20,11 +20,11 @@ export default class Link extends Mark {
         },
         target: {
           default: null
-        },
-        // In HTML5, the name attribute is obsolete
-        id: {
-          default: null
         }
+        // // In HTML5, the name attribute is obsolete
+        // id: {
+        //   default: null
+        // }
       },
       inclusive: false,
       parseDOM: [
@@ -33,7 +33,7 @@ export default class Link extends Mark {
           getAttrs: dom => ({
             href: dom.getAttribute('href'),
             // Fallback for legacy name attributes
-            id: dom.getAttribute('id') || dom.getAttribute('name'),
+            // id: dom.getAttribute('id') || dom.getAttribute('name'),
             target: dom.getAttribute('target')
           })
         }
@@ -48,7 +48,9 @@ export default class Link extends Mark {
 
   commands({ type }) {
     return attrs => {
-      if (attrs.href || attrs.target || attrs.id) {
+      if (attrs.href) {
+        console.log(type);
+        console.log(attrs);
         return updateMark(type, attrs);
       }
 
@@ -71,6 +73,7 @@ export default class Link extends Mark {
       new Plugin({
         props: {
           handleClick(view, pos) {
+            console.log('do i ever come here');
             const {
               schema, doc, tr
             } = view.state;
@@ -83,7 +86,7 @@ export default class Link extends Mark {
             const $start = doc.resolve(range.from);
             const $end = doc.resolve(range.to);
             const transaction = tr.setSelection(new TextSelection($start, $end));
-
+            console.log(transaction);
             view.dispatch(transaction);
           }
         }


### PR DESCRIPTION
https://apostrophecms.atlassian.net/browse/A30U-935?atlOrigin=eyJpIjoiYmQxNWExMzBiOWFjNDkwNGE1YWNjNWI4ZGY0ZjU0OGUiLCJwIjoiaiJ9

- remove unused form. In certain states this would be submitted, causing page refresh and loss of changes

I don't know if there is value in having the form. The tiptap example goes to lengths to use a form and prevent submissions but /shrug