### PR TITLE
3/no options components

### DIFF
--- a/modules/@apostrophecms/busy/index.js
+++ b/modules/@apostrophecms/busy/index.js
@@ -1,6 +1,5 @@
 module.exports = {
   options: {
-    components: {},
     alias: 'busy'
   },
   init(self, options) {
@@ -12,7 +11,7 @@ module.exports = {
       getBrowserData(req) {
         return {
           busy: self.busy,
-          components: { the: options.components.the || 'TheAposBusy' }
+          components: { the: 'TheAposBusy' }
         };
       }
     };

--- a/modules/@apostrophecms/modal/index.js
+++ b/modules/@apostrophecms/modal/index.js
@@ -3,7 +3,6 @@
 
 module.exports = {
   options: {
-    components: {},
     alias: 'modal'
   },
   init(self, options) {
@@ -26,8 +25,8 @@ module.exports = {
         return {
           modals: self.modals,
           components: {
-            the: options.components.the || 'TheAposModals',
-            confirm: options.components.confirm || 'AposModalConfirm'
+            the: 'TheAposModals',
+            confirm: 'AposModalConfirm'
           }
         };
       }

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -554,17 +554,6 @@ module.exports = {
         return self.apos.modules['@apostrophecms/email'].emailForModule(req, templateName, data, options, self);
       },
 
-      // Given a Vue component name, such as AposPiecesManager,
-      // return that name unless `options.components[name]` has been set to
-      // an alternate name. Overriding keys in the `components` option
-      // allows modules to provide alternative functionality for standard
-      // components while maintaining readabile Vue code via the
-      // <component :is="..."> syntax.
-
-      getVueComponentName(name) {
-        return (self.options.components && self.options.components[name]) || name;
-      },
-
       // When a CMS page is rendered, it will render the
       // template name passed on the last call to this
       // method during the processing of the request.


### PR DESCRIPTION
Removes references to, and support for, an `options.components` config object. Everywhere a module's Vue components are set, they are set in an override or extension of `getBrowserData`.