### PR TITLE
PRO-1008: trash is an action, with autopublish

### DIFF
--- a/modules/@apostrophecms/asset/lib/globalIcons.js
+++ b/modules/@apostrophecms/asset/lib/globalIcons.js
@@ -52,6 +52,7 @@ module.exports = {
   'redo-icon': 'RedoVariant',
   'refresh-icon': 'Refresh',
   'sign-text-icon': 'SignText',
+  'trash-can-icon': 'TrashCan',
   'tune-icon': 'Tune',
   'undo-icon': 'UndoVariant',
   'unfold-more-horizontal-icon': 'UnfoldMoreHorizontal',

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -239,7 +239,7 @@ export default {
     },
     saveLabel() {
       if (this.restoreOnly) {
-        return 'Restore from Trash';
+        return 'Restore';
       } else if (this.manuallyPublished) {
         if (this.original && this.original.lastPublishedAt) {
           return 'Publish Changes';
@@ -263,10 +263,10 @@ export default {
       return detectDocChange(this.schema, this.published, this.docFields.data);
     },
     canMoveToTrash() {
-      return !!(this.docId && (this.published || !this.manuallyPublished));
+      return !!(this.docId && (!this.restoreOnly) && (this.published || !this.manuallyPublished));
     },
     canDiscardDraft() {
-      return (this.docId && (!this.published)) || this.isModifiedFromPublished;
+      return (this.docId && (!this.published) && this.manuallyPublished) || this.isModifiedFromPublished;
     },
     hasMoreMenu() {
       return this.canMoveToTrash || (
@@ -482,7 +482,7 @@ export default {
             return;
           }
         }
-        if (andPublish) {
+        if (andPublish && !restoreOnly) {
           await this.publish(this.moduleAction, doc._id, !!doc.lastPublishedAt);
         }
         this.$emit('modal-result', doc);

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
@@ -39,6 +39,12 @@ export default {
         return false;
       }
     },
+    canMoveToTrash: {
+      type: Boolean,
+      default() {
+        return false;
+      }
+    },
     canDiscardDraft: {
       type: Boolean,
       default() {
@@ -73,6 +79,9 @@ export default {
     },
     isModifiedFromPublished() {
       this.menu = this.recomputeMenu();
+    },
+    isPublished() {
+      this.menu = this.recomputeMenu();
     }
   },
   methods: {
@@ -95,6 +104,13 @@ export default {
         //   label: 'Duplicate Document',
         //   action: 'duplicate'
         // },
+        ...(this.canMoveToTrash ? [
+          {
+            label: 'Move to Trash',
+            action: 'moveToTrash',
+            modifiers: [ 'danger' ]
+          }
+        ] : []),
         ...(this.canDiscardDraft ? [
           {
             label: this.isPublished ? 'Discard Changes' : 'Discard Draft',

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -74,13 +74,15 @@
         <AposButton
           v-if="activeMedia._id && !restoreOnly"
           @click="trash"
+          icon="trash-can-icon"
+          :icon-only="true"
           class="apos-media-editor__trash"
-          label="Move to Trash"
+          label="Trash"
         />
         <AposButton
           @click="save" class="apos-media-editor__save"
           :disabled="docFields.hasErrors"
-          :label="restoreOnly ? 'Restore from Trash' : 'Save'" type="primary"
+          :label="restoreOnly ? 'Restore' : 'Save'" type="primary"
         />
       </div>
     </AposModalLip>

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -72,6 +72,12 @@
           label="Cancel"
         />
         <AposButton
+          v-if="activeMedia._id && !restoreOnly"
+          @click="trash"
+          class="apos-media-editor__trash"
+          label="Move to Trash"
+        />
+        <AposButton
           @click="save" class="apos-media-editor__save"
           :disabled="docFields.hasErrors"
           :label="restoreOnly ? 'Restore from Trash' : 'Save'" type="primary"
@@ -205,6 +211,18 @@ export default {
           this.lockNotAvailable();
         }
       }
+    },
+    async trash() {
+      const route = `${this.moduleOptions.action}/${this.activeMedia._id}`;
+      await apos.http.patch(route, {
+        busy: true,
+        body: {
+          trash: true
+        },
+        draft: true
+        // Autopublish will take care of the published side
+      });
+      apos.bus.$emit('content-changed');
     },
     save() {
       this.triggerValidation = true;

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -213,6 +213,12 @@ export default {
       }
     },
     async trash() {
+      if (!await apos.confirm({
+        heading: 'Are You Sure?',
+        description: 'This will move the image to the trash.'
+      })) {
+        return;
+      }
       const route = `${this.moduleOptions.action}/${this.activeMedia._id}`;
       await apos.http.patch(route, {
         busy: true,
@@ -223,6 +229,7 @@ export default {
         // Autopublish will take care of the published side
       });
       apos.bus.$emit('content-changed');
+      await this.cancel();
     },
     save() {
       this.triggerValidation = true;

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -36,6 +36,8 @@ export default {
           field.readOnly = true;
         }
       }
+      // Trash UI is handled via action buttons
+      schema = schema.filter(field => field.name !== 'trash');
       return schema;
     }
   },

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -601,7 +601,7 @@ module.exports = {
       // improves the performance of saving all changes to a document at once after
       // accumulating a number of changes in patch form on the front end.
       //
-      // If `input._publish` launders to a boolean and the type is subject to draft/publish
+      // If `input._publish` launders to a truthy boolean and the type is subject to draft/publish
       // workflow, it is automatically published at the end of the patch operation.
 
       async convertPatchAndRefresh(req, input, _id) {


### PR DESCRIPTION
Moving pieces to the trash is now an action, and that action autopublishes. This fixes the loophole where it is impossible to publish the fact that you've moved something to the trash if it's just a boolean field, you don't publish on the first try, and you can't edit the trash.