### PR TITLE
lint for incorrectly configured modules (ported from late A2), throw …

### DIFF
--- a/index.js
+++ b/index.js
@@ -372,17 +372,17 @@ module.exports = async function(options) {
 
     for (const [ name, module ] of Object.entries(self.modules)) {
       if (module.options.extends && ((typeof module.options.extends) === 'string')) {
-        lint('The module ' + name + ' contains an "extends" option. This is probably a\nmistake. In Apostrophe "extend" is used to extend other modules.');
+        lint(`The module ${name} contains an "extends" option. This is probably a\nmistake. In Apostrophe "extend" is used to extend other modules.`);
       }
       if (module.options.singletonWarningIfNot && (name !== module.options.singletonWarningIfNot)) {
-        lint('The module ' + name + ' extends ' + module.options.singletonWarningIfNot + ', which is normally\na singleton (Apostrophe creates only one instance of it). Two competing\ninstances will lead to problems. If you are adding project-level code to it,\njust use lib/modules/' + module.options.singletonWarningIfNot + '/index.js and do not use "extend".\nIf you are improving it via an npm module, use "improve" rather than "extend".\nIf neither situation applies you should probably just make a new module that does\nnot extend anything.\n\nIf you are sure you know what you are doing, you can set the\nsingletonWarningIfNot: false option for this module.');
+        lint(`The module ${name} extends ${module.options.singletonWarningIfNot}, which is normally\na singleton (Apostrophe creates only one instance of it). Two competing\ninstances will lead to problems. If you are adding project-level code to it,\njust use lib/modules/${module.options.singletonWarningIfNot}/index.js and do not use "extend".\nIf you are improving it via an npm module, use "improve" rather than "extend".\nIf neither situation applies you should probably just make a new module that does\nnot extend anything.\n\nIf you are sure you know what you are doing, you can set the\nsingletonWarningIfNot: false option for this module.`);
       }
       if (name.match(/-widget$/) && (!extending(module)) && (!module.options.ignoreNoExtendWarning)) {
-        lint('The module ' + name + ' does not extend anything.\n\nA -widget module usually extends @apostrophecms/widget or another widget type.\nOr possibly you forgot to npm install something.\n\nIf you are sure you are doing the right thing, set the\nignoreNoExtendWarning option to true for this module.');
+        lint(`The module ${name} does not extend anything.\n\nA -widget module usually extends @apostrophecms/widget-type or another widget type.\nOr possibly you forgot to npm install something.\n\nIf you are sure you are doing the right thing, set the\nignoreNoExtendWarning option to true for this module.`);
       } else if (name.match(/-page$/) && (name !== '@apostrophecms/page') && (!extending(module)) && (!module.options.ignoreNoExtendWarning)) {
-        lint('The module ' + name + ' does not extend anything.\n\nA -page module usually extends @apostrophecms/page-type or\n@apostrophecms/piece-page-type or another page type.\nOr possibly you forgot to npm install something.\n\nIf you are sure you are doing the right thing, set the\nignoreNoExtendWarning option to true for this module.');
+        lint(`The module ${name} does not extend anything.\n\nA -page module usually extends @apostrophecms/page-type or\n@apostrophecms/piece-page-type or another page type.\nOr possibly you forgot to npm install something.\n\nIf you are sure you are doing the right thing, set the\nignoreNoExtendWarning option to true for this module.`);
       } else if ((!extending(module)) && (!hasCode(name)) && (!isBundle(name)) && (!module.options.ignoreNoCodeWarning)) {
-        lint('The module ' + name + ' does not extend anything and does not have any code. This usually means that you:\n\n1. Forgot to "extend" another module\n2. Configured a module that comes from npm without npm installing it\n3. Simply haven\'t written your "index.js" yet\n\nIf you really want a module with no code, set the ignoreNoCodeWarning option\nto true for this module.');
+        lint(`The module ${name} does not extend anything and does not have any code.\n\nThis usually means that you:\n\n1. Forgot to "extend" another module\n2. Configured a module that comes from npm without npm installing it\n3. Simply haven\'t written your "index.js" yet\n\nIf you really want a module with no code, set the ignoreNoCodeWarning option\nto true for this module.`);
       }
     }
     function hasCode(name) {
@@ -402,7 +402,8 @@ module.exports = async function(options) {
       return doesWork(d);
     }
     function doesWork(d) {
-      const code = d.routes || d.apiRoutes || d.renderRoutes || d.init || d.methods || d.beforeSuperClass || d.handlers || d.helpers || d.restApiRoutes || d.middleware || d.customTags || d.components || d.tasks;
+      const countsAsWork = [ 'routes', 'apiRoutes', 'renderRoutes', 'renderRoutes', 'init', 'methods', 'beforeSuperClass', 'handlers', 'helpers', 'restApiRoutes', 'middleware', 'customTags', 'components', 'tasks' ];
+      const code = countsAsWork.find(property => d[property]);
       if (code) {
         return true;
       }

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -611,7 +611,9 @@ module.exports = {
         const publishedLocale = draft.aposLocale.replace(':draft', ':published');
         const publishedId = `${draft.aposDocId}:${publishedLocale}`;
         let previousPublished;
-        let published = await self.findOneForEditing(req, {
+        // pages can change type, so don't use a doc-type-specific find method
+        const find = self.apos.page.isPage(draft) ? self.apos.page.findOneForEditing : self.findOneForEditing;
+        let published = await find(req, {
           _id: publishedId
         }, {
           locale: publishedLocale

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -179,10 +179,11 @@ export default {
       return groupSet;
     },
     utilityFields() {
+      let fields = [];
       if (this.groups.utility && this.groups.utility.fields) {
-        return this.groups.utility.fields;
+        fields = this.groups.utility.fields;
       }
-      return [];
+      return this.filterOutParkedFields(fields);
     },
     tabs() {
       const tabs = [];
@@ -203,8 +204,7 @@ export default {
         const tabFields = this.tabs.find((item) => {
           return item.name === this.currentTab;
         });
-
-        return tabFields.fields;
+        return this.filterOutParkedFields(tabFields.fields);
       } else {
         return [];
       }
@@ -508,6 +508,11 @@ export default {
       this.save({
         andPublish: false,
         savingDraft: true
+      });
+    },
+    filterOutParkedFields(fields) {
+      return fields.filter(fieldName => {
+        return !((this.original && this.original.parked) || []).includes(fieldName);
       });
     }
   }

--- a/modules/@apostrophecms/page-type/index.js
+++ b/modules/@apostrophecms/page-type/index.js
@@ -342,7 +342,7 @@ module.exports = {
           return self.apos.page.insert(_req, doc.aposLastTargetId.replace(':draft', ':published'), doc.aposLastPosition, published, options);
         } else if (!doc.level) {
           // Insert the home page
-          return self.apos.doc.db.insert(_req, published, options);
+          return self.apos.doc.db.insertOne(_req, published, options);
         } else {
           throw new Error('insertPublishedOf called on a page that was never inserted via the standard page APIs, has no aposLastTargetId and aposLastPosition, cannot insert equivalent published page');
         }

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -2160,8 +2160,8 @@ database.`);
       // Copy any parked properties of `page` back into `input` to
       // prevent any attempt to alter them via the PUT or PATCH APIs
       enforceParkedProperties(req, page, input) {
-        for (const parked of (page.parked || [])) {
-          input[parked] = page[parked];
+        for (const field of (page.parked || [])) {
+          input[field] = page[field];
         }
       }
     };

--- a/test/pages-public-api.js
+++ b/test/pages-public-api.js
@@ -33,6 +33,9 @@ describe('Pages Public API', function() {
               }
             ]
           }
+        },
+        'test-page': {
+          extend: '@apostrophecms/page-type'
         }
       }
     });


### PR DESCRIPTION
…an error on a page type without module to back it, allow publishing of a page type change, remove parked fields from the page settings UI

All of these issues added up to the solution to the "can't switch page type and publish that change" ticket.

I'm aware we might prefer a read-only treatment for parked fields. Removing them is simpler and consistent with 2.x, so I'd like to do that just for this ticket — which is intended as a bug fix, not as the final be-all end-all of how we handle parked fields.