### PR TITLE
PRO-1372 dethrone the P tag, impostor king

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - The home page and other parked pages should not immediately show as "pending changes." 
 - The browser-side `apos.http.parseQuery` function now handles objects and arrays properly again.
 - Skipping positional arguments in fragments now works as expected.
+- The rich text editor now supports specifying a `styles` array with no `p` tags properly. A newly added rich text widget initially contains an element with the first style, rather than always a paragraph. If no styles are configured, a `p` tag is assumed. Thanks to Stepan Jakl for reporting the issue.
 
 ## 3.0.0-beta.1.1 - 2021-05-07
 

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -96,7 +96,14 @@ export default {
     const defaultOptions = moduleOptionsBody(this.type).defaultOptions;
     const toolbar = this.options.toolbar === false ? []
       : (this.options.toolbar || defaultOptions.toolbar);
-
+    let initial = this.stripPlaceholderBrs(this.value.content);
+    if (!initial.trim().length) {
+      const defaultStyle = (this.options.styles && this.options.styles[0]) || {
+        tag: 'p'
+      };
+      const defaultClass = defaultStyle.class ? ` class="${defaultStyle.class}"` : '';
+      initial = `<${defaultStyle.tag}${defaultClass}></${defaultStyle.tag}>`;
+    }
     return {
       tools: moduleOptionsBody(this.type).tools,
       toolbar,
@@ -116,7 +123,7 @@ export default {
         ].concat((apos.tiptapExtensions || []).map(C => new C(computeEditorOptions(this.type, this.options)))),
         autoFocus: true,
         onUpdate: this.editorUpdate,
-        content: this.stripPlaceholderBrs(this.value.content)
+        content: initial
       }),
       docFields: {
         data: {

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Styles.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Styles.js
@@ -16,7 +16,7 @@ export default class Styles extends Node {
     return {
       attrs: {
         tag: {
-          default: defaultStyle.p
+          default: defaultStyle.tag
         },
         class: {
           default: defaultStyle.class

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Styles.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Styles.js
@@ -10,13 +10,16 @@ export default class Styles extends Node {
   }
 
   get schema() {
+    const defaultStyle = (this.options.styles && this.options.styles[0]) || {
+      tag: 'p'
+    };
     return {
       attrs: {
         tag: {
-          default: 'p'
+          default: defaultStyle.p
         },
         class: {
-          default: null
+          default: defaultStyle.class
         }
       },
       content: 'inline*',


### PR DESCRIPTION
The rich text editor now supports specifying a `styles` array with no `p` tags properly. A newly added rich text widget initially contains an element with the first style, rather than always a paragraph. If no styles are configured, a `p` tag is assumed. Thanks to Stepan Jakl for reporting the issue.