### PR TITLE
PRO-1185 fragments calling fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Fixes
 
 * There was a bug that allowed parked properties, such as the slug of the home page, to be edited. Note that if you don't want a property of a parked page to be locked down forever you can use the `_defaults` feature of parked pages.
+* Fragments can now call other fragments, both those declared in the same file and those imported, just like macros calling other macros.
 
 ## 3.0.0-alpha.7 - 2021-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 ### Fixes
 
 * There was a bug that allowed parked properties, such as the slug of the home page, to be edited. Note that if you don't want a property of a parked page to be locked down forever you can use the `_defaults` feature of parked pages.
-* Fragments can now call other fragments, both those declared in the same file and those imported, just like macros calling other macros.
+* Fragments can now call other fragments, both those declared in the same file and those imported, just like macros calling other macros. Thanks to Miro Yovchev for reporting the issue.
 * A required field error no longer appears immediately when you first start creating a user.
 
 ## 3.0.0-alpha.7 - 2021-04-07

--- a/modules/@apostrophecms/template/lib/custom-tags/fragment.js
+++ b/modules/@apostrophecms/template/lib/custom-tags/fragment.js
@@ -59,7 +59,8 @@ module.exports = function(self) {
           return {
             body,
             args,
-            params: rest
+            params: rest,
+            context
           };
         });
         if (name.charAt(0) !== '_') {

--- a/modules/@apostrophecms/template/lib/custom-tags/render.js
+++ b/modules/@apostrophecms/template/lib/custom-tags/render.js
@@ -5,11 +5,6 @@ module.exports = (self) => {
         // get the tag token
         const token = parser.nextToken();
         const args = new nodes.NodeList(token.lineno, token.colno);
-        // TODO this only allows a simple name, we need
-        // to permit at least a dotted expression to
-        // accommodate imports. We can't parse it as an
-        // expression because that would invoke it
-        // as a function with the args
         const invocation = parser.parsePrimary();
         args.addChild(invocation);
         parser.advanceAfterBlockEnd(token.value);
@@ -22,7 +17,9 @@ module.exports = (self) => {
     async run(context, info) {
       try {
         const req = context.env.opts.req;
-        const input = {};
+        const input = {
+          ...info.context.ctx
+        };
         let i = 0;
         for (const param of info.params) {
           if (i === info.args.length) {


### PR DESCRIPTION
Make sure fragments can:

* render other fragments declared in the same source file, like macros can
* render other fragments imported by their source file, like macros can

It took me forever to figure out these six lines of code on my own time tonight. Just couldn't let this go unfixed. Needed to know if we were going to have to pivot to twigjs or even write something new. The answer is "not today."

Nunjucks makes the proper context available in the run() function that handles the "fragment" tag itself, so I needed to return that context as part of the node so it would be available later in the run() fragment of the "render" tag.
