### PR TITLE
PRO-1341 preserve the hash when updating query strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 ### Fixes
 
 - The `name` option to widget modules, which never worked in 3.x, has been officially removed. The name of the widget type is always the name of the module, with the `-widget` suffix removed.
-- In-context editing works properly when the current browser URL has a `#` part, enabling the use of the `#` part for project-specific work. Thanks to [https://stepanjakl.com/](Štěpán Jákl) for reporting the issue.
-- When present, the `apos.http.addQueryToUrl` method preserves the `#` part of the URL intact.
+- In-context editing works properly when the current browser URL has a hash (portion beginning with `#`), enabling the use of the hash for project-specific work. Thanks to [https://stepanjakl.com/](Štěpán Jákl) for reporting the issue.
+- When present, the `apos.http.addQueryToUrl` method preserves the hash of the URL intact.
 
 ## 3.0.0-beta.1.1 - 2021-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Fixes
 
 - The `name` option to widget modules, which never worked in 3.x, has been officially removed. The name of the widget type is always the name of the module, with the `-widget` suffix removed.
+- In-context editing works properly when the current browser URL has a `#` part, enabling the use of the `#` part for project-specific work. Thanks to [https://stepanjakl.com/](Štěpán Jákl) for reporting the issue.
+- When present, the `apos.http.addQueryToUrl` method preserves the `#` part of the URL intact.
 
 ## 3.0.0-beta.1.1 - 2021-05-07
 

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
@@ -50,7 +50,7 @@ export default {
     // If the URL references a draft, go into draft mode but then clean up the URL
     const draftMode = query['aposMode'] || 'published';
     if (draftMode === 'draft') {
-      delete query['aposMode'];
+      delete query.aposMode;
       history.replaceState(null, '', apos.http.addQueryToUrl(location.href, query));
     }
     return {
@@ -453,13 +453,12 @@ export default {
       let url = window.location.href;
       const qs = {
         ...apos.http.parseQuery(window.location.search),
-        'aposRefresh': '1',
-        'aposMode': this.draftMode,
+        aposRefresh: '1',
+        aposMode: this.draftMode,
         ...(this.editMode ? {
-          'aposEdit': '1'
+          aposEdit: '1'
         } : {})
       };
-      url = url.replace(/\?.*$/, '');
       url = apos.http.addQueryToUrl(url, qs);
       const content = await apos.http.get(url, {
         qs,

--- a/modules/@apostrophecms/util/ui/public/2-http.js
+++ b/modules/@apostrophecms/util/ui/public/2-http.js
@@ -337,10 +337,16 @@
   // Adds query string data to url. Supports nested structures with objects
   // and arrays, in a way compatible with qs and most other parsers including
   // those baked into PHP frameworks etc. If the URL already contains a query
-  // it is discarded and replaced with the new one. If `data` is an empty object
-  // no ? is added to the URL.
+  // it is discarded and replaced with the new one. All non-query parts of the
+  // URL remain unchanged.
 
   apos.http.addQueryToUrl = function(url, data) {
+    var hash = '';
+    var hashAt = url.indexOf('#');
+    if (hashAt !== -1) {
+      hash = url.substring(hashAt);
+      url = url.substring(0, hashAt);
+    }
     url = url.replace(/\?.*$/, '');
     var i;
     var flat;
@@ -362,7 +368,7 @@
         }
       }
     }
-    return url;
+    return url + hash;
     function flatten(path, data) {
       var flat = [];
       var keys;


### PR DESCRIPTION
Also:

* eslint fixes.
* Don't manually chop off old query strings before calling, `addQueryToUrl` is smart enough to do that.