### PR TITLE
dismiss submissions

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
@@ -25,8 +25,10 @@
         :can-publish="canPublish"
         :ready-to-publish="readyToPublish"
         :custom-publish-label="customPublishLabel"
+        :can-dismiss-submission="canDismissSubmission"
         @switchEditMode="switchEditMode"
         @discardDraft="onDiscardDraft"
+        @dismissSubmission="onDismissSubmission"
         @publish="onPublish"
       />
     </template>
@@ -95,6 +97,9 @@ export default {
     },
     canPublish() {
       return this.getContextModule(this.context).canPublish;
+    },
+    canDismissSubmission() {
+      return this.context.submitted && (this.canPublish || (this.context.submitted.byId === apos.login.user._id));
     },
     readyToPublish() {
       return this.canPublish
@@ -516,6 +521,14 @@ export default {
         }
       } else {
         apos.bus.$emit('context-history-changed', result && result.doc);
+      }
+    },
+    async onDismissSubmission() {
+      if (await this.dismissSubmission(this.action, this.context._id)) {
+        this.context = {
+          ...this.context,
+          submitted: null
+        };
       }
     },
     async onRevertPublishedToPrevious(data) {

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextModeAndSettings.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextModeAndSettings.vue
@@ -55,13 +55,15 @@
 
       <AposDocMoreMenu
         :doc-id="context._id"
-        :disabled="!context.modified"
+        :disabled="!context.modified && !canDismissSubmission"
         :is-modified="context.modified"
         :can-discard-draft="context.modified"
         :is-modified-from-published="context.modified"
         :is-published="!!context.lastPublishedAt"
         :can-save-draft="false"
+        :can-dismiss-submission="canDismissSubmission"
         @discardDraft="onDiscardDraft"
+        @dismissSubmission="onDismissSubmission"
       />
       <AposButton
         v-if="!hasCustomUi"
@@ -101,9 +103,10 @@ export default {
     },
     editMode: Boolean,
     readyToPublish: Boolean,
-    canPublish: Boolean
+    canPublish: Boolean,
+    canDismissSubmission: Boolean
   },
-  emits: [ 'switchEditMode', 'discardDraft', 'publish' ],
+  emits: [ 'switchEditMode', 'discardDraft', 'publish', 'dismissSubmission' ],
   computed: {
     moduleOptions() {
       return window.apos.adminBar;
@@ -129,6 +132,9 @@ export default {
     },
     onDiscardDraft() {
       this.$emit('discardDraft');
+    },
+    onDismissSubmission() {
+      this.$emit('dismissSubmission');
     },
     onPublish() {
       this.$emit('publish');

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -638,6 +638,48 @@ module.exports = {
       async findOneForCopying(req, criteria) {
         return self.findOneForEditing(req, criteria);
       },
+      // Submit the current draft for review. The identity
+      // of `req.user` is associated with the submission.
+      // Returns the `submitted` object, with `by`, `byId`,
+      // and `at` properties.
+      async submit(req, draft) {
+        if (!self.apos.permission.can(req, 'edit', draft)) {
+          throw self.apos.error('forbidden');
+        }
+        const submitted = {
+          by: req.user && req.user.title,
+          byId: req.user && req.user._id,
+          at: new Date()
+        };
+        await self.apos.doc.db.update({
+          _id: draft._id
+        }, {
+          $set: {
+            submitted
+          }
+        });
+        return submitted;
+      },
+      // Dismisses a previous submission of the given draft for review.
+      // The draft is unchanged; it simply is no longer marked as needing review.
+      async dismissSubmission(req, draft) {
+        if (!self.apos.permission.can(req, 'publish', draft)) {
+          if (!self.apos.permission.can(req, 'edit', draft)) {
+            throw self.apos.error('forbidden');
+          }
+          if (!(draft.submitted && (draft.submitted.byId === req.user._id))) {
+            throw self.apos.error('forbidden');
+          }
+        }
+        // Don't use "return" here, that could leak mongodb details
+        await self.apos.doc.db.update({
+          _id: draft._id
+        }, {
+          $unset: {
+            submitted: 1
+          }
+        });
+      },
       // Publish the given draft. If `options.permissions` is explicitly
       // set to `false`, permissions checks are bypassed. If `options.autopublishing`
       // is true, then the `edit` permission is sufficient, otherwise the

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -25,9 +25,11 @@
         :can-copy="!!docId"
         :is-published="!!published"
         :can-save-draft="true"
+        :can-dismiss-submission="canDismissSubmission"
         @saveDraft="saveDraft"
         @discardDraft="onDiscardDraft"
         @moveToArchive="onMoveToArchive"
+        @dismissSubmission="onDismissSubmission"
         @copy="onCopy"
       />
       <AposButton
@@ -291,6 +293,9 @@ export default {
         (!this.published) &&
         this.manuallyPublished
       ) || this.isModifiedFromPublished;
+    },
+    canDismissSubmission() {
+      return this.original && this.original.submitted && (this.moduleOptions.canPublish || (this.original.submitted.byId === apos.login.user._id));
     },
     hasMoreMenu() {
       const hasPublishUi = this.moduleOptions.localized && !this.moduleOptions.autopublish;
@@ -649,6 +654,15 @@ export default {
       if (await this.discardDraft(this.moduleAction, this.docId, !!this.published)) {
         apos.bus.$emit('content-changed');
         this.modal.showModal = false;
+      }
+    },
+    async onDismissSubmission() {
+      if (await this.dismissSubmission(this.moduleAction, this.docId)) {
+        this.original = {
+          ...this.original,
+          submitted: null
+        };
+        apos.bus.$emit('content-changed');
       }
     },
     async onCopy(e) {

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
@@ -63,6 +63,12 @@ export default {
         return false;
       }
     },
+    canDismissSubmission: {
+      type: Boolean,
+      default() {
+        return false;
+      }
+    },
     disabled: {
       type: Boolean,
       default: false
@@ -83,6 +89,9 @@ export default {
       this.menu = this.recomputeMenu();
     },
     isPublished() {
+      this.menu = this.recomputeMenu();
+    },
+    canDismissSubmission() {
       this.menu = this.recomputeMenu();
     }
   },
@@ -124,6 +133,12 @@ export default {
           {
             label: 'Save Draft',
             action: 'saveDraft'
+          }
+        ] : []),
+        ...(this.canDismissSubmission ? [
+          {
+            label: 'Dismiss Submission',
+            action: 'dismissSubmission'
           }
         ] : []),
         ...(this.canCopy ? [

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -419,20 +419,10 @@ module.exports = {
           if (!draft) {
             throw self.apos.error('notfound');
           }
-          const submitted = {
-            by: req.user && req.user.title,
-            at: new Date()
-          };
-          await self.apos.doc.db.update({
-            _id: draft._id
-          }, {
-            $set: {
-              submitted
-            }
-          });
-          return submitted;
+          const manager = self.apos.doc.getManager(draft.type);
+          return manager.submit(req, draft);
         },
-        ':_id/reject': async (req) => {
+        ':_id/dismiss-submission': async (req) => {
           const _id = self.inferIdLocaleAndMode(req, req.params._id);
           const draft = await self.findOneForEditing({
             ...req,
@@ -443,16 +433,8 @@ module.exports = {
           if (!draft) {
             throw self.apos.error('notfound');
           }
-          if (!self.apos.permission.can(req, 'publish', draft)) {
-            throw self.apos.error('forbidden');
-          }
-          await self.apos.doc.db.update({
-            _id: draft._id
-          }, {
-            $unset: {
-              submitted: 1
-            }
-          });
+          const manager = self.apos.doc.getManager(draft.type);
+          return manager.dismissSubmission(req, draft);
         },
         ':_id/revert-draft-to-published': async (req) => {
           const _id = self.inferIdLocaleAndMode(req, req.params._id);

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -284,20 +284,9 @@ module.exports = {
           if (!draft) {
             throw self.apos.error('notfound');
           }
-          const submitted = {
-            by: req.user && req.user.title,
-            byId: req.user && req.user._id,
-            at: new Date()
-          };
-          await self.apos.doc.db.update({
-            _id: draft._id
-          }, {
-            $set: {
-              submitted
-            }
-          });
+          return self.submit(req, draft);
         },
-        ':_id/reject': async (req) => {
+        ':_id/dismiss-submission': async (req) => {
           const _id = self.inferIdLocaleAndMode(req, req.params._id);
           const draft = await self.findOneForEditing({
             ...req,
@@ -308,13 +297,7 @@ module.exports = {
           if (!draft) {
             throw self.apos.error('notfound');
           }
-          await self.apos.doc.db.update({
-            _id: draft._id
-          }, {
-            $unset: {
-              submitted: 1
-            }
-          });
+          return self.dismissSubmission(req, draft);
         },
         ':_id/revert-draft-to-published': async (req) => {
           const _id = self.inferIdLocaleAndMode(req, req.params._id);

--- a/modules/@apostrophecms/ui/ui/apos/mixins/AposPublishMixin.js
+++ b/modules/@apostrophecms/ui/ui/apos/mixins/AposPublishMixin.js
@@ -83,6 +83,27 @@ export default {
         return false;
       }
     },
+    // A UI method to dismiss a previous submission. Returns true on success.
+    // Notifies the user appropriately.
+    async dismissSubmission(action, _id) {
+      try {
+        await apos.http.post(`${action}/${_id}/dismiss-submission`, {
+          body: {},
+          busy: true
+        });
+        apos.notify('Dismissed submission.', {
+          type: 'success',
+          dismiss: true
+        });
+        return true;
+      } catch (e) {
+        await apos.alert({
+          heading: 'An Error Occurred While Dismissing',
+          description: e.message || 'An error occurred while dismissing the submission.'
+        });
+        return false;
+      }
+    },
     // A UI method to revert a draft document to the last published version or, if the document
     // has never been published, delete the draft entirely. The user is advised of the difference.
     //


### PR DESCRIPTION
* "Dismiss Submission" on the "more" menu for both pieces and pages
* Contributors can do it too, as long as it was their own submission
* Also refactored a little to reduce code duplication in the submit/dismiss routes
* /dismiss route is now /dismiss-submission to match the language elsewhere