### PR TITLE
3/docs finds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.0.0-alpha.6 - Unreleased
+
+### Adds
+* Adds note to remove deprecated `allowedInChooser` option on piece type filters.
+
+### Fixes
+* Fixes error from missing `select` method in `AposPiecesManager` component.
+
 ## 3.0.0-alpha.5 - Unreleased
 
 * Adds the option to pass context options to an area for its widgets following the `with` keyword. Context options for widgets not in that area (or that don't exist) are ignored. Syntax: `{% area data.page, 'areaName' with { '@apostrophecms/image: { size: 'full' } } %}`.

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -64,6 +64,7 @@ module.exports = {
             label: 'Any'
           }
         ],
+        // TODO: Delete `allowedInChooser` if not used.
         allowedInChooser: false,
         def: true
       },
@@ -80,6 +81,7 @@ module.exports = {
             label: 'Trash'
           }
         ],
+        // TODO: Delete `allowedInChooser` if not used.
         allowedInChooser: false,
         def: false,
         required: true

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
@@ -50,7 +50,6 @@
           class="apos-pieces-manager__relationship__items"
           @input="updateChecked"
           :value="checkedDocs"
-          @select="select"
         />
       </div>
     </template>


### PR DESCRIPTION
Addresses a couple of things found while writing documentation.
- allowedInChooser - option seems to not be used anywhere anymore.
- select method does not exist in the pieces manager component and was throwing an error.