### PR TITLE
PRO-1106 disable save properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+* When editing "Page Settings" or a piece, the "publish" button should not be clickable if there are errors.
+
 ## 3.0.0-alpha.6 - 2021-03-24
 
 ### Adds

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -32,7 +32,7 @@
       />
       <AposButton
         type="primary" :label="saveLabel"
-        :modifiers="buttonModifiers"
+        :disabled="saveDisabled"
         @click="submit"
         :tooltip="tooltip"
       />
@@ -169,12 +169,8 @@ export default {
     followingUtils() {
       return this.followingValues('utility');
     },
-    buttonModifiers() {
-      if (this.errorCount) {
-        return [ 'disabled' ];
-      } else {
-        return [];
-      }
+    saveDisabled() {
+      return this.errorCount > 0;
     },
     moduleOptions() {
       return window.apos.modules[this.docType] || {};


### PR DESCRIPTION
It's a prop in its own right on AposButton, but it was being passed as a modifier class. That looked right, so the bug went undiscovered until Ben did some thorough QA 👍 

There are no other modifier classes in play right now so I stopped passing that prop but it could come back anytime if there was a use case.