### PR TITLE
navigating to another page always puts you back in published mode, th…

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
@@ -40,17 +40,19 @@ export default {
   name: 'TheAposContextBar',
   mixins: [ AposPublishMixin, AposAdvisoryLockMixin ],
   data() {
-    // Since cookie-based login sessions and sessionStorage are not precisely the same
-    // thing, correct any forbidden combination at page load time
-    if (window.apos.mode === 'published') {
-      window.sessionStorage.setItem('aposEditMode', JSON.stringify(false));
+    const query = apos.http.parseQuery(location.search);
+    // If the URL references a draft, go into draft mode but then clean up the URL
+    const draftMode = query['apos-mode'] || 'published';
+    if (draftMode === 'draft') {
+      delete query['apos-mode'];
+      history.replaceState(null, '', apos.http.addQueryToUrl(location.href, query));
     }
     return {
       patchesSinceLoaded: [],
       undone: [],
       patchesSinceSave: [],
-      editMode: window.sessionStorage.getItem('aposEditMode') === 'true',
-      draftMode: window.apos.mode,
+      editMode: false,
+      draftMode,
       original: null,
       saving: false,
       editing: false,
@@ -308,26 +310,32 @@ export default {
       }
       try {
         // Returns the doc as represented in the new locale and mode
-        const modeDoc = await apos.http.post(`${apos.login.action}/set-context`, {
-          body: {
-            mode,
-            locale: apos.locale,
-            _id: doc._id
+        const action = (doc.slug.match(/^\//) ? self.apos.page : self.apos.modules[doc.type]).action;
+        const modeDoc = await apos.http.get(`${action}/${doc._id}`, {
+          qs: {
+            'apos-mode': mode,
+            'apos-locale': locale
           }
         });
+        if (navigate && (!modeDoc._url)) {
+          await apos.alert({
+            heading: 'Page Does Not Exist Yet',
+            description: `The page that provides a listing for this type of piece is not yet available as ${mode} in the ${locale} locale.`
+          });
+          return;
+        }
         window.sessionStorage.setItem('aposStateChange', Date.now());
         window.sessionStorage.setItem('aposStateChangeSeen', '{}');
         if (mode === 'published') {
-          window.sessionStorage.setItem('aposEditMode', JSON.stringify(false));
           this.editMode = false;
         }
-        this.draftMode = mode;
         // Patch the module options. This is necessary because we're simulating
         // something that normally would involve a new page load, but without
         // the UX negatives of that. TODO: VueX as a long term fix
         window.apos.adminBar.context = modeDoc;
         window.apos.adminBar.contextId = modeDoc._id;
         this.context = modeDoc;
+        this.draftMode = mode;
         if (navigate) {
           if (!await this.refreshOrReload(modeDoc._url)) {
             if (this.editMode) {
@@ -351,7 +359,6 @@ export default {
             description: `That document is not yet available as ${mode} in the ${locale} locale.`
           });
         } else {
-          // Should not happen
           await apos.alert({
             heading: 'An Error Occurred',
             description: 'Unable to switch modes.'
@@ -367,16 +374,10 @@ export default {
         this.save();
       }
     },
-    onStorage(e) {
-      if (e.storageArea === sessionStorage && e.key === 'aposEditMode') {
-        this.editMode = e.newValue;
-      }
-    },
     async onContentChanged() {
       this.refresh();
     },
     async switchEditMode(editing) {
-      window.sessionStorage.setItem('aposEditMode', JSON.stringify(editing));
       this.editMode = editing;
       if (editing) {
         if (!await this.lock(`${this.action}/${this.context._id}`)) {
@@ -397,6 +398,7 @@ export default {
       const qs = {
         ...apos.http.parseQuery(window.location.search),
         'apos-refresh': '1',
+        'apos-mode': this.draftMode,
         ...(this.editMode ? {
           'apos-edit': '1'
         } : {})

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -50,16 +50,12 @@ module.exports = {
         let locale;
         if (self.isValidLocale(req.query['apos-locale'])) {
           locale = req.query['apos-locale'];
-        } else if (self.isValidLocale(req.session && req.session.locale)) {
-          locale = req.session.locale;
         } else {
           locale = self.defaultLocale;
         }
         let mode;
         if (validModes.includes(req.query['apos-mode'])) {
           mode = req.query['apos-mode'];
-        } else if (validModes.includes(req.session && req.session.mode)) {
-          mode = req.session.mode;
         } else {
           mode = 'published';
         }

--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -158,36 +158,6 @@ module.exports = {
             await destroySession();
           }
         },
-        async setContext(req) {
-          if (!(self.apos.i18n.isValidLocale(req.body.locale) && [ 'draft', 'published' ].includes(req.body.mode))) {
-            throw self.apos.error('invalid');
-          }
-          const locale = req.body.locale;
-          const mode = req.body.mode;
-          let _id = self.apos.launder.id(req.body._id);
-          const [ cuid ] = _id.split(':');
-          _id = `${cuid}:${locale}:${mode}`;
-          let doc = await self.apos.doc.db.findOne({
-            _id
-          });
-          if (!doc) {
-            throw self.apos.error('notfound');
-          }
-          // Now we know the type and we can find it again with the right query builder
-          doc = await self.apos.doc.getManager(doc.type).findOneForEditing({
-            ...req,
-            locale,
-            mode
-          }, {
-            _id: doc._id
-          });
-          if (!doc) {
-            throw self.apos.error('notfound');
-          }
-          req.session.locale = locale;
-          req.session.mode = mode;
-          return doc;
-        },
         ...(self.options.passwordReset ? {
           async resetRequest(req) {
             const site = (req.headers.host || '').replace(/:\d+$/, '');

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -1395,6 +1395,29 @@ database.`);
         if (self.isFound(req)) {
           return;
         }
+        if (req.user && (req.mode === 'published')) {
+          // Try again in published mode
+          try {
+            const testReq = self.apos.task.getReq({
+              user: req.user,
+              url: req.url,
+              params: req.params,
+              query: req.query,
+              mode: 'draft'
+            });
+            await self.serveGetPage(testReq);
+            await self.emit('serve', testReq);
+            if (self.isFound(testReq)) {
+              req.redirect = self.apos.url.build(req.url, {
+                'apos-mode': 'draft'
+              });
+              return;
+            }
+          } catch (e) {
+            console.error(e);
+            // Nonfatal, we were just probing
+          }
+        }
         // Give all modules a chance to save the day
         await self.emit('notFound', req);
         // Are we happy now?

--- a/modules/@apostrophecms/template/index.js
+++ b/modules/@apostrophecms/template/index.js
@@ -602,7 +602,6 @@ module.exports = {
           modules: {},
           prefix: self.apos.prefix,
           locale: req.locale,
-          mode: req.mode,
           csrfCookieName: self.apos.csrfCookieName,
           tabId: self.apos.util.generateId(),
           scene


### PR DESCRIPTION
…e mode is no longer recorded in the session

This is a draft because we need to talk about the UX consequences. Simply refreshing the page after your edits have saved currently appears to wipe them away, and longtime apostrophe developers tend to refresh for reassurance that autosave worked. If necessary it is technically possible to save some state browser side after all and still keep the architectural improvement of not using the session.