### PR TITLE
tweaked lock language

### DIFF
--- a/modules/@apostrophecms/ui/ui/apos/mixins/AposAdvisoryLockMixin.js
+++ b/modules/@apostrophecms/ui/ui/apos/mixins/AposAdvisoryLockMixin.js
@@ -93,10 +93,6 @@ export default {
     // detect lock errors with `isLockedError` and call this method. The rest of the time,
     // it is called for you.
     async showLockedError(e) {
-      // We use an alert because it is a clear interruption of their
-      // work, and because a notification would appear in both windows
-      // if control was taken by the same user in another window,
-      // which would be confusing.
       await apos.alert({
         heading: 'Multiple Editors',
         description: `${e.body.data.me ? 'You' : e.body.data.title} took control of this document in another tab or window. A document can only be edited in one place at a time.`

--- a/modules/@apostrophecms/ui/ui/apos/mixins/AposAdvisoryLockMixin.js
+++ b/modules/@apostrophecms/ui/ui/apos/mixins/AposAdvisoryLockMixin.js
@@ -93,21 +93,14 @@ export default {
     // detect lock errors with `isLockedError` and call this method. The rest of the time,
     // it is called for you.
     async showLockedError(e) {
-      if (e.body.data.me) {
-        // We use an alert because it is a clear interruption of their
-        // work, and because a notification would appear in both windows
-        // if control was taken by the same user in another window,
-        // which would be confusing.
-        await apos.alert({
-          heading: 'You Took Control in Another Window',
-          description: 'You took control of this document in another tab or window.'
-        });
-      } else {
-        await apos.alert({
-          heading: 'Another User Took Control',
-          description: 'Another user took control of the document.'
-        });
-      }
+      // We use an alert because it is a clear interruption of their
+      // work, and because a notification would appear in both windows
+      // if control was taken by the same user in another window,
+      // which would be confusing.
+      await apos.alert({
+        heading: 'Multiple Editors',
+        description: `${e.body.data.me ? 'You' : e.body.data.title} took control of this document in another tab or window. A document can only be edited in one place at a time.`
+      });
     },
 
     // Convenience function to determine if an error is a lock error.


### PR DESCRIPTION
This language isn't quite what you suggested because:

* 1. In the case of another person taking the lock, they actively, affirmatively did that, so the language should make this clear to discourage slapfights between users.
* 2. The suggested language didn't quite address the issue when you take control from yourself. The new language is accurate in either scenario: you can only edit a particular document in one place (tab or window) at a time.