### PR TITLE
PRO-222 leave updatedAt alone if all our PATCH is doing is getting an advisory lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## UNRELEASED
+
+* Bug fix: don't update the modification timestamp of a document simply because of an advisory lock, as the user
+might decide not to save any actual edits.
+
 ## 3.0.0-alpha.6.1 - 2021-03-26
 
 ### Fixes

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -603,8 +603,21 @@ module.exports = {
       //
       // If `input._publish` launders to a truthy boolean and the type is subject to draft/publish
       // workflow, it is automatically published at the end of the patch operation.
+      //
+      // As an optimization, and to prevent unnecessary updates of `updatedAt`, no calls
+      // to `self.update()` are made when only `_advisoryLock` is present in `input` or
+      // it contains no properties at all.
 
       async convertPatchAndRefresh(req, input, _id) {
+        const keys = Object.keys(input);
+        let possiblePatchedFields;
+        if (input._advisoryLock && keys.length === 1) {
+          possiblePatchedFields = false;
+        } else if (keys.length === 0) {
+          possiblePatchedFields = false;
+        } else {
+          possiblePatchedFields = true;
+        }
         return self.apos.lock.withLock(`@apostrophecms/${_id}`, async () => {
           const piece = await self.findOneForEditing(req, { _id });
           let result;
@@ -628,11 +641,15 @@ module.exports = {
                 force
               });
             }
-            await self.applyPatch(req, piece, input, {
-              force: self.apos.launder.boolean(input._advisory)
-            });
+            if (possiblePatchedFields) {
+              await self.applyPatch(req, piece, input, {
+                force: self.apos.launder.boolean(input._advisory)
+              });
+            }
             if (i === (patches.length - 1)) {
-              await self.update(req, piece);
+              if (possiblePatchedFields) {
+                await self.update(req, piece);
+              }
               result = self.findOneForEditing(req, { _id }, { attachments: true });
             }
             if (tabId && !lock) {


### PR DESCRIPTION
We PATCH special `_` properties to do things like grabbing a lock on a document, which generally speaking feels like a good extension of REST without using verbs browsers might not support, but modifying `updatedAt` merely because we grabbed a lock is both slow and inappropriate. This will also prevent other follow-on effects of calling `update` that would be undesirable, for instance if a custom extension is present that adds versioning, grabbing a lock should not create a version.