### PR TITLE
3/add image after editing image

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
+++ b/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
@@ -79,21 +79,29 @@ export default function() {
 
     const component = window.apos.area.components.editor;
 
-    return new Vue({
-      el: el,
-      data: function() {
-        return {
-          options,
-          id: data._id,
-          items: data.items,
-          choices,
-          docId: _docId,
-          fieldId,
-          renderings
-        };
-      },
-      template: `<${component} :options="options" :items="items" :choices="choices" :id="$data.id" :docId="$data.docId" :fieldId="fieldId" :renderings="renderings" />`
-    });
-
+    if (apos.area.activeEditor && (apos.area.activeEditor.id === data._id)) {
+      // Editing a piece causes a refresh of the main content area,
+      // but this may contain the area we originally intended to add
+      // a widget to when we created a piece for that purpose. Preserve
+      // the editing experience by restoring that widget's editor to the DOM
+      // rather than creating a new one.
+      el.parentNode.replaceChild(apos.area.activeEditor.$el, el);
+    } else {
+      return new Vue({
+        el,
+        data: function() {
+          return {
+            options,
+            id: data._id,
+            items: data.items,
+            choices,
+            docId: _docId,
+            fieldId,
+            renderings
+          };
+        },
+        template: `<${component} :options="options" :items="items" :choices="choices" :id="$data.id" :docId="$data.docId" :fieldId="fieldId" :renderings="renderings" />`
+      });
+    }
   }
 };

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -9,12 +9,12 @@
           :label="'Add ' + contextMenuOptions.menu[0].label"
           type="primary"
           :icon="icon"
-          @click="add(contextMenuOptions.menu[0].name)"
+          @click="add({ index: 0, name: contextMenuOptions.menu[0].name })"
         />
       </template>
       <template v-else>
         <AposAreaMenu
-          @insert="insert"
+          @add="add"
           :context-menu-options="contextMenuOptions"
           :empty="true"
           :index="0"
@@ -45,7 +45,7 @@
         @edit="edit"
         @clone="clone"
         @update="update"
-        @insert="insert"
+        @add="add"
       />
     </div>
   </div>
@@ -298,12 +298,14 @@ export default {
 
       if (!this.widgetIsContextual(widget.type)) {
         const componentName = this.widgetEditorComponent(widget.type);
+        apos.area.activeEditor = this;
         const result = await apos.modal.execute(componentName, {
           value: widget,
           options: this.options.widgets[widget.type],
           type: widget.type,
           docId: this.docId
         });
+        apos.area.activeEditor = null;
         if (result) {
           return this.update(result);
         }
@@ -331,49 +333,47 @@ export default {
       ];
       this.edited[widget._id] = true;
     },
-    // Add a widget into a *singleton* area.
-    async add(name) {
+    // Add a widget into an area.
+    async add({ index, name }) {
       if (this.widgetIsContextual(name)) {
         return this.insert({
-          _id: cuid(),
-          type: name,
-          index: 0,
-          ...this.contextualWidgetDefaultData(name)
+          widget: {
+            _id: cuid(),
+            type: name,
+            ...this.contextualWidgetDefaultData(name)
+          },
+          index
         });
       } else {
         const componentName = this.widgetEditorComponent(name);
-        const result = await apos.modal.execute(componentName, {
+        apos.area.activeEditor = this;
+        const widget = await apos.modal.execute(componentName, {
           value: null,
           options: this.options.widgets[name],
           type: name,
           docId: this.docId
         });
-        if (result) {
-          result.index = 0;
-          await this.insert(result);
+        apos.area.activeEditor = null;
+        if (widget) {
+          await this.insert({
+            widget,
+            index
+          });
         }
       }
     },
     contextualWidgetDefaultData(type) {
       return this.moduleOptions.contextualWidgetDefaultData[type];
     },
-    async insert(e) {
-      let widget;
-      if (e.widget) {
-        widget = e.widget;
-      }
-      if (e.type) {
-        // e IS a widget
-        widget = e;
-      }
+    async insert({ index, widget }) {
       if (!widget._id) {
         widget._id = cuid();
       }
       const push = {
         $each: [ widget ]
       };
-      if (e.index < this.next.length) {
-        push.$before = this.next[e.index]._id;
+      if (index < this.next.length) {
+        push.$before = this.next[index]._id;
       }
       if (this.docId === window.apos.adminBar.contextId) {
         apos.bus.$emit('context-edited', {
@@ -383,12 +383,12 @@ export default {
         });
       }
       this.next = [
-        ...this.next.slice(0, e.index),
+        ...this.next.slice(0, index),
         widget,
-        ...this.next.slice(e.index)
+        ...this.next.slice(index)
       ];
       if (this.widgetIsContextual(widget.type)) {
-        this.edit(e.index);
+        this.edit(index);
       }
     },
     widgetIsContextual(type) {

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
@@ -104,7 +104,7 @@ export default {
       type: Boolean
     }
   },
-  emits: [ 'menu-close', 'menu-open', 'insert' ],
+  emits: [ 'menu-close', 'menu-open', 'add' ],
   data() {
     return {
       active: 0,
@@ -172,22 +172,10 @@ export default {
       // we should consider refactoring contextmenus to be able to self close when any click takes place within their el
       // as it is often the logical experience (not always, see tag menus and filters)
       this.$refs.contextMenu.isOpen = false;
-      if (this.widgetIsContextual(name)) {
-        this.insert({
-          _id: cuid(),
-          type: name,
-          ...this.contextualWidgetDefaultData(name)
-        });
-      } else {
-        const result = await apos.modal.execute(this.widgetEditorComponent(name), {
-          options: this.widgetOptions[name],
-          type: name,
-          value: null
-        });
-        if (result) {
-          this.insert(result);
-        }
-      }
+      this.$emit('add', {
+        index: this.index,
+        name
+      });
     },
     widgetEditorComponent(type) {
       return this.moduleOptions.components.widgetEditors[type];
@@ -197,12 +185,6 @@ export default {
     },
     contextualWidgetDefaultData(type) {
       return this.moduleOptions.contextualWidgetDefaultData[type];
-    },
-    insert(widget) {
-      this.$emit('insert', {
-        index: this.index,
-        widget
-      });
     },
     groupFocused() {
       this.groupIsFocused = true;

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -52,7 +52,7 @@
         <AposAreaMenu
           v-if="!foreign"
           :max-reached="maxReached"
-          @insert="$emit('insert', $event);"
+          @add="$emit('add', $event);"
           @menu-open="toggleMenuFocus($event, 'top', true)"
           @menu-close="toggleMenuFocus($event, 'top', false)"
           :context-menu-options="contextMenuOptions"
@@ -114,7 +114,7 @@
         <AposAreaMenu
           v-if="!foreign"
           :max-reached="maxReached"
-          @insert="$emit('insert', $event)"
+          @add="$emit('add', $event)"
           :context-menu-options="bottomContextMenuOptions"
           :index="i + 1"
           :widget-options="options.widgets"
@@ -188,7 +188,7 @@ export default {
       }
     }
   },
-  emits: [ 'clone', 'up', 'down', 'remove', 'edit', 'update', 'insert', 'changed' ],
+  emits: [ 'clone', 'up', 'down', 'remove', 'edit', 'update', 'add', 'changed' ],
   data() {
     const initialState = {
       controls: {

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -200,8 +200,11 @@ export default {
       this.docFields.data = klona(newMedia);
       this.generateLipKey();
       await this.unlock();
-      if (!await this.lock(`${this.moduleOptions.action}/${newMedia._id}`)) {
-        this.lockNotAvailable();
+      // Distinguish between an actual doc and an empty placeholder
+      if (newMedia._id) {
+        if (!await this.lock(`${this.moduleOptions.action}/${newMedia._id}`)) {
+          this.lockNotAvailable();
+        }
       }
     },
     save() {


### PR DESCRIPTION
Preserve the active area editor through any refreshes that occur due to piece edits while the widget editor modal and its nested modals are active.

To facilitate that, I refactored all code that launches the widget editor modal up to AposAreaEditor. Several redundancies and cases of methods with multiple argument formats have been cleaned up.

Also, because it is related to the original bug I was working on: do not throw console errors when deselecting in the media manager.