### PR TITLE
PRO-350 visually empty rich text editors are highlighted

### DIFF
--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -139,6 +139,11 @@ export default {
         return 'editor-menu-bar';
       }
       return 'editor-menu-bubble';
+    },
+    isVisuallyEmpty () {
+      const div = document.createElement('div');
+      div.appendChild(this.content);
+      return div.textContent;
     }
   },
   watch: {

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -282,12 +282,11 @@ function computeEditorOptions(type, explicitOptions) {
   }
 
   .apos-rich-text-editor__editor /deep/ .ProseMirror:focus {
-    @include apos-transition(all);
-    box-shadow: 0 0 0 0 var(--a-primary);
     outline: none;
   }
 
   .apos-rich-text-editor__editor {
+    @include apos-transition();
     position: relative;
     border-radius: var(--a-border-radius);
     box-shadow: 0 0 0 1px transparent;

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -27,7 +27,7 @@
         </div>
       </AposContextMenuDialog>
     </component>
-    <div class="apos-rich-text-editor__editor">
+    <div class="apos-rich-text-editor__editor" :class="editorModifiers">
       <editor-content :editor="editor" :class="moduleOptions.className" />
     </div>
   </div>
@@ -142,8 +142,15 @@ export default {
     },
     isVisuallyEmpty () {
       const div = document.createElement('div');
-      div.appendChild(this.content);
-      return div.textContent;
+      div.innerHTML = this.value.content;
+      return !div.textContent;
+    },
+    editorModifiers () {
+      const classes = [];
+      if (this.isVisuallyEmpty) {
+        classes.push('is-visually-empty');
+      }
+      return classes;
     }
   },
   watch: {
@@ -275,7 +282,43 @@ function computeEditorOptions(type, explicitOptions) {
   }
 
   .apos-rich-text-editor__editor /deep/ .ProseMirror:focus {
+    @include apos-transition(all);
+    box-shadow: 0 0 0 0 var(--a-primary);
     outline: none;
+  }
+
+  .apos-rich-text-editor__editor {
+    position: relative;
+    border-radius: var(--a-border-radius);
+    box-shadow: 0 0 0 1px transparent;
+    &:after {
+      @include type-small;
+      content: 'Empty Rich Text Widget';
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      display: block;
+      width: 200px;
+      height: 10px;
+      margin: auto;
+      color: var(--a-base-5);
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      text-align: center;
+    }
+  }
+  .apos-rich-text-editor__editor.is-visually-empty {
+    box-shadow: 0 0 0 1px var(--a-primary-50);
+    &:after {
+      opacity: 1;
+      visibility: visible;
+    }
   }
 
   .apos-rich-text-toolbar__inner /deep/ > .apos-rich-text-editor__control {


### PR DESCRIPTION
This change just highlights RTEs that have no `textContent` as determined by the DOM parser. Leaves the door open for future auto pruning or whatever we decide
![image](https://user-images.githubusercontent.com/1889830/116108812-41831100-a682-11eb-86d9-54e78bbd6684.png)