### PR TITLE
there is no addHelper

### DIFF
--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -272,7 +272,7 @@ module.exports = {
       // be used very sparingly, and pretty much never in npm modules. The
       // only exceptions in apostrophe core are `apos.area` and `apos.singleton`.
       //
-      // The helper must be added first with `addHelpers` or `addHelper`.
+      // The helper must be added first with `addHelpers`.
 
       addHelperShortcut(name) {
         self.apos.template.addHelperShortcutForModule(self, name);

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -272,7 +272,7 @@ module.exports = {
       // be used very sparingly, and pretty much never in npm modules. The
       // only exceptions in apostrophe core are `apos.area` and `apos.singleton`.
       //
-      // The helper must be added first with `addHelpers`.
+      // The template helper must be added first. [See the module configuration reference](https://a3.docs.apostrophecms.org/reference/module-api/module-overview.html#customization-functions) for more.
 
       addHelperShortcut(name) {
         self.apos.template.addHelperShortcutForModule(self, name);


### PR DESCRIPTION
Fixes a doc comment referencing a non-existent method.