### PR TITLE
Extends getBrowserData in doc-type rather than overwrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.0.0-alpha.5 - Unreleased
 
 * Adds the option to pass context options to an area for its widgets following the `with` keyword. Context options for widgets not in that area (or that don't exist) are ignored. Syntax: `{% area data.page, 'areaName' with { '@apostrophecms/image: { size: 'full' } } %}`.
+* Extends `getBrowserData` in `@apostrophecms/doc-type` rather than overwriting the method.
 
 ## 3.0.0-alpha.4.2 - 2021-01-27
 

--- a/modules/@apostrophecms/asset/lib/webpack.config.js
+++ b/modules/@apostrophecms/asset/lib/webpack.config.js
@@ -9,7 +9,9 @@ if (process.env.APOS_BUNDLE_ANALYZER) {
   BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 }
 
-module.exports = ({ importFile, modulesDir, outputPath, outputFilename }, apos) => {
+module.exports = ({
+  importFile, modulesDir, outputPath, outputFilename
+}, apos) => {
   const tasks = [ scss, vue ].map(task =>
     task(
       {

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -796,10 +796,16 @@ module.exports = {
     return {
       getBrowserData(_super, req) {
         const initialBrowserOptions = _super(req);
-        const docTypeOptions = _.pick(options, 'name', 'label', 'pluralLabel');
+
+        const {
+          name, label, pluralLabel
+        } = options;
+
         const browserOptions = {
           ...initialBrowserOptions,
-          ...docTypeOptions
+          name,
+          label,
+          pluralLabel
         };
         browserOptions.action = self.action;
         browserOptions.schema = self.allowedSchema(req);

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -520,15 +520,6 @@ module.exports = {
         }
         return self.apos.migration.addSortify(self.__meta.name, { type: self.name }, field);
       },
-      getBrowserData(req) {
-        const data = _.pick(options, 'name', 'label', 'pluralLabel');
-        data.action = self.action;
-        data.schema = self.allowedSchema(req);
-        data.localized = self.isLocalized();
-        data.autopublish = self.options.autopublish;
-        return data;
-      },
-
       // Convert the untrusted data supplied in `input` via the schema and
       // update the doc object accordingly.
       //
@@ -798,6 +789,24 @@ module.exports = {
             to[field.name] = from[field.name];
           }
         }
+      }
+    };
+  },
+  extendMethods(self, options) {
+    return {
+      getBrowserData(_super, req) {
+        const initialBrowserOptions = _super(req);
+        const docTypeOptions = _.pick(options, 'name', 'label', 'pluralLabel');
+        const browserOptions = {
+          ...initialBrowserOptions,
+          ...docTypeOptions
+        };
+        browserOptions.action = self.action;
+        browserOptions.schema = self.allowedSchema(req);
+        browserOptions.localized = self.isLocalized();
+        browserOptions.autopublish = self.options.autopublish;
+
+        return browserOptions;
       }
     };
   },

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -443,9 +443,6 @@ module.exports = {
       // you must explicitly opt in.
 
       getBrowserData(req) {
-        if (self.options.browser) {
-          console.info('🐯', self.__meta.name, self.options.browser);
-        }
         self.options.browser = self.options.browser || {};
         return self.options.browser;
       },

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -443,6 +443,9 @@ module.exports = {
       // you must explicitly opt in.
 
       getBrowserData(req) {
+        if (self.options.browser) {
+          console.info('🐯', self.__meta.name, self.options.browser);
+        }
         self.options.browser = self.options.browser || {};
         return self.options.browser;
       },


### PR DESCRIPTION
This allows doc type modules to use the `options.browser` setting.