### PR TITLE
Changes users title field to Display Name

### DIFF
--- a/modules/@apostrophecms/user/index.js
+++ b/modules/@apostrophecms/user/index.js
@@ -59,7 +59,7 @@ module.exports = {
         },
         title: {
           type: 'string',
-          label: 'Full Name',
+          label: 'Dislay Name',
           following: [ 'firstName', 'lastName' ],
           required: true
         },


### PR DESCRIPTION
It may not always be a full human name or they  may not want to give their full name. We're requiring it, so we can reduce mental friction by calling it Display Name instead.