### PR TITLE
Adds CI test for node 14 with mongo 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,30 @@
 version: 2
 jobs:
-  build-node14:
+  build-node14-mongo44:
     docker:
       - image: circleci/node:14-browsers
-      - image: mongo:4.2.12
+      - image: mongo:4.4
+    steps:
+      - checkout
+      - run:
+          name: update-npm
+          command: 'sudo npm install -g npm@7'
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+          name: install-npm-wee
+          command: npm install
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+      - run:
+          name: test
+          command: npm test
+  build-node14-mongo42:
+    docker:
+      - image: circleci/node:14-browsers
+      - image: mongo:4.2
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,26 @@
 version: 2
 jobs:
+  build-node14:
+    docker:
+      - image: circleci/node:14-browsers
+      - image: mongo:4.2.12
+    steps:
+      - checkout
+      - run:
+          name: update-npm
+          command: 'sudo npm install -g npm@7'
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+          name: install-npm-wee
+          command: npm install
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+      - run:
+          name: test
+          command: npm test
   build-node12:
     docker:
       - image: circleci/node:12-browsers


### PR DESCRIPTION
Adds a CI test to start checking Node 14 on the latest version of MongoDB and npm as well.