### PR TITLE
PRO-980 update secondary UI selector to match new button structure 

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -583,7 +583,7 @@ export default {
     transform: translate(-50%, 0);
   }
 
-  .apos-area-widget-inner .apos-area-widget-inner /deep/ .apos-context-menu__btn {
+  .apos-area-widget-inner .apos-area-widget-inner /deep/ .apos-context-menu__btn .apos-button {
     background-color: var(--a-secondary);
     border-color: var(--a-secondary);
   }


### PR DESCRIPTION
https://linear.app/apostrophecms/issue/PRO-980/nested-area-breadcrumbs-seems-to-be-bleeding-into-the-button