### PR TITLE
PRO-94 ensure disabled fields

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -7,6 +7,7 @@
       <template v-if="isEmptySingleton">
         <AposButton
           :label="'Add ' + contextMenuOptions.menu[0].label"
+          :disabled="field && field.readOnly"
           type="primary"
           :icon="icon"
           @click="add({ index: 0, name: contextMenuOptions.menu[0].name })"
@@ -20,6 +21,7 @@
           :index="0"
           :widget-options="options.widgets"
           :max-reached="maxReached"
+          :disabled="field && field.readOnly"
         />
       </template>
     </div>
@@ -69,6 +71,12 @@ export default {
     id: {
       type: String,
       required: true
+    },
+    field: {
+      type: Object,
+      default() {
+        return {};
+      }
     },
     fieldId: {
       type: String,
@@ -125,8 +133,8 @@ export default {
       return this.next.length === 0 &&
         this.options.widgets &&
         Object.keys(this.options.widgets).length === 1 &&
-        this.options.max &&
-        this.options.max === 1;
+        (this.options.max || this.field.max) &&
+        (this.options.max === 1 || this.field.max === 1);
     },
     icon() {
       let icon = null;

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="apos-area-menu" :class="{'is-focused': groupIsFocused}">
     <AposContextMenu
-      :disabled="disabled"
+      :disabled="isDisabled"
       :button="buttonOptions"
       v-bind="extendedContextMenuOptions"
       @open="menuOpen"
@@ -102,6 +102,10 @@ export default {
     },
     maxReached: {
       type: Boolean
+    },
+    disabled: {
+      type: Boolean,
+      default: false
     }
   },
   emits: [ 'menu-close', 'menu-open', 'add' ],
@@ -122,11 +126,15 @@ export default {
         icon: 'plus-icon',
         type: 'primary',
         modifiers: this.empty ? [] : [ 'round', 'tiny' ],
-        iconSize: this.empty ? 20 : 11,
+        iconSize: this.empty ? 20 : 11
       };
     },
-    disabled() {
-      return this.maxReached;
+    isDisabled() {
+      let flag = this.disabled;
+      if (this.maxReached) {
+        flag = true;
+      }
+      return flag;
     },
     extendedContextMenuOptions() {
       const modifiers = [ 'unpadded' ];

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1828,6 +1828,7 @@ module.exports = {
               await self.apos.util.recursionGuard(req, `${_relationship.type}:${_relationship.withType}`, () => {
                 // Allow options to the getter to be specified in the schema,
                 // notably editable: true
+                // TODO editable going away in favor of disabled for consistency
                 return self.fieldTypes[_relationship.type].relate(req, _relationship, _objects, options);
               });
               _.each(_objects, function (object) {
@@ -1875,6 +1876,7 @@ module.exports = {
 
           // Allow options to the getter to be specified in the schema,
           // notably editable: true
+          // TODO editable going away in favor of disabled for consistency
           await self.apos.util.recursionGuard(req, `${relationship.type}:${relationship.withType}`, () => {
             return self.fieldTypes[relationship.type].relate(req, relationship, _objects, options);
           });

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1827,8 +1827,6 @@ module.exports = {
               }
               await self.apos.util.recursionGuard(req, `${_relationship.type}:${_relationship.withType}`, () => {
                 // Allow options to the getter to be specified in the schema,
-                // notably editable: true
-                // TODO editable going away in favor of disabled for consistency
                 return self.fieldTypes[_relationship.type].relate(req, _relationship, _objects, options);
               });
               _.each(_objects, function (object) {
@@ -1874,9 +1872,7 @@ module.exports = {
             _.extend(options.hints, relationship.hints);
           }
 
-          // Allow options to the getter to be specified in the schema,
-          // notably editable: true
-          // TODO editable going away in favor of disabled for consistency
+          // Allow options to the getter to be specified in the schema
           await self.apos.util.recursionGuard(req, `${relationship.type}:${relationship.withType}`, () => {
             return self.fieldTypes[relationship.type].relate(req, relationship, _objects, options);
           });

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArea.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArea.vue
@@ -15,6 +15,7 @@
           :choices="choices"
           :id="next._id"
           :field-id="field._id"
+          :field="field"
           @changed="changed"
         />
       </div>

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
@@ -21,6 +21,8 @@
           <AposButton
             :label="editLabel"
             @click="edit"
+            :disabled="field.disabled"
+            :tooltip="tooltip"
           />
         </label>
       </div>

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
@@ -12,16 +12,11 @@
     </template>
     <template #body>
       <div class="apos-input-array">
-        <label
-          class="apos-input-wrapper"
-          :class="{
-            'is-disabled': field.readOnly
-          }"
-        >
+        <label class="apos-input-wrapper">
           <AposButton
             :label="editLabel"
             @click="edit"
-            :disabled="field.disabled"
+            :disabled="field.readOnly"
             :tooltip="tooltip"
           />
         </label>

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputAttachment.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputAttachment.vue
@@ -12,7 +12,6 @@
             'apos-attachment-dropzone--dragover': dragging,
             'is-disabled': disabled || limitReached
           }"
-          :disabled="disabled || limitReached"
           @drop.prevent="uploadMedia"
           @dragover="dragHandler"
           @dragleave="dragging = false"
@@ -42,7 +41,7 @@
           <AposSlatList
             :value="next ? [ next ] : []"
             @input="updated"
-            :disabled="disabled"
+            :disabled="field.readOnly"
           />
         </div>
       </div>
@@ -94,7 +93,7 @@ export default {
     }
   },
   async mounted () {
-    this.disabled = this.field.disabled || this.field.readOnly;
+    this.disabled = this.field.readOnly;
 
     const groups = apos.modules['@apostrophecms/attachment'].fileGroups;
     const groupInfo = groups.find(group => {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputAttachment.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputAttachment.vue
@@ -10,9 +10,9 @@
           class="apos-input-wrapper apos-attachment-dropzone"
           :class="{
             'apos-attachment-dropzone--dragover': dragging,
-            'is-disabled': disabled
+            'is-disabled': disabled || limitReached
           }"
-          :disabled="disabled"
+          :disabled="disabled || limitReached"
           @drop.prevent="uploadMedia"
           @dragover="dragHandler"
           @dragleave="dragging = false"
@@ -33,7 +33,7 @@
           <input
             type="file"
             class="apos-sr-only"
-            :disabled="disabled"
+            :disabled="disabled || limitReached"
             @input="uploadMedia"
             :accept="field.accept"
           >
@@ -42,6 +42,7 @@
           <AposSlatList
             :value="next ? [ next ] : []"
             @input="updated"
+            :disabled="disabled"
           />
         </div>
       </div>
@@ -74,20 +75,26 @@ export default {
   },
   computed: {
     messages () {
-      const msgs = {};
+      const msgs = {
+        primary: 'Drop a file here or',
+        highlighted: 'click to open the file explorer'
+      };
       if (this.disabled) {
+        msgs.primary = 'Field is disabled';
+        msgs.highlighted = '';
+      }
+      if (this.limitReached) {
         msgs.primary = 'Attachment limit reached';
         msgs.highlighted = '';
-      } else {
-        msgs.primary = 'Drop a file here or';
-        msgs.highlighted = 'click to open the file explorer';
       }
-
       return msgs;
+    },
+    limitReached () {
+      return !!(this.value.data && this.value.data._id);
     }
   },
   async mounted () {
-    this.disabled = this.field.disabled || !!(this.value.data && this.value.data._id);
+    this.disabled = this.field.disabled || this.field.readOnly;
 
     const groups = apos.modules['@apostrophecms/attachment'].fileGroups;
     const groupInfo = groups.find(group => {
@@ -100,7 +107,7 @@ export default {
   methods: {
     watchNext () {
       this.validateAndEmit();
-      this.disabled = !!this.next;
+      this.limitReached = !!this.next;
     },
     updated (items) {
       // NOTE: This is limited to a single item.
@@ -114,7 +121,7 @@ export default {
       return false;
     },
     async uploadMedia (event) {
-      if (!this.disabled) {
+      if (!this.disabled || !this.limitReached) {
         try {
           this.dragging = false;
           this.disabled = true;
@@ -161,8 +168,8 @@ export default {
             icon: 'alert-circle-icon',
             dismiss: true
           });
-          this.disabled = false;
         } finally {
+          this.disabled = false;
           this.uploading = false;
         }
       }
@@ -190,6 +197,7 @@ export default {
     margin: 10px 0;
     padding: 20px;
     border: 2px dashed var(--a-base-8);
+    border-radius: var(--a-border-radius);
     transition: all 0.2s ease;
     &:hover {
       border-color: var(--a-primary);
@@ -201,11 +209,11 @@ export default {
     }
     &.is-disabled {
       color: var(--a-base-4);
+      background-color: var(--a-base-7);
+      border-color: var(--a-base-4);
 
       &:hover {
         cursor: not-allowed;
-        background-color: transparent;
-        border-color: var(--a-base-8);
       }
     }
   }

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputColor.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputColor.vue
@@ -13,6 +13,8 @@
             @close="close"
             menu-placement="bottom-start"
             menu-offset="5, 20"
+            :disabled="field.disabled"
+            :tooltip="tooltip"
           >
             <Picker
               v-if="next"
@@ -63,7 +65,8 @@ export default {
     return {
       active: false,
       tinyColorObj: null,
-      startsNull: false
+      startsNull: false,
+      tooltip: this.field.disabled ? 'Field is disabled' : false
     };
   },
   computed: {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputColor.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputColor.vue
@@ -65,8 +65,7 @@ export default {
     return {
       active: false,
       tinyColorObj: null,
-      startsNull: false,
-      tooltip: this.field.disabled ? 'Field is disabled' : false
+      startsNull: false
     };
   },
   computed: {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputColor.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputColor.vue
@@ -13,7 +13,7 @@
             @close="close"
             menu-placement="bottom-start"
             menu-offset="5, 20"
-            :disabled="field.disabled"
+            :disabled="field.readOnly"
             :tooltip="tooltip"
           >
             <Picker

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRadio.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRadio.vue
@@ -8,6 +8,7 @@
       <label
         class="apos-choice-label" :for="getChoiceId(uid, choice.value)"
         v-for="choice in field.choices" :key="choice.value"
+        :class="{'apos-choice-label--disabled': field.readOnly}"
       >
         <input
           type="radio" class="apos-sr-only apos-input--choice apos-input--radio"
@@ -15,6 +16,7 @@
           :id="getChoiceId(uid, choice.value)"
           :checked="next === choice.value"
           tabindex="1"
+          :disabled="field.readOnly"
           @change="change($event.target.value)"
         >
         <span class="apos-input-indicator" aria-hidden="true">

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRange.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRange.vue
@@ -228,6 +228,11 @@ export default {
     cursor: pointer;
   }
 
+  .apos-range__input[disabled]::moz-range-thumb {
+    background: var(--a-primary-button-disabled);
+    cursor: not-allowed;
+  }
+
   .apos-range__input::-ms-track {
     width: 100%;
     height: 5px;
@@ -258,6 +263,11 @@ export default {
     background: var(--a-primary);
     cursor: pointer;
     margin-top: 0;
+  }
+
+  .apos-range__input[disabled]::-ms-thumb {
+    background: var(--a-primary-button-disabled);
+    cursor: not-allowed;
   }
 
   .apos-range__input:focus::-ms-fill-lower {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRange.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRange.vue
@@ -14,7 +14,7 @@
             class="apos-range__input"
             v-model="next"
             :id="uid"
-            :disabled="field.disabled"
+            :disabled="field.readOnly"
           >
           <div class="apos-range__scale">
             <span>

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRange.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRange.vue
@@ -61,13 +61,6 @@ export default {
     };
   },
   computed: {
-    tooltip() {
-      let msg = false;
-      if (this.field.disabled) {
-        msg = 'This field is disabled';
-      }
-      return msg;
-    },
     minLabel() {
       return this.field.min + this.unit;
     },

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRange.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRange.vue
@@ -5,7 +5,7 @@
   >
     <template #body>
       <div class="apos-input-wrapper">
-        <div class="apos-range">
+        <div class="apos-range" v-tooltip="tooltip">
           <input
             type="range"
             :min="field.min"
@@ -14,6 +14,7 @@
             class="apos-range__input"
             v-model="next"
             :id="uid"
+            :disabled="field.disabled"
           >
           <div class="apos-range__scale">
             <span>
@@ -60,6 +61,13 @@ export default {
     };
   },
   computed: {
+    tooltip() {
+      let msg = false;
+      if (this.field.disabled) {
+        msg = 'This field is disabled';
+      }
+      return msg;
+    },
     minLabel() {
       return this.field.min + this.unit;
     },
@@ -161,6 +169,10 @@ export default {
     }
   }
 
+  .apos-range__input[disabled] {
+    cursor: not-allowed;
+  }
+
   .apos-range__input::-webkit-slider-runnable-track {
     width: 100%;
     height: 5px;
@@ -174,6 +186,10 @@ export default {
     background: var(--a-primary);
   }
 
+  .apos-range__input[disabled]::-webkit-progress-value {
+    background: var(--a-primary-button-disabled);
+  }
+
   .apos-range__input::-webkit-slider-thumb {
     margin-top: -6px;
     width: 15px;
@@ -184,6 +200,9 @@ export default {
     cursor: pointer;
     /* stylelint-disable-next-line property-no-vendor-prefix */
     -webkit-appearance: none;
+  }
+  .apos-range__input[disabled]::-webkit-slider-thumb {
+    background: var(--a-primary-button-disabled);
   }
 
   .apos-range__input:focus::-webkit-slider-runnable-track {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -17,7 +17,7 @@
             class="apos-input apos-input--text apos-input--relationship"
             v-model="searchTerm" type="text"
             :placeholder="placeholder"
-            :disabled="disabled" :required="field.required"
+            :disabled="field.disabled" :required="field.required"
             :id="uid"
             @input="input"
             @focusout="handleFocusOut"
@@ -25,6 +25,7 @@
           >
           <AposButton
             class="apos-input-relationship__button"
+            :disabled="field.disabled"
             :label="browseLabel"
             :modifiers="['small']"
             type="input"
@@ -37,6 +38,7 @@
           @input="updateSelected"
           @item-clicked="editRelationship"
           :value="next"
+          :disabled="field.disabled"
         />
         <AposSearchList
           :list="searchList"

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -17,7 +17,8 @@
             class="apos-input apos-input--text apos-input--relationship"
             v-model="searchTerm" type="text"
             :placeholder="placeholder"
-            :disabled="field.disabled" :required="field.required"
+            :disabled="field.readOnly || limitReached"
+            :required="field.required"
             :id="uid"
             @input="input"
             @focusout="handleFocusOut"
@@ -25,7 +26,7 @@
           >
           <AposButton
             class="apos-input-relationship__button"
-            :disabled="field.disabled"
+            :disabled="field.readOnly || limitReached"
             :label="browseLabel"
             :modifiers="['small']"
             type="input"
@@ -38,7 +39,7 @@
           @input="updateSelected"
           @item-clicked="editRelationship"
           :value="next"
-          :disabled="field.disabled"
+          :disabled="field.readOnly"
         />
         <AposSearchList
           :list="searchList"
@@ -70,6 +71,9 @@ export default {
     };
   },
   computed: {
+    limitReached() {
+      return this.field.max === this.next.length;
+    },
     pluralLabel() {
       return apos.modules[this.field.withType].pluralLabel;
     },
@@ -90,7 +94,7 @@ export default {
       if (this.field.required && !value.length) {
         return { message: 'required' };
       }
-      if (this.field.max && this.field.max <= value.length) {
+      if (this.limitReached) {
         this.searchTerm = 'Limit reached!';
         this.disabled = true;
       } else {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSelect.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSelect.vue
@@ -11,7 +11,7 @@
         <select
           class="apos-input apos-input--select" :id="uid"
           @change="change($event.target.value)"
-          :disabled="field.disabled"
+          :disabled="field.readOnly"
         >
           <option
             v-for="choice in choices" :key="JSON.stringify(choice.value)"

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSelect.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSelect.vue
@@ -11,6 +11,7 @@
         <select
           class="apos-input apos-input--select" :id="uid"
           @change="change($event.target.value)"
+          :disabled="field.disabled"
         >
           <option
             v-for="choice in choices" :key="JSON.stringify(choice.value)"

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputString.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputString.vue
@@ -19,7 +19,8 @@
           v-model="next" :type="type"
           :placeholder="field.placeholder"
           @keydown.enter="enterEmit"
-          :disabled="field.readOnly" :required="field.required"
+          :disabled="field.readOnly || field.disabled"
+          :required="field.required"
           :id="uid" :tabindex="tabindex"
           :step="step"
         >

--- a/modules/@apostrophecms/schema/ui/apos/mixins/AposInputMixin.js
+++ b/modules/@apostrophecms/schema/ui/apos/mixins/AposInputMixin.js
@@ -76,6 +76,13 @@ export default {
         return 20;
       }
     },
+    tooltip () {
+      let msg = false;
+      if (this.field.disabled) {
+        msg = 'This field is disabled';
+      }
+      return msg;
+    },
     effectiveError () {
       return this.error || this.serverError;
     }

--- a/modules/@apostrophecms/schema/ui/apos/mixins/AposInputMixin.js
+++ b/modules/@apostrophecms/schema/ui/apos/mixins/AposInputMixin.js
@@ -79,7 +79,6 @@ export default {
     tooltip () {
       let msg = false;
       if (this.field.readOnly) {
-        // TODO For editor-facing tooltips is this the correct language?
         msg = 'This field is disabled';
       }
       return msg;

--- a/modules/@apostrophecms/schema/ui/apos/mixins/AposInputMixin.js
+++ b/modules/@apostrophecms/schema/ui/apos/mixins/AposInputMixin.js
@@ -78,7 +78,8 @@ export default {
     },
     tooltip () {
       let msg = false;
-      if (this.field.disabled) {
+      if (this.field.readOnly) {
+        // TODO For editor-facing tooltips is this the correct language?
         msg = 'This field is disabled';
       }
       return msg;

--- a/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
@@ -566,7 +566,7 @@ export default {
 
   .apos-button--inline {
     padding: 0;
-    &, &:hover, &:active, &:focus {
+    &, &[disabled], &:hover, &:active, &:focus {
       border: 0;
       background-color: transparent;
       box-shadow: none;

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCheckbox.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCheckbox.vue
@@ -1,6 +1,7 @@
 <template>
   <label
     class="apos-choice-label" :for="id"
+    :class="{'apos-choice-label--disabled': field.disabled}"
     :tabindex="{'-1' : field.hideLabel}"
   >
     <input

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCheckbox.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCheckbox.vue
@@ -1,7 +1,7 @@
 <template>
   <label
     class="apos-choice-label" :for="id"
-    :class="{'apos-choice-label--disabled': field.disabled}"
+    :class="{'apos-choice-label--disabled': field.readOnly}"
     :tabindex="{'-1' : field.hideLabel}"
   >
     <input

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -21,6 +21,7 @@
         :state="buttonState"
         ref="button"
         :disabled="disabled"
+        :tooltip="tooltip"
       />
       <template #popover class="apos-popover__slot">
         <AposContextMenuDialog
@@ -78,6 +79,10 @@ export default {
     },
     disabled: {
       type: Boolean,
+      default: false
+    },
+    tooltip: {
+      type: [ String, Boolean ],
       default: false
     }
   },

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
@@ -65,10 +65,12 @@
         <AposButton
           v-if="removable"
           @click="remove"
+          class="apos-slat__control apos-slat__control--remove"
           icon="close-icon"
           :icon-only="true"
           :modifiers="['inline']"
           label="Remove Item"
+          :disabled="disabled"
         />
       </div>
     </li>
@@ -102,6 +104,10 @@ export default {
       default: true
     },
     selected: {
+      type: Boolean,
+      default: false
+    },
+    disabled: {
       type: Boolean,
       default: false
     }
@@ -253,6 +259,7 @@ export default {
     display: flex;
     align-content: center;
     margin-right: 5px;
+    line-height: 0;
   }
 
   .apos-slat__control--remove:hover {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlatList.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlatList.vue
@@ -25,7 +25,8 @@
           :key="item._id"
           :item="item"
           :selected="selected === item._id"
-          :class="{'apos-slat-list__item--disabled' : !editable}"
+          :class="{'apos-slat-list__item--disabled' : disabled}"
+          :disabled="disabled"
           :engaged="engaged === item._id"
           :parent="listId"
           :slat-count="next.length"
@@ -53,9 +54,9 @@ export default {
       type: Array,
       required: true
     },
-    editable: {
+    disabled: {
       type: Boolean,
-      default: true
+      default: false
     },
     removable: {
       type: Boolean,
@@ -89,7 +90,7 @@ export default {
     dragOptions() {
       return {
         animation: 0,
-        disabled: !this.editable || this.next.length <= 1,
+        disabled: this.disabled || this.next.length <= 1,
         ghostClass: 'is-dragging'
       };
     }

--- a/modules/@apostrophecms/ui/ui/apos/scss/global/_inputs.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/_inputs.scss
@@ -130,9 +130,12 @@
   display: flex;
   color: var(--a-base-2);
   align-items: center;
-  &:hover {
+  &:hover:not(.apos-choice-label--disabled) {
     color: var(--a-primary-text);
     cursor: pointer;
+  }
+  &:hover.apos-choice-label--disabled {
+    cursor: not-allowed;
   }
   & + &,
   .apos-legend + & {


### PR DESCRIPTION
- `readOnly`'ify everything
- correct disabled states and slat behavior for Relationships
- Separate `disabled` from `limitReached` concepts in Attachment fields to preserve correct edit states
- provide `field` to areas so they can be disabled in editors
- Ability to disable `AposContextMenu`s from the top level props
- Provide generic `disabled` tooltip message as computed property from the inputMixin
- be able to disable `range`, `color`, `select`, `radio`
- Various style updates to slats, buttons