### PR TITLE
PRO-1219 PRO-1257 Contributors can "discard draft" properly via the on-page kebab menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@
 * A contributor who enters the page tree dialog box, opens the editor, and selects "delete draft" from within the editor of an individual page now sees the page tree reflect that change right away.
 * The page manager listens for content change events in general and its refresh mechanism is robust in possible situations where both an explicit refresh call and a content change event occur.
 * Automatically retries once if unable to bind to the port in a dev environment. This helps with occasional `EADDRINUSE` errors during nodemon restarts.
+* Update the current page's context bar properly when appropriate after actions such as "Discard Draft."
+ 
 
 ## 3.0.0-alpha.7 - 2021-04-07
 

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
@@ -456,6 +456,7 @@ export default {
         headers: {
           'Cache-Control': 'no-cache'
         },
+        draft: true,
         busy: true
       });
       const refreshable = document.querySelector('[data-apos-refreshable]');

--- a/modules/@apostrophecms/page-type/index.js
+++ b/modules/@apostrophecms/page-type/index.js
@@ -154,23 +154,6 @@ module.exports = {
           }
         }
       },
-      afterPublish: {
-        async replayMoveAfterPublish(req, { published, firstTime }) {
-          if (!firstTime) {
-            // We already do this after every move of the draft, so
-            // if there was already a published version it will have
-            // already been moved
-            return;
-          }
-          // Home page does not move
-          if (published.aposLastTargetId) {
-            return self.apos.page.move({
-              ...req,
-              mode: 'published'
-            }, published._id, published.aposLastTargetId, published.aposLastPosition);
-          }
-        }
-      },
       beforeUnpublish: {
         async descendantsMustNotBePublished(req, published) {
           const descendants = await self.apos.doc.db.countDocuments({
@@ -185,42 +168,6 @@ module.exports = {
             // acceptable coverage here for now
             throw self.apos.error('invalid', 'You must unpublish child pages before unpublishing their parent.');
           }
-        }
-      },
-      afterRevertDraftToPublished: {
-        async replayMoveAfterRevert(req, result) {
-          const _req = {
-            ...req,
-            mode: 'draft'
-          };
-          if (!result.draft.level) {
-            // The home page cannot move, so there is no
-            // chance we need to "replay" such a move
-            return;
-          }
-          await self.apos.page.move(_req, result.draft._id, result.draft.aposLastTargetId, result.draft.aposLastPosition);
-          const draft = await self.apos.page.findOneForEditing(_req, {
-            _id: result.draft._id
-          });
-          result.draft = draft;
-        }
-      },
-      afterRevertPublishedToPrevious: {
-        async replayMoveAfterRevert(req, result) {
-          const publishedReq = {
-            ...req,
-            mode: 'published'
-          };
-          if (!result.published.level) {
-            // The home page cannot move, so there is no
-            // chance we need to "replay" such a move
-            return;
-          }
-          await self.apos.page.move(publishedReq, result.published._id, result.published.aposLastTargetId, result.published.aposLastPosition);
-          const published = await self.apos.page.findOneForEditing(publishedReq, {
-            _id: result.published._id
-          });
-          result.published = published;
         }
       },
       beforeDelete: {

--- a/modules/@apostrophecms/ui/ui/apos/mixins/AposPublishMixin.js
+++ b/modules/@apostrophecms/ui/ui/apos/mixins/AposPublishMixin.js
@@ -142,22 +142,21 @@ export default {
               body: {},
               busy: true
             });
-            const notificationHeader = isPublished ? 'Draft Discarded' : 'Draft Deleted';
-            apos.notify(notificationHeader, {
+            apos.notify('Draft Discarded', {
               type: 'success',
               dismiss: true,
               icon: 'text-box-remove-icon'
             });
             apos.bus.$emit('content-changed', newDoc);
             return {
-              newDoc
+              doc: newDoc
             };
           } else {
             await apos.http.delete(`${action}/${doc._id}`, {
               body: {},
               busy: true
             });
-            apos.notify('Deleted document.', {
+            apos.notify('Draft Deleted', {
               type: 'success',
               dismiss: true
             });


### PR DESCRIPTION
Fetch draft properly when refreshing context bar after discarding draft; remove beforeMove handlers made obsolete and problematic by the decision to just autopublish moves (those scenarios no longer apply and the handlers caused the original bug of this ticket); remove redundant logic for discard draft messaging; return doc correctly from discard draft; consistent messaging
