### PR TITLE
PRO-1108 Detect a2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+* Prevent content loss by blocking attempts to connect Apostrophe 3.x to an Apostrophe 2.x database. Content migration tools are planned of course.
+
 ## 3.0.0-alpha.6.1 - 2021-03-26
 
 ### Fixes

--- a/modules/@apostrophecms/db/index.js
+++ b/modules/@apostrophecms/db/index.js
@@ -148,8 +148,7 @@ module.exports = {
         if (oldGlobal) {
           throw new Error(`There is a problem with the database: ${self.uri ? (self.uri + ' ') : ''}
 
-This database already contains an Apostrophe 2.x website. Exiting to avoid
-causing content loss. Content migration tools from 2.x to 3.x are planned.`);
+This database contains an Apostrophe 2.x website. Exiting to avoid content loss.`);
         }
       },
       // TODO: Remove this function if not necessary. Created for debugging during


### PR DESCRIPTION
A3 uses the database similarly enough that if a developer tries pointing A3 at an existing A2 database, it'll make a mess, but just subtly enough that they might not figure out what happened. Ouch. So prevent that.

Content migration tools from A2 to A3 are planned of course.