### PR TITLE
PRO-1087 add margin to spacer element

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -100,4 +100,9 @@ export default {
   }
 }
 
+// make space for a widget's breadcrumbs that are flush with the admin bar
+.apos-admin-bar-spacer {
+  margin-bottom: 25px;
+}
+
 </style>


### PR DESCRIPTION
https://linear.app/apostrophecms/issue/PRO-1087/contextbar-widgets-at-the-top-of-a-page-are-hidden-beneath

this provides clearance for an area that might be flush to the global admin bar

See a demo of a flush area here https://github.com/apostrophecms/a3-demo/pull/72