### PR TITLE
PRO-1237: factored manuallyPublished to a mixin, for use cases that make sense for the mixin already

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Admin bar menu items can now specify a custom Vue component to be used in place of `AposButton`.
 * Sets `username` fields to follow the user `title` field to remove an extra step in user creation.
 * Adds default data to the `outerLayoutBase.html` `<title>` tag: `data.piece.title or data.page.title`.
+* `manuallyPublished` computed property moved to the `AposPublishMixin` for the use cases where that mixin is otherwise warranted.
 
 ### Fixes
 

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -260,9 +260,6 @@ export default {
         return [];
       }
     },
-    manuallyPublished() {
-      return this.moduleOptions.localized && !this.moduleOptions.autopublish;
-    },
     saveLabel() {
       if (this.restoreOnly) {
         return 'Restore';

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
@@ -181,9 +181,6 @@ export default {
         emoji: '📄'
       };
     },
-    manuallyPublished() {
-      return this.moduleOptions.localized && !this.moduleOptions.autopublish;
-    },
     headers() {
       if (!this.items) {
         return this.moduleOptions.columns || [];

--- a/modules/@apostrophecms/ui/ui/apos/mixins/AposPublishMixin.js
+++ b/modules/@apostrophecms/ui/ui/apos/mixins/AposPublishMixin.js
@@ -1,6 +1,11 @@
 // Provides reusable UI methods relating to the publication and management of drafts.
 
 export default {
+  computed: {
+    manuallyPublished() {
+      return this.moduleOptions.localized && !this.moduleOptions.autopublish;
+    }
+  },
   methods: {
     // A UI method to publish a document. If errors occur they are displayed to the user
     // appropriately, not returned or thrown to the caller. If a page cannot be published

--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
     "eslint-config-apostrophe": "^3.4.0",
     "eslint-loader": "^4.0.2",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-vue": "^7.9.0",
     "mocha": "^7.1.2",
     "nyc": "^15.1.0",


### PR DESCRIPTION
I left the edge cases alone because it would be their only use of the mixin and so it is otherwise off topic for them. We could put the method in a mixin all to itself to also cover the two "cell" components that have it, but it's a one-liner so that feels really excessive to me, at least for now.

I also fixed a package.json issue: a package was required separately as a regular and a dev dependency, with different major versions. Fun times.