### PR TITLE
PRO-1203 closes #2902

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 * There was a bug that allowed parked properties, such as the slug of the home page, to be edited. Note that if you don't want a property of a parked page to be locked down forever you can use the `_defaults` feature of parked pages.
 * A required field error no longer appears immediately when you first start creating a user.
+* Vue warning in the pieces manager due to use of value rather than name of column as a Vue key.
 
 ## 3.0.0-alpha.7 - 2021-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 * There was a bug that allowed parked properties, such as the slug of the home page, to be edited. Note that if you don't want a property of a parked page to be locked down forever you can use the `_defaults` feature of parked pages.
 * A required field error no longer appears immediately when you first start creating a user.
-* Vue warning in the pieces manager due to use of value rather than name of column as a Vue key.
+* Vue warning in the pieces manager due to use of value rather than name of column as a Vue key. Thanks to Miro Yovchev for spotting the issue.
 
 ## 3.0.0-alpha.7 - 2021-04-07
 

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManagerDisplay.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManagerDisplay.vue
@@ -63,7 +63,7 @@
           v-for="header in headers"
           class="apos-table__cell apos-table__cell--pointer"
           :class="`apos-table__cell--${header.name}`"
-          :key="item[header.name]"
+          :key="header.name"
           @click="$emit('open', item)"
         >
           <component


### PR DESCRIPTION
We were using the value rather than the name of the field as a v-for key, which does not make sense (two columns could have the same value).