### PR TITLE
Addresses wonky toolbar buttons (due to content-box)

### DIFF
--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -258,7 +258,8 @@ function computeEditorOptions(type, explicitOptions) {
 
   .apos-rich-text-toolbar__inner {
     display: flex;
-    align-items: center;
+    align-items: stretch;
+    height: 35px;
     background-color: var(--a-background-primary);
     color: var(--a-text-primary);
     border-radius: var(--a-border-radius);
@@ -272,8 +273,10 @@ function computeEditorOptions(type, explicitOptions) {
     outline: none;
   }
 
-  .apos-rich-text-toolbar__inner /deep/ > * {
-    height: 35px;
+  .apos-rich-text-toolbar__inner /deep/ > .apos-rich-text-editor__control {
+    /* Addresses a Safari-only situation where it inherits the
+      `::-webkit-scrollbar-button` 2px margin. */
+    margin: 0;
   }
 
 </style>

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapStyles.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapStyles.vue
@@ -76,7 +76,8 @@ export default {
     @include apos-button-reset();
     @include type-small;
     height: 100%;
-    padding: 10px 15px 10px 10px;
+    padding: 0 15px 0 10px;
+
     &:focus, &:active {
       background-color: var(--a-base-9);
       outline: none;


### PR DESCRIPTION
Resolves https://apostrophecms.atlassian.net/browse/A30U-1035, "Rich Text Toolbar is chunky and busted"

This was another instance of removing normalize.css inflicting content-box on everything. Rather than set these individual things to `border-box`, I removed some padding and used flex powers. We could decide to use border-box for all our things, but if not we should live with what we have set.

Previously:
<img width="322" alt="Screen Shot 2021-02-16 at 5 33 06 PM" src="https://user-images.githubusercontent.com/1155984/108545724-c67e3280-72ad-11eb-8ca3-1669ca5c154a.png">