### PR TITLE
PRO-986 fix overflowing imgs in schemas

### DIFF
--- a/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
@@ -245,6 +245,11 @@ export default {
   .apos-schema /deep/ .apos-field__wrapper {
     max-width: $input-max-width;
   }
+
+  .apos-schema /deep/ img {
+    max-width: 100%;
+  }
+
   .apos-field {
     .apos-schema /deep/ & {
       margin-bottom: $spacing-triple;


### PR DESCRIPTION
https://linear.app/apostrophecms/issue/PRO-986/multisite-logo-image-still-doesnt-show-up-in-modal

![image](https://user-images.githubusercontent.com/1889830/111685436-4be9f980-87fe-11eb-8245-8ac744aa446a.png)

Trying to take a light touch on this ..
Our stock image widget has no CSS, no classes forced in the markup. I assume we still like this.
This forces `img` tags to have a max-width of 100% only while in schemas.