### PR TITLE
PRO-1403 3/no flash login

### DIFF
--- a/modules/@apostrophecms/login/views/login.html
+++ b/modules/@apostrophecms/login/views/login.html
@@ -3,6 +3,14 @@
 
 {% block bodyClass %}apos-login-page{% endblock %}
 
+{% block beforeMain %}
+  {# Hush up project level styles while login loads #}
+  <style>
+    body {
+      background-color: var(--a-background-primary) !important;
+    }
+  </style>
+{% endblock%}
 {% block main %}
   <div id="apos-login"></div>
 {% endblock %}


### PR DESCRIPTION
Project level styles get loaded as part of outerlayout while the login vue app renders. Do our best to shut those visuals off while the login app fades in.