### PR TITLE
PRO-1292 fix schema area zindex issues

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -26,7 +26,6 @@
           :widget-options="options.widgets"
           :max-reached="maxReached"
           :disabled="field && field.readOnly"
-          :in-context="inContext"
         />
       </template>
     </div>
@@ -47,7 +46,6 @@
         :widget-focused="focusedWidget"
         :max-reached="maxReached"
         :rendering="rendering(widget)"
-        :in-context="inContext"
         @up="up"
         @down="down"
         @remove="remove"
@@ -111,12 +109,6 @@ export default {
       type: Object,
       default() {
         return {};
-      }
-    },
-    inContext: {
-      type: Boolean,
-      default() {
-        return true;
       }
     }
   },

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
@@ -107,17 +107,14 @@ export default {
     disabled: {
       type: Boolean,
       default: false
-    },
-    inContext: {
-      type: Boolean,
-      default: true
     }
   },
   emits: [ 'menu-close', 'menu-open', 'add' ],
   data() {
     return {
       active: 0,
-      groupIsFocused: false
+      groupIsFocused: false,
+      inContext: true
     };
   },
   computed: {
@@ -172,6 +169,11 @@ export default {
     menuId() {
       return `areaMenu-${cuid()}`;
     }
+  },
+  mounted() {
+    // if this area is not in-context then it is assumed in a schema's modal and we need to bump
+    // the z-index of menus above them
+    this.inContext = !apos.util.closest(this.$el, '[data-apos-schema-area]');
   },
   methods: {
     menuClose(e) {

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -58,7 +58,6 @@
           :context-menu-options="contextMenuOptions"
           :index="i"
           :widget-options="options.widgets"
-          :in-context="inContext"
           :disabled="disabled"
         />
       </div>
@@ -121,7 +120,6 @@
           :context-menu-options="bottomContextMenuOptions"
           :index="i + 1"
           :widget-options="options.widgets"
-          :in-context="inContext"
           :disabled="disabled"
           @menu-open="toggleMenuFocus($event, 'bottom', true)"
           @menu-close="toggleMenuFocus($event, 'bottom', false)"
@@ -190,12 +188,6 @@ export default {
       type: Object,
       default() {
         return null;
-      }
-    },
-    inContext: {
-      type: Boolean,
-      default() {
-        return true;
       }
     },
     disabled: {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArea.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArea.vue
@@ -6,8 +6,11 @@
     :modifiers="modifiers"
   >
     <template #body>
+      <!-- data-apos-schema-area lets all the child areas know that this area is in a schema (which is in a modal)
+       and that we should position the z-index of context menus appropriately high -->
       <div
         class="apos-input-wrapper" :class="!next.items.length ? 'is-empty' : null"
+        data-apos-schema-area
       >
         <!-- We do not pass docId here because it is solely for
           contextual editing as far as the area editor is concerned. -Tom -->
@@ -20,7 +23,6 @@
           :field-id="field._id"
           :field="field"
           @changed="changed"
-          :in-context="false"
         />
       </div>
     </template>


### PR DESCRIPTION
previously we were passing this prop through a bunch of components, but as widgets get nested the chain is broken due to the unpredictable nature of what is being rendered within widgets.

Opt to simply look up the DOM tree for a data attribute that schema areas append. This attribute is not present in in-context areas