### PR TITLE
3/cut copy paste

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
+++ b/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
@@ -1,6 +1,9 @@
 import Vue from 'Modules/@apostrophecms/ui/lib/vue';
+import { klona } from 'klona';
 
 export default function() {
+
+  createWidgetClipboardApp();
 
   prepareAreas();
   apos.bus.$on('widget-rendered', function() {
@@ -104,4 +107,39 @@ export default function() {
       });
     }
   }
+
+  function createWidgetClipboardApp() {
+    // Headless app to provide simple reactivity for the clipboard state
+    apos.area.widgetClipboard = new Vue({
+      el: null,
+      data: () => {
+        const existing = window.localStorage.getItem('aposWidgetClipboard');
+        return {
+          widgetClipboard: existing ? JSON.parse(existing) : null
+        };
+      },
+      mounted() {
+        window.addEventListener('storage', this.onStorage);
+      },
+      methods: {
+        set(widget) {
+          this.widgetClipboard = widget;
+          localStorage.setItem('aposWidgetClipboard', JSON.stringify(this.widgetClipboard));
+        },
+        get() {
+          // If we don't clone, the second paste will be a duplicate key error
+          return klona(this.widgetClipboard);
+        },
+        onStorage() {
+          // When local storage changes, dump the list to
+          // the console.
+          const contents = window.localStorage.getItem('aposWidgetClipboard');
+          if (contents) {
+            this.widgetClipboard = JSON.parse(contents);
+          }
+        }
+      }
+    });
+  }
+
 };

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -265,7 +265,7 @@ export default {
       await this.remove(i);
     },
     async copy(i) {
-      localStorage.setItem('aposWidgetClipboard', JSON.stringify(this.next[i]));
+      apos.area.widgetClipboard.set(this.next[i]);
     },
     async edit(i) {
       if (this.foreign) {
@@ -350,7 +350,7 @@ export default {
     }) {
       if (clipboard) {
         this.regenerateIds(apos.modules[apos.area.widgetManagers[clipboard.type]].schema, clipboard);
-        await this.insert({
+        return this.insert({
           widget: clipboard,
           index
         });

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -42,6 +42,8 @@
         @up="up"
         @down="down"
         @remove="remove"
+        @cut="cut"
+        @copy="copy"
         @edit="edit"
         @clone="clone"
         @update="update"
@@ -54,6 +56,7 @@
 <script>
 import cuid from 'cuid';
 import { klona } from 'klona';
+import regenerateIds from '../../../../schema/lib/regenerateIds';
 
 export default {
   name: 'AposAreaEditor',
@@ -258,6 +261,13 @@ export default {
         ...this.next.slice(i + 1)
       ];
     },
+    async cut(i) {
+      localStorage.setItem('aposWidgetClipboard', JSON.stringify(this.next[i]));
+      await this.remove(i);
+    },
+    async copy(i) {
+      localStorage.setItem('aposWidgetClipboard', JSON.stringify(regenerateIds(this.next[i])));
+    },
     async edit(i) {
       if (this.foreign) {
         try {
@@ -334,8 +344,17 @@ export default {
       this.edited[widget._id] = true;
     },
     // Add a widget into an area.
-    async add({ index, name }) {
-      if (this.widgetIsContextual(name)) {
+    async add({
+      index,
+      name,
+      clipboard
+    }) {
+      if (clipboard) {
+        await this.insert({
+          widget: clipboard,
+          index
+        });
+      } else if (this.widgetIsContextual(name)) {
         return this.insert({
           widget: {
             _id: cuid(),

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
@@ -150,7 +150,7 @@ export default {
       return flag;
     },
     myMenu() {
-      const clipboard = localStorage.getItem('aposWidgetCipboard');
+      const clipboard = localStorage.getItem('aposWidgetClipboard');
       if (clipboard) {
         const widget = JSON.parse(clipboard);
         const matchingChoice = this.contextMenuOptions.menu.find(option => option.name === widget.type);
@@ -158,7 +158,6 @@ export default {
           return this.composeGroups(widget, matchingChoice);
         }
       }
-      
       if (this.groupedMenus) {
         return this.composeGroups();
       } else {
@@ -181,7 +180,10 @@ export default {
       // we should consider refactoring contextmenus to be able to self close when any click takes place within their el
       // as it is often the logical experience (not always, see tag menus and filters)
       this.$refs.contextMenu.isOpen = false;
-      this.$emit('add', item);
+      this.$emit('add', {
+        ...item,
+        index: this.index
+      });
     },
     groupFocused() {
       this.groupIsFocused = true;

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
@@ -150,9 +150,9 @@ export default {
       return flag;
     },
     myMenu() {
-      const clipboard = localStorage.getItem('aposWidgetClipboard');
+      const clipboard = apos.area.widgetClipboard.get();
       if (clipboard) {
-        const widget = JSON.parse(clipboard);
+        const widget = clipboard;
         const matchingChoice = this.contextMenuOptions.menu.find(option => option.name === widget.type);
         if (matchingChoice) {
           return this.composeGroups(widget, matchingChoice);

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -72,6 +72,8 @@
           @up="$emit('up', i);"
           @remove="$emit('remove', i);"
           @edit="$emit('edit', i);"
+          @cut="$emit('cut', i);"
+          @copy="$emit('copy', i);"
           @clone="$emit('clone', i);"
           @down="$emit('down', i);"
         />
@@ -188,7 +190,7 @@ export default {
       }
     }
   },
-  emits: [ 'clone', 'up', 'down', 'remove', 'edit', 'update', 'add', 'changed' ],
+  emits: [ 'clone', 'up', 'down', 'remove', 'edit', 'cut', 'copy', 'update', 'add', 'changed' ],
   data() {
     const initialState = {
       controls: {

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -17,6 +17,16 @@
         @click="$emit('edit')"
       />
       <AposButton
+        v-bind="cutButton"
+        v-if="!foreign"
+        @click="$emit('cut')"
+      />
+      <AposButton
+        v-bind="copyButton"
+        v-if="!foreign"
+        @click="$emit('copy')"
+      />
+      <AposButton
         v-if="!foreign"
         v-bind="cloneButton"
         @click="$emit('clone')"
@@ -59,7 +69,7 @@ export default {
       required: true
     }
   },
-  emits: [ 'remove', 'edit', 'clone', 'up', 'down' ],
+  emits: [ 'remove', 'edit', 'cut', 'copy', 'clone', 'up', 'down' ],
   data() {
     return {
       buttonDefaults: {
@@ -121,6 +131,20 @@ export default {
         ...this.buttonDefaults,
         label: 'Edit',
         icon: 'pencil-icon'
+      };
+    },
+    cutButton() {
+      return {
+        ...this.buttonDefaults,
+        label: 'Cut',
+        icon: 'scissors-cutting-icon'
+      };
+    },
+    copyButton() {
+      return {
+        ...this.buttonDefaults,
+        label: 'Copy',
+        icon: 'content-copy-icon'
       };
     }
   }

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -144,7 +144,7 @@ export default {
       return {
         ...this.buttonDefaults,
         label: 'Copy',
-        icon: 'content-copy-icon'
+        icon: 'clipboard-plus-icon'
       };
     }
   }

--- a/modules/@apostrophecms/asset/lib/globalIcons.js
+++ b/modules/@apostrophecms/asset/lib/globalIcons.js
@@ -21,6 +21,7 @@ module.exports = {
   'cursor-default-click-icon': 'CursorDefaultClick',
   'content-copy-icon': 'ContentCopy',
   'delete-icon': 'Delete',
+  'scissors-cutting-icon': 'ScissorsCutting',
   'dots-vertical-icon': 'DotsVertical',
   'drag-icon': 'Apps',
   'eye-icon': 'Eye',

--- a/modules/@apostrophecms/asset/lib/globalIcons.js
+++ b/modules/@apostrophecms/asset/lib/globalIcons.js
@@ -20,6 +20,7 @@ module.exports = {
   'cog-icon': 'Cog',
   'cursor-default-click-icon': 'CursorDefaultClick',
   'content-copy-icon': 'ContentCopy',
+  'clipboard-plus-icon': 'ClipboardPlus',
   'delete-icon': 'Delete',
   'scissors-cutting-icon': 'ScissorsCutting',
   'dots-vertical-icon': 'DotsVertical',


### PR DESCRIPTION

Works; follows the design. Needs design input on the paste experience and surfaces an issue with the grouped widgets experience styles which seem to have drifted off target a bit.

Re: the paste experience, the design is based on the idea of widget groups, but when widgets aren't grouped the presence of the clipboard kinda forces the use of the "ungrouped widgets" section, which also isn't toggled open by default because it isn't the first section. I didn't want to cowboy this bit so I'm sharing it in its unvarnished glory to get input.

Right now the icons crowd each other.

Draft for now while we figure out these issues.

See screenshots.

Per previous discussion there is just one widget on the clipboard at a time.

<img width="491" alt="Screen Shot 2021-03-14 at 4 33 15 PM" src="https://user-images.githubusercontent.com/32125/111083285-2f3e8080-84e3-11eb-8f8d-bcc7deb51167.png">
<img width="401" alt="Screen Shot 2021-03-14 at 4 33 48 PM" src="https://user-images.githubusercontent.com/32125/111083286-2fd71700-84e3-11eb-965c-b6a9ee9647b6.png">
<img width="390" alt="Screen Shot 2021-03-14 at 4 39 17 PM" src="https://user-images.githubusercontent.com/32125/111083413-dae7d080-84e3-11eb-9075-315b4a91fdab.png">


