### PR TITLE
PRO-19 3/UI theme plumbing

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -1,7 +1,5 @@
 <template>
-  <!-- TODO: Replace this and other hard-coded `apos-theme--primary-purple`
-  with implementation via JS based on user selection or default. -->
-  <div class="apos-admin-bar-wrapper apos-theme--primary-purple">
+  <div class="apos-admin-bar-wrapper" ref="adminBarOuter">
     <div class="apos-admin-bar-spacer" ref="spacer" />
     <nav class="apos-admin-bar" ref="adminBar">
       <div class="apos-admin-bar__row">
@@ -456,6 +454,7 @@ export default {
   },
   async mounted() {
     window.apos.adminBar.height = this.$refs.adminBar.offsetHeight;
+    window.apos.util.addClass(this.$refs.adminBarOuter, `apos-theme--primary-${window.apos.ui.theme.primary}`);
     // Listen for bus events coming from notification UI
     apos.bus.$on('revert-published-to-previous', this.onRevertPublishedToPrevious);
     apos.bus.$on('unpublish', this.onUnpublish);

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="apos-admin-bar-wrapper" ref="adminBarOuter">
+  <div class="apos-admin-bar-wrapper" :class="themeClass">
     <div class="apos-admin-bar-spacer" ref="spacer" />
     <nav class="apos-admin-bar" ref="adminBar">
       <div class="apos-admin-bar__row">
@@ -239,10 +239,11 @@ import { klona } from 'klona';
 import dayjs from 'dayjs';
 import AposPublishMixin from 'Modules/@apostrophecms/ui/mixins/AposPublishMixin';
 import AposAdvisoryLockMixin from 'Modules/@apostrophecms/ui/mixins/AposAdvisoryLockMixin';
+import AposThemeMixin from 'Modules/@apostrophecms/ui/mixins/AposThemeMixin';
 
 export default {
   name: 'TheAposAdminBar',
-  mixins: [ AposPublishMixin, AposAdvisoryLockMixin ],
+  mixins: [ AposPublishMixin, AposAdvisoryLockMixin, AposThemeMixin ],
   props: {
     items: {
       type: Array,
@@ -454,7 +455,6 @@ export default {
   },
   async mounted() {
     window.apos.adminBar.height = this.$refs.adminBar.offsetHeight;
-    window.apos.util.addClass(this.$refs.adminBarOuter, `apos-theme--primary-${window.apos.ui.theme.primary}`);
     // Listen for bus events coming from notification UI
     apos.bus.$on('revert-published-to-previous', this.onRevertPublishedToPrevious);
     apos.bus.$on('unpublish', this.onUnpublish);

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -1,5 +1,8 @@
 <template>
-  <div :data-apos-area="areaId" class="apos-area apos-theme--primary-purple">
+  <div
+    :data-apos-area="areaId" class="apos-area"
+    ref="areaEditor"
+  >
     <div
       v-if="next.length === 0 && !foreign"
       class="apos-empty-area"
@@ -172,6 +175,7 @@ export default {
     }
   },
   mounted() {
+    window.apos.util.addClass(this.$refs.areaEditor, `apos-theme--primary-${window.apos.ui.theme.primary}`);
     apos.bus.$on('area-updated', this.areaUpdatedHandler);
     apos.bus.$on('widget-hover', this.updateWidgetHovered);
     apos.bus.$on('widget-focus', this.updateWidgetFocused);

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -1,7 +1,8 @@
 <template>
   <div
-    :data-apos-area="areaId" class="apos-area"
-    ref="areaEditor"
+    :data-apos-area="areaId"
+    class="apos-area"
+    :class="themeClass"
   >
     <div
       v-if="next.length === 0 && !foreign"
@@ -57,9 +58,11 @@
 <script>
 import cuid from 'cuid';
 import { klona } from 'klona';
+import AposThemeMixin from 'Modules/@apostrophecms/ui/mixins/AposThemeMixin';
 
 export default {
   name: 'AposAreaEditor',
+  mixins: [ AposThemeMixin ],
   props: {
     docId: {
       type: String,
@@ -175,7 +178,6 @@ export default {
     }
   },
   mounted() {
-    window.apos.util.addClass(this.$refs.areaEditor, `apos-theme--primary-${window.apos.ui.theme.primary}`);
     apos.bus.$on('area-updated', this.areaUpdatedHandler);
     apos.bus.$on('widget-hover', this.updateWidgetHovered);
     apos.bus.$on('widget-focus', this.updateWidgetFocused);

--- a/modules/@apostrophecms/busy/ui/apos/components/TheAposBusy.vue
+++ b/modules/@apostrophecms/busy/ui/apos/components/TheAposBusy.vue
@@ -24,7 +24,7 @@ export default {
       if (this.busy) {
         classes.push('is-busy');
       }
-      return [].concat(classes, this.themeClass);
+      return classes.concat(this.themeClass);
     }
   },
   mounted() {

--- a/modules/@apostrophecms/busy/ui/apos/components/TheAposBusy.vue
+++ b/modules/@apostrophecms/busy/ui/apos/components/TheAposBusy.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="apos-busy apos-theme--primary-purple" :class="{'is-busy': busy}">
+  <div class="apos-busy" ref="busy" :class="{'is-busy': busy}">
     <AposSpinner class="apos-busy__spinner" />
   </div>
 </template>
@@ -14,6 +14,7 @@ export default {
     };
   },
   mounted() {
+    window.apos.util.addClass(this.$refs.busy, `apos-theme--primary-${window.apos.ui.theme.primary}`);
     apos.bus.$on('busy', state => {
       // TODO: Possibly add a check for `state.name === 'busy'` again if other
       // busy contexts are added.

--- a/modules/@apostrophecms/busy/ui/apos/components/TheAposBusy.vue
+++ b/modules/@apostrophecms/busy/ui/apos/components/TheAposBusy.vue
@@ -1,20 +1,33 @@
 <template>
-  <div class="apos-busy" ref="busy" :class="{'is-busy': busy}">
+  <div
+    class="apos-busy"
+    :class="classes"
+  >
     <AposSpinner class="apos-busy__spinner" />
   </div>
 </template>
 
 <script>
+import AposThemeMixin from 'Modules/@apostrophecms/ui/mixins/AposThemeMixin';
 export default {
   name: 'TheAposBusy',
+  mixins: [ AposThemeMixin ],
   data() {
     return {
       busy: false,
       busyCount: 0
     };
   },
+  computed: {
+    classes() {
+      const classes = [];
+      if (this.busy) {
+        classes.push('is-busy');
+      }
+      return [].concat(classes, this.themeClass);
+    }
+  },
   mounted() {
-    window.apos.util.addClass(this.$refs.busy, `apos-theme--primary-${window.apos.ui.theme.primary}`);
     apos.bus.$on('busy', state => {
       // TODO: Possibly add a check for `state.name === 'busy'` again if other
       // busy contexts are added.

--- a/modules/@apostrophecms/login/ui/apos/components/TheAposLogin.vue
+++ b/modules/@apostrophecms/login/ui/apos/components/TheAposLogin.vue
@@ -1,67 +1,67 @@
 <template>
-  <div ref="login">
-    <transition name="fade-stage">
-      <div
-        class="apos-login apos-theme-dark"
-        v-show="loaded"
-      >
-        <div class="apos-login__wrapper">
-          <transition name="fade-body">
-            <div class="apos-login__upper" v-show="loaded">
-              <div class="apos-login__header">
-                <label
-                  class="apos-login__project apos-login__project-env"
-                  :class="[`apos-login__project-env--${context.env}`]"
-                >
-                  {{ context.env }}
-                </label>
-                <label class="apos-login__project apos-login__project-name">
-                  {{ context.name }}
-                </label>
-                <label class="apos-login--error">
-                  {{ error }}
-                </label>
-              </div>
-
-              <div class="apos-login__body" v-show="loaded">
-                <form @submit.prevent="submit">
-                  <AposSchema
-                    :schema="schema"
-                    v-model="doc"
-                  />
-                  <!-- TODO -->
-                  <!-- <a href="#" class="apos-login__link">Forgot Password</a> -->
-                  <AposButton
-                    :busy="busy"
-                    :disabled="disabled"
-                    type="primary"
-                    label="Login"
-                    button-type="submit"
-                    :modifiers="['gradient-on-hover', 'block']"
-                    @click="submit"
-                  />
-                </form>
-              </div>
+  <transition name="fade-stage">
+    <div
+      class="apos-login apos-theme-dark"
+      v-show="loaded"
+      :class="themeClass"
+    >
+      <div class="apos-login__wrapper">
+        <transition name="fade-body">
+          <div class="apos-login__upper" v-show="loaded">
+            <div class="apos-login__header">
+              <label
+                class="apos-login__project apos-login__project-env"
+                :class="[`apos-login__project-env--${context.env}`]"
+              >
+                {{ context.env }}
+              </label>
+              <label class="apos-login__project apos-login__project-name">
+                {{ context.name }}
+              </label>
+              <label class="apos-login--error">
+                {{ error }}
+              </label>
             </div>
-          </transition>
-        </div>
-        <transition name="fade-footer">
-          <div class="apos-login__footer" v-show="loaded">
-            <AposLogo class="apos-login__logo" />
-            <label class="apos-login__project-version">
-              Version {{ context.version }}
-            </label>
+
+            <div class="apos-login__body" v-show="loaded">
+              <form @submit.prevent="submit">
+                <AposSchema
+                  :schema="schema"
+                  v-model="doc"
+                />
+                <!-- TODO -->
+                <!-- <a href="#" class="apos-login__link">Forgot Password</a> -->
+                <AposButton
+                  :busy="busy"
+                  :disabled="disabled"
+                  type="primary"
+                  label="Login"
+                  button-type="submit"
+                  :modifiers="['gradient-on-hover', 'block']"
+                  @click="submit"
+                />
+              </form>
+            </div>
           </div>
         </transition>
       </div>
-    </transition>
-  </div>
-
+      <transition name="fade-footer">
+        <div class="apos-login__footer" v-show="loaded">
+          <AposLogo class="apos-login__logo" />
+          <label class="apos-login__project-version">
+            Version {{ context.version }}
+          </label>
+        </div>
+      </transition>
+    </div>
+  </transition>
 </template>
 
 <script>
+import AposThemeMixin from 'Modules/@apostrophecms/ui/mixins/AposThemeMixin';
 export default {
   name: 'TheAposLogin',
+  mixins: [ AposThemeMixin ],
   data() {
     return {
       loaded: false,
@@ -117,7 +117,6 @@ export default {
   },
   mounted() {
     this.loaded = true;
-    window.apos.util.addClass(this.$refs.login, `apos-theme--primary-${window.apos.ui.theme.primary}`);
   },
   methods: {
     async submit() {

--- a/modules/@apostrophecms/login/ui/apos/components/TheAposLogin.vue
+++ b/modules/@apostrophecms/login/ui/apos/components/TheAposLogin.vue
@@ -1,59 +1,62 @@
 <template>
-  <transition name="fade-stage">
-    <div
-      class="apos-login apos-theme-dark apos-theme--primary-purple"
-      v-show="loaded"
-    >
-      <div class="apos-login__wrapper">
-        <transition name="fade-body">
-          <div class="apos-login__upper" v-show="loaded">
-            <div class="apos-login__header">
-              <label
-                class="apos-login__project apos-login__project-env"
-                :class="[`apos-login__project-env--${context.env}`]"
-              >
-                {{ context.env }}
-              </label>
-              <label class="apos-login__project apos-login__project-name">
-                {{ context.name }}
-              </label>
-              <label class="apos-login--error">
-                {{ error }}
-              </label>
-            </div>
+  <div ref="login">
+    <transition name="fade-stage">
+      <div
+        class="apos-login apos-theme-dark"
+        v-show="loaded"
+      >
+        <div class="apos-login__wrapper">
+          <transition name="fade-body">
+            <div class="apos-login__upper" v-show="loaded">
+              <div class="apos-login__header">
+                <label
+                  class="apos-login__project apos-login__project-env"
+                  :class="[`apos-login__project-env--${context.env}`]"
+                >
+                  {{ context.env }}
+                </label>
+                <label class="apos-login__project apos-login__project-name">
+                  {{ context.name }}
+                </label>
+                <label class="apos-login--error">
+                  {{ error }}
+                </label>
+              </div>
 
-            <div class="apos-login__body" v-show="loaded">
-              <form @submit.prevent="submit">
-                <AposSchema
-                  :schema="schema"
-                  v-model="doc"
-                />
-                <!-- TODO -->
-                <!-- <a href="#" class="apos-login__link">Forgot Password</a> -->
-                <AposButton
-                  :busy="busy"
-                  :disabled="disabled"
-                  type="primary"
-                  label="Login"
-                  button-type="submit"
-                  :modifiers="['gradient-on-hover', 'block']"
-                  @click="submit"
-                />
-              </form>
+              <div class="apos-login__body" v-show="loaded">
+                <form @submit.prevent="submit">
+                  <AposSchema
+                    :schema="schema"
+                    v-model="doc"
+                  />
+                  <!-- TODO -->
+                  <!-- <a href="#" class="apos-login__link">Forgot Password</a> -->
+                  <AposButton
+                    :busy="busy"
+                    :disabled="disabled"
+                    type="primary"
+                    label="Login"
+                    button-type="submit"
+                    :modifiers="['gradient-on-hover', 'block']"
+                    @click="submit"
+                  />
+                </form>
+              </div>
             </div>
+          </transition>
+        </div>
+        <transition name="fade-footer">
+          <div class="apos-login__footer" v-show="loaded">
+            <AposLogo class="apos-login__logo" />
+            <label class="apos-login__project-version">
+              Version {{ context.version }}
+            </label>
           </div>
         </transition>
       </div>
-      <transition name="fade-footer">
-        <div class="apos-login__footer" v-show="loaded">
-          <AposLogo class="apos-login__logo" />
-          <label class="apos-login__project-version">
-            Version {{ context.version }}
-          </label>
-        </div>
-      </transition>
-    </div>
-  </transition>
+    </transition>
+  </div>
+
 </template>
 
 <script>
@@ -114,6 +117,7 @@ export default {
   },
   mounted() {
     this.loaded = true;
+    window.apos.util.addClass(this.$refs.login, `apos-theme--primary-${window.apos.ui.theme.primary}`);
   },
   methods: {
     async submit() {

--- a/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="apos-modals" class="apos-theme--primary-purple">
+  <div id="apos-modals" ref="modals">
     <component
       v-for="modal in stack" :key="modal.id"
       :is="modal.componentName"
@@ -27,6 +27,7 @@ export default {
     };
   },
   mounted() {
+    window.apos.util.addClass(this.$refs.modals, `apos-theme--primary-${window.apos.ui.theme.primary}`);
     // Open one of the server-side configured top level admin bar menus by name.
     // To allow for injecting additional props dynamically, if itemName is an
     // object, it must have an itemName property and a props property. The props

--- a/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="apos-modals" ref="modals">
+  <div id="apos-modals" :class="themeClass">
     <component
       v-for="modal in stack" :key="modal.id"
       :is="modal.componentName"
@@ -12,9 +12,10 @@
 
 <script>
 import cuid from 'cuid';
-
+import AposThemeMixin from 'Modules/@apostrophecms/ui/mixins/AposThemeMixin';
 export default {
   name: 'TheAposModals',
+  mixins: [ AposThemeMixin ],
   props: {
     modals: {
       type: Array,
@@ -27,7 +28,6 @@ export default {
     };
   },
   mounted() {
-    window.apos.util.addClass(this.$refs.modals, `apos-theme--primary-${window.apos.ui.theme.primary}`);
     // Open one of the server-side configured top level admin bar menus by name.
     // To allow for injecting additional props dynamically, if itemName is an
     // object, it must have an itemName property and a props property. The props

--- a/modules/@apostrophecms/notification/ui/apos/components/TheAposNotifications.vue
+++ b/modules/@apostrophecms/notification/ui/apos/components/TheAposNotifications.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="apos-notifications" ref="notifications">
+  <div class="apos-notifications" :class="themeClass">
     <AposNotification
       v-for="notification in notifications"
       :key="notification._id"
@@ -14,8 +14,10 @@
 </template>
 
 <script>
+import AposThemeMixin from 'Modules/@apostrophecms/ui/mixins/AposThemeMixin';
 export default {
   name: 'TheAposNotifications',
+  mixins: [ AposThemeMixin ],
   data () {
     return {
       notifications: [],
@@ -23,7 +25,6 @@ export default {
     };
   },
   async mounted() {
-    window.apos.util.addClass(this.$refs.notifications, `apos-theme--primary-${window.apos.ui.theme.primary}`);
     apos.notify = async function(message, options) {
       const strings = [];
       let i = 1;

--- a/modules/@apostrophecms/notification/ui/apos/components/TheAposNotifications.vue
+++ b/modules/@apostrophecms/notification/ui/apos/components/TheAposNotifications.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="apos-notifications apos-theme--primary-purple">
+  <div class="apos-notifications" ref="notifications">
     <AposNotification
       v-for="notification in notifications"
       :key="notification._id"
@@ -23,6 +23,7 @@ export default {
     };
   },
   async mounted() {
+    window.apos.util.addClass(this.$refs.notifications, `apos-theme--primary-${window.apos.ui.theme.primary}`);
     apos.notify = async function(message, options) {
       const strings = [];
       let i = 1;

--- a/modules/@apostrophecms/ui/index.js
+++ b/modules/@apostrophecms/ui/index.js
@@ -1,6 +1,28 @@
 module.exports = {
+  options: {
+    alias: 'ui'
+  },
   icons: {
     'earth-icon': 'Earth',
     'database-check-icon': 'DatabaseCheck'
+  },
+  init(self) {
+    self.enableBrowserData();
+  },
+  methods(self) {
+    return {
+      getBrowserData(req) {
+        const theme = {
+          primary: 'default'
+        };
+        if (req.data.global && req.data.global.aposThemePrimary) {
+          theme.primary = req.data.global.aposThemePrimary;
+        }
+        if (req.data.user && req.data.user.aposThemePrimary) {
+          theme.primary = req.data.user.aposThemePrimary;
+        }
+        return { theme };
+      }
+    };
   }
 };

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -40,12 +40,14 @@
 import {
   VPopover
 } from 'v-tooltip';
+import AposThemeMixin from 'Modules/@apostrophecms/ui/mixins/AposThemeMixin';
 
 export default {
   name: 'AposContextMenu',
   components: {
     'v-popover': VPopover
   },
+  mixins: [ AposThemeMixin ],
   props: {
     menu: {
       type: Array,
@@ -86,11 +88,13 @@ export default {
     return {
       isOpen: false,
       position: '',
-      event: null,
-      popoverClass: `apos-popover apos-theme--primary-${window.apos.ui.theme.primary}`
+      event: null
     };
   },
   computed: {
+    popoverClass() {
+      return [ 'apos-popover' ].concat(this.themeClass);
+    },
     classList() {
       const classes = [];
       const baseClass = 'apos-context-menu__popup';

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -9,7 +9,7 @@
       :placement="menuPlacement"
       :open="isOpen"
       :delay="{ show: 0, hide: 0 }"
-      popover-class="apos-popover"
+      :popover-class="popoverClass"
       popover-wrapper-class="apos-popover__wrapper"
       popover-inner-class="apos-popover__inner"
     >
@@ -86,7 +86,8 @@ export default {
     return {
       isOpen: false,
       position: '',
-      event: null
+      event: null,
+      popoverClass: `apos-popover apos-theme--primary-${window.apos.ui.theme.primary}`
     };
   },
   computed: {
@@ -107,7 +108,6 @@ export default {
     buttonState() {
       return this.open ? [ 'active' ] : null;
     }
-
   },
   watch: {
     isOpen(newVal, oldVal) {

--- a/modules/@apostrophecms/ui/ui/apos/mixins/AposThemeMixin.js
+++ b/modules/@apostrophecms/ui/ui/apos/mixins/AposThemeMixin.js
@@ -1,0 +1,11 @@
+// Provides computed classes for decorating top-level Apos vue apps with a UI theme
+
+export default {
+  computed: {
+    themeClass() {
+      const classes = [];
+      classes.push(`apos-theme--primary-${window.apos.ui.theme.primary}`);
+      return classes;
+    }
+  }
+};

--- a/modules/@apostrophecms/ui/ui/apos/scss/global/_theme.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/_theme.scss
@@ -5,11 +5,6 @@
   --a-warning: #ffce00;
   --a-progress-bg: #2c354d;
 
-  .apos-theme--primary-purple {
-    @include apos-primary-mixin(#6516dd);
-    --a-secondary: #e65100;
-  }
-
   --a-danger-button-hover: #c00717;
   --a-danger-button-active: #a10000;
   --a-danger-button-disabled: #ff9d98;
@@ -104,23 +99,23 @@
   --a-text-primary: #fff;
   --a-text-inverted: #000;
 }
-
+.apos-theme--primary-default {
+  @include apos-primary-mixin(#6516dd);
+  --a-secondary: #e65100;
+}
 .apos-theme--primary-blue {
   @include apos-primary-mixin(#0062ff);
-}
-.apos-theme--primary-purple {
-  @include apos-primary-mixin(rgb(2, 2, 2));
 }
 .apos-theme--primary-orange {
   @include apos-primary-mixin(#e65100);
 }
-.apos-theme--primary-light-blue {
+.apos-theme--primary-aqua {
   @include apos-primary-mixin(#1eacc7);
 }
 .apos-theme--primary-sun {
   @include apos-primary-mixin(#f7a704);
 }
-.apos-theme--primary-money {
+.apos-theme--primary-green {
   @include apos-primary-mixin(#00b075);
 }
 .apos-theme--primary-pink {


### PR DESCRIPTION
This PR goes beyond the [scope of the ticket](https://linear.app/apostrophecms/issue/PRO-19/trash-filter-missing-radio-button-for-the-active-state)

- tees up a theme object that might contain various UI preferences by cascading through user and global preferences
- pushes it to the browser's `apos` object
- top level apos vue apps apply it to there wrapper, replacing the hardcoded version
- ✅ context menus now apply the theme, which solves the original bug of missing UI from the ticket

requesting review from both @abea and @boutell for their perspectives