### PR TITLE
you can copy pages and pieces. The copyOfId property is set on the ne…

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -208,7 +208,7 @@
               :can-discard-draft="context.modified"
               :is-modified-from-published="context.modified"
               :is-published="!!context.lastPublishedAt"
-              :options="{ saveDraft: false }"
+              :can-save-draft="false"
               @discardDraft="onDiscardDraft"
             />
             <AposButton

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -17,14 +17,16 @@
         menu in many cases because all of the operations
         depend on modification from published -->
       <AposDocMoreMenu
-        v-if="moduleOptions.localized && !moduleOptions.autopublish && (isModified || isModifiedFromPublished || canDiscardDraft)"
+        v-if="hasMoreMenu"
         :is-modified="isModified"
         :is-modified-from-published="isModifiedFromPublished"
         :can-discard-draft="canDiscardDraft"
+        :can-copy="true"
         :is-published="!!published"
         :options="{ saveDraft: true }"
         @saveDraft="saveDraft"
         @discardDraft="onDiscardDraft"
+        @copy="onCopy"
       />
       <AposButton
         type="primary" :label="saveLabel"
@@ -119,6 +121,10 @@ export default {
     },
     docId: {
       type: String,
+      default: null
+    },
+    copyOf: {
+      type: Object,
       default: null
     },
     filterValues: {
@@ -222,7 +228,7 @@ export default {
       return tabs;
     },
     modalTitle() {
-      return `Edit ${this.moduleOptions.label || ''}`;
+      return this.copyOf ? `Copy ${this.moduleOptions.label || ''}` : `Edit ${this.moduleOptions.label || ''}`;
     },
     currentFields() {
       if (this.currentTab) {
@@ -262,6 +268,17 @@ export default {
     },
     canDiscardDraft() {
       return (this.docId && (!this.published)) || this.isModifiedFromPublished;
+    },
+    hasMoreMenu() {
+      if (this.docId) {
+        // Copy is allowed
+        return true;
+        // All other scenarios apply only when the user needs publishing-related UI
+      } else if (this.moduleOptions.localized && !this.moduleOptions.autopublish) {
+        return (this.isModified || this.isModifiedFromPublished || this.canDiscardDraft);
+      } else {
+        return false;
+      }
     }
   },
   watch: {
@@ -343,6 +360,16 @@ export default {
           });
         }
       }
+    } else if (this.copyOf) {
+      const newInstance = klona(this.copyOf);
+      delete newInstance._id;
+      this.original = newInstance;
+      if (newInstance && newInstance.type !== this.docType) {
+        this.docType = newInstance.type;
+      }
+      this.docFields.data = newInstance;
+      this.prepErrors();
+      this.docReady = true;
     } else {
       this.$nextTick(() => {
         this.loadNewInstance();
@@ -434,6 +461,9 @@ export default {
             // New pages are always born as drafts
             body._targetId = apos.page.page._id.replace(':published', ':draft');
             body._position = 'lastChild';
+          }
+          if (this.copyOf) {
+            body._copyingId = this.copyOf._id;
           }
         }
         let doc;
@@ -529,8 +559,25 @@ export default {
         this.modal.showModal = false;
       }
     },
+    async onCopy(e) {
+      if (this.isModified) {
+        await this.saveDraft();
+      } else {
+        this.$emit('modal-result', false);
+        this.modal.showModal = false;
+      }
+      apos.bus.$emit('admin-menu-click', {
+        itemName: `${this.moduleName}:editor`,
+        props: {
+          copyOf: {
+            ...this.docFields.data,
+            _id: this.docId
+          }
+        }
+      });
+    },
     saveDraft() {
-      this.save({
+      return this.save({
         andPublish: false,
         savingDraft: true
       });

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
@@ -45,6 +45,12 @@ export default {
         return false;
       }
     },
+    canCopy: {
+      type: Boolean,
+      default() {
+        return false;
+      }
+    },
     options: {
       type: Object,
       required: true
@@ -106,6 +112,12 @@ export default {
           {
             label: 'Save Draft',
             action: 'saveDraft'
+          }
+        ] : []),
+        ...(this.canCopy ? [
+          {
+            label: 'Copy',
+            action: 'copy'
           }
         ] : [])
       ];

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
@@ -39,6 +39,12 @@ export default {
         return false;
       }
     },
+    canSaveDraft: {
+      type: Boolean,
+      default() {
+        return false;
+      }
+    },
     canDiscardDraft: {
       type: Boolean,
       default() {
@@ -50,16 +56,6 @@ export default {
       default() {
         return false;
       }
-    },
-    options: {
-      type: Object,
-      required: true
-      // subproperties:
-      // saveDraft: Boolean
-      // If true, the save draft option is offered
-      // when isModified is currently true. This does
-      // not make sense in the onpage contextual editor,
-      // because it continuously saves drafts.
     },
     disabled: {
       type: Boolean,
@@ -108,7 +104,7 @@ export default {
             modifiers: [ 'danger' ]
           }
         ] : []),
-        ...((this.isModified && this.options.saveDraft) ? [
+        ...(this.canSaveDraft ? [
           {
             label: 'Save Draft',
             action: 'saveDraft'

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -163,7 +163,9 @@ export default {
     finishExit () {
       this.removeEventListeners();
       this.$emit('no-modal');
-      apos.modal.stack.pop();
+      // pop doesn't quite suffice because of race conditions when
+      // closing one and opening another
+      apos.modal.stack = apos.modal.stack.filter(modal => modal !== this);
     },
     bindEventListeners () {
       window.addEventListener('keydown', this.esc);

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposModalModifiedMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposModalModifiedMixin.js
@@ -18,6 +18,7 @@ export default {
     };
   },
   methods: {
+    // Returns true if the cancellation does occur
     async confirmAndCancel() {
       let dismiss;
       if (this.isModified) {
@@ -41,6 +42,7 @@ export default {
       if (dismiss) {
         this.modal.showModal = false;
       }
+      return dismiss;
     }
   }
 };

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -500,7 +500,8 @@ module.exports = {
       //
       // If `input._copyingId` is present, fetches that
       // piece and, if we have permission to view it, copies any schema properties
-      // not defined in `input`. Also emits `copyExtras` with (req, copyOf, input, piece).
+      // not defined in `input`. `_copyingId` becomes the `copyOfId` property of
+      // the doc, which may be watched for in event handlers to detect copies.
       //
       // Only fields that are not undefined in `input` are
       // considered. The rest respect their defaults. To intentionally
@@ -509,8 +510,6 @@ module.exports = {
       //
       // The module emits the `afterConvert` async event with `(req, input, piece)`
       // before inserting the piece.
-      //
-      // If copying, the module also emits `copyExtras` with `(req, copyOf, input, piece)`.
 
       async convertInsertAndRefresh(req, input, options) {
         const piece = self.newInstance();

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -2464,6 +2464,29 @@ module.exports = {
           result.push(field);
         }
         return result;
+      },
+      // Regenerate all array item, area and widget ids so they are considered
+      // new. Useful when copying an entire doc.
+      regenerateIds(req, schema, doc) {
+        for (const field of schema) {
+          if (field.type === 'array') {
+            for (const item of (doc[field.name] || [])) {
+              item._id = self.apos.util.generateId();
+              self.regenerateIds(req, field.schema, item);
+            }
+          } else if (field.type === 'area') {
+            if (doc[field.name]) {
+              doc[field.name]._id = self.apos.util.generateId();
+              for (const item of (doc[field.name].items || [])) {
+                item._id = self.apos.util.generateId();
+                const schema = self.apos.area.getWidgetManager(item.type).schema;
+                self.regenerateIds(req, schema, item);
+              }
+            }
+          }
+          // We don't want to regenerate attachment ids. They correspond to
+          // actual files, and the reference count will update automatically
+        }
       }
     };
   },


### PR DESCRIPTION
…w document, providing a way to detect copies, for instance the multisite module will need to pay attention when copies are born.

I eliminated the `copyExtra` event because it is redundant, you can look at `copyOfId`.
