### PR TITLE
PRO-1170 contributors cannot touch files and images

### DIFF
--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -3,7 +3,10 @@ const _ = require('lodash');
 module.exports = {
   options: {
     localized: true,
-    contextBar: true
+    contextBar: true,
+    editRole: 'contributor',
+    publishRole: 'editor',
+    viewRole: false
   },
   cascades: [ 'fields' ],
   fields(self) {
@@ -405,10 +408,6 @@ module.exports = {
       // desired text.
       decorateChange(doc, change) {
         change.text = doc.title;
-      },
-      // Returns true if only admins are allowed to edit this type.
-      isAdminOnly() {
-        return self.options.adminOnly;
       },
       // Return a new schema containing only fields for which the
       // current user has the permission specified by the `permission`
@@ -1318,7 +1317,7 @@ module.exports = {
             const property = query.get('explicitOrderProperty');
             if (!values.length) {
               // MongoDB gets mad if you have an empty $in
-              criteria[property] = { _id: '__iNeverMatch' };
+              criteria[property] = { _id: null };
               query.and(criteria);
               return;
             }

--- a/modules/@apostrophecms/file-tag/index.js
+++ b/modules/@apostrophecms/file-tag/index.js
@@ -3,7 +3,9 @@ module.exports = {
   options: {
     label: 'File Tag',
     quickCreate: false,
-    autopublish: true
+    autopublish: true,
+    editRole: 'editor',
+    publishRole: 'editor'
   },
   fields: {
     remove: [ 'visibility' ]

--- a/modules/@apostrophecms/file/index.js
+++ b/modules/@apostrophecms/file/index.js
@@ -16,7 +16,9 @@ module.exports = {
     quickCreate: false,
     insertViaUpload: true,
     slugPrefix: 'file-',
-    autopublish: true
+    autopublish: true,
+    editRole: 'editor',
+    publishRole: 'editor'
   },
   fields: {
     add: {

--- a/modules/@apostrophecms/image-tag/index.js
+++ b/modules/@apostrophecms/image-tag/index.js
@@ -3,7 +3,9 @@ module.exports = {
   options: {
     label: 'Image Tag',
     quickCreate: false,
-    autopublish: true
+    autopublish: true,
+    editRole: 'editor',
+    publishRole: 'editor'
   },
   fields: {
     remove: [ 'visibility' ]

--- a/modules/@apostrophecms/image/index.js
+++ b/modules/@apostrophecms/image/index.js
@@ -21,7 +21,9 @@ module.exports = {
     insertViaUpload: true,
     searchable: false,
     slugPrefix: 'image-',
-    autopublish: true
+    autopublish: true,
+    editRole: 'editor',
+    publishRole: 'editor'
   },
   fields: {
     add: {

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -27,7 +27,7 @@
       <AposButton
         type="primary"
         :label="`Select ${moduleLabels.pluralLabel || ''}`"
-        :disabled="relationshipErrors"
+        :disabled="!!relationshipErrors"
         @click="saveRelationship"
       />
     </template>
@@ -62,6 +62,7 @@
             :accept="accept"
             :items="items"
             :module-options="options"
+            :can-edit="options.canEdit"
             @edit="updateEditing"
             v-model="checked"
             @select="select"
@@ -94,6 +95,7 @@
           />
           <AposMediaManagerSelections
             :items="selected"
+            :can-edit="options.canEdit"
             @clear="clearSelected" @edit="updateEditing"
             v-show="!editing"
           />
@@ -291,6 +293,9 @@ export default {
       this.editing = undefined;
     },
     async updateEditing(id) {
+      if (!this.options.canEdit) {
+        return;
+      }
       // We only care about the current doc for this prompt,
       // we are not in danger of discarding a selection when
       // we switch images

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
@@ -2,6 +2,7 @@
   <div class="apos-media-manager-display">
     <div class="apos-media-manager-display__grid">
       <AposMediaUploader
+        v-if="canEdit"
         :disabled="maxReached"
         :action="moduleOptions.action"
         :accept="accept"
@@ -81,6 +82,10 @@ export default {
     event: 'change'
   },
   props: {
+    canEdit: {
+      type: Boolean,
+      default: false
+    },
     maxReached: {
       type: Boolean,
       default: false

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerSelections.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerSelections.vue
@@ -30,6 +30,7 @@
               {{ item.title }}
             </div>
             <AposButton
+              v-if="canEdit"
               label="Edit"
               type="quiet"
               :modifiers="['no-motion']"
@@ -48,6 +49,10 @@
 <script>
 export default {
   props: {
+    canEdit: {
+      type: Boolean,
+      default: false
+    },
     items: {
       type: Array,
       required: true

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
@@ -50,11 +50,11 @@ export default {
       this.$emit('sort', action);
     },
     headers() {
-      if (!this.pieces) {
+      if (!this.items) {
         return this.options.columns || [];
       }
       return (this.options.columns || []).filter(column => {
-        return (column.name !== '_url') || this.pieces.find(item => item._url);
+        return (column.name !== '_url') || this.items.find(item => item._url);
       });
     },
     selectAllValue() {
@@ -62,7 +62,7 @@ export default {
     },
     selectAllChoice() {
       const checkCount = this.checked.length;
-      const itemCount = this.items.length;
+      const itemCount = (this.items && this.items.length) || 0;
 
       return checkCount > 0 && checkCount !== itemCount ? {
         value: 'checked',

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -77,8 +77,7 @@ module.exports = {
       // array of pages.
 
       async getAll(req) {
-        // Edit access to draft is sufficient to fetch either
-        self.publicApiCheck(req, 'draft');
+        self.publicApiCheck(req);
         const all = self.apos.launder.boolean(req.query.all);
         const archived = self.apos.launder.booleanOrNull(req.query.archived);
         const flat = self.apos.launder.boolean(req.query.flat);
@@ -185,7 +184,7 @@ module.exports = {
       async getOne(req, _id) {
         _id = self.inferIdLocaleAndMode(req, _id);
         // Edit access to draft is sufficient to fetch either
-        self.publicApiCheck(req, 'draft');
+        self.publicApiCheck(req);
         const criteria = self.getIdCriteria(_id);
         const result = await self.getRestQuery(req).and(criteria).toObject();
         if (!result) {
@@ -575,11 +574,12 @@ database.`);
               self.apos.doc.managers[type] = {
                 // Do-nothing placeholder manager
                 schema: [],
+                options: {
+                  editRole: 'admin',
+                  publishRole: 'admin'
+                },
                 find(req) {
                   return [];
-                },
-                isAdminOnly() {
-                  return true;
                 },
                 isLocalized() {
                   return false;
@@ -2105,12 +2105,12 @@ database.`);
       getRestQuery(req) {
         const query = self.find(req).ancestors(true).children(true).applyBuildersSafely(req.query);
         // Minimum standard for a REST query without a public projection
-        // is being allowed to edit the draft
-        if (!self.apos.permission.can(req, 'edit', self.__meta.name, 'draft')) {
+        // is being allowed to view drafts on the site
+        if (!self.apos.permission.can(req, 'view-draft')) {
           if (!self.options.publicApiProjection) {
             // Shouldn't be needed thanks to publicApiCheck, but be sure
             query.and({
-              _id: '__iNeverMatch'
+              _id: null
             });
           } else {
             query.project(self.options.publicApiProjection);
@@ -2135,11 +2135,13 @@ database.`);
         return self.findForEditing(req, criteria, builders).toObject();
       },
       // Throws a `notfound` exception if a public API projection is
-      // not specified and the user does not have editing permissions. Otherwise does
-      // nothing. Simplifies implementation of `getAll` and `getOne`.
-      publicApiCheck(req, mode) {
+      // not specified and the user does not have the `view-draft` permission,
+      // which all roles capable of editing the site at all will have. This is needed because
+      // although all API calls check permissions specifically where appropriate,
+      // we also want to flunk all public access to REST APIs if not specifically configured.
+      publicApiCheck(req) {
         if (!self.options.publicApiProjection) {
-          if (!self.apos.permission.can(req, 'edit', self.__meta.name, mode || req.mode)) {
+          if (!self.apos.permission.can(req, 'view-draft')) {
             throw self.apos.error('notfound');
           }
         }

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -10,6 +10,13 @@
 // them alone. Editors can edit anything except user accounts, and admins
 // can edit anything.
 
+const ranks = {
+  guest: 0,
+  contributor: 1,
+  editor: 2,
+  admin: 3
+};
+
 module.exports = {
   options: {
     alias: 'permission',
@@ -66,7 +73,7 @@ module.exports = {
           return false;
         }
         if (action === 'view') {
-          if (manager && manager.isAdminOnly()) {
+          if (manager && manager.options.viewRole && (ranks[role] < ranks[manager.options.viewRole])) {
             return false;
           } else if (((typeof docOrType) === 'object') && (docOrType.visibility !== 'public')) {
             return (role === 'guest') || (role === 'contributor') || (role === 'editor');
@@ -78,7 +85,7 @@ module.exports = {
           // be allowed to be set to draft at all
           return (role === 'contributor') || (role === 'editor');
         } else if (action === 'edit') {
-          if (manager && manager.isAdminOnly()) {
+          if (manager && manager.options.editRole && (ranks[role] < ranks[manager.options.editRole])) {
             return false;
           } else if (mode === 'draft') {
             return (role === 'contributor') || (role === 'editor');
@@ -86,7 +93,7 @@ module.exports = {
             return role === 'editor';
           }
         } else if (action === 'publish') {
-          if (manager && manager.isAdminOnly()) {
+          if (manager && manager.options.publishRole && (ranks[role] < ranks[manager.options.publishRole])) {
             return false;
           } else {
             return role === 'editor';
@@ -116,7 +123,9 @@ module.exports = {
         if (role === 'admin') {
           return {};
         }
-        const restrictedTypes = Object.keys(self.apos.doc.managers).filter(name => self.apos.doc.getManager(name).isAdminOnly());
+        const restrictedViewTypes = Object.keys(self.apos.doc.managers).filter(name => ranks[self.apos.doc.getManager(name).options.viewRole] > ranks[role]);
+        const restrictedEditTypes = Object.keys(self.apos.doc.managers).filter(name => ranks[self.apos.doc.getManager(name).options.editRole] > ranks[role]);
+        const restrictedPublishTypes = Object.keys(self.apos.doc.managers).filter(name => ranks[self.apos.doc.getManager(name).options.publishRole] > ranks[role]);
         if (action === 'view') {
           if (role === 'guest') {
             return {
@@ -127,13 +136,13 @@ module.exports = {
                 $in: [ 'public', 'loginRequired' ]
               },
               type: {
-                $nin: restrictedTypes
+                $nin: restrictedViewTypes
               }
             };
           } else if ((role === 'contributor') || (role === 'editor')) {
             return {
               type: {
-                $nin: restrictedTypes
+                $nin: restrictedViewTypes
               }
             };
           } else {
@@ -143,7 +152,7 @@ module.exports = {
               },
               visibility: 'public',
               type: {
-                $nin: restrictedTypes
+                $nin: restrictedViewTypes
               }
             };
           }
@@ -154,13 +163,13 @@ module.exports = {
                 $in: [ null, 'draft' ]
               },
               type: {
-                $nin: restrictedTypes
+                $nin: restrictedEditTypes
               }
             };
           } else if (role === 'editor') {
             return {
               type: {
-                $nin: restrictedTypes
+                $nin: restrictedEditTypes
               }
             };
           } else {
@@ -172,7 +181,7 @@ module.exports = {
           if (role === 'editor') {
             return {
               type: {
-                $nin: restrictedTypes
+                $nin: restrictedPublishTypes
               }
             };
           } else {
@@ -232,7 +241,6 @@ module.exports = {
         const permissionSet = {
           label: module.options.permissionsLabel || module.options.pluralLabel || module.options.label,
           name: module.__meta.name,
-          adminOnly: module.options.adminOnly,
           singleton: module.options.singleton,
           page: module.__meta.name === '@apostrophecms/any-page-type',
           ...options
@@ -247,13 +255,8 @@ module.exports = {
         }
         permissions.push({
           name: 'edit',
-          label: 'Modify',
+          label: module.options.singleton ? 'Modify' : 'Modify / Delete',
           value: self.can(req, 'edit', module.name)
-        });
-        permissions.push({
-          name: 'archive',
-          label: 'Archive / Restore',
-          value: self.can(req, 'publish', module.name)
         });
         permissions.push({
           name: 'publish',
@@ -285,7 +288,8 @@ module.exports = {
         return newPermissionSets;
       },
       matchTypicalPieceType(permissionSet) {
-        return permissionSet.piece && !permissionSet.adminOnly && !self.options.interestingTypes.includes(permissionSet.name);
+        const manager = self.apos.doc.getManager(permissionSet.name);
+        return permissionSet.piece && (manager.options.viewRole === false) && (manager.options.editRole === 'contributor') && (manager.options.publishRole === 'editor') && !self.options.interestingTypes.includes(permissionSet.name);
       }
     };
   },

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -150,8 +150,7 @@ module.exports = {
   },
   restApiRoutes: (self) => ({
     async getAll(req) {
-      // Edit access to draft is sufficient to see either
-      self.publicApiCheck(req, 'draft');
+      self.publicApiCheck(req);
       const query = self.getRestQuery(req);
       if (!query.get('perPage')) {
         query.perPage(
@@ -178,7 +177,6 @@ module.exports = {
     },
     async getOne(req, _id) {
       _id = self.inferIdLocaleAndMode(req, _id);
-      // Edit access to draft is sufficient to see either
       self.publicApiCheck(req);
       const doc = await self.getRestQuery(req).and({ _id }).toObject();
       if (!doc) {
@@ -770,11 +768,11 @@ module.exports = {
       getRestQuery(req) {
         const query = self.find(req);
         query.applyBuildersSafely(req.query);
-        if (!self.apos.permission.can(req, 'edit', self.name)) {
+        if (!self.apos.permission.can(req, 'view-draft')) {
           if (!self.options.publicApiProjection) {
             // Shouldn't be needed thanks to publicApiCheck, but be sure
             query.and({
-              _id: '__iNeverMatch'
+              _id: null
             });
           } else {
             query.project(self.options.publicApiProjection);
@@ -783,11 +781,13 @@ module.exports = {
         return query;
       },
       // Throws a `notfound` exception if a public API projection is
-      // not specified and the user does not have editing permissions. Otherwise does
-      // nothing. Simplifies implementation of `getAll` and `getOne`.
-      publicApiCheck(req, mode) {
+      // not specified and the user does not have the `view-draft` permission,
+      // which all roles capable of editing the site at all will have. This is needed because
+      // although all API calls check permissions specifically where appropriate,
+      // we also want to flunk all public access to REST APIs if not specifically configured.
+      publicApiCheck(req) {
         if (!self.options.publicApiProjection) {
-          if (!self.apos.permission.can(req, 'edit', self.name, mode || req.mode)) {
+          if (!self.apos.permission.can(req, 'view-draft')) {
             throw self.apos.error('notfound');
           }
         }
@@ -831,6 +831,7 @@ module.exports = {
         browserOptions.quickCreate = self.options.quickCreate && self.apos.permission.can(req, 'edit', self.name);
         browserOptions.previewDraft = self.options.previewDraft;
         browserOptions.managerHasNewButton = self.options.managerHasNewButton !== false;
+        browserOptions.canEdit = self.apos.permission.can(req, 'edit', self.name, 'draft');
         _.defaults(browserOptions, {
           components: {}
         });
@@ -846,7 +847,7 @@ module.exports = {
     };
   },
   tasks(self) {
-    return self.isAdminOnly() ? {} : {
+    return (self.options.editRole === 'admin') ? {} : {
       generate: {
         usage: 'Invoke this task to generate sample docs of this type. Use the --total option to control how many are added to the database.\nYou can remove them all later with the --remove option.',
         async task(argv) {

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
@@ -32,7 +32,7 @@
         @click="saveRelationship"
       />
       <AposButton
-        v-else-if="options.managerHasNewButton"
+        v-else-if="options.canEdit && options.managerHasNewButton"
         :label="`New ${ options.label }`" type="primary"
         @click="create"
       />
@@ -78,8 +78,8 @@
         </template>
         <template #bodyMain>
           <AposDocsManagerDisplay
-            v-if="pieces.length > 0"
-            :items="pieces"
+            v-if="items.length > 0"
+            :items="items"
             :headers="headers"
             v-model="checked"
             @open="edit"
@@ -91,7 +91,8 @@
             :options="{
               disableUnchecked: maxReached(),
               hideCheckboxes: !relationshipField,
-              disableUnpublished: !!relationshipField
+              disableUnpublished: !!relationshipField,
+              canEdit: options.canEdit
             }"
           />
           <div v-else class="apos-pieces-manager__empty">
@@ -131,7 +132,7 @@ export default {
         type: 'overlay',
         showModal: false
       },
-      pieces: [],
+      items: [],
       lastSelected: null,
       totalPages: 1,
       currentPage: 1,
@@ -193,7 +194,7 @@ export default {
     // Get the data. This will be more complex in actuality.
     this.modal.active = true;
     this.getPieces();
-    if (this.relationshipField) {
+    if (this.relationshipField && this.options.canEdit) {
       // Add computed singular label to context menu
       this.moreMenu.menu.unshift({
         action: 'new',
@@ -254,7 +255,7 @@ export default {
 
       this.currentPage = getResponse.currentPage;
       this.totalPages = getResponse.pages;
-      this.pieces = getResponse.results;
+      this.items = getResponse.results;
       this.filterChoices = getResponse.choices;
       this.holdQueries = false;
     },
@@ -265,22 +266,22 @@ export default {
       }
     },
     onPreview(id) {
-      this.preview(this.findDocById(this.pieces, id));
+      this.preview(this.findDocById(this.items, id));
     },
     async onArchive(id) {
-      const piece = this.findDocById(this.pieces, id);
+      const piece = this.findDocById(this.items, id);
       if (await this.archive(this.options.action, id, !!piece.lastPublishedAt)) {
         apos.bus.$emit('content-changed');
       }
     },
     async onRestore(id) {
-      const piece = this.findDocById(this.pieces, id);
+      const piece = this.findDocById(this.items, id);
       if (await this.restore(this.options.action, id, !!piece.lastPublishedAt)) {
         apos.bus.$emit('content-changed');
       }
     },
     async onDiscardDraft(id) {
-      const piece = this.findDocById(this.pieces, id);
+      const piece = this.findDocById(this.items, id);
       if (await this.discardDraft(this.options.action, id, !!piece.lastPublishedAt)) {
         apos.bus.$emit('content-changed');
       };
@@ -289,7 +290,7 @@ export default {
       apos.bus.$emit('admin-menu-click', {
         itemName: `${this.options.name}:editor`,
         props: {
-          copyOf: this.findDocById(this.pieces, id)
+          copyOf: this.findDocById(this.items, id)
         }
       });
     },

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManagerDisplay.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManagerDisplay.vue
@@ -64,7 +64,7 @@
           class="apos-table__cell apos-table__cell--pointer"
           :class="`apos-table__cell--${header.name}`"
           :key="item[header.name]"
-          @click="$emit('open', item)"
+          @click="options.canEdit && $emit('open', item)"
         >
           <component
             v-if="header.component" :is="header.component"
@@ -76,7 +76,7 @@
           />
         </td>
         <!-- append the context menu -->
-        <td class="apos-table__cell apos-table__cell--context-menu">
+        <td v-if="options.canEdit" class="apos-table__cell apos-table__cell--context-menu">
           <AposCellContextMenu
             :state="state[item._id]" :item="item"
             @edit="$emit('open', item._id)"

--- a/modules/@apostrophecms/user/index.js
+++ b/modules/@apostrophecms/user/index.js
@@ -41,10 +41,12 @@ module.exports = {
     label: 'User',
     pluralLabel: 'Users',
     quickCreate: false,
-    adminOnly: true,
     searchable: false,
     slugPrefix: 'user-',
-    localized: false
+    localized: false,
+    editRole: 'admin',
+    publishRole: 'admin',
+    viewRole: 'admin'
   },
   fields(self) {
     return {


### PR DESCRIPTION
But you still have to select things for relationships. So there is a basic read only experience in the manage view when used as a chooser. Did not attempt to open the editors in read only mode, I just don't let you launch editors for now when using the manage view as a chooser without permission to edit. That could be a follow-on at some point.

One unrelated change: "this.pieces" is now "this.items" in the docs manager because that is what some of the mixins were expecting and I ran into showstoppers that wouldn't let me continue.