### PR TITLE
Allowing Disabling of Global Piece Admin Permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-### Changes
-* It's now possible to set the status code when redirecting using `req.redirect` by setting `req.statusCode`. When it it is not set, `apostrophe-pages` will fallback to 302 (Found) as previously.
+### Features
+* It's now possible to set the status code when redirecting using `req.redirect` by setting `req.statusCode`. When it it is not set, `apostrophe-pages` will fallback to 302 (Found) as previously. Thanks to Jonathan Garijo for contributing this feature.
 
 ## 2.117.1 (2021-04-07)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,12 @@ PRs to resolve existing issues are fantastic. Two good places to start are the
 ["help wanted"](https://github.com/apostrophecms/apostrophe/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
 and ["good first issue"](https://github.com/apostrophecms/apostrophe/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) issues.
 
+Please not that if you are using Windows for development, we strongly recommend
+using 
+[Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/dev-environment/javascript/windows-or-wsl)
+both for development on the core Apostrophe modules and developing your own
+applications.
+
 If you’ve perused our open issues labeled `bug` and decide to work to resolve
 one, or you’ve got a new feature that you’d like to commit to the core project,
 please keep these things in mind:
@@ -86,7 +92,8 @@ We don't expect that every contributor is ready to write Nightwatch tests like
 these, but it is surely appreciated. If you are submit bug fix, please do
 include a test that reproduces the issue.
 2. **Make sure existing tests pass.** Run `npm test` to run the tests, including
-the code linters.
+the code linters. Note that tests require access to the /test folder in order to
+create symlinks, so on Windows you may need to run the tests as an administrator.
 3. **Enhancements should include documentation** and include implementation details
 were applicable. For Apostrophe core, that should be in the
 [main documentation](https://github.com/apostrophecms/apostrophe-documentation)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ PRs to resolve existing issues are fantastic. Two good places to start are the
 ["help wanted"](https://github.com/apostrophecms/apostrophe/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
 and ["good first issue"](https://github.com/apostrophecms/apostrophe/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) issues.
 
-Please not that if you are using Windows for development, we strongly recommend
+Please note that if you are using Windows for development, we strongly recommend
 using 
 [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/dev-environment/javascript/windows-or-wsl)
 both for development on the core Apostrophe modules and developing your own
@@ -92,8 +92,7 @@ We don't expect that every contributor is ready to write Nightwatch tests like
 these, but it is surely appreciated. If you are submit bug fix, please do
 include a test that reproduces the issue.
 2. **Make sure existing tests pass.** Run `npm test` to run the tests, including
-the code linters. Note that tests require access to the /test folder in order to
-create symlinks, so on Windows you may need to run the tests as an administrator.
+the code linters.
 3. **Enhancements should include documentation** and include implementation details
 were applicable. For Apostrophe core, that should be in the
 [main documentation](https://github.com/apostrophecms/apostrophe-documentation)

--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -272,7 +272,7 @@ module.exports = {
       // immediately let you do anything, just makes it easier to see
       // you are a candidate to do things like edit pages if given
       // specific rights to them. Also simplifies outerLayout's logic
-      if (!self.apos.permissions.options.disableAdminPiecesEditing) {
+      if (!self.apos.permissions.options.typeAdminsCanEditAllTypes) {
         if (_.some(user._permissions, function(val, key) {
           return key.match(/^admin-/);
         })) {

--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -98,16 +98,6 @@
 // administrators to edit the configuration for groups, make new ones, and
 // check the box to require TOTP.
 //
-// `disableAdminPiecesEditing`
-//
-// By default, assigning any admin piece permissions to a group
-// (i.e. 'admin-apostrophe-image') will enable admin bar controls for
-// all other pieces. This is to make management of joined items simpler in
-// management dialogs. If this option is set to `true`, the admin bar will
-// only show piece types that the user's group has been given explicit
-// admin or edit permissions on. You will need to manage permissions for
-// any joined pieces that also need to be editable.
-//
 // ## Notable properties of apos.modules['apostrophe-login']
 //
 // `passport`

--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -272,7 +272,7 @@ module.exports = {
       // immediately let you do anything, just makes it easier to see
       // you are a candidate to do things like edit pages if given
       // specific rights to them. Also simplifies outerLayout's logic
-      if (!self.apos.permissions.options.typeAdminsCanEditAllTypes) {
+      if (self.apos.permissions.options.typeAdminsCanEditAllTypes !== false) {
         if (_.some(user._permissions, function(val, key) {
           return key.match(/^admin-/);
         })) {

--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -98,6 +98,16 @@
 // administrators to edit the configuration for groups, make new ones, and
 // check the box to require TOTP.
 //
+// `disableAdminPiecesEditing`
+//
+// By default, assigning any admin piece permissions to a group
+// (i.e. 'admin-apostrophe-image') will enable admin bar controls for
+// all other pieces. This is to make management of joined items simpler in
+// management dialogs. If this option is set to `true`, the admin bar will
+// only show piece types that the user's group has been given explicit
+// admin or edit permissions on. You will need to manage permissions for
+// any joined pieces that also need to be editable.
+//
 // ## Notable properties of apos.modules['apostrophe-login']
 //
 // `passport`
@@ -266,19 +276,19 @@ module.exports = {
         user._permissions.guest = true;
       }
 
-      // TODO: make this a deprecated default behavior (sigh)
-
       // If you are admin- for any type of content, you need to be
       // at least guest to effectively attach media to your content,
       // and the edit permission also makes sense because it does not
       // immediately let you do anything, just makes it easier to see
       // you are a candidate to do things like edit pages if given
       // specific rights to them. Also simplifies outerLayout's logic
-      if (_.some(user._permissions, function(val, key) {
-        return key.match(/^admin-/);
-      })) {
-        user._permissions.guest = true;
-        user._permissions.edit = true;
+      if (!self.apos.permissions.options.disableAdminPiecesEditing) {
+        if (_.some(user._permissions, function(val, key) {
+          return key.match(/^admin-/);
+        })) {
+          user._permissions.guest = true;
+          user._permissions.edit = true;
+        }
       }
     };
 

--- a/lib/modules/apostrophe-permissions/index.js
+++ b/lib/modules/apostrophe-permissions/index.js
@@ -1,4 +1,16 @@
 // This module manages the permissions of docs in Apostrophe.
+//
+// ## Options
+//
+// `disableAdminPiecesEditing`
+//
+// By default, assigning any admin piece permissions to a group
+// (i.e. 'admin-apostrophe-image') will enable admin bar controls for
+// all other pieces. This is to make management of joined items simpler in
+// management dialogs. If this option is set to `true`, the admin bar will
+// only show piece types that the user's group has been given explicit
+// admin or edit permissions on. You will need to manage permissions for
+// any joined pieces that also need to be editable.
 
 var Promise = require('bluebird');
 var _ = require('@sailshq/lodash');

--- a/lib/modules/apostrophe-permissions/index.js
+++ b/lib/modules/apostrophe-permissions/index.js
@@ -2,7 +2,7 @@
 //
 // ## Options
 //
-// `disableAdminPiecesEditing`
+// `typeAdminsCanEditAllTypes`
 //
 // By default, assigning any admin piece permissions to a group
 // (i.e. 'admin-apostrophe-image') will enable admin bar controls for


### PR DESCRIPTION
No issue to link to, but this is a simple pull request asked for in Discord by another Apostrophe-CMS user. This is my first pull request, let me know if there's anything I forgot/should improve on. I'm also not completely sure the option name makes sense, but couldn't think of anything better that wasn't very long - let me know if you prefer a different name.

I did update the documentation (and add an Options header) for the apostrophe-permissions module.

Current behavior for admin permissions on piece types is that if you apply admin permissions for a single piece type, all piece types become visible in the admin bar, even though the editing windows end up being empty. It sounds like this was originally done to prevent errors for joins and relationships between piece types (i.e. if you have a join for another piece type which the group doesn't have permission to access).

Now that there are extra modules to manage access to particular fields, it seems safe to include an option to disable this behavior and only apply editing/submission permissions to the piece types that were selected in the particular group.

Requirements:

- The default behavior should remain the same
- The flag to control this behavior should be located in options for apostrophe-permissions, as it makes the most sense here
- The control of the code should happen on loginDeserialize in apostrophe-login
