### PR TITLE
3/ungroup trash

### DIFF
--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -56,8 +56,7 @@ module.exports = {
         },
         utility: {
           fields: [
-            'slug',
-            'trash'
+            'slug'
           ]
         },
         permissions: {


### PR DESCRIPTION
The trash field is no longer in the UI, so we don't need to include it in a group. Doing so would only confuse people logging out inherited groups while working on their schema.