### PR TITLE
Detect changes in relationships (does not yet support alternate `idsStorage` settings)

### DIFF
--- a/modules/@apostrophecms/schema/ui/apos/lib/detectChange.js
+++ b/modules/@apostrophecms/schema/ui/apos/lib/detectChange.js
@@ -32,8 +32,15 @@ export function detectFieldChange(field, v1, v2) {
           newObject._id = o._id;
         } else if (key.substring(0, 1) === '_') {
           // Different results for temporary properties
-          // don't matter
-          continue;
+          // don't matter, except for relationships
+          if (Array.isArray(o[key])) {
+            newObject[key] = o[key].map(item => ({
+              _id: item._id,
+              _fields: relevant(item.fields)
+            }));
+          } else {
+            continue;
+          }
         } else {
           newObject[key] = relevant(val);
         }


### PR DESCRIPTION
This fixes the problem where the images widget doesn't reliably save it when you swap out one of the images.