### PR TITLE
PRO-1101 optional separate uploadfs instance for asset module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Adds
 
 - The new `afterAposScripts` nunjucks block allows for pushing markup after Apostrophe's asset bundle script tag, at the end of the body. This is a useful way to add a script tag for Webpack's hot reload capabilities in development while still ensuring that Apostrophe's utility methods are available first, like they are in production.
+- An `uploadfs` option may be passed to the `@apostrophecms/asset` module, in order to pass options configuring a separate instance of `uploadfs` specifically for the static assets. The `@apostrophecms/uploadfs` module now exports a method to instantiate an uploadfs instance. The default behavior, in which user-uploaded attachments and static assets share a single instance of uploadfs, is unchanged. Note that asset builds never use uploadfs unless `APOS_UPLOADFS_ASSETS=1` is set in the environment.
 
 ### Breaks
 

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -43,6 +43,13 @@ module.exports = {
             });
           }
         }
+      },
+      'apostrophe:destroy': {
+        async destroyUploadfs() {
+          if (self.uploadfs && (self.uploadfs !== self.apos.uploadfs)) {
+            await Promise.promisify(self.uploadfs.destroy)();
+          }
+        }
       }
     };
   },

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -22,6 +22,7 @@ module.exports = {
     self.iconMap = {
       ...globalIcons
     };
+    self.initUploadfs();
   },
   handlers (self) {
     return {
@@ -296,7 +297,7 @@ module.exports = {
             if (process.env.APOS_UPLOADFS_ASSETS) {
               // The right choice if uploadfs is mapped to S3, Azure, etc.,
               // not the local filesystem
-              copyIn = require('util').promisify(self.apos.uploadfs.copyIn);
+              copyIn = require('util').promisify(self.uploadfs.copyIn);
               releaseDir = `/apos-frontend/releases/${releaseId}/${namespace}`;
             } else {
               // The right choice with Docker if uploadfs is just the local filesystem
@@ -387,6 +388,13 @@ module.exports = {
   },
   methods(self) {
     return {
+      async initUploadfs() {
+        if (self.options.uploadfs) {
+          self.uploadfs = await self.apos.modules['@apostrophecms/uploadfs'].getInstance(self.options.uploadfs);
+        } else {
+          self.uploadfs = self.apos.uploadfs;
+        }
+      },
       stylesheetsHelper(when) {
         const base = self.getAssetBaseUrl();
         // The styles for apostrophe admin UI are baked into the JS bundle. But
@@ -469,7 +477,7 @@ module.exports = {
           const releaseId = self.getReleaseId();
           const releaseDir = `/apos-frontend/releases/${releaseId}/${namespace}`;
           if (process.env.APOS_UPLOADFS_ASSETS) {
-            return `${self.apos.uploadfs.getUrl()}${releaseDir}`;
+            return `${self.uploadfs.getUrl()}${releaseDir}`;
           } else {
             return releaseDir;
           }

--- a/modules/@apostrophecms/uploadfs/index.js
+++ b/modules/@apostrophecms/uploadfs/index.js
@@ -5,30 +5,7 @@ const Promise = require('bluebird');
 
 module.exports = {
   async init(self) {
-
-    const uploadfsDefaultSettings = {
-      backend: 'local',
-      uploadsPath: self.apos.rootDir + '/public/uploads',
-      uploadsUrl: (self.apos.baseUrl || '') + self.apos.prefix + '/uploads',
-      tempPath: self.apos.rootDir + '/data/temp/uploadfs'
-    };
-
-    self.uploadfsSettings = {};
-    _.merge(self.uploadfsSettings, uploadfsDefaultSettings);
-
-    _.merge(self.uploadfsSettings, self.options.uploadfs || {});
-
-    if (process.env.APOS_S3_BUCKET) {
-      _.merge(self.uploadfsSettings, {
-        backend: 's3',
-        endpoint: process.env.APOS_S3_ENDPOINT,
-        secret: process.env.APOS_S3_SECRET,
-        key: process.env.APOS_S3_KEY,
-        bucket: process.env.APOS_S3_BUCKET,
-        region: process.env.APOS_S3_REGION
-      });
-    }
-    await self.initUploadfs();
+    self.uploadfs = await self.getInstance(self.options.uploadfs || {});
     // Like @apostrophecms/express or @apostrophecms/db, this module has no alias and instead
     // points to the service it provides because that is more useful
     self.apos.uploadfs = self.uploadfs;
@@ -36,11 +13,33 @@ module.exports = {
 
   methods(self) {
     return {
-      async initUploadfs() {
-        safeMkdirp(self.uploadfsSettings.uploadsPath);
-        safeMkdirp(self.uploadfsSettings.tempPath);
-        self.uploadfs = uploadfs();
-        await Promise.promisify(self.uploadfs.init)(self.uploadfsSettings);
+      // Initializes and returns a new instance of uploadfs, applying the appropriate defaults
+      // and environment variables where not overridden by the given options object
+      async getInstance(options = {}) {
+        const uploadfsDefaultSettings = {
+          backend: 'local',
+          uploadsPath: self.apos.rootDir + '/public/uploads',
+          uploadsUrl: (self.apos.baseUrl || '') + self.apos.prefix + '/uploads',
+          tempPath: self.apos.rootDir + '/data/temp/uploadfs'
+        };
+        const uploadfsSettings = {};
+        _.merge(uploadfsSettings, uploadfsDefaultSettings);
+        _.merge(uploadfsSettings, options);
+        if (process.env.APOS_S3_BUCKET) {
+          _.merge(uploadfsSettings, {
+            backend: 's3',
+            endpoint: process.env.APOS_S3_ENDPOINT,
+            secret: process.env.APOS_S3_SECRET,
+            key: process.env.APOS_S3_KEY,
+            bucket: process.env.APOS_S3_BUCKET,
+            region: process.env.APOS_S3_REGION
+          });
+        }
+        safeMkdirp(uploadfsSettings.uploadsPath);
+        safeMkdirp(uploadfsSettings.tempPath);
+        const instance = uploadfs();
+        await Promise.promisify(instance.init)(uploadfsSettings);
+        return instance;
         function safeMkdirp(path) {
           try {
             mkdirp.sync(path);

--- a/modules/@apostrophecms/uploadfs/index.js
+++ b/modules/@apostrophecms/uploadfs/index.js
@@ -57,7 +57,9 @@ module.exports = {
     return {
       'apostrophe:destroy': {
         async destroyUploadfs() {
-          await Promise.promisify(self.apos.uploadfs.destroy)();
+          if (self.apos.uploadfs) {
+            await Promise.promisify(self.apos.uploadfs.destroy)();
+          }
         }
       }
     };


### PR DESCRIPTION
See ticket. This allows for environments where several apos objects should share static assets. The default behavior has not changed.