### PR TITLE
Removes padding from color button

### DIFF
--- a/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
@@ -259,6 +259,7 @@ export default {
   .apos-button.apos-button--color {
     width: 50px;
     height: 50px;
+    padding: 0;
     border: 0;
     border-radius: 50%;
     box-shadow: var(--a-box-shadow);


### PR DESCRIPTION
A normalize regression. The button has no visible label to center using padding and the padding make it look like this:
![Screen Shot 2021-02-17 at 11 06 16 AM](https://user-images.githubusercontent.com/1155984/108240255-4b334a00-7110-11eb-8fa2-bf7c41fe682c.png)

The alternative would be to set box-sizing to border-box, but I'd like to not default to that always.