### PR TITLE
Copy alt field from apostrophe-images to attachment piece

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# Changelog
+
+## Unreleased
+
+### Features
+
+* When `enableAltField` option is set to `true`, we now copy the `alt` field from `apostrophe-images` schema to the `attachment` piece when using `apos.images.first` or `apos.attachments.first`.
 
 ## 2.118.0 (2021-05-05)
 

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -502,6 +502,9 @@ module.exports = function(self, options) {
             if (o.title) {
               value._title = o.title;
             }
+            if (o.alt) {
+              value._alt = o.alt;
+            }
             break;
           }
         }


### PR DESCRIPTION
When `enableAltField` option is set to `true` and you author the `alt` on the `apostrophe-images`, the `alt` attribute was not captured if you were using `apos.images.first` or `apos.attachments.first`. This pull request is an attempt to fix it. 

Please ensure your pull request follows these guidelines:

- [x] Link to the related issue with requirements and/or clearly describe 1) what problem this solves and 2) the requirements to review it against.
- [x] Update the `CHANGELOG.md` file with the added feature or fix. If there is not yet a heading for an upcoming release, add one following the established pattern.
- [x] Keep the pull request minimal! Break large updates into separate pull requests for individual features/fixes whenever possible. Small requests get reviewed more quickly.
- [x] All tests must pass, including the linters. Run `npm run lint` to test code linting independently.

Thanks for contributing!