### PR TITLE
3/page title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Routes support the `before` syntax, allowing routes that are added to Express prior to the routes or middleware of another module. The syntax `before: 'middleware:moduleName'` must be used to add the route prior to the middleware of `moduleName`. If `middleware:` is not used, the route is added before the routes of `moduleName`. Note that normally all middleware is added before all routes.
 * A `url` property can now optionally be specified when adding middleware. By default all middleware is global.
 * Sets `username` fields to follow the user `title` field to remove an extra step in user creation.
+* Adds default data to the `outerLayoutBase.html` `<title>` tag: `data.piece.title or data.page.title`.
 
 ### Fixes
 

--- a/modules/@apostrophecms/template/views/outerLayoutBase.html
+++ b/modules/@apostrophecms/template/views/outerLayoutBase.html
@@ -4,7 +4,7 @@
     {% block startHead %}
     {% endblock %}
     {% component '@apostrophecms/template:inject' with { where: 'head', end: 'prepend' } %}
-    <title>{% block title %}{% endblock %}</title>
+    <title>{% block title %}{{ data.piece.title or data.page.title }}{% endblock %}</title>
     {{ apos.asset.stylesheets(data.scene) }}
     {% block standardHead %}
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Updates the base layout template's title tag to include the piece or page title by default. This can be overridden in project templates.