### PR TITLE
PRO-1282 check for drafts modified prop

### DIFF
--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManagerDisplay.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManagerDisplay.vue
@@ -75,7 +75,6 @@
           <AposCellBasic
             v-else
             :header="header"
-            :item="item._publishedDoc || item"
             :draft="item"
             :published="item._publishedDoc"
           />

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellLabels.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellLabels.vue
@@ -3,7 +3,7 @@
     class="apos-table__cell-field apos-table__cell-field--labels"
     :class="`apos-table__cell-field--${header.name}`"
   >
-    <span v-if="manuallyPublished && item.modified && !item.submitted && item.lastPublishedAt">
+    <span v-if="manuallyPublished && (item.modified || draft.modified) && !item.submitted && item.lastPublishedAt">
       <AposLabel
         label="Pending Updates" class="apos-table__cell-field__label"
         tooltip="There are active changes to this document."
@@ -38,6 +38,10 @@ export default {
   name: 'AposCellLabels',
   props: {
     item: {
+      type: Object,
+      required: true
+    },
+    draft: {
       type: Object,
       required: true
     },

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellLabels.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellLabels.vue
@@ -3,28 +3,28 @@
     class="apos-table__cell-field apos-table__cell-field--labels"
     :class="`apos-table__cell-field--${header.name}`"
   >
-    <span v-if="manuallyPublished && (item.modified || draft.modified) && !item.submitted && item.lastPublishedAt">
+    <span v-if="manuallyPublished && draft.modified && draft.submitted && draft.lastPublishedAt">
       <AposLabel
         label="Pending Updates" class="apos-table__cell-field__label"
         tooltip="There are active changes to this document."
         :modifiers="[ 'is-success', 'is-filled' ]"
       />
     </span>
-    <span v-else-if="item.submitted">
+    <span v-else-if="draft.submitted">
       <AposLabel
         label="Pending" class="apos-table__cell-field__label"
         tooltip="Changes to this document are awaiting approval by an admin or editor."
         :modifiers="[ 'is-filled' ]"
       />
     </span>
-    <span v-if="manuallyPublished && !item.lastPublishedAt">
+    <span v-if="manuallyPublished && !draft.lastPublishedAt">
       <AposLabel
         label="Draft" class="apos-table__cell-field__label"
         :modifiers="[ 'is-warning', 'is-filled' ]"
         tooltip="This document hasn't been published yet."
       />
     </span>
-    <span v-if="item.archived">
+    <span v-if="draft.archived">
       <AposLabel
         label="Archived" class="apos-table__cell-field__label"
         :modifiers="[ 'is-filled', 'is-danger' ]"
@@ -34,22 +34,11 @@
 </template>
 
 <script>
+import AposCellMixin from 'Modules/@apostrophecms/ui/mixins/AposCellMixin';
+
 export default {
   name: 'AposCellLabels',
-  props: {
-    item: {
-      type: Object,
-      required: true
-    },
-    draft: {
-      type: Object,
-      required: true
-    },
-    header: {
-      type: Object,
-      required: true
-    }
-  },
+  mixins: [ AposCellMixin ],
   computed: {
     manuallyPublished() {
       const module = apos.modules[this.item.type];

--- a/modules/@apostrophecms/ui/ui/apos/mixins/AposCellMixin.js
+++ b/modules/@apostrophecms/ui/ui/apos/mixins/AposCellMixin.js
@@ -6,10 +6,6 @@ export default {
       type: Object,
       required: true
     },
-    item: {
-      type: Object,
-      required: true
-    },
     draft: {
       type: Object,
       required: true
@@ -34,6 +30,11 @@ export default {
         namespace = 'item';
       }
       return get(this[namespace], path);
+    }
+  },
+  computed: {
+    item() {
+      return this.published || this.draft;
     }
   }
 };

--- a/modules/@apostrophecms/ui/ui/apos/mixins/AposCellMixin.js
+++ b/modules/@apostrophecms/ui/ui/apos/mixins/AposCellMixin.js
@@ -12,9 +12,7 @@ export default {
     },
     draft: {
       type: Object,
-      default() {
-        return null;
-      }
+      required: true
     },
     published: {
       type: Object,


### PR DESCRIPTION
https://linear.app/apostrophecms/issue/PRO-1282/pieces-not-getting-the-pending-update-label

@boutell as a side note, its confusing we're passing `item`, `draft`, and `published` into all these components, `item` being a moving target. Should we just normalize all the cells to expect `draft` and `published`?