### PR TITLE
PRO-1049 redux

### DIFF
--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -140,6 +140,11 @@ module.exports = {
         });
         // Guarantee that `items` at least exists
         area.items = area.items || [];
+        if (area._docId) {
+          for (const item of area.items) {
+            item._docId = area._docId;
+          }
+        }
         const canEdit = area._edit && (options.edit !== false) && req.query['apos-edit'];
         if (canEdit) {
           // Ease of access to image URLs. When not editing we


### PR DESCRIPTION
I did not try to address the thing about file links specifically yet because there is a separate ticket for it, but I have fixed the original PRO-1049 foreign document trap complaint here: if you build out a card widget fully with image and rich text widgets and save it to the page, you are now able to edit those subwidgets on the page, without a foreign document warning.