### PR TITLE
PRO-1172 manager tables, manager context menus, etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Four permissions roles are supported and enforced: guest, contributor, editor and admin. See the documentation for details. Pre-existing alpha users are automatically migrated to the admin role, as they already could do anything.
 * The admin bar menu is fully responsive to user roles.
 * The context bar entirely appears or disappears based on user roles.
-* Documents in managers now have context sensitive action menus that allow actions like edit, discard draft, archive, unarchive, etc
+* Documents in managers now have context sensitive action menus that allow actions like edit, discard draft, archive, restore, etc
 * New label component
 * Doc states in managers now reflected w labels (Active Draft, Archived, Unpublished)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Four permissions roles are supported and enforced: guest, contributor, editor and admin. See the documentation for details. Pre-existing alpha users are automatically migrated to the admin role, as they already could do anything.
 * The admin bar menu is fully responsive to user roles.
 * The context bar entirely appears or disappears based on user roles.
+* Documents in managers now have context sensitive action menus that allow actions like edit, discard draft, archive, unarchive, etc
+* New label component
+* Doc states in managers now reflected w labels (Active Draft, Archived, Unpublished)
 
 ## 3.0.0-alpha.7 - 2021-04-07
 

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarMenu.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarMenu.vue
@@ -3,7 +3,7 @@
     <li class="apos-admin-bar__item" v-if="pageTree">
       <AposButton
         type="subtle" label="Page Tree"
-        icon="file-tree-icon" class="apos-admin-bar__btn"
+        class="apos-admin-bar__btn"
         :modifiers="['no-motion']"
         @click="emitEvent('@apostrophecms/page:manager')"
       />

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -283,7 +283,7 @@ export default {
       if (this.original) {
         return !!this.original._url;
       } else {
-        return null;
+        return false;
       }
     },
     canArchive() {
@@ -421,10 +421,7 @@ export default {
   },
   methods: {
     async preview() {
-      if (!await this.confirmAndCancel()) {
-        return;
-      }
-      window.location = this.original._url;
+      window.open(this.original._url, '_blank').focus();
     },
     async saveDraftAndPreview() {
       await this.save({

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -23,11 +23,13 @@
         :can-discard-draft="canDiscardDraft"
         :can-archive="canArchive"
         :can-copy="!!docId"
+        :can-preview="canPreview"
         :is-published="!!published"
         :can-save-draft="true"
         @saveDraft="saveDraft"
+        @preview="preview"
         @discardDraft="onDiscardDraft"
-        @moveToArchive="onMoveToArchive"
+        @archive="onArchive"
         @copy="onCopy"
       />
       <AposButton
@@ -106,6 +108,7 @@ import AposModalModifiedMixin from 'Modules/@apostrophecms/modal/mixins/AposModa
 import AposModalTabsMixin from 'Modules/@apostrophecms/modal/mixins/AposModalTabsMixin';
 import AposEditorMixin from 'Modules/@apostrophecms/modal/mixins/AposEditorMixin';
 import AposPublishMixin from 'Modules/@apostrophecms/ui/mixins/AposPublishMixin';
+import AposArchiveMixin from 'Modules/@apostrophecms/ui/mixins/AposArchiveMixin';
 import AposAdvisoryLockMixin from 'Modules/@apostrophecms/ui/mixins/AposAdvisoryLockMixin';
 import { detectDocChange } from 'Modules/@apostrophecms/schema/lib/detectChange';
 import { klona } from 'klona';
@@ -118,7 +121,8 @@ export default {
     AposModalModifiedMixin,
     AposEditorMixin,
     AposPublishMixin,
-    AposAdvisoryLockMixin
+    AposAdvisoryLockMixin,
+    AposArchiveMixin
   ],
   props: {
     moduleName: {
@@ -275,6 +279,13 @@ export default {
     canPreviewDraft() {
       return !this.docId && this.moduleOptions.previewDraft;
     },
+    canPreview() {
+      if (this.original) {
+        return !!this.original._url;
+      } else {
+        return null;
+      }
+    },
     canArchive() {
       return !!(this.docId &&
         !(this.moduleName === '@apostrophecms/page') &&
@@ -409,6 +420,12 @@ export default {
     }
   },
   methods: {
+    async preview() {
+      if (!await this.confirmAndCancel()) {
+        return;
+      }
+      window.location = this.original._url;
+    },
     async saveDraftAndPreview() {
       await this.save({
         andPublish: false,
@@ -605,35 +622,10 @@ export default {
         return this.$refs[field.group.name][0];
       }
     },
-    async onMoveToArchive(e) {
-      try {
-        if (await apos.confirm({
-          heading: 'Are You Sure?',
-          description: this.published
-            ? 'This will move the document to the archive and un-publish it.'
-            : 'This will move the document to the archive.'
-        })) {
-          await apos.http.patch(`${this.moduleAction}/${this.docId}`, {
-            body: {
-              archived: true,
-              _publish: true
-            },
-            busy: true,
-            draft: true
-          });
-          if (this.docId === window.apos.adminBar.contextId) {
-            // With the current context doc gone, we need to move to safe ground
-            location.assign(`${window.apos.prefix}/`);
-            return;
-          }
-          apos.bus.$emit('content-changed');
-          this.modal.showModal = false;
-        }
-      } catch (e) {
-        await apos.alert({
-          heading: 'An Error Occurred',
-          description: e.message || 'An error occurred while moving the document to the archive.'
-        });
+    async onArchive(e) {
+      if (await this.archive(this.moduleAction, this.docId, !!this.published)) {
+        apos.bus.$emit('content-changed');
+        this.modal.showModal = false;
       }
     },
     async onDiscardDraft(e) {

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -421,7 +421,10 @@ export default {
   },
   methods: {
     async preview() {
-      window.open(this.original._url, '_blank').focus();
+      if (!await this.confirmAndCancel()) {
+        return;
+      }
+      window.location = this.original._url;
     },
     async saveDraftAndPreview() {
       await this.save({

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
@@ -39,7 +39,19 @@ export default {
         return false;
       }
     },
+    canOpenEditor: {
+      type: Boolean,
+      default() {
+        return false;
+      }
+    },
     canArchive: {
+      type: Boolean,
+      default() {
+        return false;
+      }
+    },
+    canPreview: {
       type: Boolean,
       default() {
         return false;
@@ -106,10 +118,33 @@ export default {
         //   label: 'Duplicate Document',
         //   action: 'duplicate'
         // },
+        ...(this.canOpenEditor ? [
+          {
+            label: 'Edit',
+            action: 'edit'
+          }
+        ] : []),
+        {
+          label: 'Preview',
+          action: 'preview',
+          modifiers: !this.canPreview ? [ 'disabled' ] : null
+        },
+        ...(this.canSaveDraft ? [
+          {
+            label: 'Save Draft',
+            action: 'saveDraft'
+          }
+        ] : []),
+        ...(this.canCopy ? [
+          {
+            label: 'Duplicate...',
+            action: 'copy'
+          }
+        ] : []),
         ...(this.canArchive ? [
           {
-            label: 'Move to Archive',
-            action: 'moveToArchive',
+            label: 'Archive',
+            action: 'archive',
             modifiers: [ 'danger' ]
           }
         ] : []),
@@ -120,18 +155,6 @@ export default {
             modifiers: [ 'danger' ]
           }
         ] : []),
-        ...(this.canSaveDraft ? [
-          {
-            label: 'Save Draft',
-            action: 'saveDraft'
-          }
-        ] : []),
-        ...(this.canCopy ? [
-          {
-            label: 'Copy',
-            action: 'copy'
-          }
-        ] : [])
       ];
     }
   }

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
@@ -59,7 +59,7 @@ export default {
         return false;
       }
     },
-    canUnarchive: {
+    canRestore: {
       type: Boolean,
       default() {
         return false;
@@ -158,10 +158,10 @@ export default {
             modifiers: [ 'danger' ]
           }
         ] : []),
-        ...(this.canUnarchive ? [
+        ...(this.canRestore ? [
           {
-            label: 'Unarchive',
-            action: 'unarchive'
+            label: 'Restore from Archive',
+            action: 'restore'
           }
         ] : [])
       ];

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
@@ -5,6 +5,8 @@
     :disabled="disabled"
     menu-placement="bottom-end"
     @item-clicked="menuHandler"
+    @open="$emit('menuOpen')"
+    @close="$emit('menuClose')"
     :button="{
       tooltip: { content: 'More Options', placement: 'bottom' },
       label: 'More Options',
@@ -57,6 +59,12 @@ export default {
         return false;
       }
     },
+    canUnarchive: {
+      type: Boolean,
+      default() {
+        return false;
+      }
+    },
     canSaveDraft: {
       type: Boolean,
       default() {
@@ -80,6 +88,7 @@ export default {
       default: false
     }
   },
+  emits: [ 'menuOpen', 'menuClose' ],
   data() {
     const menu = {
       isOpen: false,
@@ -111,24 +120,18 @@ export default {
         //     action: 'share'
         //   }
         // ] : []),
-        // TODO
-        // // You can always do this, if you do it with a new item
-        // // it just saves and you start a second one
-        // {
-        //   label: 'Duplicate Document',
-        //   action: 'duplicate'
-        // },
         ...(this.canOpenEditor ? [
           {
             label: 'Edit',
             action: 'edit'
           }
         ] : []),
-        {
-          label: 'Preview',
-          action: 'preview',
-          modifiers: !this.canPreview ? [ 'disabled' ] : null
-        },
+        ...(this.canPreview ? [
+          {
+            label: 'Preview',
+            action: 'preview'
+          }
+        ] : []),
         ...(this.canSaveDraft ? [
           {
             label: 'Save Draft',
@@ -141,13 +144,6 @@ export default {
             action: 'copy'
           }
         ] : []),
-        ...(this.canArchive ? [
-          {
-            label: 'Archive',
-            action: 'archive',
-            modifiers: [ 'danger' ]
-          }
-        ] : []),
         ...(this.canDiscardDraft ? [
           {
             label: this.isPublished ? 'Discard Changes' : 'Discard Draft',
@@ -155,6 +151,19 @@ export default {
             modifiers: [ 'danger' ]
           }
         ] : []),
+        ...(this.canArchive ? [
+          {
+            label: 'Archive',
+            action: 'archive',
+            modifiers: [ 'danger' ]
+          }
+        ] : []),
+        ...(this.canUnarchive ? [
+          {
+            label: 'Unarchive',
+            action: 'unarchive'
+          }
+        ] : [])
       ];
     }
   }

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
@@ -5,8 +5,8 @@
     :disabled="disabled"
     menu-placement="bottom-end"
     @item-clicked="menuHandler"
-    @open="$emit('menuOpen')"
-    @close="$emit('menuClose')"
+    @open="$emit('menu-open')"
+    @close="$emit('menu-close')"
     :button="{
       tooltip: { content: 'More Options', placement: 'bottom' },
       label: 'More Options',
@@ -88,7 +88,7 @@ export default {
       default: false
     }
   },
-  emits: [ 'menuOpen', 'menuClose' ],
+  emits: [ 'menu-open', 'menu-close' ],
   data() {
     const menu = {
       isOpen: false,

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -333,7 +333,7 @@ export default {
   }
 
   .apos-modal__header__main {
-    border-bottom: 1px solid var(--a-base-4);
+    border-bottom: 1px solid var(--a-base-9);
   }
 
   .apos-modal__footer {

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -18,7 +18,7 @@
       </transition>
       <transition :name="transitionType" @after-leave="$emit('inactive')">
         <div
-          v-if="modal.showModal"
+          v-if="modal.showModal" :class="innerClasses"
           class="apos-modal__inner" data-apos-modal-inner
         >
           <header class="apos-modal__header" v-if="!modal.disableHeader">
@@ -121,6 +121,13 @@ export default {
         classes.push('apos-modal--full-height');
       }
       return classes.join(' ');
+    },
+    innerClasses() {
+      const classes = [];
+      if (this.modal.width) {
+        classes.push(`apos-modal__inner--${this.modal.width}`);
+      };
+      return classes;
     },
     gridModifier() {
       if (this.hasLeftRail && this.hasRightRail) {
@@ -252,6 +259,18 @@ export default {
 
       @media screen and (min-width: 800px) {
         max-width: 540px;
+      }
+    }
+
+    &.apos-modal__inner--two-thirds {
+      @media screen and (min-width: 800px) {
+        max-width: 66%;
+      }
+    }
+
+    &.apos-modal__inner--half {
+      @media screen and (min-width: 800px) {
+        max-width: 50%;
       }
     }
 

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -236,7 +236,7 @@ export default {
     height: calc(100vh - #{$spacing-double * 2});
     border-radius: var(--a-border-radius);
     background-color: var(--a-background-primary);
-    border: 1px solid var(--a-base-4);
+    border: 1px solid var(--a-base-9);
     color: var(--a-text-primary);
 
     .apos-modal--slide & {

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
@@ -99,11 +99,11 @@ export default {
     }
   },
   methods: {
-    preview(docId, docs) {
-      const doc = docs.filter(d => d._id === docId)[0];
-      if (doc._url) {
-        window.open(doc._url, '_blank').focus();
-      }
+    preview(doc) {
+      window.open(doc._url, '_blank').focus();
+    },
+    findDoc(id, docs) {
+      return docs.find(p => p._id === id);
     },
     // It would have been nice for this to be computed, however
     // AposMediaManagerDisplay does not re-render when it is

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
@@ -99,6 +99,12 @@ export default {
     }
   },
   methods: {
+    preview(docId, docs) {
+      const doc = docs.filter(d => d._id === docId)[0];
+      if (doc._url) {
+        window.open(doc._url, '_blank').focus();
+      }
+    },
     // It would have been nice for this to be computed, however
     // AposMediaManagerDisplay does not re-render when it is
     // a computed prop rather than a method call in the template.

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
@@ -29,6 +29,49 @@ export default {
   },
   emits: [ 'modal-result', 'sort' ],
   computed: {
+    contextMenus() {
+      if (!this.pieces[0]) {
+        return [];
+      }
+      const menus = {};
+      this.pieces.forEach(item => {
+        menus[item._id] = [ {
+          label: 'Edit',
+          action: 'edit'
+        } ];
+
+        if (item._url) {
+          menus[item._id].push({
+            label: 'Preview',
+            action: 'preview'
+          });
+        };
+
+        menus[item._id].push({
+          label: 'Duplicate...',
+          action: 'duplicate'
+        },
+        // TODO check for draft/published differences
+        {
+          label: 'Discard Draft',
+          action: 'discardDraft'
+        });
+
+        if (!item.archived) {
+          menus[item._id].push({
+            label: 'Archive',
+            action: 'archive',
+            modifiers: [ 'danger' ]
+          });
+        } else {
+          menus[item._id].push({
+            label: 'Restore',
+            action: 'restore'
+          });
+        }
+      });
+      return menus;
+    },
     relationshipErrors() {
       if (!this.relationshipField) {
         return false;

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
@@ -102,7 +102,7 @@ export default {
     preview(doc) {
       window.open(doc._url, '_blank').focus();
     },
-    findDoc(id, docs) {
+    findDocById(docs, id) {
       return docs.find(p => p._id === id);
     },
     // It would have been nice for this to be computed, however

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
@@ -29,49 +29,6 @@ export default {
   },
   emits: [ 'modal-result', 'sort' ],
   computed: {
-    contextMenus() {
-      if (!this.pieces[0]) {
-        return [];
-      }
-      const menus = {};
-      this.pieces.forEach(item => {
-        menus[item._id] = [ {
-          label: 'Edit',
-          action: 'edit'
-        } ];
-
-        if (item._url) {
-          menus[item._id].push({
-            label: 'Preview',
-            action: 'preview'
-          });
-        };
-
-        menus[item._id].push({
-          label: 'Duplicate...',
-          action: 'duplicate'
-        },
-        // TODO check for draft/published differences
-        {
-          label: 'Discard Draft',
-          action: 'discardDraft'
-        });
-
-        if (!item.archived) {
-          menus[item._id].push({
-            label: 'Archive',
-            action: 'archive',
-            modifiers: [ 'danger' ]
-          });
-        } else {
-          menus[item._id].push({
-            label: 'Restore',
-            action: 'restore'
-          });
-        }
-      });
-      return menus;
-    },
     relationshipErrors() {
       if (!this.relationshipField) {
         return false;

--- a/modules/@apostrophecms/notification/ui/apos/components/AposNotification.vue
+++ b/modules/@apostrophecms/notification/ui/apos/components/AposNotification.vue
@@ -194,10 +194,11 @@ export default {
 
     & /deep/ button {
       @include apos-button-reset();
+      padding: 0 3px;
+      font-size: inherit;
       text-decoration: underline;
       text-decoration-color: var(--a-success);
       text-underline-offset: 3px;
-      padding: 0 3px;
     }
   }
 

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -1233,7 +1233,7 @@ database.`);
       // slug of the page's former parent, and `changed` is an array
       // of objects with _id and slug properties, including all subpages that
       // had to move too.
-      async moveToArchive(req, _id) {
+      async archive(req, _id) {
         const archive = await findArchive();
         if (!archive) {
           throw new Error('Site has no archive, contact administrator');

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -2093,7 +2093,8 @@ database.`);
           parked: 1,
           lastPublishedAt: 1,
           aposDocId: 1,
-          aposLocale: 1
+          aposLocale: 1,
+          updatedAt: 1
         };
       },
       addArchivedMigration() {

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -79,7 +79,7 @@
             @preview="onPreview"
             @copy="copy"
             @archive="onArchive"
-            @unarchive="onUnarchive"
+            @restore="onRestore"
           />
         </template>
       </AposModalBody>
@@ -123,9 +123,9 @@ export default {
           },
           {
             columnHeader: 'Last Edited',
-            property: 'lastPublishedAt',
+            property: 'updatedAt',
             component: 'AposCellLastEdited',
-            cellValue: 'lastPublishedAt'
+            cellValue: 'updatedAt'
           },
           {
             columnHeader: '',
@@ -209,23 +209,23 @@ export default {
   },
   methods: {
     onPreview(id) {
-      this.preview(this.findDoc(id, this.pagesFlat));
+      this.preview(this.findDocById(this.pagesFlat, id));
     },
     async onArchive(id) {
-      const doc = this.findDoc(id, this.pagesFlat);
+      const doc = this.findDocById(this.pagesFlat, id);
       if (await this.archive(this.moduleOptions.action, id, !!doc.lastPublishedAt, true)) {
         await this.getPages();
       }
     },
-    async onUnarchive(id) {
-      if (await this.unarchive(this.moduleOptions.action, id, true)) {
+    async onRestore(id) {
+      if (await this.restore(this.moduleOptions.action, id, true)) {
         await this.getPages();
       }
     },
     async copy(id) {
       const doc = await apos.modal.execute(this.moduleOptions.components.insertModal, {
         moduleName: this.moduleName,
-        copyOf: this.findDoc(id, this.pagesFlat)
+        copyOf: this.findDocById(this.pagesFlat, id)
       });
       if (!doc) {
         return;

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -103,8 +103,9 @@ export default {
       moduleName: '@apostrophecms/page',
       modal: {
         active: false,
-        type: 'overlay',
-        showModal: false
+        type: 'slide',
+        showModal: false,
+        width: 'two-thirds'
       },
       pages: [],
       pagesFlat: [],

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -79,6 +79,7 @@
             @preview="onPreview"
             @copy="copy"
             @archive="onArchive"
+            @unarchive="onUnarchive"
           />
         </template>
       </AposModalBody>
@@ -206,7 +207,12 @@ export default {
     },
     async onArchive(id) {
       const page = this.pagesFlat.filter(p => p._id === id)[0];
-      if (await this.archive(this.moduleOptions.action, id, !!page.lastPublishedAt)) {
+      if (await this.archive(this.moduleOptions.action, id, !!page.lastPublishedAt, true)) {
+        await this.getPages();
+      }
+    },
+    async onUnarchive(id) {
+      if (await this.unarchive(this.moduleOptions.action, id, true)) {
         await this.getPages();
       }
     },

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -116,6 +116,11 @@ export default {
             cellValue: 'title'
           },
           {
+            name: 'labels',
+            columnHeader: '',
+            component: 'AposCellLabels'
+          },
+          {
             columnHeader: 'Last Edited',
             property: 'lastPublishedAt',
             component: 'AposCellLastEdited',
@@ -203,24 +208,24 @@ export default {
   },
   methods: {
     onPreview(id) {
-      this.preview(id, this.pagesFlat);
+      this.preview(this.findDoc(id, this.pagesFlat));
     },
     async onArchive(id) {
-      const page = this.pagesFlat.filter(p => p._id === id)[0];
-      if (await this.archive(this.moduleOptions.action, id, !!page.lastPublishedAt, true)) {
+      const doc = this.findDoc(id, this.pagesFlat);
+      if (await this.archive(this.moduleOptions.action, id, !!doc.lastPublishedAt, true)) {
         await this.getPages();
       }
     },
     async onUnarchive(id) {
+      console.log(id);
       if (await this.unarchive(this.moduleOptions.action, id, true)) {
         await this.getPages();
       }
     },
     async copy(id) {
-      const page = this.pagesFlat.filter(p => p._id === id)[0];
       const doc = await apos.modal.execute(this.moduleOptions.components.insertModal, {
         moduleName: this.moduleName,
-        copyOf: page
+        copyOf: this.findDoc(id, this.pagesFlat)
       });
       if (!doc) {
         return;

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -218,7 +218,6 @@ export default {
       }
     },
     async onUnarchive(id) {
-      console.log(id);
       if (await this.unarchive(this.moduleOptions.action, id, true)) {
         await this.getPages();
       }

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -32,18 +32,46 @@ module.exports = {
           component: 'AposCellButton'
         },
         updatedAt: {
-          label: 'Edited on',
+          label: 'Last Edited',
           component: 'AposCellDate'
         },
-        visibility: {
-          label: 'Visibility'
-        },
+        moreMenu: {
+          label: 'More Operations',
+          hideLabel: true,
+          component: 'AposCellMenu',
+          menu: [
+            {
+              label: 'Edit',
+              action: 'edit'
+            },
+            {
+              label: 'Preview',
+              action: 'preview'
+            },
+            {
+              label: 'Duplicate...',
+              action: 'duplicate'
+            },
+            {
+              label: 'Discard Draft',
+              action: 'discardDraft'
+            },
+            {
+              label: 'Archive',
+              action: 'archive',
+              modifiers: [ 'danger' ]
+            }
+          ]
+        }
+        // visibility: {
+        //   label: 'Visibility'
+        // },
         // Automatically hidden if none of the pieces
         // actually have a URL
-        _url: {
-          label: 'Link',
-          component: 'AposCellLink'
-        }
+        // _url: {
+        //   label: 'Link',
+        //   component: 'AposCellLink'
+        // }
       }
     };
   },

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -32,10 +32,15 @@ module.exports = {
           name: 'title',
           component: 'AposCellButton'
         },
+        labels: {
+          name: 'labels',
+          label: '',
+          component: 'AposCellLabels'
+        },
         updatedAt: {
           name: 'updatedAt',
           label: 'Last Edited',
-          component: 'AposCellDate'
+          component: 'AposCellLastEdited'
         }
       }
     };

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -29,9 +29,11 @@ module.exports = {
       add: {
         title: {
           label: 'Title',
+          name: 'title',
           component: 'AposCellButton'
         },
         updatedAt: {
+          name: 'updatedAt',
           label: 'Last Edited',
           component: 'AposCellDate'
         }

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -34,44 +34,7 @@ module.exports = {
         updatedAt: {
           label: 'Last Edited',
           component: 'AposCellDate'
-        },
-        moreMenu: {
-          label: 'More Operations',
-          hideLabel: true,
-          component: 'AposCellMenu',
-          menu: [
-            {
-              label: 'Edit',
-              action: 'edit'
-            },
-            {
-              label: 'Preview',
-              action: 'preview'
-            },
-            {
-              label: 'Duplicate...',
-              action: 'duplicate'
-            },
-            {
-              label: 'Discard Draft',
-              action: 'discardDraft'
-            },
-            {
-              label: 'Archive',
-              action: 'archive',
-              modifiers: [ 'danger' ]
-            }
-          ]
         }
-        // visibility: {
-        //   label: 'Visibility'
-        // },
-        // Automatically hidden if none of the pieces
-        // actually have a URL
-        // _url: {
-        //   label: 'Link',
-        //   component: 'AposCellLink'
-        // }
       }
     };
   },

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
@@ -87,6 +87,7 @@
             @copy="copy"
             @discardDraft="onDiscardDraft"
             @archive="onArchive"
+            @unarchive="onUnarchive"
             :options="{
               disableUnchecked: maxReached(),
               hideCheckboxes: !relationshipField,
@@ -272,6 +273,12 @@ export default {
     async onArchive(pieceId) {
       const piece = this.pieces.filter(p => p._id === pieceId)[0];
       if (await this.archive(this.options.action, pieceId, !!piece.lastPublishedAt)) {
+        apos.bus.$emit('content-changed');
+      }
+    },
+    async onUnarchive(pieceId) {
+      const piece = this.pieces.filter(p => p._id === pieceId)[0];
+      if (await this.unarchive(this.options.action, pieceId, !!piece.lastPublishedAt)) {
         apos.bus.$emit('content-changed');
       }
     },

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
@@ -18,7 +18,6 @@
       />
     </template>
     <template #primaryControls>
-      <!-- TODO Make sure this gets positioned correctly after Vue3/teleport -->
       <AposContextMenu
         v-if="moreMenu.menu.length"
         :button="moreMenu.button"
@@ -79,11 +78,13 @@
         </template>
         <template #bodyMain>
           <AposPiecesManagerDisplay
-            v-if="items.length > 0"
-            :items="items"
+            v-if="pieces.length > 0"
+            :items="pieces"
             :headers="headers"
             v-model="checked"
             @open="edit"
+            @preview="preview"
+            :context-menus="contextMenus"
             :options="{
               disableUnchecked: maxReached(),
               hideCheckboxes: !relationshipField,
@@ -159,29 +160,6 @@ export default {
     modalTitle () {
       const verb = this.relationshipField ? 'Choose' : 'Manage';
       return `${verb} ${this.moduleLabels.plural}`;
-    },
-    items() {
-      const items = [];
-      if (!this.pieces || !this.headers.length) {
-        return [];
-      }
-
-      this.pieces.forEach(piece => {
-        const data = {};
-
-        // Extra data for internal use
-        data.lastPublishedAt = piece.lastPublishedAt;
-
-        this.headers.forEach(column => {
-          data[column.name] = piece[column.name];
-        });
-
-        data._id = piece._id;
-
-        items.push(data);
-      });
-
-      return items;
     },
     emptyDisplay() {
       return {
@@ -274,6 +252,12 @@ export default {
       if (num) {
         this.currentPage = num;
         this.getPieces();
+      }
+    },
+    preview(pieceId) {
+      const piece = this.pieces.filter(p => p._id === pieceId)[0];
+      if (piece._url) {
+        window.open(piece._url, '_blank').focus();
       }
     },
     async edit(pieceId) {

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
@@ -87,7 +87,7 @@
             @copy="copy"
             @discardDraft="onDiscardDraft"
             @archive="onArchive"
-            @unarchive="onUnarchive"
+            @restore="onRestore"
             :options="{
               disableUnchecked: maxReached(),
               hideCheckboxes: !relationshipField,
@@ -265,22 +265,22 @@ export default {
       }
     },
     onPreview(id) {
-      this.preview(this.findDoc(id, this.pieces));
+      this.preview(this.findDocById(this.pieces, id));
     },
     async onArchive(id) {
-      const piece = this.findDoc(id, this.pieces);
+      const piece = this.findDocById(this.pieces, id);
       if (await this.archive(this.options.action, id, !!piece.lastPublishedAt)) {
         apos.bus.$emit('content-changed');
       }
     },
-    async onUnarchive(id) {
-      const piece = this.findDoc(id, this.pieces);
-      if (await this.unarchive(this.options.action, id, !!piece.lastPublishedAt)) {
+    async onRestore(id) {
+      const piece = this.findDocById(this.pieces, id);
+      if (await this.restore(this.options.action, id, !!piece.lastPublishedAt)) {
         apos.bus.$emit('content-changed');
       }
     },
     async onDiscardDraft(id) {
-      const piece = this.findDoc(id, this.pieces);
+      const piece = this.findDocById(this.pieces, id);
       if (await this.discardDraft(this.options.action, id, !!piece.lastPublishedAt)) {
         apos.bus.$emit('content-changed');
       };
@@ -289,7 +289,7 @@ export default {
       apos.bus.$emit('admin-menu-click', {
         itemName: `${this.options.name}:editor`,
         props: {
-          copyOf: this.findDoc(id, this.pieces)
+          copyOf: this.findDocById(this.pieces, id)
         }
       });
     },

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
@@ -265,32 +265,31 @@ export default {
       }
     },
     onPreview(id) {
-      this.preview(id, this.pieces);
+      this.preview(this.findDoc(id, this.pieces));
     },
-    async onArchive(pieceId) {
-      const piece = this.pieces.filter(p => p._id === pieceId)[0];
-      if (await this.archive(this.options.action, pieceId, !!piece.lastPublishedAt)) {
+    async onArchive(id) {
+      const piece = this.findDoc(id, this.pieces);
+      if (await this.archive(this.options.action, id, !!piece.lastPublishedAt)) {
         apos.bus.$emit('content-changed');
       }
     },
-    async onUnarchive(pieceId) {
-      const piece = this.pieces.filter(p => p._id === pieceId)[0];
-      if (await this.unarchive(this.options.action, pieceId, !!piece.lastPublishedAt)) {
+    async onUnarchive(id) {
+      const piece = this.findDoc(id, this.pieces);
+      if (await this.unarchive(this.options.action, id, !!piece.lastPublishedAt)) {
         apos.bus.$emit('content-changed');
       }
     },
-    async onDiscardDraft(pieceId) {
-      const piece = this.pieces.filter(p => p._id === pieceId)[0];
-      if (await this.discardDraft(this.options.action, pieceId, !!piece.lastPublishedAt)) {
+    async onDiscardDraft(id) {
+      const piece = this.findDoc(id, this.pieces);
+      if (await this.discardDraft(this.options.action, id, !!piece.lastPublishedAt)) {
         apos.bus.$emit('content-changed');
       };
     },
-    async copy(pieceId) {
-      const piece = this.pieces.filter(p => p._id === pieceId)[0];
+    async copy(id) {
       apos.bus.$emit('admin-menu-click', {
         itemName: `${this.options.name}:editor`,
         props: {
-          copyOf: piece
+          copyOf: this.findDoc(id, this.pieces)
         }
       });
     },

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManager.vue
@@ -83,7 +83,7 @@
             :headers="headers"
             v-model="checked"
             @open="edit"
-            @preview="preview"
+            @preview="onPreview"
             @copy="copy"
             @discardDraft="onDiscardDraft"
             @archive="onArchive"
@@ -264,11 +264,8 @@ export default {
         this.getPieces();
       }
     },
-    preview(pieceId) {
-      const piece = this.pieces.filter(p => p._id === pieceId)[0];
-      if (piece._url) {
-        window.open(piece._url, '_blank').focus();
-      }
+    onPreview(id) {
+      this.preview(id, this.pieces);
     },
     async onArchive(pieceId) {
       const piece = this.pieces.filter(p => p._id === pieceId)[0];

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManagerDisplay.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManagerDisplay.vue
@@ -70,10 +70,6 @@
             v-if="header.component" :is="header.component"
             :header="header" :item="item"
           />
-          <AposCellLink
-            v-else-if="header.name === '_url' && item[header.name]"
-            :header="header" :item="item"
-          />
           <AposCellBasic
             v-else
             :header="header" :item="item"

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManagerDisplay.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManagerDisplay.vue
@@ -84,7 +84,7 @@
             @copy="$emit('copy', item._id)"
             @discardDraft="$emit('discardDraft', item._id)"
             @archive="$emit('archive', item._id)"
-            @unarchive="$emit('unarchive', item._id)"
+            @restore="$emit('restore', item._id)"
           />
         </td>
       </tr>
@@ -129,7 +129,7 @@ export default {
     'copy',
     'discardDraft',
     'archive',
-    'unarchive'
+    'restore'
   ],
   data() {
     const state = {

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManagerDisplay.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManagerDisplay.vue
@@ -23,6 +23,14 @@
             {{ header.label }}
           </component>
         </th>
+        <th class="apos-table__header" key="contextMenu">
+          <component
+            :is="getEl({})"
+            class="apos-table__header-label"
+          >
+            More Operations
+          </component>
+        </th>
       </tr>
       <tr
         class="apos-table__row"
@@ -60,7 +68,6 @@
             v-if="header.component" :is="header.component"
             :header="header" :item="item"
             :state="state[item._id]"
-            @edit="$emit('open', item._id)"
           />
           <AposCellLink
             v-else-if="header.name === '_url' && item[header.name]"
@@ -69,6 +76,14 @@
           <AposCellBasic
             v-else
             :header="header" :item="item"
+          />
+        </td>
+        <!-- append context menu -->
+        <td class="apos-table__cell apos-table__cell--context-menu">
+          <AposCellContextMenu
+            :state="{}" :menu="contextMenus[item._id]"
+            @edit="$emit('open', item._id)"
+            @preview="$emit('preview', item._id)"
           />
         </td>
       </tr>
@@ -83,6 +98,10 @@ export default {
     event: 'change'
   },
   props: {
+    contextMenus: {
+      type: Object,
+      required: true
+    },
     headers: {
       type: Array,
       required: true
@@ -107,7 +126,8 @@ export default {
   emits: [
     'open',
     'change',
-    'updated'
+    'updated',
+    'preview'
   ],
   data() {
     const state = {};
@@ -130,13 +150,9 @@ export default {
   },
   methods: {
     over(id) {
-      console.log(id);
-      console.log(this.state[id]);
       this.state[id].hover = true;
-      console.log(JSON.stringify(this.state[id].hover));
     },
     out(id) {
-      console.log('fire out');
       this.state[id].hover = false;
     },
     getEl(header) {

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManagerDisplay.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManagerDisplay.vue
@@ -78,7 +78,7 @@
         <!-- append the context menu -->
         <td class="apos-table__cell apos-table__cell--context-menu">
           <AposCellContextMenu
-            :state="state[item._id]" :doc="item"
+            :state="state[item._id]" :item="item"
             @edit="$emit('open', item._id)"
             @preview="$emit('preview', item._id)"
             @copy="$emit('copy', item._id)"

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManagerDisplay.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManagerDisplay.vue
@@ -9,10 +9,10 @@
         <th
           v-for="header in headers" scope="col"
           class="apos-table__header" :key="header.label"
+          :class="`apos-table__header--${header.name}`"
         >
           <component
-            :is="getEl(header)"
-            class="apos-table__header-label"
+            :is="getEl(header)" class="apos-table__header-label"
           >
             <component
               v-if="header.labelIcon"
@@ -26,7 +26,7 @@
         <th class="apos-table__header" key="contextMenu">
           <component
             :is="getEl({})"
-            class="apos-table__header-label"
+            class="apos-table__header-label is-hidden"
           >
             More Operations
           </component>
@@ -60,7 +60,9 @@
           />
         </td>
         <td
-          class="apos-table__cell apos-table__cell--pointer" v-for="header in headers"
+          v-for="header in headers"
+          class="apos-table__cell apos-table__cell--pointer"
+          :class="`apos-table__cell--${header.name}`"
           :key="item[header.name]"
           @click="$emit('open',item._id)"
         >
@@ -77,7 +79,7 @@
             :header="header" :item="item"
           />
         </td>
-        <!-- append context menu -->
+        <!-- append the context menu -->
         <td class="apos-table__cell apos-table__cell--context-menu">
           <AposCellContextMenu
             :state="state[item._id]" :doc="item"
@@ -86,6 +88,7 @@
             @copy="$emit('copy', item._id)"
             @discardDraft="$emit('discardDraft', item._id)"
             @archive="$emit('archive', item._id)"
+            @unarchive="$emit('unarchive', item._id)"
           />
         </td>
       </tr>
@@ -129,7 +132,8 @@ export default {
     'preview',
     'copy',
     'discardDraft',
-    'archive'
+    'archive',
+    'unarchive'
   ],
   data() {
     const state = {
@@ -167,11 +171,13 @@ export default {
       this.state[id].hover = false;
     },
     refreshState() {
+      const template = klona(this.state._template);
+      const state = {};
       this.items.forEach(item => {
-        if (!this.state[item._id]) {
-          this.state[item._id] = klona(this.state._template);
-        }
+        state[item._id] = klona(template);
       });
+      state._template = template;
+      this.state = state;
     },
     getEl(header) {
       if (header.action) {

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManagerDisplay.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposPiecesManagerDisplay.vue
@@ -29,6 +29,7 @@
         v-for="item in items"
         :key="item._id"
         :class="{'is-selected': false }"
+        @mouseover="over(item._id)" @mouseout="out(item._id)"
       >
         <td
           class="apos-table__cell"
@@ -58,6 +59,8 @@
           <component
             v-if="header.component" :is="header.component"
             :header="header" :item="item"
+            :state="state[item._id]"
+            @edit="$emit('open', item._id)"
           />
           <AposCellLink
             v-else-if="header.name === '_url' && item[header.name]"
@@ -106,6 +109,15 @@ export default {
     'change',
     'updated'
   ],
+  data() {
+    const state = {};
+    this.items.forEach(item => {
+      state[item._id] = { hover: false };
+    });
+    return {
+      state
+    };
+  },
   computed: {
     checkProxy: {
       get() {
@@ -117,6 +129,16 @@ export default {
     }
   },
   methods: {
+    over(id) {
+      console.log(id);
+      console.log(this.state[id]);
+      this.state[id].hover = true;
+      console.log(JSON.stringify(this.state[id].hover));
+    },
+    out(id) {
+      console.log('fire out');
+      this.state[id].hover = false;
+    },
     getEl(header) {
       if (header.action) {
         return 'button';

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
@@ -8,7 +8,7 @@
         :is-modified-from-published="item.modified"
         :is-published="!!item.lastPublishedAt"
         :can-save-draft="false"
-        :can-open-editor="true"
+        :can-open-editor="!item.archived"
         :can-preview="(!!item._url && !item.archived)"
         :can-archive="!item.archived"
         :can-unarchive="item.archived"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
@@ -67,9 +67,10 @@ export default {
 <style lang="scss" scoped>
   .apos-table__cell-field--context-menu__content {
     @include apos-transition();
+    display: inline-block;
     opacity: 0;
-  }
-  .is-visible {
-    opacity: 1;
+    &.is-visible {
+      opacity: 1;
+    }
   }
 </style>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
@@ -10,14 +10,18 @@
       :is-published="!!doc.lastPublishedAt"
       :can-save-draft="false"
       :can-open-editor="true"
-      :can-preview="!!doc._url"
-      :can-archive="!!doc.lastPublishedAt"
-      :can-copy="!!doc._id"
+      :can-preview="(!!doc._url && !doc.archived)"
+      :can-archive="!doc.archived"
+      :can-unarchive="doc.archived"
+      :can-copy="(!!doc._id && !doc.archived)"
       @edit="$emit('edit')"
       @preview="$emit('preview')"
       @copy="$emit('copy')"
       @archive="$emit('archive')"
+      @unarchive="$emit('unarchive')"
       @discardDraft="$emit('discardDraft')"
+      @menuOpen="menuOpen = true"
+      @menuClose="menuOpen = false"
     />
   </div>
 </template>
@@ -37,17 +41,17 @@ export default {
       required: true
     }
   },
-  emits: [ 'edit', 'preview', 'copy', 'archive', 'discardDraft' ],
+  emits: [ 'edit', 'preview', 'copy', 'archive', 'discardDraft', 'unarchive' ],
   data() {
     return {
-      hidden: true
+      menuOpen: false
     };
   },
   computed: {
     classes() {
       const classes = [ ];
-      if (this.state.hover) {
-        classes.push('is-hovered');
+      if (this.state.hover || this.menuOpen) {
+        classes.push('is-visible');
       }
       return classes;
     }
@@ -61,7 +65,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  // .is-hovered {
-  //   border: 3px solid var(--a-danger);
-  // }
+  .apos-table__cell-field--context-menu {
+    @include apos-transition();
+    opacity: 0;
+  }
+  .is-visible {
+    opacity: 1;
+  }
 </style>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
@@ -11,13 +11,13 @@
         :can-open-editor="!item.archived"
         :can-preview="(!!item._url && !item.archived)"
         :can-archive="!item.archived"
-        :can-unarchive="item.archived"
+        :can-restore="item.archived"
         :can-copy="(!!item._id && !item.archived)"
         @edit="$emit('edit')"
         @preview="$emit('preview')"
         @copy="$emit('copy')"
         @archive="$emit('archive')"
-        @unarchive="$emit('unarchive')"
+        @restore="$emit('restore')"
         @discardDraft="$emit('discardDraft')"
         @menuOpen="menuOpen = true"
         @menuClose="menuOpen = false"
@@ -41,7 +41,7 @@ export default {
       required: true
     }
   },
-  emits: [ 'edit', 'preview', 'copy', 'archive', 'discardDraft', 'unarchive' ],
+  emits: [ 'edit', 'preview', 'copy', 'archive', 'discardDraft', 'restore' ],
   data() {
     return {
       menuOpen: false

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
@@ -19,8 +19,8 @@
         @archive="$emit('archive')"
         @restore="$emit('restore')"
         @discardDraft="$emit('discardDraft')"
-        @menuOpen="menuOpen = true"
-        @menuClose="menuOpen = false"
+        @menu-open="menuOpen = true"
+        @menu-close="menuOpen = false"
       />
     </span>
   </div>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
@@ -1,28 +1,28 @@
 <template>
-  <div
-    class="apos-table__cell-field apos-table__cell-field--context-menu" :class="classes"
-  >
-    <AposDocMoreMenu
-      :doc-id="doc._id"
-      :is-modified="doc.modified"
-      :can-discard-draft="doc.modified"
-      :is-modified-from-published="doc.modified"
-      :is-published="!!doc.lastPublishedAt"
-      :can-save-draft="false"
-      :can-open-editor="true"
-      :can-preview="(!!doc._url && !doc.archived)"
-      :can-archive="!doc.archived"
-      :can-unarchive="doc.archived"
-      :can-copy="(!!doc._id && !doc.archived)"
-      @edit="$emit('edit')"
-      @preview="$emit('preview')"
-      @copy="$emit('copy')"
-      @archive="$emit('archive')"
-      @unarchive="$emit('unarchive')"
-      @discardDraft="$emit('discardDraft')"
-      @menuOpen="menuOpen = true"
-      @menuClose="menuOpen = false"
-    />
+  <div class="apos-table__cell-field apos-table__cell-field--context-menu">
+    <span class="apos-table__cell-field--context-menu__content" :class="classes">
+      <AposDocMoreMenu
+        :doc-id="item._id"
+        :is-modified="item.modified"
+        :can-discard-draft="item.modified"
+        :is-modified-from-published="item.modified"
+        :is-published="!!item.lastPublishedAt"
+        :can-save-draft="false"
+        :can-open-editor="true"
+        :can-preview="(!!item._url && !item.archived)"
+        :can-archive="!item.archived"
+        :can-unarchive="item.archived"
+        :can-copy="(!!item._id && !item.archived)"
+        @edit="$emit('edit')"
+        @preview="$emit('preview')"
+        @copy="$emit('copy')"
+        @archive="$emit('archive')"
+        @unarchive="$emit('unarchive')"
+        @discardDraft="$emit('discardDraft')"
+        @menuOpen="menuOpen = true"
+        @menuClose="menuOpen = false"
+      />
+    </span>
   </div>
 </template>
 
@@ -33,10 +33,10 @@ export default {
     state: {
       type: Object,
       default() {
-        return {};
+        return null;
       }
     },
-    doc: {
+    item: {
       type: Object,
       required: true
     }
@@ -50,7 +50,7 @@ export default {
   computed: {
     classes() {
       const classes = [ ];
-      if (this.state.hover || this.menuOpen) {
+      if (!this.state || this.state.hover || this.menuOpen) {
         classes.push('is-visible');
       }
       return classes;
@@ -65,7 +65,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .apos-table__cell-field--context-menu {
+  .apos-table__cell-field--context-menu__content {
     @include apos-transition();
     opacity: 0;
   }

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
@@ -1,10 +1,10 @@
 <template>
   <div
-    class="apos-table__cell-field" :class="classes"
+    class="apos-table__cell-field apos-table__cell-field--context-menu" :class="classes"
   >
     <AposContextMenu
       class="apos-admin-bar__sub"
-      :menu="header.menu"
+      :menu="menu"
       :button="{
         label: 'More Operations',
         modifiers: [ 'no-motion', 'tiny' ],
@@ -20,18 +20,14 @@
 
 <script>
 export default {
-  name: 'AposCellMenu',
+  name: 'AposCellContextMenu',
   props: {
     state: {
       type: Object,
       required: true
     },
-    item: {
-      type: Object,
-      required: true
-    },
-    header: {
-      type: Object,
+    menu: {
+      type: Array,
       required: true
     }
   },
@@ -42,7 +38,7 @@ export default {
   },
   computed: {
     classes() {
-      const classes = [ `apos-table__cell-field--${this.header.name}` ];
+      const classes = [ ];
       if (this.state.hover) {
         classes.push('is-hovered');
       }

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
@@ -2,18 +2,22 @@
   <div
     class="apos-table__cell-field apos-table__cell-field--context-menu" :class="classes"
   >
-    <AposContextMenu
-      class="apos-admin-bar__sub"
-      :menu="menu"
-      :button="{
-        label: 'More Operations',
-        modifiers: [ 'no-motion', 'tiny' ],
-        iconOnly: true,
-        icon: 'dots-vertical-icon',
-        type: 'outline'
-      }"
-      menu-position="bottom-end"
-      @item-clicked="handler"
+    <AposDocMoreMenu
+      :doc-id="doc._id"
+      :is-modified="doc.modified"
+      :can-discard-draft="doc.modified"
+      :is-modified-from-published="doc.modified"
+      :is-published="!!doc.lastPublishedAt"
+      :can-save-draft="false"
+      :can-open-editor="true"
+      :can-preview="!!doc._url"
+      :can-archive="!!doc.lastPublishedAt"
+      :can-copy="!!doc._id"
+      @edit="$emit('edit')"
+      @preview="$emit('preview')"
+      @copy="$emit('copy')"
+      @archive="$emit('archive')"
+      @discardDraft="$emit('discardDraft')"
     />
   </div>
 </template>
@@ -24,13 +28,16 @@ export default {
   props: {
     state: {
       type: Object,
-      required: true
+      default() {
+        return {};
+      }
     },
-    menu: {
-      type: Array,
+    doc: {
+      type: Object,
       required: true
     }
   },
+  emits: [ 'edit', 'preview', 'copy', 'archive', 'discardDraft' ],
   data() {
     return {
       hidden: true

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellDate.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellDate.vue
@@ -9,7 +9,7 @@
 
 <script>
 export default {
-  name: 'AposCellBasic',
+  name: 'AposCellDate',
   props: {
     item: {
       type: Object,
@@ -24,10 +24,47 @@ export default {
     formattedDate () {
       const value = this.item[this.header.name];
 
-      return this.formatDateColumn(value);
+      return this.getRelativeTime(value);
     }
   },
   methods: {
+    getRelativeTime (value) {
+      // cribbed from https://gist.github.com/pomber/6195066a9258d1fb93bb59c206345b38
+      const d = new Date(value);
+      if (Number.isNaN(d.getDate())) {
+        // We're not sure what this is, but it's not a date.
+        return value;
+      }
+      const secondsAgo = Math.round((+new Date() - d) / 1000);
+      let divisor = null;
+      let unit = null;
+      const MINUTE = 60;
+      const HOUR = MINUTE * 60;
+      const DAY = HOUR * 24;
+      const WEEK = DAY * 7;
+      const MONTH = DAY * 30;
+      const YEAR = DAY * 365;
+
+      if (secondsAgo < MINUTE) {
+        return secondsAgo + ' seconds ago';
+      } else if (secondsAgo < HOUR) {
+        [ divisor, unit ] = [ MINUTE, 'minute' ];
+      } else if (secondsAgo < DAY) {
+        [ divisor, unit ] = [ HOUR, 'hour' ];
+      } else if (secondsAgo < WEEK) {
+        [ divisor, unit ] = [ DAY, 'day' ];
+      } else if (secondsAgo < MONTH) {
+        [ divisor, unit ] = [ WEEK, 'week' ];
+      } else if (secondsAgo < YEAR) {
+        [ divisor, unit ] = [ MONTH, 'month' ];
+      } else if (secondsAgo > YEAR) {
+        [ divisor, unit ] = [ YEAR, 'year' ];
+      }
+
+      const count = Math.floor(secondsAgo / divisor);
+      return `${count} ${unit}${(count > 1) ? 's' : ''} ago`;
+
+    },
     formatDateColumn (value) {
       const d = new Date(value);
       if (Number.isNaN(d.getDate())) {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellLabels.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellLabels.vue
@@ -5,18 +5,18 @@
   >
     <span v-if="item.modified">
       <AposLabel
-        label="Active Draft"
+        label="Active Draft" class="apos-table__cell-field__label"
       />
     </span>
     <span v-if="!item.lastPublishedAt">
       <AposLabel
-        label="Unpublished"
+        label="Unpublished" class="apos-table__cell-field__label"
         :modifiers="[ 'is-warning' ]"
       />
     </span>
     <span v-if="item.archived">
       <AposLabel
-        label="Archived"
+        label="Archived" class="apos-table__cell-field__label"
       />
     </span>
   </p>
@@ -42,9 +42,8 @@ export default {
   .apos-table__cell-field--labels {
     display: inline-flex;
     padding-right: 10px;
-    & /deep/ .apos-label {
-      margin-left: 5px;
-    }
   }
-
+  .apos-table__cell-field__label {
+    margin-left: 5px;
+  }
 </style>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellLabels.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellLabels.vue
@@ -34,11 +34,6 @@ export default {
       type: Object,
       required: true
     }
-  },
-  computed: {
-  },
-  methods: {
-
   }
 };
 </script>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellLabels.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellLabels.vue
@@ -1,6 +1,6 @@
 <template>
   <p
-    class="apos-table__cell-field"
+    class="apos-table__cell-field apos-table__cell-field--labels"
     :class="`apos-table__cell-field--${header.name}`"
   >
     <span v-if="item.modified">
@@ -45,7 +45,11 @@ export default {
 
 <style lang="scss" scoped>
   .apos-table__cell-field--labels {
-    text-align: right;
+    display: inline-flex;
     padding-right: 10px;
+    & /deep/ .apos-label {
+      margin-left: 5px;
+    }
   }
+
 </style>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellLabels.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellLabels.vue
@@ -1,0 +1,51 @@
+<template>
+  <p
+    class="apos-table__cell-field"
+    :class="`apos-table__cell-field--${header.name}`"
+  >
+    <span v-if="item.modified">
+      <AposLabel
+        label="Active Draft"
+      />
+    </span>
+    <span v-if="!item.lastPublishedAt">
+      <AposLabel
+        label="Unpublished"
+        :modifiers="[ 'is-warning' ]"
+      />
+    </span>
+    <span v-if="item.archived">
+      <AposLabel
+        label="Archived"
+      />
+    </span>
+  </p>
+</template>
+
+<script>
+export default {
+  name: 'AposCellLabels',
+  props: {
+    item: {
+      type: Object,
+      required: true
+    },
+    header: {
+      type: Object,
+      required: true
+    }
+  },
+  computed: {
+  },
+  methods: {
+
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+  .apos-table__cell-field--labels {
+    text-align: right;
+    padding-right: 10px;
+  }
+</style>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellLastEdited.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellLastEdited.vue
@@ -9,7 +9,7 @@
 
 <script>
 export default {
-  name: 'AposCellDate',
+  name: 'AposCellLastEdited',
   props: {
     item: {
       type: Object,
@@ -23,7 +23,6 @@ export default {
   computed: {
     formattedDate () {
       const value = this.item[this.header.name];
-
       return this.getRelativeTime(value);
     }
   },
@@ -64,40 +63,6 @@ export default {
       const count = Math.floor(secondsAgo / divisor);
       return `${count} ${unit}${(count > 1) ? 's' : ''} ago`;
 
-    },
-    formatDateColumn (value) {
-      const d = new Date(value);
-      if (Number.isNaN(d.getDate())) {
-        // We're not sure what this is, but it's not a date.
-        return value;
-      }
-      const month = d.getMonth();
-      const date = d.getDate();
-      const year = d.getFullYear();
-      let hour = d.getHours();
-      const period = hour > 11 ? 'pm' : 'am';
-      if (hour > 12) {
-        hour = hour - 12;
-      } else if (hour === 0) {
-        hour = 12;
-      }
-      const minute = d.getMinutes();
-
-      return `${toTwoChars(month)}/${toTwoChars(date)}/${toTwoChars(year)} at ${hour}:${minute} ${period}`;
-
-      function toTwoChars(num) {
-        num = parseInt(num);
-
-        if (num < 10) {
-          return `0${num.toString()}`;
-        } else if (num > 1000) {
-          // Good as long as we replace this by year 10,000.
-          return toTwoChars(num.toString().slice(2, 4));
-        } else {
-          // If it's more than 12 and less than 1000, the problem isn't here.
-          return num;
-        };
-      }
     }
 
   }

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellLastEdited.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellLastEdited.vue
@@ -62,9 +62,7 @@ export default {
 
       const count = Math.floor(secondsAgo / divisor);
       return `${count}${unit} ago`;
-
     }
-
   }
 };
 </script>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellLastEdited.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellLastEdited.vue
@@ -1,6 +1,6 @@
 <template>
   <p
-    class="apos-table__cell-field"
+    class="apos-table__cell-field apos-table__cell-field--relative-time"
     :class="`apos-table__cell-field--${header.name}`"
   >
     {{ formattedDate }}
@@ -22,7 +22,7 @@ export default {
   },
   computed: {
     formattedDate () {
-      const value = this.item[this.header.name];
+      const value = this.item[this.header.name || this.header.property];
       return this.getRelativeTime(value);
     }
   },
@@ -45,26 +45,32 @@ export default {
       const YEAR = DAY * 365;
 
       if (secondsAgo < MINUTE) {
-        return secondsAgo + ' seconds ago';
+        return secondsAgo + 's';
       } else if (secondsAgo < HOUR) {
-        [ divisor, unit ] = [ MINUTE, 'minute' ];
+        [ divisor, unit ] = [ MINUTE, 'm' ];
       } else if (secondsAgo < DAY) {
-        [ divisor, unit ] = [ HOUR, 'hour' ];
+        [ divisor, unit ] = [ HOUR, 'h' ];
       } else if (secondsAgo < WEEK) {
-        [ divisor, unit ] = [ DAY, 'day' ];
+        [ divisor, unit ] = [ DAY, 'd' ];
       } else if (secondsAgo < MONTH) {
-        [ divisor, unit ] = [ WEEK, 'week' ];
+        [ divisor, unit ] = [ WEEK, 'w' ];
       } else if (secondsAgo < YEAR) {
-        [ divisor, unit ] = [ MONTH, 'month' ];
+        [ divisor, unit ] = [ MONTH, 'mo' ];
       } else if (secondsAgo > YEAR) {
-        [ divisor, unit ] = [ YEAR, 'year' ];
+        [ divisor, unit ] = [ YEAR, 'yr' ];
       }
 
       const count = Math.floor(secondsAgo / divisor);
-      return `${count} ${unit}${(count > 1) ? 's' : ''} ago`;
+      return `${count}${unit} ago`;
 
     }
 
   }
 };
 </script>
+
+<style lang="scss" scoped>
+  .apos-table__cell-field--relative-time {
+    color: var(--a-base-4);
+  }
+</style>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellMenu.vue
@@ -1,0 +1,64 @@
+<template>
+  <div
+    class="apos-table__cell-field" :class="classes"
+  >
+    <AposContextMenu
+      class="apos-admin-bar__sub"
+      :menu="header.menu"
+      :button="{
+        label: 'More Operations',
+        modifiers: [ 'no-motion', 'tiny' ],
+        iconOnly: true,
+        icon: 'dots-vertical-icon',
+        type: 'outline'
+      }"
+      menu-position="bottom-end"
+      @item-clicked="handler"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'AposCellMenu',
+  props: {
+    state: {
+      type: Object,
+      required: true
+    },
+    item: {
+      type: Object,
+      required: true
+    },
+    header: {
+      type: Object,
+      required: true
+    }
+  },
+  data() {
+    return {
+      hidden: true
+    };
+  },
+  computed: {
+    classes() {
+      const classes = [ `apos-table__cell-field--${this.header.name}` ];
+      if (this.state.hover) {
+        classes.push('is-hovered');
+      }
+      return classes;
+    }
+  },
+  methods: {
+    handler(action) {
+      this.$emit(action);
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+  // .is-hovered {
+  //   border: 3px solid var(--a-danger);
+  // }
+</style>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -16,7 +16,7 @@
       <!-- TODO refactor buttons to take a single config obj -->
       <AposButton
         class="apos-context-menu__btn"
-        @click="buttonClicked($event)"
+        @click.stop="buttonClicked($event)"
         v-bind="button"
         :state="buttonState"
         ref="button"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposLabel.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposLabel.vue
@@ -20,10 +20,6 @@ export default {
         return [];
       }
     }
-  },
-  computed: {
-  },
-  methods: {
   }
 };
 </script>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposLabel.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposLabel.vue
@@ -1,0 +1,47 @@
+<template>
+  <span
+    class="apos-label" :class="modifiers"
+  >
+    {{ label }}
+  </span>
+</template>
+
+<script>
+export default {
+  name: 'AposLabel',
+  props: {
+    label: {
+      type: String,
+      required: true
+    },
+    modifiers: {
+      type: Array,
+      default() {
+        return [];
+      }
+    }
+  },
+  computed: {
+  },
+  methods: {
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+  .apos-label {
+    display: inline-block;
+    padding: 5px;
+    border: 1px solid var(--a-base-8);
+    border-radius: var(--a-border-radius);
+    font-size: var(--a-type-tiny);
+  }
+
+  .is-warning {
+    border-color: var(--a-warning);
+  }
+
+  .is-error {
+    border-color: var(--a-danger);
+  }
+</style>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
@@ -20,6 +20,11 @@
       :nested="nested"
       @update="update"
       @edit="$emit('edit', $event)"
+      @preview="$emit('preview', $event)"
+      @copy="$emit('copy', $event)"
+      @discardDraft="$emit('discardDraft', $event)"
+      @archive="$emit('archive', $event)"
+      @unarchive="$emit('unarchive', $event)"
       list-id="root"
       :options="options"
       :tree-id="treeId"
@@ -73,7 +78,7 @@ export default {
       }
     }
   },
-  emits: [ 'update', 'change', 'edit' ],
+  emits: [ 'update', 'change', 'edit', 'preview', 'copy', 'discardDraft', 'archive', 'unarchive' ],
   data() {
     return {
       // Copy the `items` property to mutate with VueDraggable.
@@ -173,6 +178,9 @@ export default {
     }
   },
   methods: {
+    test() {
+      console.log('am i here?');
+    },
     setWidths(widths) {
       this.colWidths = widths;
     },

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
@@ -178,9 +178,6 @@ export default {
     }
   },
   methods: {
-    test() {
-      console.log('am i here?');
-    },
     setWidths(widths) {
       this.colWidths = widths;
     },

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
@@ -24,7 +24,7 @@
       @copy="$emit('copy', $event)"
       @discardDraft="$emit('discardDraft', $event)"
       @archive="$emit('archive', $event)"
-      @unarchive="$emit('unarchive', $event)"
+      @restore="$emit('restore', $event)"
       list-id="root"
       :options="options"
       :tree-id="treeId"
@@ -78,7 +78,7 @@ export default {
       }
     }
   },
-  emits: [ 'update', 'change', 'edit', 'preview', 'copy', 'discardDraft', 'archive', 'unarchive' ],
+  emits: [ 'update', 'change', 'edit', 'preview', 'copy', 'discardDraft', 'archive', 'restore' ],
   data() {
     return {
       // Copy the `items` property to mutate with VueDraggable.

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -300,12 +300,6 @@ export default {
         }
       ];
 
-      if (this.options.ghostUnpublished) {
-        classes.push({
-          'is-unpublished': !row.lastPublishedAt
-        });
-      }
-
       return classes;
     },
     getEffectiveType(col, row) {
@@ -449,9 +443,6 @@ export default {
 
   .apos-tree__row {
     &.is-dragging {
-      opacity: 0.5;
-    }
-    &.is-unpublished > .apos-tree__row-data {
       opacity: 0.5;
     }
   }

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -34,13 +34,21 @@
           v-for="(col, index) in headers"
           :key="`${col.property}-${index}`"
           :is="getEffectiveType(col, row)"
+          :item="row"
+          :header="col"
           :href="(getEffectiveType(col, row) === 'a') ? row[col.property] : false"
           :target="col.type === 'link' ? '_blank' : false"
           :class="getCellClasses(col, row)"
           :disabled="getCellDisabled(col, row)"
           :data-col="col.property"
           :style="getCellStyles(col.property, index)"
-          @click="((getEffectiveType(col, row) !== 'span') && col.action) ? $emit(col.action, row._id) : null"
+          @click="((getEffectiveType(col, row) === 'button') && col.action) ? $emit(col.action, row._id) : null"
+          @edit="$emit('edit', row._id)"
+          @preview="$emit('preview', row._id)"
+          @copy="$emit('copy', row._id)"
+          @discardDraft="$emit('discardDraft', row._id)"
+          @archive="$emit('archive', row._id)"
+          @unarchive="$emit('unarchive', row._id)"
         >
           <AposIndicator
             v-if="options.draggable && index === 0 && !row.parked"
@@ -104,6 +112,11 @@
         }"
         @update="$emit('update', $event)"
         @edit="$emit('edit', $event)"
+        @preview="$emit('preview', $event)"
+        @copy="$emit('copy', $event)"
+        @discardDraft="$emit('discardDraft', $event)"
+        @archive="$emit('archive', $event)"
+        @unarchive="$emit('unarchive', $event)"
         v-model="checkedProxy"
       />
     </li>
@@ -176,7 +189,7 @@ export default {
       required: true
     }
   },
-  emits: [ 'update', 'change', 'edit' ],
+  emits: [ 'update', 'change', 'edit', 'preview', 'copy', 'discardDraft', 'archive', 'unarchive' ],
   computed: {
     myRows() {
       return this.rows;
@@ -214,6 +227,9 @@ export default {
     });
   },
   methods: {
+    test() {
+      console.log('hi?');
+    },
     setHeights() {
       this.$refs['tree-branches'].forEach(branch => {
         // Add padding to the max-height to avoid needing a `resize`
@@ -296,6 +312,9 @@ export default {
       return classes;
     },
     getEffectiveType(col, row) {
+      if (col.component) {
+        return col.component;
+      }
       if (row.type === '@apostrophecms/archive-page') {
         return 'span';
       } else if (col.type === 'link') {
@@ -309,7 +328,7 @@ export default {
     getEffectiveIcon(col, row) {
       const boolStr = (!!row[col.property]).toString();
 
-      if (row.type === '@apostrophecms/archive-page') {
+      if (row.type === '@apostrophecms/archive-page' || !col.cellValue) {
         return false;
       }
 

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -227,9 +227,6 @@ export default {
     });
   },
   methods: {
-    test() {
-      console.log('hi?');
-    },
     setHeights() {
       this.$refs['tree-branches'].forEach(branch => {
         // Add padding to the max-height to avoid needing a `resize`

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -48,7 +48,7 @@
           @copy="$emit('copy', row._id)"
           @discardDraft="$emit('discardDraft', row._id)"
           @archive="$emit('archive', row._id)"
-          @unarchive="$emit('unarchive', row._id)"
+          @restore="$emit('restore', row._id)"
         >
           <AposIndicator
             v-if="options.draggable && index === 0 && !row.parked"
@@ -116,7 +116,7 @@
         @copy="$emit('copy', $event)"
         @discardDraft="$emit('discardDraft', $event)"
         @archive="$emit('archive', $event)"
-        @unarchive="$emit('unarchive', $event)"
+        @restore="$emit('restore', $event)"
         v-model="checkedProxy"
       />
     </li>
@@ -189,7 +189,7 @@ export default {
       required: true
     }
   },
-  emits: [ 'update', 'change', 'edit', 'preview', 'copy', 'discardDraft', 'archive', 'unarchive' ],
+  emits: [ 'update', 'change', 'edit', 'preview', 'copy', 'discardDraft', 'archive', 'restore' ],
   computed: {
     myRows() {
       return this.rows;

--- a/modules/@apostrophecms/ui/ui/apos/mixins/AposArchiveMixin.js
+++ b/modules/@apostrophecms/ui/ui/apos/mixins/AposArchiveMixin.js
@@ -48,7 +48,7 @@ export default {
         });
       }
     },
-    async unarchive (action, _id, isPage) {
+    async restore (action, _id, isPage) {
       const body = {
         archived: false
       };

--- a/modules/@apostrophecms/ui/ui/apos/mixins/AposArchiveMixin.js
+++ b/modules/@apostrophecms/ui/ui/apos/mixins/AposArchiveMixin.js
@@ -1,4 +1,5 @@
 // Provides reusable UI methods relating to the archiving and restoring documents
+import AposAdvisoryLockMixin from 'Modules/@apostrophecms/ui/mixins/AposAdvisoryLockMixin';
 
 export default {
   methods: {
@@ -39,6 +40,29 @@ export default {
           heading: 'An Error Occurred',
           description: e.message || 'An error occurred while moving the document to the archive.'
         });
+      }
+    },
+    async unarchive (action, _id) {
+      const body = {
+        archived: false
+      };
+      AposAdvisoryLockMixin.methods.addLockToRequest(body);
+      try {
+        await apos.http.patch(`${action}/${_id}`, {
+          body,
+          busy: true,
+          draft: true
+        });
+        apos.bus.$emit('content-changed');
+      } catch (e) {
+        if (AposAdvisoryLockMixin.methods.isLockedError(e)) {
+          await this.showLockedError(e);
+        } else {
+          await apos.alert({
+            heading: 'An Error Occurred',
+            description: e.message || 'An error occurred while moving the document to the archive.'
+          });
+        }
       }
     }
   }

--- a/modules/@apostrophecms/ui/ui/apos/mixins/AposArchiveMixin.js
+++ b/modules/@apostrophecms/ui/ui/apos/mixins/AposArchiveMixin.js
@@ -1,0 +1,45 @@
+// Provides reusable UI methods relating to the archiving and restoring documents
+
+export default {
+  methods: {
+    // A UI method to archive a document. `action` must be the base action URL of the
+    // module whose API should be invoked. If errors occur they are displayed to the user
+    // appropriately, not returned or thrown to the caller.
+    //
+    // A notification of success is displayed, with a button to revert the published
+    // mode of the document to its previous value.
+    //
+    // Returns `true` if the document was ultimately archived.
+    async archive(action, _id, isPublished) {
+      try {
+        if (await apos.confirm({
+          heading: 'Are You Sure?',
+          description: isPublished
+            ? 'This will move the document to the archive and un-publish it.'
+            : 'This will move the document to the archive.'
+        })) {
+          await apos.http.patch(`${action}/${_id}`, {
+            body: {
+              archived: true,
+              _publish: true
+            },
+            busy: true,
+            draft: true
+          });
+          if (_id === window.apos.adminBar.contextId) {
+            // With the current context doc gone, we need to move to safe ground
+            location.assign(`${window.apos.prefix}/`);
+            return;
+          }
+          apos.bus.$emit('content-changed');
+          return true;
+        }
+      } catch (e) {
+        await apos.alert({
+          heading: 'An Error Occurred',
+          description: e.message || 'An error occurred while moving the document to the archive.'
+        });
+      }
+    }
+  }
+};

--- a/modules/@apostrophecms/ui/ui/apos/scss/global/_tables.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/_tables.scss
@@ -84,7 +84,7 @@ span.apos-table__header-label:hover {
 
 // might have to be expanded kinda magic
 .apos-table__cell-field--title {
-  max-width: 65vw;
+  max-width: 50vw;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/modules/@apostrophecms/ui/ui/apos/scss/global/_tables.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/_tables.scss
@@ -11,6 +11,10 @@
   text-align: left;
 }
 
+.apos-table__header--title {
+  width: 100%;
+}
+
 .apos-table__header-icon {
   @include apos-align-icon();
   margin-right: 5px;
@@ -25,7 +29,13 @@
 .apos-table__header-label {
   display: flex;
   align-items: center;
+  white-space: nowrap;
+  &.is-hidden {
+    visibility: hidden;
+    position: absolute;
+  }
 }
+
 span.apos-table__header-label:hover {
   cursor: auto;
 }
@@ -39,8 +49,20 @@ span.apos-table__header-label:hover {
   @include apos-transition(all, 0.05s);
 }
 .apos-table__cell {
-  padding: 12.5px 4.5px;
-  border-bottom: 1px solid var(--a-base-9);
+  padding: 5px;
+  border-bottom: 1px solid var(--a-base-10);
+}
+
+.apos-table__cell--context-menu  {
+  width: 40px;
+}
+
+.apos-table__cell-field--context-menu  {
+  width: 100%;
+}
+
+.apos-table__cell:not(.apos-table__cell--title) {
+  white-space: nowrap;
 }
 
 .apos-table__link {
@@ -62,7 +84,7 @@ span.apos-table__header-label:hover {
 
 // might have to be expanded kinda magic
 .apos-table__cell-field--title {
-  max-width: 400px;
+  max-width: 65vw;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/modules/@apostrophecms/ui/ui/apos/scss/shared/_table-rows.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/shared/_table-rows.scss
@@ -4,6 +4,10 @@
   padding: $cell-padding;
   border-bottom: 1px solid var(--a-base-8);
   box-sizing: border-box;
+  align-items: center;
+}
+.apos-tree__cell--contextMenu {
+  padding: 0;
 }
 
 // Let the title cell column grow.

--- a/modules/@apostrophecms/ui/ui/apos/scss/shared/_table-vars.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/shared/_table-vars.scss
@@ -1,2 +1,2 @@
 $row-nested-h-padding: 24px;
-$cell-padding: 16px;
+$cell-padding: 12px;

--- a/test/pages.js
+++ b/test/pages.js
@@ -398,7 +398,7 @@ describe('Pages', function() {
   });
 
   it('is able to move parent to the archive', async function() {
-    await apos.page.moveToArchive(apos.task.getReq(), 'parent:en:published');
+    await apos.page.archive(apos.task.getReq(), 'parent:en:published');
 
     const cursor = apos.page.find(apos.task.getAnonReq(), { _id: 'parent' });
     const page = await cursor.toObject();


### PR DESCRIPTION
#### Main ticket
- https://linear.app/apostrophecms/issue/PRO-1172/general-manager-sprucing

#### Related tickets
- https://linear.app/apostrophecms/issue/PRO-1156/signal-a-document-is-draft-only

#### Main points
- Adds context menus for documents in piece managers and page manager
- Wires up context actions for docs (archive, unarchive, edit, preview, discard draft)
- Adds generic AposLabel component
- Adds labels to docs in managers indicating unpublished, active draft, archived
