### PR TITLE
1046 optimization of db queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.116.1 (2021-18-02)
+* Stop processing `updateDocReferences` method when the document schema does not allow attachments.
+
 ## 2.116.0 (2021-10-02)
 * Fixes an error when saving an edited Tag in the Tag Manager.
 

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -861,8 +861,7 @@ module.exports = function(self, options) {
   // Or if the document schema doesn't allow attachments.
 
   self.updateDocReferences = function(doc, callback) {
-    // Adding a 's' for plural
-    const docModule = self.apos.modules[doc.type] || self.apos.modules[`${doc.type}s`];
+    const docModule = self.apos.docs.getManager(doc.type);
 
     if (!docModule) {
       return callback();
@@ -963,7 +962,6 @@ module.exports = function(self, options) {
         return self.db.update(criteria, query, callback);
       }, callback);
     }
-
   };
 
   // We check that no attachment is possible for a doc by
@@ -977,8 +975,34 @@ module.exports = function(self, options) {
     return findAttachment(schema);
 
     function findAttachment(fields) {
-      return fields.some((field) => field.type === 'attachment' ||
-        (field.schema && findAttachment(field.schema)));
+      return fields.some((field) => {
+        const isSingleton = field.type === 'singleton';
+
+        if (isSingleton || field.type === 'area') {
+
+          // If we are on a singleton type field we check the widget's type
+          // if it's an area, we checks the widgets in options
+          const widgetSchemaHasAttachments = checkWidgetsSchemas(
+            isSingleton
+              ? [field.widgetType]
+              : Object.keys((field.options && field.options.widgets) || {})
+          );
+
+          if (widgetSchemaHasAttachments) {
+            return true;
+          }
+        }
+
+        return field.type === 'attachment' ||
+        (field.schema && findAttachment(field.schema));
+      });
+    }
+
+    function checkWidgetsSchemas (widgets) {
+      return widgets.some((widget) => {
+        const widgetModule = self.apos.areas.getWidgetManager(widget);
+        return widgetModule.schema && findAttachment(widgetModule.schema);
+      });
     }
   };
 

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -857,7 +857,6 @@ module.exports = function(self, options) {
   // This method is invoked after any doc is inserted, updated, trashed
   // or rescued.
   // We don't go further if the document has no module associated to its type
-  // (ex: pages types are not associated to modules, but they don't have attachments)
   // Or if the document schema doesn't allow attachments.
 
   self.updateDocReferences = function(doc, callback) {

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -856,8 +856,23 @@ module.exports = function(self, options) {
   //
   // This method is invoked after any doc is inserted, updated, trashed
   // or rescued.
+  // We don't go further if the document has no module associated to its type
+  // (ex: pages types are not associated to modules, but they don't have attachments)
+  // Or if the document schema doesn't allow attachments.
 
   self.updateDocReferences = function(doc, callback) {
+    // Adding a 's' for plural
+    const docModule = self.apos.modules[doc.type] || self.apos.modules[`${doc.type}s`];
+
+    if (!docModule) {
+      return callback();
+    }
+
+    const attachmentsInSchema = self.findAttachmentsInSchema(docModule.schema);
+
+    if (!attachmentsInSchema) {
+      return callback();
+    }
 
     // We "own" only the attachments that are permanent properties
     // of the doc, drop any joins first
@@ -949,6 +964,18 @@ module.exports = function(self, options) {
       }, callback);
     }
 
+  };
+
+  // We check that no attachment is possible for a doc by
+  // parsing its schema recursively until we find an 'attachment' type.
+  // If a doc has currently no attachments but could have some before it keeps updating.
+  self.findAttachmentsInSchema = function(schema) {
+    return findAttachment(schema);
+
+    function findAttachment(fields) {
+      return fields.some((field) => field.type === 'attachment' ||
+        (field.schema && findAttachment(field.schema)));
+    }
   };
 
   // Update the permissions in uploadfs of all attachments

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -968,8 +968,12 @@ module.exports = function(self, options) {
 
   // We check that no attachment is possible for a doc by
   // parsing its schema recursively until we find an 'attachment' type.
-  // If a doc has currently no attachments but could have some before it keeps updating.
+  // If a doc has currently no attachments but could have had some in the past, it keeps updating.
   self.findAttachmentsInSchema = function(schema) {
+    if (!schema) {
+      return false;
+    }
+
     return findAttachment(schema);
 
     function findAttachment(fields) {

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -979,9 +979,6 @@ module.exports = function(self, options) {
         const isSingleton = field.type === 'singleton';
 
         if (isSingleton || field.type === 'area') {
-
-          // If we are on a singleton type field we check the widget's type
-          // if it's an area, we checks the widgets in options
           const widgetSchemaHasAttachments = checkWidgetsSchemas(
             isSingleton
               ? [field.widgetType]

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -959,8 +959,8 @@ module.exports = function(self, options) {
     ], callback);
 
     function updateCounts(callback) {
-      return async.eachSeries(commands, function(command, callback) {
-        return self.db.update(command[0], command[1], callback);
+      return async.eachSeries(commands, function([criteria, query], callback) {
+        return self.db.update(criteria, query, callback);
       }, callback);
     }
 

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -863,13 +863,13 @@ module.exports = function(self, options) {
     const docModule = self.apos.docs.getManager(doc.type);
 
     if (!docModule) {
-      return callback();
+      return callback(null);
     }
 
     const attachmentsInSchema = self.findAttachmentsInSchema(docModule.schema);
 
     if (!attachmentsInSchema) {
-      return callback();
+      return callback(null);
     }
 
     // We "own" only the attachments that are permanent properties


### PR DESCRIPTION
Modify `updateDocReferences` method to avoid processing attachments  update when none could exist here. To do that we parse the doc schema recursively to check that no field has an `attachment` type .