### PR TITLE
PRO-1074 skip migrations on new sites

### DIFF
--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -30,7 +30,7 @@ module.exports = {
     self.managers = {};
     self.enableBrowserData();
     await self.enableCollection();
-    self.apos.isNew = self.detectNew();
+    self.apos.isNew = await self.detectNew();
     await self.createIndexes();
     self.addDuplicateOrMissingWidgetIdMigration();
     self.addDraftPublishedMigration();
@@ -257,8 +257,8 @@ module.exports = {
       // This can't be done later because after this point init()
       // functions are permitted to insert documents
       async detectNew() {
-        const existing = await self.db.find({}).project({ _id: 1 }).limit(1).toArray();
-        self.apos.isNew = existing.length === 0;
+        const existing = await self.db.countDocuments();
+        return !existing;
       },
       async createSlugIndex() {
         const params = self.getSlugIndexParams();

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -30,6 +30,7 @@ module.exports = {
     self.managers = {};
     self.enableBrowserData();
     await self.enableCollection();
+    self.apos.isNew = self.detectNew();
     await self.createIndexes();
     self.addDuplicateOrMissingWidgetIdMigration();
     self.addDraftPublishedMigration();
@@ -251,6 +252,13 @@ module.exports = {
     return {
       async enableCollection() {
         self.db = await self.apos.db.collection('aposDocs');
+      },
+      // Detect whether the database is brand new (zero documents).
+      // This can't be done later because after this point init()
+      // functions are permitted to insert documents
+      async detectNew() {
+        const existing = await self.db.find({}).project({ _id: 1 }).limit(1).toArray();
+        self.apos.isNew = existing.length === 0;
       },
       async createSlugIndex() {
         const params = self.getSlugIndexParams();

--- a/modules/@apostrophecms/migration/index.js
+++ b/modules/@apostrophecms/migration/index.js
@@ -260,7 +260,7 @@ module.exports = {
           await migration.fn();
           await self.db.insertOne({
             _id: migration.name,
-            at: new Date(),
+            at: new Date()
           });
         } catch (err) {
           if (err) {

--- a/modules/@apostrophecms/migration/index.js
+++ b/modules/@apostrophecms/migration/index.js
@@ -230,8 +230,20 @@ module.exports = {
       async migrate(options) {
         await self.apos.lock.lock(self.__meta.name);
         try {
-          for (const migration of self.migrations) {
-            await self.runOne(migration);
+          if (self.apos.isNew) {
+            // Since the site is brand new (zero documents), we may assume
+            // it requires no migrations. Mark them all as "done" but note
+            // that they were skipped, just in case we decide that's an issue later
+            const at = new Date();
+            await self.db.insertMany(self.migrations.map(migration => ({
+              _id: migration.name,
+              at,
+              skipped: true
+            })));
+          } else {
+            for (const migration of self.migrations) {
+              await self.runOne(migration);
+            }
           }
         } finally {
           await self.apos.lock.unlock(self.__meta.name);
@@ -248,7 +260,7 @@ module.exports = {
           await migration.fn();
           await self.db.insertOne({
             _id: migration.name,
-            at: new Date()
+            at: new Date(),
           });
         } catch (err) {
           if (err) {


### PR DESCRIPTION
There is no need to run migrations on a new site. We must detect new-ness early enough that there's no possibility of being faked out by inserts in another module.

This won't detect a site that was constructed in advance in mongo by some custom script, but that advanced developer is probably not going to care, and migrations have a documented obligation to do no harm.