### PR TITLE
PRO-1053 infinite loop warning editing page titles

### DIFF
--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -169,6 +169,7 @@ export default {
       }
     },
     moduleOptions() {
+      console.log('in moduleOptions with ' + this.docType);
       return window.apos.modules[this.docType] || {};
     },
     moduleAction () {
@@ -265,15 +266,13 @@ export default {
     }
   },
   watch: {
-    'docFields.data': {
-      deep: true,
+    'docFields.data.type': {
       handler(newVal, oldVal) {
-        if (this.moduleName !== '@apostrophecms/page' || this.splittingDoc) {
+        if (this.moduleName !== '@apostrophecms/page') {
           return;
         }
-
-        if (this.docType !== newVal.type) {
-          this.docType = newVal.type;
+        if (this.docType !== newVal) {
+          this.docType = newVal;
           this.prepErrors();
         }
       }
@@ -281,7 +280,7 @@ export default {
 
     tabs() {
       if ((!this.currentTab) || (!this.tabs.find(tab => tab.name === this.currentTab))) {
-        this.currentTab = this.tabs[0].name;
+        this.currentTab = this.tabs[0] && this.tabs[0].name;
       }
     }
 

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -169,7 +169,6 @@ export default {
       }
     },
     moduleOptions() {
-      console.log('in moduleOptions with ' + this.docType);
       return window.apos.modules[this.docType] || {};
     },
     moduleAction () {

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -29,6 +29,8 @@ export default {
 
   computed: {
     schema() {
+      console.log(this.docType);
+      console.log('>>', JSON.stringify(this.moduleOptions, null, '  '));
       let schema = (this.moduleOptions.schema || []).filter(field => apos.schema.components.fields[field.type]);
       if (this.restoreOnly) {
         schema = klona(schema);

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -29,8 +29,6 @@ export default {
 
   computed: {
     schema() {
-      console.log(this.docType);
-      console.log('>>', JSON.stringify(this.moduleOptions, null, '  '));
       let schema = (this.moduleOptions.schema || []).filter(field => apos.schema.components.fields[field.type]);
       if (this.restoreOnly) {
         schema = klona(schema);

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
@@ -85,9 +85,14 @@ export default {
         if (this.compatible(oldValue, this.next)) {
           // If this is a page slug, we only replace the last section of the slug.
           if (this.field.page) {
-            const parts = this.next.match(/[^/]+/g);
-            parts.pop();
-            this.next = `/${parts.join('/')}${this.slugify(newValue)}`;
+            let parts = this.next.split('/');
+            parts = parts.filter(part => part.length > 0);
+            if (parts.length) {
+              // Remove last path component so we can replace it
+              parts.pop();
+            }
+            parts.push(this.slugify(newValue, { componentOnly: true }));
+            this.next = '/' + parts.join('/');
           } else {
             this.next = this.slugify(newValue);
           }
@@ -146,9 +151,12 @@ export default {
       }
       return ((title === '') && (slug === `${this.prefix}none`)) || this.slugify(title) === this.slugify(slug);
     },
-    slugify(s) {
+    // if componentOnly is true, we are slugifying just one component of
+    // a slug as part of following the title field, and so we do *not*
+    // want to allow slashes (when editing a page) or set a prefix.
+    slugify(s, { componentOnly = false } = {}) {
       const options = {};
-      if (this.field.page) {
+      if (this.field.page && (!componentOnly)) {
         options.allow = '/';
       }
       let preserveSlash = false;
@@ -162,7 +170,7 @@ export default {
       if (preserveSlash) {
         s += '-';
       }
-      if (this.field.page) {
+      if (this.field.page && (!componentOnly)) {
         if (!s.charAt(0) !== '/') {
           s = `/${s}`;
         }
@@ -174,13 +182,15 @@ export default {
       if (!s.length) {
         s = 'none';
       }
-      if (!s.startsWith(this.prefix)) {
-        if (this.prefix.startsWith(s)) {
-          // If they delete the `-`, and the prefix is `recipe-`,
-          // we want to restore `recipe-`, not set it to `recipe-recipe`
-          s = this.prefix;
-        } else {
-          s = this.prefix + s;
+      if (!componentOnly) {
+        if (!s.startsWith(this.prefix)) {
+          if (this.prefix.startsWith(s)) {
+            // If they delete the `-`, and the prefix is `recipe-`,
+            // we want to restore `recipe-`, not set it to `recipe-recipe`
+            s = this.prefix;
+          } else {
+            s = this.prefix + s;
+          }
         }
       }
       return s;

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
@@ -92,7 +92,7 @@ export default {
               parts.pop();
             }
             parts.push(this.slugify(newValue, { componentOnly: true }));
-            this.next = '/' + parts.join('/');
+            this.next = `/${parts.join('/')}`;
           } else {
             this.next = this.slugify(newValue);
           }
@@ -156,7 +156,7 @@ export default {
     // want to allow slashes (when editing a page) or set a prefix.
     slugify(s, { componentOnly = false } = {}) {
       const options = {};
-      if (this.field.page && (!componentOnly)) {
+      if (this.field.page && !componentOnly) {
         options.allow = '/';
       }
       let preserveSlash = false;
@@ -170,7 +170,7 @@ export default {
       if (preserveSlash) {
         s += '-';
       }
-      if (this.field.page && (!componentOnly)) {
+      if (this.field.page && !componentOnly) {
         if (!s.charAt(0) !== '/') {
           s = `/${s}`;
         }


### PR DESCRIPTION
fixed the infinite loop warning / performance hit when editing page titles. Had to do with slugifying the final component correctly when the slug is following the title.