### PR TITLE
3/area context options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 3.0.0-alpha.4.2
+## 3.0.0-alpha.5 - Unreleased
+
+* Adds the option to pass context options to an area for its widgets following the `with` keyword. Context options for widgets not in that area (or that don't exist) are ignored. Syntax: `{% area data.page, 'areaName' with { '@apostrophecms/image: { size: 'full' } } %}`.
+
+## 3.0.0-alpha.4.2 - 2021-01-27
 
 * The `label` option is no longer required for widget type modules. This was already true for piece type and page type modules.
 * Ability to namespace asset builds. Do not push asset builds to uploadfs unless specified.

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -119,7 +119,7 @@ module.exports = {
       // Render the given `area` object via `area.html`, with the given `context`
       // which may be omitted. Called for you by the `{% area %}` and `{% singleton %}`
       // custom tags.
-      async renderArea(req, area, context) {
+      async renderArea(req, area, _with) {
         if (!area._id) {
           throw new Error('All areas must have an _id property in A3.x. Area details:\n\n' + JSON.stringify(area));
         }
@@ -153,7 +153,7 @@ module.exports = {
           field,
           options,
           choices,
-          context,
+          _with,
           canEdit
         });
       },
@@ -219,7 +219,7 @@ module.exports = {
       },
       // Sanitize an input array of items intended to become
       // the `items` property of an area. Invokes the
-      // sanitize method for each widget's manager. Widgets
+      // sanitize method for each widget manager. Widgets
       // with no manager are discarded. Invoked for you by
       // the routes that save areas and by the implementation
       // of the `area` schema field type.

--- a/modules/@apostrophecms/area/lib/custom-tags/area.js
+++ b/modules/@apostrophecms/area/lib/custom-tags/area.js
@@ -8,11 +8,27 @@ module.exports = function(self, options) {
       const token = parser.nextToken();
 
       const args = new nodes.NodeList(token.lineno, token.colno);
+      let argsCount = 0;
 
       while (true) {
         // get the arguments before "with"
         const object = parser.parseExpression();
-        args.addChild(object);
+
+        if (argsCount < 2) {
+          args.addChild(object);
+          argsCount++;
+        } else {
+          const argList = args.children;
+          if (
+            argList && argList[1] &&
+            typeof argList[1].value === 'string'
+          ) {
+            throw usage(`Too many arguments were passed to the "${argList[1].value}" area before the "with" keyword.`);
+          } else {
+            throw usage('Too many arguments were passed to an area before the "with" keyword.');
+          }
+        }
+
         const w = parser.peekToken();
         if (!(w.type === 'comma')) {
           break;
@@ -23,8 +39,8 @@ module.exports = function(self, options) {
       const w = parser.peekToken();
       if ((w.type === 'symbol') && (w.value === 'with')) {
         parser.nextToken();
-        const context = parser.parseExpression();
-        args.addChild(context);
+        const _with = parser.parseExpression();
+        args.addChild(_with);
       }
       parser.advanceAfterBlockEnd(token.value);
       return { args };
@@ -89,13 +105,14 @@ module.exports = function(self, options) {
 
       const content = await self.apos.area.renderArea(req, area, _with);
       return content;
-      function usage(message) {
-        return new Error(`${message}
-
-  Usage: {% area data.page, 'areaName' with { optional object visible as data.context in widgets } %}
-`
-        );
-      }
     }
   };
+
+  function usage(message) {
+    return new Error(`${message}
+
+Usage: {% area data.page, 'areaName' with { optional object visible as data.context in widgets } %}
+`
+    );
+  }
 };

--- a/modules/@apostrophecms/area/lib/custom-tags/widget.js
+++ b/modules/@apostrophecms/area/lib/custom-tags/widget.js
@@ -4,7 +4,42 @@
 module.exports = function(self, options) {
 
   return {
-    async run(context, item, options) {
+    // We need a custom parser because of the "with" syntax
+    parse(parser, nodes, lexer) {
+      // get the tag token
+      const token = parser.nextToken();
+
+      const args = new nodes.NodeList(token.lineno, token.colno);
+      let argsCount = 0;
+
+      while (true) {
+        // get the arguments before "with"
+        const object = parser.parseExpression();
+
+        if (argsCount < 2) {
+          args.addChild(object);
+          argsCount++;
+        } else {
+          throw new Error('Too many arguments were passed to the widget tag before the "with" keyword.');
+        }
+
+        const w = parser.peekToken();
+        if (!(w.type === 'comma')) {
+          break;
+        }
+        parser.nextToken();
+      }
+
+      const w = parser.peekToken();
+      if ((w.type === 'symbol') && (w.value === 'with')) {
+        parser.nextToken();
+        const _with = parser.parseExpression();
+        args.addChild(_with);
+      }
+      parser.advanceAfterBlockEnd(token.value);
+      return { args };
+    },
+    async run(context, item, options, _with) {
       const req = context.env.opts.req;
       if (!item) {
         self.apos.util.warn('a null widget was encountered.');
@@ -13,13 +48,19 @@ module.exports = function(self, options) {
       if (!options) {
         options = {};
       }
+
+      let contextOptions = {};
+      if (typeof _with === 'object' && _with[item.type]) {
+        contextOptions = typeof _with[item.type] === 'object' ? _with[item.type] : {};
+      }
+
       const manager = self.getWidgetManager(item.type);
       if (!manager) {
         // Not configured in this project
         self.warnMissingWidgetType(item.type);
         return '';
       }
-      return manager.output(req, item, options);
+      return manager.output(req, item, options, contextOptions);
     }
   };
 

--- a/modules/@apostrophecms/area/views/area.html
+++ b/modules/@apostrophecms/area/views/area.html
@@ -8,7 +8,7 @@
     {%- if data.canEdit -%}
       <div data-apos-widget="{{ item._id }}">
     {%- endif -%}
-    {% widget item, widgetOptions %}
+    {% widget item, widgetOptions with data._with %}
     {%- if data.canEdit -%}
       </div>
     {%- endif -%}

--- a/modules/@apostrophecms/template/index.js
+++ b/modules/@apostrophecms/template/index.js
@@ -657,8 +657,8 @@ module.exports = {
         try {
           content = await module.render(req, template, args);
         } catch (e) {
-          // The page template
-          // threw an exception. Log where it
+          console.info('🍅');
+          // The page template threw an exception. Log where it
           // occurred for easier debugging
           return error(e, 'template');
         }

--- a/modules/@apostrophecms/template/index.js
+++ b/modules/@apostrophecms/template/index.js
@@ -435,7 +435,7 @@ module.exports = {
 
       addStandardFilters(env) {
 
-        // Format the given date with the given momentjs
+        // Format the given date with the given moment.js
         // format string.
 
         env.addFilter('date', function (date, format) {

--- a/modules/@apostrophecms/template/index.js
+++ b/modules/@apostrophecms/template/index.js
@@ -657,7 +657,6 @@ module.exports = {
         try {
           content = await module.render(req, template, args);
         } catch (e) {
-          console.info('🍅');
           // The page template threw an exception. Log where it
           // occurred for easier debugging
           return error(e, 'template');

--- a/modules/@apostrophecms/widget-type/index.js
+++ b/modules/@apostrophecms/widget-type/index.js
@@ -184,12 +184,12 @@ module.exports = {
       //
       // async, as are all functions that invoke a nunjucks render in
       // Apostrophe 3.x.
-
-      async output(req, widget, options) {
+      async output(req, widget, options, _with) {
         return self.render(req, self.template, {
           widget: widget,
           options: options,
-          manager: self
+          manager: self,
+          contextOptions: _with
         });
       },
 

--- a/test/modules/args-bad-page/index.js
+++ b/test/modules/args-bad-page/index.js
@@ -1,0 +1,19 @@
+module.exports = {
+  extend: '@apostrophecms/page-type',
+  options: {
+    label: 'Bad Page'
+  },
+  fields: {
+    add: {
+      main: {
+        type: 'area',
+        label: 'Main',
+        options: {
+          widgets: {
+            args: {}
+          }
+        }
+      }
+    }
+  }
+};

--- a/test/modules/args-bad-page/views/page.html
+++ b/test/modules/args-bad-page/views/page.html
@@ -1,0 +1,4 @@
+<h2>Bad args page</h2>
+{% area data.page, 'baddies', {
+  'args': [ '💔', 'illegal', 'outlaw' ]
+} %}

--- a/test/modules/args-good-page/index.js
+++ b/test/modules/args-good-page/index.js
@@ -1,0 +1,19 @@
+module.exports = {
+  extend: '@apostrophecms/page-type',
+  options: {
+    label: 'Good Page'
+  },
+  fields: {
+    add: {
+      main: {
+        type: 'area',
+        label: 'Main',
+        options: {
+          widgets: {
+            args: {}
+          }
+        }
+      }
+    }
+  }
+};

--- a/test/modules/args-good-page/views/page.html
+++ b/test/modules/args-good-page/views/page.html
@@ -1,0 +1,6 @@
+<h2>Good args page</h2>
+{% area data.page, 'main' with {
+  'args': {
+    color: '🟣'
+  }
+} %}

--- a/test/modules/args-widget/index.js
+++ b/test/modules/args-widget/index.js
@@ -1,0 +1,14 @@
+module.exports = {
+  extend: '@apostrophecms/widget-type',
+  options: {
+    label: 'Arguments Testing Widget'
+  },
+  fields: {
+    add: {
+      snippet: {
+        type: 'string',
+        label: 'Snippet'
+      }
+    }
+  }
+};

--- a/test/modules/args-widget/views/widget.html
+++ b/test/modules/args-widget/views/widget.html
@@ -1,0 +1,7 @@
+<h2>Arguments test widget</h2>
+<p>{{ data.widget.snippet }}</p>
+<ul>
+{% for key, val in data.contextOptions %}
+  <li>{{ key }}: {{ val }}</li>
+{% endfor %}
+</ul>

--- a/test/widgets.js
+++ b/test/widgets.js
@@ -101,10 +101,10 @@ describe('Widgets', function() {
   it('should be able to render page template with well constructed area tag', async function() {
     const req = apos.task.getAnonReq();
 
-    const goodPage = await apos.page.find(req, { slug: '/good-page' }).toObject();
-    goodPage.metaType = 'doc';
+    const goodPageDoc = await apos.page.find(req, { slug: '/good-page' }).toObject();
+    goodPageDoc.metaType = 'doc';
 
-    const result = await apos.modules['args-good-page'].renderPage(req, 'page', { page: goodPage });
+    const result = await apos.modules['args-good-page'].renderPage(req, 'page', { page: goodPageDoc });
 
     assert(result.indexOf('<h2>Good args page</h2>') !== -1);
     assert(result.indexOf('<p>You can control what happens when the text reaches the edges of its content area using its attributes.</p>') !== -1);
@@ -114,11 +114,11 @@ describe('Widgets', function() {
   it('should error while trying to render page template with poorly constructed area tag', async function() {
     const req = apos.task.getAnonReq();
 
-    const goodPage = await apos.page.find(req, { slug: '/bad-page' }).toObject();
-    goodPage.metaType = 'doc';
+    const badPageDoc = await apos.page.find(req, { slug: '/bad-page' }).toObject();
+    badPageDoc.metaType = 'doc';
 
     try {
-      await apos.modules['args-bad-page'].renderPage(req, 'page', { page: goodPage });
+      await apos.modules['args-bad-page'].renderPage(req, 'page', { page: badPageDoc });
       assert(false);
     } catch (error) {
       assert(error);

--- a/test/widgets.js
+++ b/test/widgets.js
@@ -101,10 +101,26 @@ describe('Widgets', function() {
   it('should be able to render page template with well constructed area tag', async function() {
     const req = apos.task.getAnonReq();
 
-    const goodPageDoc = await apos.page.find(req, { slug: '/good-page' }).toObject();
+    const goodPageDoc = await apos.page.find(req, { slug: '/good-page' })
+      .toObject();
     goodPageDoc.metaType = 'doc';
 
-    const result = await apos.modules['args-good-page'].renderPage(req, 'page', { page: goodPageDoc });
+    const args = {
+      outerLayout: '@apostrophecms/template:outerLayout.html',
+      permissions: req.user && (req.user._permissions || {}),
+      scene: 'apos',
+      refreshing: false,
+      query: req.query,
+      url: req.url,
+      page: goodPageDoc
+    };
+
+    let result;
+    try {
+      result = await apos.modules['args-good-page'].render(req, 'page', args);
+    } catch (error) {
+      assert(false);
+    }
 
     assert(result.indexOf('<h2>Good args page</h2>') !== -1);
     assert(result.indexOf('<p>You can control what happens when the text reaches the edges of its content area using its attributes.</p>') !== -1);
@@ -114,14 +130,26 @@ describe('Widgets', function() {
   it('should error while trying to render page template with poorly constructed area tag', async function() {
     const req = apos.task.getAnonReq();
 
-    const badPageDoc = await apos.page.find(req, { slug: '/bad-page' }).toObject();
+    const badPageDoc = await apos.page.find(req, { slug: '/bad-page' })
+      .toObject();
     badPageDoc.metaType = 'doc';
 
+    const args = {
+      outerLayout: '@apostrophecms/template:outerLayout.html',
+      permissions: req.user && (req.user._permissions || {}),
+      scene: 'apos',
+      refreshing: false,
+      query: req.query,
+      url: req.url,
+      page: badPageDoc
+    };
+
     try {
-      await apos.modules['args-bad-page'].renderPage(req, 'page', { page: badPageDoc });
+      await apos.modules['args-bad-page'].render(req, 'page', args);
+
       assert(false);
     } catch (error) {
-      assert(error);
+      assert(error.toString().indexOf('Too many arguments were passed'));
     }
   });
 });

--- a/test/widgets.js
+++ b/test/widgets.js
@@ -1,0 +1,127 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert');
+// const cheerio = require('cheerio');
+
+let apos;
+
+describe('Widgets', function() {
+
+  this.timeout(t.timeout);
+
+  after(async () => {
+    return t.destroy(apos);
+  });
+
+  it('should add test modules', async () => {
+    apos = await t.create({
+      root: module,
+      modules: {
+        'args-bad-page': {},
+        'args-good-page': {},
+        'args-widget': {}
+      }
+    });
+    assert(apos.modules['args-good-page']);
+    assert(apos.modules['args-bad-page']);
+    assert(apos.modules['args-widget']);
+  });
+
+  let testItems;
+
+  it('should insert test documents', async function() {
+    const home = await apos.page.find(apos.task.getAnonReq(), { level: 0 }).toObject();
+
+    assert(home);
+    const homeId = home._id;
+
+    testItems = [
+      {
+        _id: 'goodPageId:en:published',
+        aposLocale: 'en:published',
+        aposDocId: 'goodPageId',
+        type: 'args-good-page',
+        slug: '/good-page',
+        visibility: 'public',
+        path: `${homeId.replace(':en:published', '')}/good-page`,
+        level: 1,
+        rank: 0,
+        main: {
+          _id: 'randomAreaId1',
+          items: [
+            {
+              _id: 'randomWidgetId1',
+              snippet: 'You can control what happens when the text reaches the edges of its content area using its attributes.',
+              metaType: 'widget',
+              type: 'args'
+            }
+          ],
+          metaType: 'area'
+        }
+      },
+      {
+        _id: 'badPageId:en:published',
+        aposLocale: 'en:published',
+        aposDocId: 'badPageId',
+        type: 'args-bad-page',
+        slug: '/bad-page',
+        visibility: 'public',
+        path: `${homeId.replace(':en:published', '')}/bad-page`,
+        level: 1,
+        rank: 0,
+        main: {
+          _id: 'randomAreaId2',
+          items: [
+            {
+              _id: 'randomWidgetId2',
+              snippet: 'You can control what happens when the text reaches the edges of its content area using its attributes.',
+              metaType: 'widget',
+              type: 'args'
+            }
+          ],
+          metaType: 'area'
+        }
+      }
+    ];
+
+    // Insert draft versions too to match the A3 data model
+    const draftItems = await apos.doc.db.insertMany(testItems.map(item => ({
+      ...item,
+      aposLocale: item.aposLocale.replace(':published', ':draft'),
+      _id: item._id.replace(':published', ':draft')
+    })));
+    assert(draftItems.result.ok === 1);
+    assert(draftItems.insertedCount === 2);
+
+    const items = await apos.doc.db.insertMany(testItems);
+
+    assert(items.result.ok === 1);
+    assert(items.insertedCount === 2);
+  });
+
+  it('should be able to render page template with well constructed area tag', async function() {
+    const req = apos.task.getAnonReq();
+
+    const goodPage = await apos.page.find(req, { slug: '/good-page' }).toObject();
+    goodPage.metaType = 'doc';
+
+    const result = await apos.modules['args-good-page'].renderPage(req, 'page', { page: goodPage });
+
+    assert(result.indexOf('<h2>Good args page</h2>') !== -1);
+    assert(result.indexOf('<p>You can control what happens when the text reaches the edges of its content area using its attributes.</p>') !== -1);
+    assert(result.indexOf('<li>color: 🟣</li>') !== -1);
+  });
+
+  it('should error while trying to render page template with poorly constructed area tag', async function() {
+    const req = apos.task.getAnonReq();
+
+    const goodPage = await apos.page.find(req, { slug: '/bad-page' }).toObject();
+    goodPage.metaType = 'doc';
+
+    try {
+      await apos.modules['args-bad-page'].renderPage(req, 'page', { page: goodPage });
+      assert(false);
+    } catch (error) {
+      assert(error);
+    }
+  });
+});

--- a/test/widgets.js
+++ b/test/widgets.js
@@ -149,7 +149,7 @@ describe('Widgets', function() {
 
       assert(false);
     } catch (error) {
-      assert(error.toString().indexOf('Too many arguments were passed'));
+      assert(error.toString().indexOf('Too many arguments were passed') !== -1);
     }
   });
 });


### PR DESCRIPTION
Adds the option to pass context options to an area for its widgets. Context options for widgets not in that area (or that don't exist) are ignored.