### PR TITLE
PRO-1083 when a page is moved to a trash, it should only exist as a draft. Thi…

### DIFF
--- a/modules/@apostrophecms/page-type/index.js
+++ b/modules/@apostrophecms/page-type/index.js
@@ -118,6 +118,11 @@ module.exports = {
           if (!doc._id.includes(':draft')) {
             return;
           }
+          if (doc.parkedId === 'trash') {
+            // The root trash can exists in both draft and published to
+            // avoid overcomplicating parked pages
+            return;
+          }
           return self.apos.doc.db.removeMany({
             _id: {
               $in: [

--- a/modules/@apostrophecms/page-type/index.js
+++ b/modules/@apostrophecms/page-type/index.js
@@ -123,6 +123,13 @@ module.exports = {
             // avoid overcomplicating parked pages
             return;
           }
+          await self.apos.doc.db.updateOne({
+            _id: doc._id
+          }, {
+            $set: {
+              lastPublishedAt: null
+            }
+          });
           return self.apos.doc.db.removeMany({
             _id: {
               $in: [

--- a/modules/@apostrophecms/page-type/index.js
+++ b/modules/@apostrophecms/page-type/index.js
@@ -113,6 +113,21 @@ module.exports = {
           }
         }
       },
+      afterTrash: {
+        async trashIsDraftOnly(req, doc) {
+          if (!doc._id.includes(':draft')) {
+            return;
+          }
+          return self.apos.doc.db.removeMany({
+            _id: {
+              $in: [
+                doc._id.replace(':draft', ':published'),
+                doc._id.replace(':draft', ':previous')
+              ]
+            }
+          });
+        }
+      },
       beforePublish: {
         async ancestorsMustBePublished(req, { draft, published }) {
           const ancestorAposDocIds = draft.path.split('/');


### PR DESCRIPTION
…s avoids conflict with the mechanisms that autopublish page tree movements for previously published pages to prevent UX and permissions nightmares previously discussed and resolved

Please ensure your pull request follows these guidelines:

- [ ] Link to the related issue with requirements and/or clearly describe 1) what problem this solves and 2) the requirements to review it against.
- [ ] Update the `CHANGELOG.md` file with the added feature or fix. If there is not yet a heading for an upcoming release, add one following the established pattern.
- [ ] Keep the pull request minimal! Break large updates into separate pull requests for individual features/fixes whenever possible. Small requests get reviewed more quickly.
- [ ] All tests must pass, including the linters. Run `npm run lint` to test code linting independently.

Thanks for contributing!