### PR TITLE
PRO-1255 fix for edge cases re: when you're allowed to click Submit Changes and when you're not

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
@@ -102,9 +102,15 @@ export default {
       return this.context.submitted && (this.canPublish || (this.context.submitted.byId === apos.login.user._id));
     },
     readyToPublish() {
-      return this.canPublish
-        ? this.context.modified && (!this.needToAutosave) && (!this.editing)
-        : (!this.context.submitted) || (this.context.updatedAt > this.context.submitted.at);
+      if (this.canPublish) {
+        return this.context.modified && (!this.needToAutosave) && (!this.editing);
+      } else if (this.context.submitted) {
+        return this.context.updatedAt > this.context.submitted.at;
+      } else if (this.context.lastPublishedAt) {
+        return this.context.updatedAt > this.context.lastPublishedAt;
+      } else {
+        return true;
+      }
     },
     moduleOptions() {
       return window.apos.adminBar;

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -215,6 +215,10 @@ export default {
         return true;
       }
       // Contributor case. Button is "submit"
+      // If previously published and not modified since, we can't submit
+      if (this.published && !this.isModifiedFromPublished) {
+        return true;
+      }
       if (!this.original.submitted) {
         // Allow initial submission
         return false;


### PR DESCRIPTION
I believe this resolves it for all cases. Keep in mind though that detecting changes in real time — changes made by another user, while this page was open for this user— is out of scope, so a page refresh is needed before checking what a contributor can do after an admin in another window takes some action.