### PR TITLE
when logged in, always initialize areas in such a way that prerendere…

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
+++ b/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
@@ -2,13 +2,23 @@ import Vue from 'Modules/@apostrophecms/ui/lib/vue';
 
 export default function() {
 
-  createAreaApps();
-  window.apos.bus.$on('widget-rendered', function() {
-    createAreaApps();
+  prepareAreas();
+  apos.bus.$on('widget-rendered', function() {
+    prepareAreas();
   });
-  window.apos.bus.$on('refreshed', function() {
-    createAreaApps();
+  apos.bus.$on('refreshed', function() {
+    prepareAreas();
   });
+
+  function prepareAreas() {
+    // Doing this first allows markup to be captured for the editor
+    // before players alter it
+    createAreaApps();
+    // Even though we invoke the player directly from
+    // the widget mixin used for editable widgets, we still have to
+    // call runPlayers eventually to account for any foreign area widgets
+    apos.util.runPlayers();
+  }
 
   function createAreaApps() {
     // Sort the areas by DOM depth to ensure parents light up before children

--- a/modules/@apostrophecms/util/ui/public/1-util.js
+++ b/modules/@apostrophecms/util/ui/public/1-util.js
@@ -131,11 +131,10 @@
   apos.util.widgetPlayers = {};
 
   // Run the given function whenever the DOM has new changes that
-  // may require attention. For instance, we use this function to
-  // schedule apos.util.runPlayers to run widget player code for
-  // widgets that are new in the DOM. The passed function will be
+  // may require attention. The passed function will be
   // called when the DOM is ready on initial page load, and also
   // when the main content area has been refreshed by the editor.
+  // Note that you don't need this for widgets; see widget players.
 
   apos.util.onReadyAndRefresh = function(fn) {
     onReady(fn);
@@ -203,23 +202,11 @@
   // Schedule runPlayers to run as soon as the document is ready, and also
   // when the page is partially refreshed by the editor.
 
-  apos.util.onReadyAndRefresh(function() {
-    apos.util.runPlayers();
-  });
-
-  // Also run widget players when an individual widget is
-  // rendered by the editor. A refresh event is not emitted
-  // in this situation.
-
-  setTimeout(function() {
-    if (apos.bus) {
-      apos.bus.$on('widget-rendered', function() {
-        setTimeout(function() {
-          apos.util.runPlayers();
-        }, 0);
-      });
-    }
-  }, 0);
+  if (!apos.bus) {
+    apos.util.onReadyAndRefresh(function() {
+      apos.util.runPlayers();
+    });
+  }
 
   // Given an attachment field value,
   // return the file URL. If options.size is set, return the URL for

--- a/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
+++ b/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
@@ -26,10 +26,9 @@ export default {
       playerOpts: null
     };
   },
-  mounted: function() {
+  mounted() {
     this.renderContent();
     this.playerOpts = apos.util.widgetPlayers[this.type] || null;
-    this.runPlayer();
   },
   updated () {
     this.runPlayer();
@@ -50,6 +49,7 @@ export default {
       try {
         if (this.rendering && (isEqual(this.rendering.parameters, parameters))) {
           this.rendered = this.rendering.html;
+          this.runPlayer();
         } else {
           this.rendered = '...';
           this.rendered = await apos.http.post(`${apos.area.action}/render-widget?apos-edit=1`, {
@@ -58,7 +58,8 @@ export default {
           });
         }
         // Wait for reactivity to populate v-html so the
-        // AposAreas manager can spot any new area divs
+        // AposAreas manager can spot any new area divs.
+        // This will also run the player
         setTimeout(function() {
           apos.bus.$emit('widget-rendered');
         }, 0);


### PR DESCRIPTION
…d markup is captured for the editor before players are invoked. When logged out, use onReadyAndRefresh normally. The refresh case will not come up but that is OK (that method is still the right one to provide to developers with non-widget content that needs to be invigorated when we alter the DOM, and we already have such developers in the community).