### PR TITLE
PRO-1391 PRO-1392 restore ability to move pages, with correct enforcement

### DIFF
--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -105,6 +105,7 @@
         :style="{
           'max-height': options.startCollapsed ? '0' : null
         }"
+        @update="$emit('update', $event)"
         v-model="checkedProxy"
       />
     </li>


### PR DESCRIPTION
I lost a lot of time on this because I stopped being able to even see drop zones for quite a while. I went back to beta 1 and even earlier and still had the problem, did more npm installs, got it working in beta 1.2, then said wait a minute and came back to this one-line fix for beta 2 and... working fine.

So I think I experienced some red herrings due to dependency hell, and in any case experienced them in long-published releases, so even if that were ever to recur it's not a new regression. This one-line fix is correct for the ticket that was opened.