### PR TITLE
3/fix schema field max length

### DIFF
--- a/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
@@ -242,6 +242,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+  .apos-schema /deep/ .apos-field__wrapper {
+    max-width: $input-max-width;
+  }
   .apos-field {
     .apos-schema /deep/ & {
       margin-bottom: $spacing-triple;

--- a/modules/@apostrophecms/ui/ui/apos/scss/global/_inputs.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/_inputs.scss
@@ -123,7 +123,6 @@
 
 .apos-input-wrapper {
   position: relative;
-  max-width: $input-max-width;
 }
 
 .apos-choice-label {


### PR DESCRIPTION
Move the burden of applying a max width to fields within schemas rather than the field components themselves. Prevents help and label fields from overflowing