### PR TITLE
PRO-1075 3/tab id replaces html page id

### DIFF
--- a/modules/@apostrophecms/admin-bar/index.js
+++ b/modules/@apostrophecms/admin-bar/index.js
@@ -277,7 +277,7 @@ module.exports = {
           contextBar: context && self.apos.doc.getManager(context.type).options.contextBar,
           // Simplifies frontend logic
           contextId: context && context._id,
-          htmlPageId: cuid(),
+          tabId: cuid(),
           contextEditorName,
           pageTree: self.options.pageTree
         };

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -525,7 +525,7 @@ export default {
       this.refresh();
     });
 
-    // sessionStorage because it is deliberately tab-specific
+    // sessionStorage because it is deliberately browser-tab specific
     let tabId = sessionStorage.getItem('aposTabId');
     if (!tabId) {
       tabId = cuid();

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -237,6 +237,7 @@
 <script>
 import { klona } from 'klona';
 import dayjs from 'dayjs';
+import cuid from 'cuid';
 import AposPublishMixin from 'Modules/@apostrophecms/ui/mixins/AposPublishMixin';
 import AposAdvisoryLockMixin from 'Modules/@apostrophecms/ui/mixins/AposAdvisoryLockMixin';
 import AposThemeMixin from 'Modules/@apostrophecms/ui/mixins/AposThemeMixin';
@@ -523,6 +524,14 @@ export default {
     apos.bus.$on('content-changed', async () => {
       this.refresh();
     });
+
+    // sessionStorage because it is deliberately tab-specific
+    let tabId = sessionStorage.getItem('aposTabId');
+    if (!tabId) {
+      tabId = cuid();
+      sessionStorage.setItem('aposTabId', tabId);
+    }
+    window.apos.adminBar.tabId = tabId;
 
     if (this.editMode) {
       // Watch out for legacy situations where edit mode is active

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -679,9 +679,9 @@ module.exports = {
       getManager(type) {
         return self.managers[type];
       },
-      // Lock the given doc to a given `htmlPageId`, such
+      // Lock the given doc to a given `tabId`, such
       // that other calls to `apos.doc.lock` for that doc id will
-      // fail unless they have the same `htmlPageId`. If
+      // fail unless they have the same `tabId`. If
       // `options.force` is true, any existing lock is
       // overwritten. The `options` argument may be
       // omitted entirely.
@@ -696,7 +696,7 @@ module.exports = {
       // by someone else. Other errors are thrown as appropriate.
       //
       // If you need to refresh a lock in order to avoid
-      // expiration, just lock it again. As long as the htmlPageId
+      // expiration, just lock it again. As long as the tabId
       // is the same as the current lock holder you will receive
       // another successful response.
       //
@@ -705,7 +705,7 @@ module.exports = {
       // that you pass to it. This ensures it is present if you
       // follow this call up with an `update()` of the document.
 
-      async lock(req, doc, htmlPageId, options) {
+      async lock(req, doc, tabId, options) {
         if (!options) {
           options = {};
         }
@@ -718,8 +718,8 @@ module.exports = {
           throw self.apos.error('invalid', 'No doc was passed');
         }
         const _id = doc._id;
-        if (!htmlPageId) {
-          throw self.apos.error('invalid', 'no htmlPageId was passed');
+        if (!tabId) {
+          throw self.apos.error('invalid', 'no tabId was passed');
         }
         let criteria = { _id };
         if (!options.force) {
@@ -735,7 +735,7 @@ module.exports = {
               }
             },
             {
-              'advisoryLock._id': htmlPageId
+              'advisoryLock._id': tabId
             }
           ];
         }
@@ -750,7 +750,7 @@ module.exports = {
         doc.advisoryLock = {
           username: req.user && req.user.username,
           title: req.user && req.user.title,
-          _id: htmlPageId,
+          _id: tabId,
           updatedAt: new Date()
         };
         const result = await self.db.updateOne(criteria, {
@@ -795,14 +795,14 @@ module.exports = {
       getAdvisoryLockExpiration() {
         return new Date(Date.now() - 1000 * self.options.advisoryLockTimeout);
       },
-      // Release a document lock set via `lock` for a particular htmlPageId.
+      // Release a document lock set via `lock` for a particular tabId.
       // If the lock is already gone no error occurs.
       //
       // This method will unset the `advisoryLock` property of the
       // document both in the database and in the `doc` object
       // that you pass to it. This ensures it is present if you
       // follow this call up with an `update()` of the document.
-      async unlock(req, doc, htmlPageId) {
+      async unlock(req, doc, tabId) {
         if (!(req && req.res)) {
           // Use 'error' because this is always a code bug, not a bad
           // HTTP request, and the message should not be disclosed to the client
@@ -812,12 +812,12 @@ module.exports = {
         if (!id) {
           throw self.apos.error('invalid', 'no doc');
         }
-        if (!htmlPageId) {
-          throw self.apos.error('invalid', 'no htmlPageId');
+        if (!tabId) {
+          throw self.apos.error('invalid', 'no tabId');
         }
         await self.db.updateOne({
           _id: id,
-          'advisoryLock._id': htmlPageId
+          'advisoryLock._id': tabId
         }, {
           $unset: {
             advisoryLock: 1

--- a/modules/@apostrophecms/express/index.js
+++ b/modules/@apostrophecms/express/index.js
@@ -320,21 +320,6 @@ module.exports = {
       absoluteUrl(req, res, next) {
         self.addAbsoluteUrlsToReq(req);
         next();
-      },
-      // Makes the `@apostrophecms/Html-Page-Id` header available
-      // as `req.htmlPageId`. This header is passed by
-      // all jQuery AJAX requests made by Apostrophe. It
-      // contains a unique identifier just for the current
-      // webpage in the browser; that is, navigating to a new
-      // page always generates a *new* id, the same page in two tabs
-      // will have *different* ids, etc. This makes it easy to
-      // identify requests that come from the "same place"
-      // for purposes of conflict resolution and locking.
-      // (Note that conflicts can occur between two tabs
-      // belonging to the same user, so a session ID is not enough.)
-      htmlPageId(req, res, next) {
-        req.htmlPageId = req.header('@apostrophecms/Html-Page-Id');
-        next();
       }
     };
   },

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -269,11 +269,11 @@ module.exports = {
       //
       // This call is atomic with respect to other REST write operations on pages.
       //
-      // If `_advisoryLock: { htmlPageId: 'xyz', lock: true }` is passed, the operation will begin by obtaining an advisory
+      // If `_advisoryLock: { tabId: 'xyz', lock: true }` is passed, the operation will begin by obtaining an advisory
       // lock on the document for the given context id, and no other items in the patch will be addressed
       // unless that succeeds. The client must then refresh the lock frequently (by default, at least
       // every 30 seconds) with repeated PATCH requests of the `_advisoryLock` property with the same
-      // context id. If `_advisoryLock: { htmlPageId: 'xyz', lock: false }` is passed, the advisory lock will be
+      // context id. If `_advisoryLock: { tabId: 'xyz', lock: false }` is passed, the advisory lock will be
       // released *after* addressing other items in the same patch. If `force: true` is added to
       // the `_advisoryLock` object it will always remove any competing advisory lock.
       //
@@ -296,16 +296,16 @@ module.exports = {
           if (!manager) {
             throw self.apos.error('invalid');
           }
-          let htmlPageId = null;
+          let tabId = null;
           let lock = false;
           let force = false;
           if (input._advisoryLock && ((typeof input._advisoryLock) === 'object')) {
-            htmlPageId = self.apos.launder.string(input._advisoryLock.htmlPageId);
+            tabId = self.apos.launder.string(input._advisoryLock.tabId);
             lock = self.apos.launder.boolean(input._advisoryLock.lock);
             force = self.apos.launder.boolean(input._advisoryLock.force);
           }
-          if (htmlPageId && lock) {
-            await self.apos.doc.lock(req, page, htmlPageId, {
+          if (tabId && lock) {
+            await self.apos.doc.lock(req, page, tabId, {
               force
             });
           }
@@ -317,8 +317,8 @@ module.exports = {
             const position = self.apos.launder.string(input._position);
             await self.move(req, page._id, targetId, position);
           }
-          if (htmlPageId && !lock) {
-            await self.apos.doc.unlock(req, page, htmlPageId);
+          if (tabId && !lock) {
+            await self.apos.doc.unlock(req, page, tabId);
           }
           return self.findOneForEditing(req, { _id: page._id }, { attachments: true });
         });
@@ -570,11 +570,11 @@ database.`);
       // However if you plan to submit many patches over a period of time while editing you may also
       // want to use the advisory lock mechanism.
       //
-      // If `_advisoryLock: { htmlPageId: 'xyz', lock: true }` is passed, the operation will begin by obtaining an advisory
+      // If `_advisoryLock: { tabId: 'xyz', lock: true }` is passed, the operation will begin by obtaining an advisory
       // lock on the document for the given context id, and no other items in the patch will be addressed
       // unless that succeeds. The client must then refresh the lock frequently (by default, at least
       // every 30 seconds) with repeated PATCH requests of the `_advisoryLock` property with the same
-      // context id. If `_advisoryLock: { htmlPageId: 'xyz', lock: false }` is passed, the advisory lock will be
+      // context id. If `_advisoryLock: { tabId: 'xyz', lock: false }` is passed, the advisory lock will be
       // released *after* addressing other items in the same patch. If `force: true` is added to
       // the `_advisoryLock` object it will always remove any competing advisory lock.
       //
@@ -604,16 +604,16 @@ database.`);
           // Conventional for loop so we can handle the last one specially
           for (let i = 0; (i < patches.length); i++) {
             const input = patches[i];
-            let htmlPageId = null;
+            let tabId = null;
             let lock = false;
             let force;
             if (input._advisoryLock && ((typeof input._advisoryLock) === 'object')) {
-              htmlPageId = self.apos.launder.string(input._advisoryLock.htmlPageId);
+              tabId = self.apos.launder.string(input._advisoryLock.tabId);
               lock = self.apos.launder.boolean(input._advisoryLock.lock);
               force = self.apos.launder.boolean(input._advisoryLock.force);
             }
-            if (htmlPageId && lock) {
-              await self.apos.doc.lock(req, page, htmlPageId, {
+            if (tabId && lock) {
+              await self.apos.doc.lock(req, page, tabId, {
                 force
               });
             }
@@ -628,8 +628,8 @@ database.`);
               }
               result = self.findOneForEditing(req, { _id }, { attachments: true });
             }
-            if (htmlPageId && !lock) {
-              await self.apos.doc.unlock(req, page, htmlPageId);
+            if (tabId && !lock) {
+              await self.apos.doc.unlock(req, page, tabId);
             }
           }
           if (!result) {

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -533,11 +533,11 @@ module.exports = {
       // For partial updates use convertPatchAndRefresh. Employs a lock to avoid overwriting the work of
       // concurrent PUT and PATCH calls or getting into race conditions with their side effects.
       //
-      // If `_advisoryLock: { htmlPageId: 'xyz', lock: true }` is passed, the operation will begin by obtaining an advisory
+      // If `_advisoryLock: { tabId: 'xyz', lock: true }` is passed, the operation will begin by obtaining an advisory
       // lock on the document for the given context id, and no other items in the patch will be addressed
       // unless that succeeds. The client must then refresh the lock frequently (by default, at least
       // every 30 seconds) with repeated PATCH requests of the `_advisoryLock` property with the same
-      // context id. If `_advisoryLock: { htmlPageId: 'xyz', lock: false }` is passed, the advisory lock will be
+      // context id. If `_advisoryLock: { tabId: 'xyz', lock: false }` is passed, the advisory lock will be
       // released *after* addressing other items in the same patch. If `force: true` is added to
       // the `_advisoryLock` object it will always remove any competing advisory lock.
       //
@@ -553,24 +553,24 @@ module.exports = {
           if (!piece._edit) {
             throw self.apos.error('forbidden');
           }
-          let htmlPageId = null;
+          let tabId = null;
           let lock = false;
           let force = false;
           if (input._advisoryLock && ((typeof input._advisoryLock) === 'object')) {
-            htmlPageId = self.apos.launder.string(input._advisoryLock.htmlPageId);
+            tabId = self.apos.launder.string(input._advisoryLock.tabId);
             lock = self.apos.launder.boolean(input._advisoryLock.lock);
             force = self.apos.launder.boolean(input._advisoryLock.force);
           }
-          if (htmlPageId && lock) {
-            await self.apos.doc.lock(req, piece, htmlPageId, {
+          if (tabId && lock) {
+            await self.apos.doc.lock(req, piece, tabId, {
               force
             });
           }
           await self.convert(req, input, piece);
           await self.emit('afterConvert', req, input, piece);
           await self.update(req, piece);
-          if (htmlPageId && !lock) {
-            await self.apos.doc.unlock(req, piece, htmlPageId);
+          if (tabId && !lock) {
+            await self.apos.doc.unlock(req, piece, tabId);
           }
           return self.findOneForEditing(req, { _id }, { attachments: true });
         });
@@ -583,11 +583,11 @@ module.exports = {
       // However if you plan to submit many patches over a period of time while editing you may also
       // want to use the advisory lock mechanism.
       //
-      // If `_advisoryLock: { htmlPageId: 'xyz', lock: true }` is passed, the operation will begin by obtaining an advisory
+      // If `_advisoryLock: { tabId: 'xyz', lock: true }` is passed, the operation will begin by obtaining an advisory
       // lock on the document for the given context id, and no other items in the patch will be addressed
       // unless that succeeds. The client must then refresh the lock frequently (by default, at least
       // every 30 seconds) with repeated PATCH requests of the `_advisoryLock` property with the same
-      // context id. If `_advisoryLock: { htmlPageId: 'xyz', lock: false }` is passed, the advisory lock will be
+      // context id. If `_advisoryLock: { tabId: 'xyz', lock: false }` is passed, the advisory lock will be
       // released *after* addressing other items in the same patch. If `force: true` is added to
       // the `_advisoryLock` object it will always remove any competing advisory lock.
       //
@@ -614,16 +614,16 @@ module.exports = {
           // Conventional for loop so we can handle the last one specially
           for (let i = 0; (i < patches.length); i++) {
             const input = patches[i];
-            let htmlPageId = null;
+            let tabId = null;
             let lock = false;
             let force = false;
             if (input._advisoryLock && ((typeof input._advisoryLock) === 'object')) {
-              htmlPageId = self.apos.launder.string(input._advisoryLock.htmlPageId);
+              tabId = self.apos.launder.string(input._advisoryLock.tabId);
               lock = self.apos.launder.boolean(input._advisoryLock.lock);
               force = self.apos.launder.boolean(input._advisoryLock.force);
             }
-            if (htmlPageId && lock) {
-              await self.apos.doc.lock(req, piece, htmlPageId, {
+            if (tabId && lock) {
+              await self.apos.doc.lock(req, piece, tabId, {
                 force
               });
             }
@@ -634,8 +634,8 @@ module.exports = {
               await self.update(req, piece);
               result = self.findOneForEditing(req, { _id }, { attachments: true });
             }
-            if (htmlPageId && !lock) {
-              await self.apos.doc.unlock(req, piece, htmlPageId);
+            if (tabId && !lock) {
+              await self.apos.doc.unlock(req, piece, tabId);
             }
           }
           if (!result) {

--- a/modules/@apostrophecms/template/index.js
+++ b/modules/@apostrophecms/template/index.js
@@ -604,7 +604,7 @@ module.exports = {
           locale: req.locale,
           mode: req.mode,
           csrfCookieName: self.apos.csrfCookieName,
-          htmlPageId: self.apos.util.generateId(),
+          tabId: self.apos.util.generateId(),
           scene
         };
         if (req.user) {

--- a/modules/@apostrophecms/ui/ui/apos/mixins/AposAdvisoryLockMixin.js
+++ b/modules/@apostrophecms/ui/ui/apos/mixins/AposAdvisoryLockMixin.js
@@ -34,7 +34,7 @@ export default {
         await apos.http.patch(lockApiUrl, {
           body: {
             _advisoryLock: {
-              htmlPageId: apos.adminBar.htmlPageId,
+              tabId: apos.adminBar.tabId,
               lock: true
             }
           },
@@ -52,17 +52,16 @@ export default {
           // in edit mode. However, in the rare case where the "other tab"
           // getting its lock busted really is another tab, we do notify
           // the user there.
-          if (e.body.data.me ||
-            await apos.confirm({
-              heading: 'Another User Is Editing',
-              description: `${e.body.data.title} is editing that document. Do you want to take control?`
-            })
-          ) {
+          if (await apos.confirm({
+            heading: e.body.data.me ? 'Editing in Another Tab or Window' : 'Another User Is Editing',
+            description: e.body.data.me ? 'You are editing that document in another tab or window. Do you want to take control in this tab?'
+              : `${e.body.data.title} is editing that document. Do you want to take control?`
+          })) {
             try {
               await apos.http.patch(this.lockApiUrl, {
                 body: {
                   _advisoryLock: {
-                    htmlPageId: apos.adminBar.htmlPageId,
+                    tabId: apos.adminBar.tabId,
                     lock: true,
                     force: true
                   }
@@ -114,7 +113,7 @@ export default {
     // method you already wrote.
     addLockToRequest(body) {
       body._advisoryLock = {
-        htmlPageId: apos.adminBar.htmlPageId,
+        tabId: apos.adminBar.tabId,
         lock: true
       };
     },
@@ -137,7 +136,7 @@ export default {
           await apos.http.patch(this.lockApiUrl, {
             body: {
               _advisoryLock: {
-                htmlPageId: apos.adminBar.htmlPageId,
+                tabId: apos.adminBar.tabId,
                 lock: false
               }
             },
@@ -163,7 +162,7 @@ export default {
           await apos.http.patch(this.lockApiUrl, {
             body: {
               _advisoryLock: {
-                htmlPageId: apos.adminBar.htmlPageId,
+                tabId: apos.adminBar.tabId,
                 lock: true
               }
             },

--- a/test/docs.js
+++ b/test/docs.js
@@ -545,7 +545,7 @@ describe('Docs', function() {
     }
   });
 
-  it('should not be able to lock a document with a different htmlPageId', async function() {
+  it('should not be able to lock a document with a different tabId', async function() {
     const req = apos.task.getReq();
     const doc = await apos.doc.db.findOne({ _id: 'i27:en:published' });
 
@@ -557,7 +557,7 @@ describe('Docs', function() {
     }
   });
 
-  it('should be able to refresh the lock with the same htmlPageId', async function() {
+  it('should be able to refresh the lock with the same tabId', async function() {
     const req = apos.task.getReq();
     const doc = await apos.doc.db.findOne({ _id: 'i27:en:published' });
 

--- a/test/pages-rest.js
+++ b/test/pages-rest.js
@@ -1410,7 +1410,7 @@ describe('Pages REST', function() {
       jar,
       body: {
         _advisoryLock: {
-          htmlPageId: 'xyz',
+          tabId: 'xyz',
           lock: true
         },
         title: 'Advisory Test Patched'
@@ -1425,7 +1425,7 @@ describe('Pages REST', function() {
         jar,
         body: {
           _advisoryLock: {
-            htmlPageId: 'pdq',
+            tabId: 'pdq',
             lock: true
           }
         }
@@ -1443,7 +1443,7 @@ describe('Pages REST', function() {
       jar,
       body: {
         _advisoryLock: {
-          htmlPageId: 'pdq',
+          tabId: 'pdq',
           lock: true,
           force: true
         }
@@ -1456,7 +1456,7 @@ describe('Pages REST', function() {
       jar,
       body: {
         _advisoryLock: {
-          htmlPageId: 'pdq',
+          tabId: 'pdq',
           lock: true
         }
       }
@@ -1468,7 +1468,7 @@ describe('Pages REST', function() {
       jar,
       body: {
         _advisoryLock: {
-          htmlPageId: 'pdq',
+          tabId: 'pdq',
           lock: false
         },
         title: 'Advisory Test Patched Again'
@@ -1482,7 +1482,7 @@ describe('Pages REST', function() {
       jar,
       body: {
         _advisoryLock: {
-          htmlPageId: 'xyz',
+          tabId: 'xyz',
           lock: true
         }
       }
@@ -1521,13 +1521,13 @@ describe('Pages REST', function() {
     assert(page.match(/logged in/));
   });
 
-  it('second user with a distinct htmlPageId gets an appropriate error specifying who has the lock', async () => {
+  it('second user with a distinct tabId gets an appropriate error specifying who has the lock', async () => {
     try {
       await apos.http.patch(`/api/v1/@apostrophecms/page/${advisoryLockTestId}`, {
         jar: jar2,
         body: {
           _advisoryLock: {
-            htmlPageId: 'nbc',
+            tabId: 'nbc',
             lock: true
           }
         }

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -817,7 +817,7 @@ describe('Pieces', function() {
       jar,
       body: {
         _advisoryLock: {
-          htmlPageId: 'xyz',
+          tabId: 'xyz',
           lock: true
         },
         title: 'Advisory Test Patched'
@@ -832,7 +832,7 @@ describe('Pieces', function() {
         jar,
         body: {
           _advisoryLock: {
-            htmlPageId: 'pdq',
+            tabId: 'pdq',
             lock: true
           }
         }
@@ -850,7 +850,7 @@ describe('Pieces', function() {
       jar,
       body: {
         _advisoryLock: {
-          htmlPageId: 'pdq',
+          tabId: 'pdq',
           lock: true,
           force: true
         }
@@ -863,7 +863,7 @@ describe('Pieces', function() {
       jar,
       body: {
         _advisoryLock: {
-          htmlPageId: 'pdq',
+          tabId: 'pdq',
           lock: true
         }
       }
@@ -875,7 +875,7 @@ describe('Pieces', function() {
       jar,
       body: {
         _advisoryLock: {
-          htmlPageId: 'pdq',
+          tabId: 'pdq',
           lock: false
         },
         title: 'Advisory Test Patched Again'
@@ -889,7 +889,7 @@ describe('Pieces', function() {
       jar,
       body: {
         _advisoryLock: {
-          htmlPageId: 'xyz',
+          tabId: 'xyz',
           lock: true
         }
       }
@@ -928,13 +928,13 @@ describe('Pieces', function() {
     assert(page.match(/logged in/));
   });
 
-  it('second user with a distinct htmlPageId gets an appropriate error specifying who has the lock', async () => {
+  it('second user with a distinct tabId gets an appropriate error specifying who has the lock', async () => {
     try {
       await apos.http.patch(`/api/v1/product/${advisoryLockTestId}`, {
         jar: jar2,
         body: {
           _advisoryLock: {
-            htmlPageId: 'nbc',
+            tabId: 'nbc',
             lock: true
           }
         }


### PR DESCRIPTION
Advisory locking based on an id that remains constant for the lifetime of the tab. This eliminates nuisance logging about locks but more importantly it gives us the ability to detect when we really are taking control from another tab that belongs to ourselves and ask if we want to go through with that. This prevents lost work without nuisance prompts.

Also removed some dead code to parse a header we no longer use to transmit the lock identifier.