### PR TITLE
make sure we use the same logical database name for the session store

### DIFF
--- a/modules/@apostrophecms/express/index.js
+++ b/modules/@apostrophecms/express/index.js
@@ -438,6 +438,7 @@ module.exports = {
           if (!name || name.match(/^connect-mongo/)) {
             if (!sessionOptions.store.options.client) {
               sessionOptions.store.options.client = self.apos.dbClient;
+              sessionOptions.store.options.dbName = sessionOptions.store.options.dbName || self.apos.db.databaseName;
             }
           }
           if (!sessionOptions.store.name) {


### PR DESCRIPTION
connect-mongo does its best to store sessions in the right database by looking at the database name in the connection URL associated with the mongodb client object given to it. However this won't work in situations where a single client object is being used to access multiple logical databases. So pass the actual database name associated with the current apos object. This way sessions are not inadvertently shared between sites in this situation.