### PR TITLE
sets custom page types to default their action to @apostrophecms/page's

### DIFF
--- a/modules/@apostrophecms/page-type/index.js
+++ b/modules/@apostrophecms/page-type/index.js
@@ -392,6 +392,9 @@ module.exports = {
   },
   extendMethods(self) {
     return {
+      enableAction() {
+        self.action = self.apos.modules['@apostrophecms/page'].action;
+      },
       copyForPublication(_super, req, from, to) {
         _super(req, from, to);
         const newMode = to.aposLocale.endsWith(':published') ? ':published' : ':draft';


### PR DESCRIPTION
custom page's `action` route doesn't do anything as far as i know .. this would be helpful for generic functions that work with both pages and pieces