### PR TITLE
pass referer to oembetter, use oembetter 1.x, support allowlist as a …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 ## Unreleased
 
+### Fixes
+
+* Send the `Referer` header with oembed requests. This allows vimeo private videos locked down by domain name to be embedded.
+
 ### Features
 
 * When `enableAltField` option is set to `true`, we now copy the `alt` field from `apostrophe-images` schema to the `attachment` piece when using `apos.images.first` or `apos.attachments.first`.

--- a/lib/modules/apostrophe-oembed/index.js
+++ b/lib/modules/apostrophe-oembed/index.js
@@ -17,6 +17,9 @@
 // Your `safeList` option is concatenated with `oembetter`'s standard
 // list, plus wufoo.com, infogr.am, and slideshare.net.
 //
+// The option name `allowlist` is also permitted for consistency with oembetter
+// and other tools.
+//
 // Your `endpoints` option is concatenated with `oembetter`'s standard
 // endpoints list.
 
@@ -52,8 +55,8 @@ module.exports = {
       // Don't permit oembed of untrusted sites, which could
       // lead to XSS attacks
 
-      self.safeList = self.oembetter.suggestedWhitelist.concat(self.options.safeList || self.options.whitelist || [], [ 'wufoo.com', 'infogr.am', 'slideshare.net' ]);
-      self.oembetter.whitelist(self.safeList);
+      self.safeList = self.oembetter.suggestedAllowlist.concat(self.options.safeList || self.options.allowlist || self.options.whitelist || [], [ 'wufoo.com', 'infogr.am', 'slideshare.net' ]);
+      self.oembetter.allowlist(self.safeList);
       self.oembetter.endpoints(self.oembetter.suggestedEndpoints.concat(self.options.endpoints || []));
     };
 

--- a/lib/modules/apostrophe-oembed/lib/api.js
+++ b/lib/modules/apostrophe-oembed/lib/api.js
@@ -25,6 +25,19 @@ module.exports = function(self, options) {
       mainCallback = options;
       options = {};
     }
+    if (!options.headers) {
+      options = Object.assign({}, options, {
+        headers: {
+          // Enables access to vimeo private videos locked to this domain
+          Referer: req.baseUrlWithPrefix
+        }
+      });
+    }
+    if (!options.headers.Referer) {
+      options.headers = Object.assign({}, options.headers, {
+        Referer: req.baseUrlWithPrefix
+      });
+    }
     if (!self.cache) {
       self.cache = self.apos.caches.get('oembed');
     }

--- a/lib/modules/apostrophe-oembed/lib/vimeo.js
+++ b/lib/modules/apostrophe-oembed/lib/vimeo.js
@@ -6,8 +6,11 @@ module.exports = function(self, oembetter) {
     if (!url.match(/vimeo/)) {
       return setImmediate(callback);
     }
-    // Fix vimeo thumbnails to be larger
-    response.thumbnail_url = response.thumbnail_url.replace('640.jpg', '1000.jpg');
+    // Don't crash on missing thumbnail URLs (a private video and our referer does not match)
+    if (response.thumbnail_url) {
+      // Fix vimeo thumbnails to be larger
+      response.thumbnail_url = response.thumbnail_url.replace('640.jpg', '1000.jpg');
+    }
     return callback(null);
   });
 };

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "moment": "^2.29.1",
     "moog-require": "^1.1.0",
     "nodemailer": "^4.7.0",
-    "oembetter": "^0.1.23",
+    "oembetter": "^1.0.0",
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",
     "passport-totp": "0.0.2",


### PR DESCRIPTION
…synonym for safeList to be more consistent with other tools
