### PR TITLE
PRO-1190 sensible singletons

### DIFF
--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -22,7 +22,7 @@
         :is-modified-from-published="isModifiedFromPublished"
         :can-discard-draft="canDiscardDraft"
         :can-archive="canArchive"
-        :can-copy="!!docId"
+        :can-copy="!!docId && !moduleOptions.singleton"
         :can-preview="canPreview"
         :is-published="!!published"
         :can-save-draft="true"
@@ -294,10 +294,13 @@ export default {
       }
     },
     canArchive() {
-      return !!(this.docId &&
+      return !!(
+        !this.moduleOptions.singleton &&
+        this.docId &&
         !(this.moduleName === '@apostrophecms/page') &&
         !this.restoreOnly &&
-        (this.published || !this.manuallyPublished));
+        (this.published || !this.manuallyPublished)
+      );
     },
     canDiscardDraft() {
       return (

--- a/modules/@apostrophecms/global/index.js
+++ b/modules/@apostrophecms/global/index.js
@@ -138,7 +138,6 @@ module.exports = {
         const browserOptions = _super(req);
         // _id of the piece, which is a singleton
         browserOptions._id = req.data.global && req.data.global._id;
-        browserOptions.quickCreate = false;
         return browserOptions;
       }
     };

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -828,7 +828,8 @@ module.exports = {
         browserOptions.columns = self.columns;
         browserOptions.batchOperations = self.batchOperations;
         browserOptions.insertViaUpload = self.options.insertViaUpload;
-        browserOptions.quickCreate = self.options.quickCreate && self.apos.permission.can(req, 'edit', self.name);
+        browserOptions.quickCreate = !self.options.singleton && self.options.quickCreate && self.apos.permission.can(req, 'edit', self.name);
+        browserOptions.singleton = self.options.singleton;
         browserOptions.previewDraft = self.options.previewDraft;
         browserOptions.managerHasNewButton = self.options.managerHasNewButton !== false;
         _.defaults(browserOptions, {


### PR DESCRIPTION
* Piece types marked as singletons (like the global doc) should never offer "archive" or "duplicate" on the More menu.
* Also streamlined the process of setting appropriate browser side config for singletons to be more automatic.
* I opened a separate ticket to address the fact that you can "preview draft" (and of course you then get an error) because it is not a given that no singleton piece type will ever have a `_url`, so we want a separate option there.
