### PR TITLE
PRO-1261 You can now "view" an archived item via the context menu

### DIFF
--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocMoreMenu.vue
@@ -131,7 +131,8 @@ export default {
         // ] : []),
         ...(this.canOpenEditor ? [
           {
-            label: 'Edit',
+            // When archived the edit action opens a read-only "editor"
+            label: this.canRestore ? 'View' : 'Edit',
             action: 'edit'
           }
         ] : []),

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
@@ -9,7 +9,7 @@
         :is-modified-from-published="manuallyPublished && item.modified"
         :is-published="manuallyPublished && !!item.lastPublishedAt"
         :can-save-draft="false"
-        :can-open-editor="!item.archived"
+        :can-open-editor="true"
         :can-preview="(!!item._url && !item.archived)"
         :can-archive="!item.archived && item._publish && (!manuallyPublished || !!item.lastPublishedAt)"
         :can-restore="item.archived && item._publish"


### PR DESCRIPTION
Both for and for pieces.

Related: removed unnecessary logic to pass on filters from the manager modal, which caused a secondary bug blocking the "view" feature after I added it. All we ever really needed there was to pass on `archived=any` to make sure this use case was accommodated.

@localghost443 has also asked whether something should happen when you click on the title of a page in the page tree, I'm not going there in this PR, just addressing the original ask for the context menu to provide a "view" option and for it to work for both pages and pieces.