### PR TITLE
PRO-1211 restore page tree

### DIFF
--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
@@ -49,14 +49,6 @@ export default {
     sort(action) {
       this.$emit('sort', action);
     },
-    headers() {
-      if (!this.items) {
-        return this.options.columns || [];
-      }
-      return (this.options.columns || []).filter(column => {
-        return (column.name !== '_url') || this.items.find(item => item._url);
-      });
-    },
     selectAllValue() {
       return this.checked.length > 0 ? { data: [ 'checked' ] } : { data: [] };
     },

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -200,6 +200,9 @@ export default {
       } else {
         return 'Select Pages';
       }
+    },
+    headers() {
+      return this.options.columns || [];
     }
   },
   async mounted() {

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
@@ -178,6 +178,14 @@ export default {
         message: '',
         emoji: '📄'
       };
+    },
+    headers() {
+      if (!this.items) {
+        return this.options.columns || [];
+      }
+      return (this.options.columns || []).filter(column => {
+        return (column.name !== '_url') || this.items.find(item => item._url);
+      });
     }
   },
   created() {


### PR DESCRIPTION
Page tree was inadvertently nuked by a recursive loop because "items" is computed and references headers in the page manager, and vice versa. Moved the computed property for "headers" to the respective managers because it is no longer a good candidate to share.