### PR TITLE
PRO-1098: allow "if" and "following values" in arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* Conditional fields (`if`) and the "following values" mechanism now work properly in array item fields.
+
 ## 3.0.0-alpha.6 - 2021-03-24
 
 ### Adds

--- a/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
@@ -278,6 +278,9 @@ export default {
       const currentIndex = this.next.findIndex(item => item._id === this.currentId);
       this.next[currentIndex] = this.currentDoc.data;
     },
+    getFieldValue(name) {
+      return this.currentDoc.data[name];
+    },
     isModified() {
       if (this.currentId) {
         const currentIndex = this.next.findIndex(item => item._id === this.currentId);


### PR DESCRIPTION
Conditional fields were broken in arrays, and following values were missing the same piece of plumbing.