### PR TITLE
PRO-1201 3/labels not clickable

### DIFF
--- a/modules/@apostrophecms/ui/ui/apos/components/AposLabel.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposLabel.vue
@@ -31,6 +31,9 @@ export default {
     border: 1px solid var(--a-base-8);
     border-radius: var(--a-border-radius);
     font-size: var(--a-type-tiny);
+    &:hover {
+      cursor: auto;
+    }
   }
 
   .is-warning {


### PR DESCRIPTION
Right now labels are not clickable, enforce an auto cursor state for cases where they're inside clickable elements
https://linear.app/apostrophecms/issue/PRO-1201/the-new-status-pills-appear-clickable