### PR TITLE
find the alt attribute as we pass by in image.first and friends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ might decide not to save any actual edits.
 * Prevent content loss by blocking attempts to connect Apostrophe 3.x to an Apostrophe 2.x database. Content migration tools are planned of course.
 * You can always save a draft of a new document, wherever the concept is relevant.
 * Areas nested in array schema fields can now be edited in context on the page.
+* When using `apos.image.first`, the alt attribute of the image piece is available on the returned attachment object as `._alt`. In addition, `_credit` and `_creditUrl` are available.
 
 ## 3.0.0-alpha.6.1 - 2021-03-26
 

--- a/modules/@apostrophecms/image-widget/views/widget.html
+++ b/modules/@apostrophecms/image-widget/views/widget.html
@@ -3,7 +3,7 @@
   <img{% if data.manager.options.className %} class="{{ data.manager.options.className }}"{% endif %}
     srcset="{{ apos.image.srcset(attachment) }}"
     src="{{ apos.attachment.url(attachment, { size: data.options.size or 'full' }) }}"
-    alt="{{ data.widget._image[0].alt or '' }}"
+    alt="{{ attachment._alt or '' }}"
     {% if data.contextOptions and data.contextOptions.sizes %}
       sizes="{{ data.contextOptions.sizes }}"
     {% endif %}


### PR DESCRIPTION
Turns out we were very close to doing this already, so I just updated the list of attributes that make sense to capture.

I simplified the logic a bit by always cloning the attachment object, which is not complex.