### PR TITLE
Fix relationship change detection so the global doc does not always offer "discard changes"

### DIFF
--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1,5 +1,4 @@
 const _ = require('lodash');
-const { klona } = require('klona');
 
 module.exports = {
   options: {

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -635,7 +635,10 @@ module.exports = {
           });
           published = await self.insertPublishedOf(req, draft, published, options);
         } else {
-          previousPublished = klona(published);
+          // As found in db, not with relationships etc.
+          previousPublished = await self.apos.doc.db.findOne({
+            _id: published._id
+          });
           self.copyForPublication(req, draft, published);
           await self.emit('beforePublish', req, {
             draft,
@@ -688,15 +691,23 @@ module.exports = {
       // returning, which receives `req, { draft }` and may
       // replace the `draft` property to alter the returned value.
       async revertDraftToPublished(req, draft) {
+        if (!draft.modified) {
+          return false;
+        }
         const published = await self.apos.doc.db.findOne({
           _id: draft._id.replace(':draft', ':published')
         });
         if (!published) {
           return false;
         }
-        if (!draft.modified) {
-          return false;
-        }
+
+        // We must load relationships as if we had done a regular find
+        // because relationships are read/write in A3,
+        // but we don't have to call widget loaders
+        const query = self.find(req).areas(false);
+        await query.finalize();
+        await query.after([ published ]);
+
         // Draft and published roles intentionally reversed
         self.copyForPublication(req, published, draft);
         draft.modified = false;
@@ -725,6 +736,14 @@ module.exports = {
           // Feature has already been used
           throw self.apos.error('invalid');
         }
+
+        // We must load relationships as if we had done a regular find
+        // because relationships are read/write in A3,
+        // but we don't have to call widget loaders
+        const query = self.find(req).areas(false);
+        await query.finalize();
+        await query.after([ previous ]);
+
         self.copyForPublication(req, previous, published);
         published.lastPublishedAt = previous.lastPublishedAt;
         published = await self.update({

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -3,7 +3,6 @@
 
 const _ = require('lodash');
 const sanitizeHtml = require('sanitize-html');
-const jsDiff = require('diff');
 
 module.exports = {
   extend: '@apostrophecms/widget-type',

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -256,54 +256,6 @@ module.exports = {
         });
       },
 
-      compare(old, current) {
-        let oldContent = old.content;
-        if (oldContent === undefined) {
-          oldContent = '';
-        }
-        let currentContent = current.content;
-        if (currentContent === undefined) {
-          currentContent = '';
-        }
-        const diff = jsDiff.diffSentences(self.apos.util.htmlToPlaintext(oldContent).replace(/\s+/g, ' '), self.apos.util.htmlToPlaintext(currentContent).replace(/\s+/g, ' '), { ignoreWhitespace: true });
-
-        const changes = _.map(_.filter(diff, function (diffChange) {
-          return diffChange.added || diffChange.removed;
-        }), function (diffChange) {
-          // Convert a jsDiff change object to an
-          // apos versions change object
-          if (diffChange.removed) {
-            return {
-              action: 'remove',
-              text: diffChange.value,
-              field: {
-                type: 'string',
-                label: 'Content'
-              }
-            };
-          } else {
-            return {
-              action: 'add',
-              text: diffChange.value,
-              field: {
-                type: 'string',
-                label: 'Content'
-              }
-            };
-          }
-        });
-
-        if (!changes.length) {
-          // Well, something changed! Presumably the formatting.
-          return [ {
-            action: 'change',
-            field: { label: 'Formatting' }
-          } ];
-        }
-
-        return changes;
-      },
-
       isEmpty(widget) {
         const text = self.apos.util.htmlToPlaintext(widget.content || '');
         return !text.trim().length;

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1705,6 +1705,7 @@ module.exports = {
         }
 
         const objects = _.isArray(objectOrArray) ? objectOrArray : [ objectOrArray ];
+
         if (!objects.length) {
           // Don't waste effort
           return;

--- a/modules/@apostrophecms/schema/lib/joinr.js
+++ b/modules/@apostrophecms/schema/lib/joinr.js
@@ -62,6 +62,9 @@ const joinr = module.exports = {
     let otherIds = [];
     const othersById = {};
     for (const item of items) {
+      if (!item[objectsField]) {
+        item[objectsField] = [];
+      }
       if (joinr._has(item, idsStorage)) {
         otherIds = otherIds.concat(joinr._get(item, idsStorage).map(idMapper));
       }
@@ -76,9 +79,6 @@ const joinr = module.exports = {
       for (const item of items) {
         for (const id of (joinr._get(item, idsStorage) || []).map(idMapper)) {
           if (othersById[id]) {
-            if (!item[objectsField]) {
-              item[objectsField] = [];
-            }
             if (fieldsStorage) {
               const fieldsById = joinr._get(item, fieldsStorage) || {};
               item[objectsField].push({
@@ -108,7 +108,7 @@ const joinr = module.exports = {
   // groupIds).
   //
   // The optional third argument is the name of an object property in each of
-  // thoe related documents that describes the relationship between the related
+  // those related documents that describes the relationship between the related
   // document and each of your documents. This object is expected to be structured
   // like this:
   //
@@ -154,6 +154,11 @@ const joinr = module.exports = {
 
   byArrayReverse: async function(items, idsStorage, fieldsStorage, objectsField, getter, idMapper) {
     const itemIds = items.map(item => idMapper(item._id));
+    for (const item of items) {
+      if (!item[objectsField]) {
+        item[objectsField] = [];
+      }
+    }
     if (itemIds.length) {
       const others = await getter(itemIds);
       const itemsById = {};
@@ -165,9 +170,6 @@ const joinr = module.exports = {
         for (const id of (joinr._get(other, idsStorage) || []).map(idMapper)) {
           if (itemsById[id]) {
             const item = itemsById[id];
-            if (!item[objectsField]) {
-              item[objectsField] = [];
-            }
             if (fieldsStorage) {
               const fieldsById = joinr._get(other, fieldsStorage) || {};
               item[objectsField].push({

--- a/modules/@apostrophecms/schema/ui/apos/lib/detectChange.js
+++ b/modules/@apostrophecms/schema/ui/apos/lib/detectChange.js
@@ -11,8 +11,16 @@ export function detectDocChange(schema, v1, v2) {
 }
 
 export function detectFieldChange(field, v1, v2) {
-  v1 = relevant(v1);
-  v2 = relevant(v2);
+  if (field.type === 'relationshipReverse') {
+    return false;
+  }
+  if (field.type === 'relationship') {
+    v1 = relevantRelationship(v1);
+    v2 = relevantRelationship(v2);
+  } else {
+    v1 = relevant(v1);
+    v2 = relevant(v2);
+  }
   if (isEqual(v1, v2)) {
     return false;
   } else if (!v1 && !v2) {
@@ -29,15 +37,13 @@ export function detectFieldChange(field, v1, v2) {
         if (key === '_docId') {
           newObject._docId = o._docId.replace(/:.*$/, '');
         } else if (key === '_id') {
-          newObject._id = o._id;
+          // So draft and published can be compared
+          newObject._id = o._id.replace(/:[\w-]+:[\w]+$/, '');
         } else if (key.substring(0, 1) === '_') {
           // Different results for temporary properties
           // don't matter, except for relationships
           if (Array.isArray(o[key])) {
-            newObject[key] = o[key].map(item => ({
-              _id: item._id,
-              _fields: relevant(item.fields)
-            }));
+            newObject[key] = relevantRelationship(o[key]);
           } else {
             continue;
           }
@@ -48,5 +54,12 @@ export function detectFieldChange(field, v1, v2) {
       return newObject;
     }
     return o;
+  }
+  function relevantRelationship(a) {
+    return a.map(item => ({
+      // So draft and published can be compared
+      _id: item._id.replace(/:[\w-]+:[\w]+$/, ''),
+      _fields: relevant(item._fields)
+    }));
   }
 }

--- a/modules/@apostrophecms/widget-type/index.js
+++ b/modules/@apostrophecms/widget-type/index.js
@@ -261,7 +261,9 @@ module.exports = {
         // Shut off relationships because we already did them and the query would try to do them
         // again based on `type`, which isn't really a doc type.
         const query = self.apos.doc.find(req).relationships(false);
-        // Call .after with our own results
+        // Do everything we'd do if the query had fetched the widgets
+        // as docs
+        await query.finalize();
         await query.after(widgets);
       },
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "dayjs": "^1.9.8",
     "debounce-async": "0.0.2",
     "deep-get-set": "^0.1.1",
-    "diff": "^2.2.3",
     "express": "^4.16.4",
     "express-bearer-token": "^2.4.0",
     "express-session": "^1.17.1",


### PR DESCRIPTION
Related changes:

* A relationship that has no ids or no findable ids should still populate as an empty array, so it can be saved again as empty, rather than falling back to a nonempty ids array that wasn't part of what was copied during "discard" because relationships are writable in 3.x.
* In revert methods, documents should be loaded as if they went through the full query process so their relationships can be compared; this includes calling finalize to make sure relationships defaults to true.
* The relationship comparison logic should only care about _id and _fields, even for a top level relationship field.

Unrelated minor change:

* Removed jsdiff and dead code that used it, to quiet npm audit.