### PR TITLE
a copy operation must set copyOfId properly

### DIFF
--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -554,11 +554,11 @@ module.exports = {
           }
           input = {
             ...copyOf,
-            ...input,
-            copyOfId: copyOf._id
+            ...input
           };
         }
         await self.apos.schema.convert(req, schema, input, doc);
+        doc.copyOfId = copyOf && copyOf._id;
         if (copyOf) {
           self.apos.schema.regenerateIds(req, fullSchema, doc);
         }


### PR DESCRIPTION
Without this followup in modules like multisite is not possible. I had it as input to schema.convert whereas it should have been attached directly.