### PR TITLE
PRO-1298 PRO-1300 make sure parked pages get inserted if the database is brand new, even if in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 * Fixed unique key errors in the migrate task by moving the parking of parked pages to a new `@apostrophecms/migrate:after` event handler, which runs only after migrations, whether that is at startup (in dev) or at the end of the migration task (in production).
 * UI does not offer "Archive" for the home page, or other archived pages.
 * Notification checks and other polling requests now occur only when the tab is in the foreground, resolving a number of problems that masqueraded as other bugs when the browser hit its connection limit for multiple tabs on the same site.
+* Parked pages are now parked immediately after database migrations are checked and/or run. In dev this still happens at each startup. In production this happens when the database is brand new and when the migration task is manually run.
 
 ## 3.0.0-alpha.7 - 2021-04-07
 

--- a/modules/@apostrophecms/migration/index.js
+++ b/modules/@apostrophecms/migration/index.js
@@ -40,8 +40,11 @@ module.exports = {
           });
         },
         async executeMigrations() {
-          if (process.env.NODE_ENV !== 'production') {
-            // Run migrations at dev startup (low friction)
+          if ((process.env.NODE_ENV !== 'production') || self.apos.isNew) {
+            // Run migrations at dev startup (low friction).
+            // Also always run migrations at first startup, so even
+            // in prod with a brand new database the after event always fires
+            // and we get a chance to mark the migrations as skipped
             await self.migrate(self.apos.argv);
           }
         }


### PR DESCRIPTION
I tested this using:

```
NODE_ENV=production npx mocha test/pages
```

Which fails without this patch, passes with it.