### PR TITLE
PRO-1277: newly inserted images and files should still be visible to the public

### DIFF
--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -646,6 +646,11 @@ module.exports = {
           // different from the published, which won't exist yet
           doc.modified = true;
         }
+        if (!doc.visibility) {
+          // If the visibility property has been removed from the schema
+          // (images and files), make sure public queries can still match this type
+          doc.visibility = 'public';
+        }
         return self.retryUntilUnique(req, doc, async function () {
           return self.db.insertOne(self.apos.util.clonePermanent(doc));
         });


### PR DESCRIPTION
There is no migration to go with this because I did not want to add that weight for something that was never publicly released. So if you try to use an EXISTING image in an image widget to test this you will not be able to see it in an incognito window, but if you upload a new image to an image widget you will see it.