### PR TITLE
the point of release-id was that it would be deployed, though not com…

### DIFF
--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -321,7 +321,7 @@ module.exports = {
         return options.refreshOnRestart && (process.env.NODE_ENV !== 'production');
       },
       // Returns a unique identifier for the current version of the
-      // codebase (the current release). Checks for a data/release-id file
+      // codebase (the current release). Checks for a release-id file
       // (ideal for webpack which can create such a file in a build step),
       // HEROKU_RELEASE_VERSION (for Heroku), PLATFORM_TREE_ID (for platform.sh),
       // APOS_RELEASE_ID (for custom cases), a directory component containing at
@@ -330,7 +330,7 @@ module.exports = {
       // and some people do deploy this way).
       //
       // If none of these are found, throws an error demanding that APOS_RELEASE_ID
-      // or data/release-id be set up.
+      // or release-id be set up.
       //
       // TODO: auto-detect more cases, such as Azure app service. In the meantime
       // you can set APOS_RELEASE_ID from whatever you have before running Apostrophe.
@@ -343,7 +343,7 @@ module.exports = {
           return viaEnv;
         }
         try {
-          return fs.readFileSync(`${self.apos.rootDir}/data/release-id`, 'utf8').trim();
+          return fs.readFileSync(`${self.apos.rootDir}/release-id`, 'utf8').trim();
         } catch (e) {
           // OK, consider fallbacks instead
         }
@@ -361,7 +361,7 @@ module.exports = {
         } catch (e) {
           throw new Error(`When running in production you must set the APOS_RELEASE_ID
 environment variable to a short, unique string identifying this particular
-release of the application, or write it to the file data/release-id. Apostrophe will
+release of the application, or write it to the file release-id. Apostrophe will
 also autodetect HEROKU_RELEASE_VERSION, PLATFORM_TREE_ID or the current git commit
 if your deployment is a git checkout.`);
         }


### PR DESCRIPTION
…mitted. Including it in the data/ folder prevents that.