### PR TITLE
Override the default redirection status code when req.statusCode is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+* It's now possible to set the status code when redirecting using `req.redirect` by setting `req.statusCode`. When it it is not set, `apostrophe-pages` will attempt to use the `statusCode` option of `apostrophe-soft-redirects` if it exists. It will fallback to 302 (Found) otherwise, which was the existing behavior.
+
 ## 2.117.1 (2021-04-07)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Changes
-* It's now possible to set the status code when redirecting using `req.redirect` by setting `req.statusCode`. When it it is not set, `apostrophe-pages` will attempt to use the `statusCode` option of `apostrophe-soft-redirects` if it exists. It will fallback to 302 (Found) otherwise, which was the existing behavior.
+* It's now possible to set the status code when redirecting using `req.redirect` by setting `req.statusCode`. When it it is not set, `apostrophe-pages` will fallback to 302 (Found) as previously.
 
 ## 2.117.1 (2021-04-07)
 

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -1119,8 +1119,6 @@ module.exports = function(self, options) {
   };
 
   self.serveDeliver = function(req, err) {
-    const soft = self.apos.modules['apostrophe-soft-redirects'];
-
     var providePage = true;
 
     // A2 treats req as a notepad of things we'd
@@ -1134,7 +1132,7 @@ module.exports = function(self, options) {
     }
 
     if (req.redirect) {
-      const status = req.statusCode || soft.options.statusCode || 302;
+      const status = req.statusCode || 302;
       return req.res.redirect(status, req.redirect);
     }
 

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -1119,6 +1119,7 @@ module.exports = function(self, options) {
   };
 
   self.serveDeliver = function(req, err) {
+    const soft = self.apos.modules['apostrophe-soft-redirects'];
 
     var providePage = true;
 
@@ -1133,7 +1134,8 @@ module.exports = function(self, options) {
     }
 
     if (req.redirect) {
-      return req.res.redirect(req.redirect);
+      const status = req.statusCode || soft.options.statusCode || 302;
+      return req.res.redirect(status, req.redirect);
     }
 
     // Handle 500 errors

--- a/test/pages.js
+++ b/test/pages.js
@@ -42,15 +42,9 @@ describe('Pages', function() {
         'redirect-to-home-pages': {
           extend: 'apostrophe-custom-pages',
 
-          addFields: [{
-            name: 'redirectWith',
-            type: 'integer',
-            def: null
-          }],
-
           construct: function (self, options) {
             self.dispatch('/', function (req, callback) {
-              req.statusCode = req.data.page.redirectWith;
+              req.statusCode = 301;
               req.redirect = '/';
               req.template = 'home';
               callback();
@@ -464,8 +458,7 @@ describe('Pages', function() {
       slug: '/redirect-default',
       published: true,
       type: 'redirect-to-home-page',
-      title: 'Redirect to home page',
-      redirectWith: null
+      title: 'Redirect to home page'
     };
 
     const req = apos.tasks.getReq();
@@ -476,31 +469,7 @@ describe('Pages', function() {
         followRedirect: false
       }, function(err, response, body) {
         assert(!err);
-        assert.equal(response.statusCode, 302);
-        done();
-      });
-    });
-  });
-
-  it('should redirect a page with the provided status code when both req.redirect and req.statusCode are set', function (done) {
-    const parentId = homeId;
-    const newPage = {
-      slug: '/redirect-with-307',
-      published: true,
-      type: 'redirect-to-home-page',
-      title: 'Redirect to home page with a 307',
-      redirectWith: 307
-    };
-
-    const req = apos.tasks.getReq();
-    apos.pages.insert(req, parentId, newPage, function (err) {
-      assert(!err, 'Could not create page "/redirect-with-307" for the test');
-      request({
-        url: 'http://localhost:7900/redirect-with-307',
-        followRedirect: false
-      }, function(err, response, body) {
-        assert(!err);
-        assert.equal(response.statusCode, 307);
+        assert.equal(response.statusCode, 301);
         done();
       });
     });


### PR DESCRIPTION
Currently, when redirecting a page using `req.redirect = '/somewhere'`, it is not possible to set the status code to be used for the redirection. In fact, the redirection will always use the status code 302 Found.

However, some modules like `apostrophe-personas` makes the assumption that setting `req.statusCode` will override the status code ([check index.js:302-305 on the latest commit to this day](https://github.com/apostrophecms/apostrophe-personas/blob/31c84c86bd26f42c901b4c91c2d1fd2464da8622/index.js#L302-L305)).

I found this assumption very reasonable in the idea of using ["req as a notepad of things we'd like to happen in res"](https://github.com/apostrophecms/apostrophe/blob/3360af419d73a80a7828472078da4d9b9242edfb/lib/modules/apostrophe-pages/lib/api.js#L1125-L1126), so this PR is my take on it. :slightly_smiling_face: 

Here is the updated behavior when `req.redirect` is set:
- If `req.statusCode` is set, use it for the redirection;
- If it isn't, try to use the option `statusCode` from `apostrophe-soft-redirects` ([similar to what `apostrophe-personas` does](https://github.com/apostrophecms/apostrophe-personas/blob/31c84c86bd26f42c901b4c91c2d1fd2464da8622/index.js#L304));
- Otherwise fallback to using `302` like before.
