### PR TITLE
Bug fix: documents with locales and those without have always been co…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## UNRELEASED
+* Bug fix: documents with locales and those without have always been considered to have different locales for purposes of the unique slug index, but the UI feature to detect slug conflicts and offer help regarded them as in the same namespace, preventing save operations in the UI.
+
 ## 2.117.0 (2021-03-24)
 * The browser-pushed versions of jQuery and lodash have been updated to address security scanner reports. jQuery is now on its latest release, 3.6.0. lodash is now on version 3.10.4 as found in the [maintained branch of lodash 3.x](https://github.com/sailshq/lodash) provided by the [Sails](https://sailsjs.com) team. Note that in "lean mode," we do not push these libraries at all except when a user is logged in. If you do not want the overhead we encourage you to learn about lean mode.
 * Fixes `options.arrangeFields` for `apostrophe-html-widgets`

--- a/lib/modules/apostrophe-docs/lib/routes.js
+++ b/lib/modules/apostrophe-docs/lib/routes.js
@@ -60,7 +60,7 @@ module.exports = function(self, options) {
     const _id = self.apos.launder.id(req.body._id);
     let original;
     if (_id) {
-      original = self.apos.docs.db.findOne({ _id });
+      original = await self.apos.docs.db.findOne({ _id });
       if (!original) {
         return next(null);
       }

--- a/lib/modules/apostrophe-docs/lib/routes.js
+++ b/lib/modules/apostrophe-docs/lib/routes.js
@@ -52,30 +52,43 @@ module.exports = function(self, options) {
   // Determine if a particular slug is available. Since the slug namespace
   // is shared by all doc types, you only need to be a user to access this
   // route. No other information about the document with that slug is returned
-  self.apiRoute('post', 'slug-taken', function(req, res, next) {
+  self.apiRoute('post', 'slug-taken', async (req, res, next) => {
     if (!req.user) {
       return res.status(404).send('notfound');
     }
-    var slug = self.apos.launder.string(req.body.slug);
-    var _id = self.apos.launder.id(req.body._id);
-    var criteria = {
+    const slug = self.apos.launder.string(req.body.slug);
+    const _id = self.apos.launder.id(req.body._id);
+    let original;
+    if (_id) {
+      original = self.apos.docs.db.findOne({ _id });
+      if (!original) {
+        return next(null);
+      }
+    }
+    const criteria = {
       slug: slug
     };
     if (_id) {
       criteria._id = { $ne: _id };
+      // We should worry only if workflowLocale is the same, including
+      // both being null/undefined (considered strictly equal in mongodb).
+      // Otherwise we detect false slug conflicts between exempt and
+      // nonexempt types.
+      criteria.workflowLocale = original.workflowLocale || null;
     }
-    return self.find(req, criteria).permission(false).trash(null).published(null).projection({ _url: 1, title: 1 }).toObject().then(function(doc) {
+    try {
+      const doc = await self.find(req, criteria).permission(false).trash(null).published(null).projection({ _url: 1, title: 1 }).toObject();
       if (doc) {
-        var pageType = _.find(self.apos.pages.options.types, { name: doc.type });
-        var label = (pageType && pageType.label) || self.apos.docs.getManager(doc.type).options.label || doc.type;
-        var hint = req.__ns('apostrophe', 'The slug you want to use is currently claimed by the %s %s. Do you want to edit that document in order to change its slug?', req.__ns('apostrophe', label), doc.title);
+        const pageType = _.find(self.apos.pages.options.types, { name: doc.type });
+        const label = (pageType && pageType.label) || self.apos.docs.getManager(doc.type).options.label || doc.type;
+        const hint = req.__ns('apostrophe', 'The slug you want to use is currently claimed by the %s %s. Do you want to edit that document in order to change its slug?', req.__ns('apostrophe', label), doc.title);
         return next('taken', null, { doc: doc, hint: hint });
       } else {
         return next(null);
       }
-    }).catch(function(err) {
-      return next(err);
-    });
+    } catch (e) {
+      return next(e);
+    }
   });
 
   self.apiRoute('post', 'slug-deconflict', function(req, res, next) {


### PR DESCRIPTION
…nsidered to have different locales for purposes of the unique slug index, but the UI feature to detect slug conflicts and offer help regarded them as in the same namespace, preventing save operations in the UI.

Please ensure your pull request follows these guidelines:

- [ ] Link to the related issue with requirements and/or clearly describe 1) what problem this solves and 2) the requirements to review it against.
- [ ] Update the `CHANGELOG.md` file with the added feature or fix. If there is not yet a heading for an upcoming release, add one following the established pattern.
- [ ] Keep the pull request minimal! Break large updates into separate pull requests for individual features/fixes whenever possible. Small requests get reviewed more quickly.
- [ ] All tests must pass, including the linters. Run `npm run lint` to test code linting independently.

Thanks for contributing!