### PR TITLE
Busy overlays and modal overlays get different treatments

### DIFF
--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -291,7 +291,7 @@ export default {
     right: 0;
     bottom: 0;
     left: 0;
-    background-color: var(--a-overlay);
+    background-color: var(--a-overlay-modal);
 
     .apos-modal--slide &,
     .apos-modal--overlay & {

--- a/modules/@apostrophecms/ui/ui/apos/scss/global/_theme.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/_theme.scss
@@ -36,6 +36,7 @@
   --a-background-primary: #fff;
   --a-background-inverted: #323232;
   --a-overlay: #1f004ce0;
+  --a-overlay-modal: #0202025e;
 
   // Universal
   --a-white: #fff;
@@ -97,7 +98,7 @@
 
   --a-background-primary: #0b0b0c;
   --a-background-inverted: #fff;
-  --a-overlay: #0b0b0c90;
+  --a-overlay: #0062ffe0;
 
   --a-text-primary: #fff;
   --a-text-inverted: #000;


### PR DESCRIPTION
In a previous PR I styled the base modal blackout to play off the theme's primary color, but that looks weird when placing modals on that overlay.

This PR separates prominent busy overlays and themes them, from generic modal overlays which are the base blackouts
