### PR TITLE
Fragment `rendercall` and keyword arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 * There was a bug that allowed parked properties, such as the slug of the home page, to be edited. Note that if you don't want a property of a parked page to be locked down forever you can use the `_defaults` feature of parked pages.
 * Fragments can now call other fragments, both those declared in the same file and those imported, just like macros calling other macros. Thanks to Miro Yovchev for reporting the issue.
+* Fragments support `rendercall`/`rendercaller` syntax similar to the `call`/`caller` macro syntax
+* Fragments support [keyword arguments](https://mozilla.github.io/nunjucks/templating.html#keyword-arguments)
 * A required field error no longer appears immediately when you first start creating a user.
 * Vue warning in the pieces manager due to use of value rather than name of column as a Vue key. Thanks to Miro Yovchev for spotting the issue.
 

--- a/modules/@apostrophecms/template/index.js
+++ b/modules/@apostrophecms/template/index.js
@@ -36,7 +36,8 @@ module.exports = {
     return {
       component: require('./lib/custom-tags/component')(self),
       fragment: require('./lib/custom-tags/fragment')(self),
-      render: require('./lib/custom-tags/render')(self)
+      // render & rendercall
+      ...require('./lib/custom-tags/render')(self)
     };
   },
   components(self) {

--- a/modules/@apostrophecms/template/lib/custom-tags/fragment.js
+++ b/modules/@apostrophecms/template/lib/custom-tags/fragment.js
@@ -8,8 +8,12 @@ module.exports = function(self) {
         const args = parser.parseSignature();
         args.addChild(primary);
         args.children = args.children.map(child => {
-          const node = new nodes.Literal(child.lineno, child.colno, child.value);
-          return node;
+          if (child.typename === 'KeywordArgs') {
+            // Keep the KeywordsArgs nodelist in order to enable keyword arguments support
+            // https://mozilla.github.io/nunjucks/templating.html#keyword-arguments
+            return child;
+          }
+          return new nodes.Literal(child.lineno, child.colno, child.value);
         });
         parser.advanceAfterBlockEnd(symbolToken.value);
         // We need to capture the body source code, not parse it. For that

--- a/modules/@apostrophecms/template/lib/custom-tags/render.js
+++ b/modules/@apostrophecms/template/lib/custom-tags/render.js
@@ -1,48 +1,123 @@
+const util = require('util');
+
 module.exports = (self) => {
-  return {
-    parse(parser, nodes, lexer) {
-      try {
-        // get the tag token
-        const token = parser.nextToken();
-        const args = new nodes.NodeList(token.lineno, token.colno);
-        const invocation = parser.parsePrimary();
-        args.addChild(invocation);
-        parser.advanceAfterBlockEnd(token.value);
-        return { args };
-      } catch (e) {
-        console.error(e);
-        throw e;
+  // Create the render input object, used to parse the fragment source
+  function createRenderInput(info) {
+    const input = {
+      ...info.context.ctx
+    };
+    let i = 0;
+    let kwparams = null;
+    for (const param of info.params) {
+      if (i === info.args.length) {
+        break;
       }
-    },
-    async run(context, info) {
-      try {
-        const req = context.env.opts.req;
-        const input = {
-          ...info.context.ctx
+      // CHANGE START
+      // it is kwargs, merge them so we can mix
+      // positional and keyword arguments
+
+      // This is faster!
+      if (param && typeof param !== 'string' && param.__keywords === true) {
+        kwparams = param;
+        continue;
+      }
+      // CHANGE END
+
+      input[param] = info.args[i];
+      i++;
+    }
+
+    // CHANGE START
+    // Deal with kwargs
+    if (kwparams) {
+      // Those are the defaults
+      Object.assign(input, kwparams);
+      // Those are the passed arguments
+      // andare ALWAYS the last array item
+      const kwargs = info.args[info.args.length - 1];
+      if (kwargs && kwargs.__keywords === true) {
+        Object.assign(input, kwargs);
+      }
+    }
+    // CHANGE END
+    return input;
+  };
+
+  // `parse` factory for `render` and `rendercall`
+  const parseRenderFactory = (hasBody = false) => function parse(parser, nodes, lexer) {
+    try {
+      // get the tag token
+      const token = parser.nextToken();
+      const args = new nodes.NodeList(token.lineno, token.colno);
+
+      // parse function name and arguments
+      const invocation = parser.parsePrimary();
+      args.addChild(invocation);
+      parser.advanceAfterBlockEnd(token.value);
+
+      // get the body if it's `rendercall` block
+      if (hasBody) {
+        const body = parser.parseUntilBlocks('end' + token.value);
+        parser.advanceAfterBlockEnd();
+
+        return {
+          args,
+          blocks: [ body ]
         };
-        let i = 0;
-        for (const param of info.params) {
-          if (i === info.args.length) {
-            break;
-          }
-          input[param] = info.args[i];
-          i++;
-        }
-        const body = info.body();
-
-        const env = self.getEnv(req, context.env.opts.module);
-
-        input.apos = self.templateApos;
-        input.__ = req.res.__;
-
-        const result = await require('util').promisify((s, args, callback) => {
-          return env.renderString(s, args, callback);
-        })(body, input);
-        return result;
-      } catch (e) {
-        console.error(e);
-        throw e;
       }
+
+      return { args };
+    } catch (e) {
+      console.error(e);
+      throw e;
+    }
+  };
+
+  // `run` factory for `render` and `rendercall`
+  const runRenderFactory = (hasBody = false) => async function run(context, ...rest) {
+    try {
+      // A `noop` function for `rendercaller`
+      let rendercaller = () => '';
+      if (hasBody) {
+        // wait for the body string and make caller return safe string
+        const renderBody = await util.promisify(rest.pop())();
+        rendercaller = () => self.safe(renderBody);
+        // This is the other option, but we need to mark it safe...
+        // rendercaller = rest.pop();
+      }
+
+      const info = rest.pop();
+      const body = info.body();
+      const input = createRenderInput(info);
+
+      const req = context.env.opts.req;
+      const env = self.getEnv(req, context.env.opts.module);
+      input.apos = self.templateApos;
+      input.__ = req.res.__;
+      // attach the render caller as a function
+      // it's just a string, but we keep
+      // the convention from the macro `call`
+      input.rendercaller = rendercaller;
+
+      const result = await require('util').promisify((s, args, callback) => {
+        return env.renderString(s, args, callback);
+      })(body, input);
+      return result;
+    } catch (e) {
+      console.error(e);
+      throw e;
+    }
+  };
+
+  return {
+    render: {
+      parse: parseRenderFactory(),
+      run: runRenderFactory()
+    },
+
+    rendercall: {
+      parse: parseRenderFactory(true),
+      run: runRenderFactory(true)
     }
   };
 };

--- a/test/modules/fragment-all/views/fragment-print.html
+++ b/test/modules/fragment-all/views/fragment-print.html
@@ -1,0 +1,3 @@
+{% fragment print(text) %}
+  {{ text }}
+{% endfragment %}

--- a/test/modules/fragment-all/views/fragment.html
+++ b/test/modules/fragment-all/views/fragment.html
@@ -1,0 +1,16 @@
+{% import "fragment-print.html" as f %}
+{% import "macro.html" as m %}
+
+{% fragment test(pos1, pos2, kw1 = 'kw1_default', kw2 = 'kw2_default', pos3, kw3 = 'kw3_default') %}
+  {{ pos1 }}
+  {{ pos2 }}
+  {{ pos3 }}
+  {{ rendercaller() }}
+  {% render _print(kw1) %}
+  {% render f.print(kw2) %}
+  {{ m.print(kw3) }}
+{% endfragment %}
+
+{% fragment _print(text) %}
+  {{ text }}
+{% endfragment %}

--- a/test/modules/fragment-all/views/macro.html
+++ b/test/modules/fragment-all/views/macro.html
@@ -1,0 +1,3 @@
+{% macro print(text) %}
+  {{ text }}
+{% endmacro %}

--- a/test/modules/fragment-all/views/page.html
+++ b/test/modules/fragment-all/views/page.html
@@ -1,0 +1,25 @@
+{% extends data.outerLayout %}
+
+{% import "fragment.html" as fragment %}
+
+{% block main %}
+--test1--
+Above Fragment
+
+{% render fragment.test('pos1', 'pos2', kw2 = 'kw2', 'pos3') %}
+
+Below Fragment
+--endtest1--
+
+--test2--
+Above Call Fragment
+
+{% rendercall fragment.test('pos1', 'pos2', kw2 = 'kw2', 'pos3') %}
+  Start Call Body
+  {% component "fragment-page:test" with { text: 'called' } %}
+  End Call Body
+{% endrendercall %}
+
+Below Call Fragment
+--endtest2--
+{% endblock %}

--- a/test/modules/fragment-all/views/test.html
+++ b/test/modules/fragment-all/views/test.html
@@ -1,0 +1,4 @@
+Text is {{ data.text }}
+{% if data.afterDelay %}
+  After Delay
+{% endif %}


### PR DESCRIPTION
## Feature `rendercall`
Allow similar to macro `call`/`caller` feature:
```njk
{% rendercall fragment.test() %}
  BODY
{% endrendercall %}
```
where `BODY` can be any valid sync and async nunjucks source.
The fragment definition is able to access the `BODY` via `rendercall` local function:
```njk
{% fragment test() %}
  ...
  {{ rendercaller() }}
  ...
{% endfragment %}
```
ref #2930

## Feature [keyword arguments](https://mozilla.github.io/nunjucks/templating.html#keyword-arguments)
Allows a mix of positional and keyword arguments (see the docs from the link above)
```njk
{% fragment test(pos1, pos2, kw1 = 'default value', kw2 = 'default value') %}
  ...
{% endfragment %}
```
This would be called in various ways, just some examples (some weird too!):
```njk
{% render test('pos1', 'pos2') %}
{% render test('pos1', 'pos2', kw2 = 'value') %}
{% render test(kw1 = 'value', 'pos1', 'pos2') %}
```
