### PR TITLE
PRO-1303 brought back context menus in page tree by using the mixin, resolving a bug

### DIFF
--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManagerDisplay.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManagerDisplay.vue
@@ -83,6 +83,13 @@
         <td v-if="options.canEdit" class="apos-table__cell apos-table__cell--context-menu">
           <AposCellContextMenu
             :state="state[item._id]" :item="item"
+            :draft="item"
+            :published="item._publishedDoc"
+            :header="{
+              columnHeader: '',
+              property: 'contextMenu',
+              component: 'AposCellContextMenu'
+            }"
             :options="contextMenuOptions"
             @edit="$emit('open', item._id)"
             @preview="$emit('preview', item._id)"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellContextMenu.vue
@@ -30,18 +30,18 @@
 </template>
 
 <script>
+
+import AposCellMixin from 'Modules/@apostrophecms/ui/mixins/AposCellMixin';
+
 export default {
   name: 'AposCellContextMenu',
+  mixins: [ AposCellMixin ],
   props: {
     state: {
       type: Object,
       default() {
         return null;
       }
-    },
-    item: {
-      type: Object,
-      required: true
     },
     options: {
       type: Object,


### PR DESCRIPTION
Also fixed docs manager to call the context menu exactly like it is a cell, even if it does not choose to invoke it through the loop like other cells, because the page manager does invoke it like a cell and it expects certain params like a cell otherwise it throws errors.

Yes this is a workaround! I have opened PRO-1304 to refactor this in beta 2. I want to refactor this, it's giving me hives. However doing so today would risk introducing too many issues on a launch day. Would die on this hill.