### PR TITLE
apos object should be available in macros without "with context", sam…

### DIFF
--- a/modules/@apostrophecms/template/index.js
+++ b/modules/@apostrophecms/template/index.js
@@ -255,17 +255,6 @@ module.exports = {
         const args = {};
 
         args.data = merged;
-        args.module = self.templateApos.modules[module.__meta.name];
-        args.getOption = function(key, def) {
-          const colonAt = key.indexOf(':');
-          let optionModule = module;
-          if (colonAt !== -1) {
-            const name = key.substring(0, colonAt);
-            key = key.substring(colonAt + 1);
-            optionModule = self.apos.modules[name];
-          }
-          return optionModule.getOption(req, key, def);
-        };
 
         // // Allows templates to render other templates in an independent
         // // nunjucks environment, rather than including them
@@ -353,8 +342,20 @@ module.exports = {
 
         const env = new self.nunjucks.Environment(loader, {
           autoescape: true,
-          apos: self.apos,
           req
+        });
+
+        env.addGlobal('apos', self.templateApos);
+        env.addGlobal('module', self.templateApos.modules[moduleName]);
+        env.addGlobal('getOption', function(key, def) {
+          const colonAt = key.indexOf(':');
+          let optionModule = self.apos.modules[moduleName];
+          if (colonAt !== -1) {
+            const name = key.substring(0, colonAt);
+            key = key.substring(colonAt + 1);
+            optionModule = self.apos.modules[name];
+          }
+          return optionModule.getOption(req, key, def);
         });
 
         self.addStandardFilters(env);


### PR DESCRIPTION
…e for getOption and module

closes #2692 