### PR TITLE
PRO-1161 restrict permissions by role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Adds
 
 * Major performance improvement to the `nestedModuleSubdirs` option.
+* Four permissions roles are supported and enforced: guest, contributor, editor and admin. See the documentation for details. Pre-existing alpha users are automatically migrated to the admin role, as they already could do anything.
 
 ## 3.0.0-alpha.7 - 2021-04-07
 

--- a/modules/@apostrophecms/admin-bar/index.js
+++ b/modules/@apostrophecms/admin-bar/index.js
@@ -233,12 +233,16 @@ module.exports = {
           // Being logged in is good enough to see this
           return true;
         }
-        return self.apos.permission.can(req, item.permission.action, item.permission.type);
+        // Test the permission as if we were in draft mode, as when you actually
+        // manage the items those requests will be made in draft mode (when
+        // applicable to the content type)
+        return self.apos.permission.can(req, item.permission.action, item.permission.type, 'draft');
       },
 
       getBrowserData(req) {
         const items = self.getVisibleItems(req);
         if (!items.length) {
+          console.log('no visible items');
           return false;
         }
         const context = req.data.piece || req.data.page;

--- a/modules/@apostrophecms/admin-bar/index.js
+++ b/modules/@apostrophecms/admin-bar/index.js
@@ -242,7 +242,6 @@ module.exports = {
       getBrowserData(req) {
         const items = self.getVisibleItems(req);
         if (!items.length) {
-          console.log('no visible items');
           return false;
         }
         const context = req.data.piece || req.data.page;

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
@@ -458,27 +458,26 @@ export default {
     },
     async onDiscardDraft(e) {
       const result = await this.discardDraft(this.action, this.context._id, !!this.context.lastPublishedAt);
-      if (!result) {
-        return;
-      }
       this.context = {
         ...this.context,
         modified: false
       };
-      if (this.contextStack.length) {
-        // Pushed contexts might edit any property of the doc
-        this.original = klona(result.doc);
-      } else {
-        // On-page we only edit areas
-        this.original = Object.fromEntries(
-          Object.entries(
-            result.doc
-          ).filter(
-            ([ key, value ]) => value && value.metaType === 'area'
-          ).map(
-            ([ key, value ]) => [ key, klona(value) ]
-          )
-        );
+      if (result.doc) {
+        if (this.contextStack.length) {
+          // Pushed contexts might edit any property of the doc
+          this.original = klona(result.doc);
+        } else {
+          // On-page we only edit areas
+          this.original = Object.fromEntries(
+            Object.entries(
+              result.doc
+            ).filter(
+              ([ key, value ]) => value && value.metaType === 'area'
+            ).map(
+              ([ key, value ]) => [ key, klona(value) ]
+            )
+          );
+        }
       }
       this.patchesSinceLoaded = [];
       this.undone = [];

--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -391,7 +391,7 @@ module.exports = {
           archivedDocIds: []
         };
         if (!(options.permissions === false)) {
-          if (!self.apos.permission.can(req, 'edit', 'attachment')) {
+          if (!self.apos.permission.can(req, 'upload-attachment')) {
             throw self.apos.error('forbidden');
           }
         }
@@ -1032,7 +1032,7 @@ module.exports = {
       },
       // Middleware method used when only those with attachment privileges should be allowed to do something
       canUpload(req, res, next) {
-        if (!self.apos.permission.can(req, 'edit', 'attachment')) {
+        if (!self.apos.permission.can(req, 'upload-attachment')) {
           res.statusCode = 403;
           return res.send({
             type: 'forbidden',

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -142,7 +142,7 @@ module.exports = {
       },
       '@apostrophecms/doc-type:beforePublish': {
         testPermissions(req, doc) {
-          if (!self.apos.permission.can(req, 'publish', doc)) {
+          if (!self.apos.permission.can(req, 'publish', doc.draft)) {
             throw self.apos.error('forbidden');
           }
         }

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -141,9 +141,11 @@ module.exports = {
         }
       },
       '@apostrophecms/doc-type:beforePublish': {
-        testPermissions(req, doc) {
-          if (!self.apos.permission.can(req, 'publish', doc.draft)) {
-            throw self.apos.error('forbidden');
+        testPermissions(req, info) {
+          if (info.options.permissions !== false) {
+            if (!self.apos.permission.can(req, info.options.autopublishing ? 'edit' : 'publish', info.draft)) {
+              throw self.apos.error('forbidden');
+            }
           }
         }
       },

--- a/modules/@apostrophecms/express/index.js
+++ b/modules/@apostrophecms/express/index.js
@@ -494,7 +494,6 @@ module.exports = {
           // See options.csrfExceptions
           if (!req.cookies[self.apos.csrfCookieName] || req.get('X-XSRF-TOKEN') !== req.cookies[self.apos.csrfCookieName] || req.session['XSRF-TOKEN'] !== req.cookies[self.apos.csrfCookieName]) {
             res.statusCode = 403;
-            console.log('CSRF exception on ' + req.url);
             return res.send({
               name: 'forbidden',
               message: 'CSRF exception'

--- a/modules/@apostrophecms/express/index.js
+++ b/modules/@apostrophecms/express/index.js
@@ -494,6 +494,7 @@ module.exports = {
           // See options.csrfExceptions
           if (!req.cookies[self.apos.csrfCookieName] || req.get('X-XSRF-TOKEN') !== req.cookies[self.apos.csrfCookieName] || req.session['XSRF-TOKEN'] !== req.cookies[self.apos.csrfCookieName]) {
             res.statusCode = 403;
+            console.log('CSRF exception on ' + req.url);
             return res.send({
               name: 'forbidden',
               message: 'CSRF exception'

--- a/modules/@apostrophecms/global/index.js
+++ b/modules/@apostrophecms/global/index.js
@@ -124,7 +124,7 @@ module.exports = {
             '@apostrophecms/global:singleton-editor',
             self.label,
             {
-              action: 'admin',
+              action: 'edit',
               type: self.name
             }
           );

--- a/modules/@apostrophecms/page-type/index.js
+++ b/modules/@apostrophecms/page-type/index.js
@@ -92,6 +92,13 @@ module.exports = {
           await matched.handler(req);
         }
       },
+      beforeMove: {
+        checkPermissions(req, doc) {
+          if (doc.lastPublishedAt && !self.apos.permission.can(req, 'publish', '@apostrophecms/page')) {
+            throw self.apos.error('forbidden', 'Contributors may only move unpublished pages.');
+          }
+        }
+      },
       afterMove: {
         async replayMoveAfterMoved(req, doc) {
           if (!doc._id.includes(':draft')) {

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -235,7 +235,7 @@ module.exports = {
         }
 
         return self.withLock(req, async () => {
-          const targetPage = await self.findForEditing(req, targetId ? { _id: targetId } : { level: 0 }).ancestors(true).permission('edit-@apostrophecms/page').toObject();
+          const targetPage = await self.findForEditing(req, targetId ? { _id: targetId } : { level: 0 }).ancestors(true).permission('edit').toObject();
           if (!targetPage) {
             throw self.apos.error('notfound');
           }

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -182,8 +182,8 @@ module.exports = {
       // _id may be a page _id, or the convenient shorthands
       // `_home` or `_archive`
       async getOne(req, _id) {
-        self.publicApiCheck(req);
         _id = self.inferIdLocaleAndMode(req, _id);
+        self.publicApiCheck(req);
         const criteria = self.getIdCriteria(_id);
         const result = await self.getRestQuery(req).and(criteria).toObject();
         if (!result) {
@@ -287,8 +287,8 @@ module.exports = {
       // editing it in a modal or similar.
 
       async put(req, _id) {
-        self.publicApiCheck(req);
         _id = self.inferIdLocaleAndMode(req, _id);
+        self.publicApiCheck(req);
         return self.withLock(req, async () => {
           const page = await self.find(req, { _id }).toObject();
           if (!page) {
@@ -335,8 +335,8 @@ module.exports = {
       // confirmation on it. Future implementation must also consider whether attachments have zero remaining references not
       // fully deleted, which isn't the same as having references still in the archive.
       async delete(req, _id) {
-        self.publicApiCheck(req);
         _id = self.inferIdLocaleAndMode(req, _id);
+        self.publicApiCheck(req);
         const page = await self.findOneForEditing(req, {
           _id
         });
@@ -348,8 +348,8 @@ module.exports = {
       // may be `before`, `after` or `inside`. To move a page into or out of the archive, set
       // `archived` to `true` or `false`.
       patch(req, _id) {
-        self.publicApiCheck(req);
         _id = self.inferIdLocaleAndMode(req, _id);
+        self.publicApiCheck(req);
         return self.patch(req, _id);
       }
     };

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -907,8 +907,8 @@ database.`);
       },
       // Move a page already in the page tree to another location.
       //
-      // Insert a page. `targetId` must be an existing page id, and
-      // `position` may be `before`, `inside` or `after`. Alternatively
+      // `movedId` is the id of the page being moved. ``targetId` must be an existing page
+      // id, and `position` may be `before`, `inside` or `after`. Alternatively
       // `position` may be a zero-based offset for the new child
       // of `targetId` (note that the `rank` property of sibling pages
       // is not strictly ascending, so use an array index into `_children` to
@@ -926,7 +926,7 @@ database.`);
       // `req, moved, target, position`.
       async move(req, movedId, targetId, position) {
         // Handle numeric positions
-        const normalized = await self.getTargetIdAndPosition(req, null, targetId, position);
+        const normalized = await self.getTargetIdAndPosition(req, movedId, targetId, position);
         targetId = normalized.targetId;
         position = normalized.position;
         return self.withLock(req, body);

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -104,7 +104,7 @@ module.exports = {
             return self.can(req, 'publish', doc);
           }
         } else {
-          return false;
+          throw self.apos.error('invalid', 'That action is not implemented');
         }
       },
 
@@ -181,10 +181,7 @@ module.exports = {
             };
           }
         } else {
-          // If I don't understand it, I don't allow it
-          return {
-            _id: 'thisIdWillNeverMatch'
-          };
+          throw self.apos.error('invalid', `The action ${action} is not implemented for apos.permission.criteria`);
         }
       },
 

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -90,6 +90,14 @@ module.exports = {
           } else {
             return role === 'editor';
           }
+        } else if (action === 'upload-attachment') {
+          if ((role === 'contributor') || (role === 'editor')) {
+            return true;
+          } else {
+            return false;
+          }
+        } else {
+          return false;
         }
       },
 

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -165,7 +165,7 @@ module.exports = {
             };
           } else {
             return {
-              _id: 'thisIdWillNeverMatch'
+              _id: null
             };
           }
         } else if (action === 'publish') {
@@ -177,7 +177,7 @@ module.exports = {
             };
           } else {
             return {
-              _id: 'thisIdWillNeverMatch'
+              _id: null
             };
           }
         } else {

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -59,6 +59,7 @@ module.exports = {
           return true;
         }
         const type = docOrType && (docOrType.type || docOrType);
+        const doc = (docOrType && docOrType._id) ? docOrType : null;
         const manager = type && self.apos.doc.getManager(type);
         if (type && !manager) {
           self.apos.util.warn(`A permission.can() call was made with a type that has no manager: ${type}`);
@@ -95,6 +96,12 @@ module.exports = {
             return true;
           } else {
             return false;
+          }
+        } else if (action === 'delete') {
+          if (doc && !doc.lastPublishedAt) {
+            return self.can(req, 'edit', doc);
+          } else {
+            return self.can(req, 'publish', doc);
           }
         } else {
           return false;

--- a/modules/@apostrophecms/permission/ui/apos/components/AposInputRole.vue
+++ b/modules/@apostrophecms/permission/ui/apos/components/AposInputRole.vue
@@ -29,22 +29,22 @@
       </div>
       <ul class="apos-input--permission-grid">
         <li
-          v-for="type in types"
-          :key="type.name"
+          v-for="permissionSet in permissionSets"
+          :key="permissionSet.name"
         >
           <h4>
-            {{ type.label }}
+            {{ permissionSet.label }}
             <AposIndicator
-              v-if="type.tooltip"
+              v-if="permissionSet.tooltip"
               icon="help-circle-icon"
               class="apos-field__help-tooltip__icon"
-              :tooltip="type.tooltip"
+              :tooltip="permissionSet.tooltip"
               :icon-size="11"
               icon-color="var(--a-base-4)"
             />
           </h4>
           <ul>
-            <li v-for="permission in type.permissions" :key="permission.name">
+            <li v-for="permission in permissionSet.permissions" :key="permission.name">
               <AposIndicator v-if="permission.value" icon="check-bold-icon" icon-color="var(--a-success)" />
               <AposIndicator v-else icon="alpha-x-icon" icon-color="var(--a-danger)" />
               &nbsp;{{ permission.label }}
@@ -72,12 +72,12 @@ export default {
     return {
       next: (this.value.data == null) ? null : this.value.data,
       choices: [],
-      types: []
+      permissionSets: []
     };
   },
   watch: {
     async next() {
-      this.types = await this.getTypes(this.next);
+      this.permissionSets = await this.getPermissionSets(this.next);
     }
   },
   async mounted() {
@@ -98,7 +98,7 @@ export default {
         this.next = this.field.choices[0].value;
       }
     });
-    this.types = await this.getTypes(this.next);
+    this.permissionSets = await this.getPermissionSets(this.next);
   },
   methods: {
     validate(value) {
@@ -114,13 +114,13 @@ export default {
       // Allows expression of non-string values
       this.next = this.choices.find(choice => choice.value === JSON.parse(value)).value;
     },
-    async getTypes(role) {
+    async getPermissionSets(role) {
       return (await apos.http.get(`${apos.permission.action}/grid`, {
         qs: {
           role
         },
         busy: true
-      })).types;
+      })).permissionSets;
     }
   }
 };

--- a/modules/@apostrophecms/permission/ui/apos/components/AposInputRole.vue
+++ b/modules/@apostrophecms/permission/ui/apos/components/AposInputRole.vue
@@ -75,6 +75,11 @@ export default {
       types: []
     };
   },
+  watch: {
+    async next() {
+      this.types = await this.getTypes(this.next);
+    }
+  },
   async mounted() {
     // Add an null option if there isn't one already
     if (!this.field.required && !this.field.choices.find(choice => {
@@ -93,7 +98,7 @@ export default {
         this.next = this.field.choices[0].value;
       }
     });
-    this.types = await this.getTypes();
+    this.types = await this.getTypes(this.next);
   },
   methods: {
     validate(value) {
@@ -109,8 +114,13 @@ export default {
       // Allows expression of non-string values
       this.next = this.choices.find(choice => choice.value === JSON.parse(value)).value;
     },
-    async getTypes() {
-      return (await apos.http.get(`${apos.permission.action}/grid`, {})).types;
+    async getTypes(role) {
+      return (await apos.http.get(`${apos.permission.action}/grid`, {
+        qs: {
+          role
+        },
+        busy: true
+      })).types;
     }
   }
 };

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -178,8 +178,8 @@ module.exports = {
       return result;
     },
     async getOne(req, _id) {
-      self.publicApiCheck(req);
       _id = self.inferIdLocaleAndMode(req, _id);
+      self.publicApiCheck(req);
       const doc = await self.getRestQuery(req).and({ _id }).toObject();
       if (!doc) {
         throw self.apos.error('notfound');
@@ -199,21 +199,21 @@ module.exports = {
       return await self.convertInsertAndRefresh(req, req.body);
     },
     async put(req, _id) {
-      self.publicApiCheck(req);
       _id = self.inferIdLocaleAndMode(req, _id);
+      self.publicApiCheck(req);
       return self.convertUpdateAndRefresh(req, req.body, _id);
     },
     async delete(req, _id) {
-      self.publicApiCheck(req);
       _id = self.inferIdLocaleAndMode(req, _id);
+      self.publicApiCheck(req);
       const piece = await self.findOneForEditing(req, {
         _id
       });
       return self.delete(req, piece);
     },
     async patch(req, _id) {
-      self.publicApiCheck(req);
       _id = self.inferIdLocaleAndMode(req, _id);
+      self.publicApiCheck(req);
       return self.convertPatchAndRefresh(req, req.body, _id);
     }
   }),

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -190,6 +190,7 @@ module.exports = {
       return doc;
     },
     async post(req) {
+      console.log('made it to a POST route');
       self.publicApiCheck(req);
       if (req.body._newInstance) {
         return self.newInstance();
@@ -745,6 +746,7 @@ module.exports = {
       publicApiCheck(req) {
         if (!self.options.publicApiProjection) {
           if (!self.apos.permission.can(req, 'edit', self.name)) {
+            console.log(`user cannot edit ${self.name}`);
             throw self.apos.error('notfound');
           }
         }

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -191,7 +191,6 @@ module.exports = {
       return doc;
     },
     async post(req) {
-      console.log('made it to a POST route');
       self.publicApiCheck(req);
       if (req.body._newInstance) {
         return self.newInstance();
@@ -747,7 +746,6 @@ module.exports = {
       publicApiCheck(req) {
         if (!self.options.publicApiProjection) {
           if (!self.apos.permission.can(req, 'edit', self.name)) {
-            console.log(`user cannot edit ${self.name}`);
             throw self.apos.error('notfound');
           }
         }

--- a/modules/@apostrophecms/task/index.js
+++ b/modules/@apostrophecms/task/index.js
@@ -223,7 +223,7 @@ module.exports = {
       },
 
       // Convenience wrapper for `getReq`. Returns a request
-      // object simulating a user with the editor role.
+      // object simulating a user with the guest role.
       getGuestReq(options) {
         return self.getReq({
           role: 'guest',
@@ -250,7 +250,7 @@ module.exports = {
       },
 
       // Convenience wrapper for `getReq`. Returns a request
-      // object simulating a user with the editor role.
+      // object simulating a user with the admin role.
       getAdminReq(options) {
         // For bc reasons this is the default behavior of getReq
         return self.getReq(options);

--- a/modules/@apostrophecms/user/index.js
+++ b/modules/@apostrophecms/user/index.js
@@ -183,6 +183,17 @@ module.exports = {
           return self.insertOrUpdateSafe(req, doc, 'update');
         }
       },
+      beforeSave: {
+        // There is a migration that sets the role to admin if the role does
+        // not exist, accommodating databases prior to 3.0 beta 1. To keep this
+        // from becoming a possible security concern, refuse any new inserts/updates
+        // with no role
+        async requireRole(req, doc, options) {
+          if (![ 'guest', 'editor', 'contributor', 'admin' ].includes(doc.role)) {
+            throw self.apos.error('invalid', `The role property of a user must be guest, editor, contributor or admin'`);
+          }
+        }
+      },
       // Reflect email and username changes in the safe after deduplicating in the piece
       afterArchived: {
         async updateSafe(req, piece) {

--- a/test/login.js
+++ b/test/login.js
@@ -35,6 +35,7 @@ describe('Login', function() {
     user.username = 'HarryPutter';
     user.password = 'crookshanks';
     user.email = 'hputter@aol.com';
+    user.role = 'admin';
 
     assert(user.type === '@apostrophecms/user');
     assert(apos.user.insert);

--- a/test/pages-rest.js
+++ b/test/pages-rest.js
@@ -136,6 +136,7 @@ describe('Pages REST', function() {
     user.username = 'admin';
     user.password = 'admin';
     user.email = 'ad@min.com';
+    user.role = 'admin';
 
     await apos.user.insert(apos.task.getReq(), user);
 
@@ -148,6 +149,7 @@ describe('Pages REST', function() {
     user2.username = 'admin2';
     user2.password = 'admin2';
     user2.email = 'ad@min2.com';
+    user2.role = 'admin';
 
     return apos.user.insert(apos.task.getReq(), user2);
 

--- a/test/permissions.js
+++ b/test/permissions.js
@@ -22,13 +22,19 @@ describe('Permissions', function() {
       assert(apos.permission.can(apos.task.getAnonReq(), 'view', '@apostrophecms/home-page'));
     });
     it('allows the admin to view by type', function() {
-      assert(apos.permission.can(apos.task.getReq(), 'view', '@apostrophecms/home-page'));
+      assert(apos.permission.can(apos.task.getAdminReq(), 'view', '@apostrophecms/home-page'));
     });
     it('Forbids the public to update by type', function() {
       assert(!apos.permission.can(apos.task.getAnonReq(), 'edit', '@apostrophecms/home-page'));
     });
+    it('Forbids the contributor to update by type in published mode', function() {
+      assert(!apos.permission.can(apos.task.getContributorReq(), 'edit', '@apostrophecms/home-page'));
+    });
+    it('Allows the editor to update by type in published mode', function() {
+      assert(apos.permission.can(apos.task.getEditorReq(), 'edit', '@apostrophecms/home-page'));
+    });
     it('Allows the admin to update by type', function() {
-      assert(apos.permission.can(apos.task.getReq(), 'edit', '@apostrophecms/home-page'));
+      assert(apos.permission.can(apos.task.getAdminReq(), 'edit', '@apostrophecms/home-page'));
     });
     it('allows the public to view a particular doc via criteria and via can()', async () => {
       const req = apos.task.getAnonReq();
@@ -43,12 +49,67 @@ describe('Permissions', function() {
       try {
         home.visibility = 'loginRequired';
         await apos.page.update(req, home);
+        assert(false);
       } catch (e) {
         assert(e.message === 'forbidden');
       }
     });
+    it('contributor cannot update published doc via actual update api', async () => {
+      const req = apos.task.getContributorReq();
+      const home = await apos.page.find(req, { slug: '/' }).toObject();
+      assert(home);
+      try {
+        home.title = 'Contributor Updated';
+        await apos.page.update(req, home);
+        assert(false);
+      } catch (e) {
+        assert(e.message === 'forbidden');
+      }
+    });
+    it('contributor can update draft doc via actual update api', async () => {
+      const req = apos.task.getContributorReq({
+        mode: 'draft'
+      });
+      const home = await apos.page.find(req, { slug: '/' }).toObject();
+      assert(home);
+      home.title = 'Contributor Updated';
+      const updated = await apos.page.update(req, home);
+      assert(updated.title === 'Contributor Updated');
+    });
+    it('contributor cannot publish doc', async () => {
+      const req = apos.task.getContributorReq({
+        mode: 'draft'
+      });
+      const home = await apos.page.find(req, { slug: '/' }).toObject();
+      assert(home);
+      try {
+        await apos.page.publish(req, home);
+        assert(false);
+      } catch (e) {
+        assert(e.message === 'forbidden');
+      }
+    });
+    it('editor can publish doc', async () => {
+      const req = apos.task.getEditorReq({
+        mode: 'draft'
+      });
+      const home = await apos.page.find(req, { slug: '/' }).toObject();
+      assert(home);
+      await apos.page.publish(req, home);
+      const pReq = apos.task.getEditorReq();
+      const pHome = await apos.page.find(pReq, { slug: '/' }).toObject();
+      assert(pHome.title === 'Contributor Updated');
+    });
+    it('editor can update published doc via actual update api', async () => {
+      const req = apos.task.getEditorReq();
+      const home = await apos.page.find(req, { slug: '/' }).toObject();
+      assert(home);
+      home.title = 'Editor Updated';
+      const updated = await apos.page.update(req, home);
+      assert(updated.title === 'Editor Updated');
+    });
     it('admin can update via actual update api', async () => {
-      const req = apos.task.getReq();
+      const req = apos.task.getAdminReq();
       const home = await apos.page.find(req, { slug: '/' }).toObject();
       assert(home);
       home.visibility = 'loginRequired';
@@ -56,12 +117,13 @@ describe('Permissions', function() {
     });
     it('public cannot access when visibility is loginRequired', async () => {
       const anonReq = apos.task.getAnonReq();
-      try {
-        const home = await apos.page.find(anonReq, { slug: '/' }).toObject();
-        assert(!home);
-      } catch (e) {
-        assert(e.message === 'forbidden');
-      }
+      const home = await apos.page.find(anonReq, { slug: '/' }).toObject();
+      assert(!home);
+    });
+    it('guest can access when visibility is loginRequired', async () => {
+      const guestReq = apos.task.getGuestReq();
+      const home = await apos.page.find(guestReq, { slug: '/' }).toObject();
+      assert(home);
     });
   });
 });

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -357,6 +357,7 @@ describe('Pieces', function() {
     user.username = 'admin';
     user.password = 'admin';
     user.email = 'ad@min.com';
+    user.role = 'admin';
 
     await apos.user.insert(apos.task.getReq(), user);
 
@@ -367,6 +368,7 @@ describe('Pieces', function() {
     user2.username = 'admin2';
     user2.password = 'admin2';
     user2.email = 'ad@min2.com';
+    user2.role = 'admin';
 
     return apos.user.insert(apos.task.getReq(), user2);
 

--- a/test/users.js
+++ b/test/users.js
@@ -31,6 +31,7 @@ describe('Users', function() {
     user.username = 'JaneD';
     user.password = '123password';
     user.email = 'jane@aol.com';
+    user.role = 'admin';
 
     assert(user.type === '@apostrophecms/user');
     assert(apos.user.insert);
@@ -83,6 +84,7 @@ describe('Users', function() {
     user.username = 'DaneJ';
     user.password = '321password';
     user.email = 'jane@aol.com';
+    user.role = 'admin';
     assert(user.type === '@apostrophecms/user');
 
     assert(apos.user.insert);
@@ -114,6 +116,7 @@ describe('Users', function() {
     user.username = 'DaneJ';
     user.password = '321password';
     user.email = 'jane@aol.com';
+    user.role = 'admin';
     await apos.user.insert(apos.task.getReq(), user);
   });
 
@@ -158,6 +161,7 @@ describe('Users', function() {
     user.username = 'JaneD';
     user.password = '321password';
     user.email = 'somethingelse@aol.com';
+    user.role = 'admin';
     await apos.user.insert(apos.task.getReq(), user);
   });
 


### PR DESCRIPTION
Permissions restrictions by role are now fully enforced.

This is *not* a PR to adjust the UI so we don't show inappropriate functionality, etc. I'll be addressing that in other tickets. However it's actually pretty convenient for evaluation purposes, because you can try things and get appropriate error messages. (Bearing in mind that most of those would never be seen under normal circumstances once we do add the UI affordances, so we don't need to go nuts making every "forbidden" pretty.)