### PR TITLE
PRO-1033 fix the preview button so it goes right into preview mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Sets `username` fields to follow the user `title` field to remove an extra step in user creation.
 * Adds default data to the `outerLayoutBase.html` `<title>` tag: `data.piece.title or data.page.title`.
 * Admin bar items can include a `when` function as an option. The `when` function is called with `req` on each page request and the admin bar item in question only appears if it returns a truthy value.
+* `apos.http.addQueryToUrl` now supports an `options.merge` argument, which allows merging new query parameters with an existing query string, if any.
 
 ### Fixes
 

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -447,7 +447,7 @@ export default {
       if (!await this.confirmAndCancel()) {
         return;
       }
-      window.location = this.original._url;
+      window.location = apos.http.addQueryToUrl(this.original._url, { 'apos-mode': 'draft' }, { merge: true });
     },
     async saveDraftAndPreview() {
       await this.save({

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
@@ -92,7 +92,7 @@ export default {
   },
   methods: {
     preview(doc) {
-      window.open(doc._url, '_blank').focus();
+      window.open(apos.http.addQueryToUrl(doc._url, { 'apos-mode': 'draft' }, { merge: true }), '_blank').focus();
     },
     findDocById(docs, id) {
       return docs.find(p => p._id === id);

--- a/modules/@apostrophecms/util/ui/public/2-http.js
+++ b/modules/@apostrophecms/util/ui/public/2-http.js
@@ -334,9 +334,18 @@
   // and arrays, in a way compatible with qs and most other parsers including
   // those baked into PHP frameworks etc. If the URL already contains a query
   // it is discarded and replaced with the new one. If `data` is an empty object
-  // no ? is added to the URL.
+  // no ? is added to the URL. `options` may be omitted. If `options.merge`
+  // is truthy then the properties of `data` are merged with any existing
+  // query string properties.
 
-  apos.http.addQueryToUrl = function(url, data) {
+  apos.http.addQueryToUrl = function(url, data, options) {
+    if (options && options.merge) {
+      var existing = url.indexOf('?');
+      if (existing !== -1) {
+        existing = apos.http.parseQuery(url.substring(existing + 1));
+        data = apos.util.assign({}, existing, data);
+      }
+    }
     url = url.replace(/\?.*$/, '');
     var i;
     var flat;


### PR DESCRIPTION
The preview button should immediately land on the page in preview mode.

Note that the query parameter you see added here gets hidden after arrival for a clean URL.

`apos.http.addQueryToUrl` now supports a merge option to make this kind of thing all the way easy on the front end.