### PR TITLE
newInstance should make sure all properties exist at least as a null …

### DIFF
--- a/modules/@apostrophecms/area/lib/custom-tags/area.js
+++ b/modules/@apostrophecms/area/lib/custom-tags/area.js
@@ -88,7 +88,7 @@ module.exports = function(self) {
             _id: docId,
             // Prevent race condition
             [areaDotPath]: {
-              $exists: 0
+              $eq: null
             }
           }, {
             $set: {

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1430,6 +1430,9 @@ module.exports = {
         for (const field of schema) {
           if (field.def !== undefined) {
             instance[field.name] = klona(field.def);
+          } else {
+            // All fields should have an initial value in the database
+            instance[field.name] = null;
           }
         }
         return instance;


### PR DESCRIPTION
…value, so it is possible to undo with a patch back to original value

Re: that one bit where I had to stop using `$exists: 0`, I have verified that `$eq: null` matches both null and undefined, both in reality and according to the sages.