### PR TITLE
Adds eslint rules to warn when not kebab-casing Vue events

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,8 @@
     "no-console": 0,
     "multiline-ternary": "off",
     "vue/no-deprecated-destroyed-lifecycle": 0,
+    "vue/v-on-event-hyphenation": 1,
+    "vue/custom-event-name-casing": ["warn", "kebab-case"],
     "vue/component-tags-order": [
       "warn",
       {


### PR DESCRIPTION
We've got out of the habit of being consistent about this. I thought our linter was already catching this, but I guess not. Just a warning to not hold us up with eslint fixes.

CC @boutell 