### PR TITLE
no need to restate all of minimumPark when you override the parking of the home page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The `nlbr` and `nlp` Nunjucks filters marked their output as safe to preserve th
 - Removed many unused dependencies.
 - The data retained for "Undo Publish" no longer causes slug conflicts in certain situations.
 - Custom piece types using `localized: false` or `autopublish: true,` as well as singleton types, now display the correct options on the "Save" dropdown.
+- The "Save and View," "Publish and View" and/or "Save Draft and Preview" options now appear only if an appropriate piece page actually exists for the piece type.
 
 ### Notices
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The `nlbr` and `nlp` Nunjucks filters marked their output as safe to preserve th
 - Updated dependencies on `sanitize-html` and `nodemailer` to new major versions, causing no bc breaks at the ApostropheCMS level. This resolved two critical vulnerabilities according to `npm audit`.
 - Removed many unused dependencies.
 - The data retained for "Undo Publish" no longer causes slug conflicts in certain situations.
+- Custom piece types using `localized: false` or `autopublish: true,` as well as singleton types, now display the correct options on the "Save" dropdown.
 
 ### Notices
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ The `nlbr` and `nlp` Nunjucks filters marked their output as safe to preserve th
 - `AposModal` now emits a `ready` event when it is fully painted and can be interacted with by users or code.
 - The video widget is now compatible with vimeo private videos when the domain is on the allowlist in vimeo.
 
+### Changes
+
+- You can now override the parked page definition for the home page without copying the entirety of `minimumPark` from the source code. Specifically, you will not lose the root archive page if you park the home page without explicitly parking the archive page as well. This makes it easier to choose your own type for the home page, in lieu of `@apostrophecms/home-page`.
+
 ### Fixes
 
 - Piece types like users that have a slug prefix no longer trigger a false positive as being "modified" when you first click the "New" button.

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -723,18 +723,9 @@ export default {
       const typeLabel = this.moduleOptions
         ? this.moduleOptions.label.toLowerCase()
         : 'document';
-      const newBlocklist = [ '@apostrophecms/global' ];
-      const previewBlocklist = [
-        '@apostrophecms/global',
-        '@apostrophecms/file',
-        '@apostrophecms/file-tag',
-        '@apostrophecms/image',
-        '@apostrophecms/image-tag',
-        '@apostrophecms/user'
-      ];
       const isNew = !this.docId;
-      const canPreview = !previewBlocklist.includes(this.moduleName);
-      const canNew = !newBlocklist.includes(this.moduleName);
+      const canPreview = this.manuallyPublished;
+      const canNew = this.moduleOptions.showCreate;
       const menu = [
         {
           label: this.saveLabel,

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -350,6 +350,9 @@ export default {
     manuallyPublished() {
       this.saveMenu = this.computeSaveMenu();
     },
+    original() {
+      this.saveMenu = this.computeSaveMenu();
+    },
     tabs() {
       if ((!this.currentTab) || (!this.tabs.find(tab => tab.name === this.currentTab))) {
         this.currentTab = this.tabs[0] && this.tabs[0].name;
@@ -637,7 +640,7 @@ export default {
           window.location = doc._url;
         } else {
           const subject = andPublish ? 'Document published' : 'Draft saved';
-          await apos.notify(`${subject} but could not navigate to a preview. Try creating a ${(this.moduleOptions.label || '')} index page`, {
+          await apos.notify(`${subject} but could not navigate to a preview.`, {
             type: 'warning',
             icon: 'alert-circle-icon'
           });
@@ -724,7 +727,8 @@ export default {
         ? this.moduleOptions.label.toLowerCase()
         : 'document';
       const isNew = !this.docId;
-      const canPreview = this.manuallyPublished;
+      // this.original takes a moment to populate, don't crash
+      const canPreview = this.original && (this.original._id ? this.original._url : this.original._previewable);
       const canNew = this.moduleOptions.showCreate;
       const menu = [
         {

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -199,10 +199,12 @@ module.exports = {
 
         if (req.body._newInstance) {
           // If we're looking for a fresh page instance and aren't saving yet,
-          // simply get a new page doc and return;
+          // simply get a new page doc and return it
           const parentPage = await self.findForEditing(req, { _id: targetId })
             .permission('edit', '@apostrophecms/any-page-type').toObject();
-          return self.newChild(parentPage);
+          const newChild = self.newChild(parentPage);
+          newChild._previewable = true;
+          return newChild;
         }
 
         return self.withLock(req, async () => {

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -20,17 +20,15 @@ module.exports = {
         _defaults: {
           title: 'Home',
           type: '@apostrophecms/home-page'
-        },
-        _children: [
-          {
-            slug: '/archive',
-            parkedId: 'archive',
-            type: '@apostrophecms/archive-page',
-            archived: true,
-            orphan: true,
-            title: 'Archive'
-          }
-        ]
+        }
+      },
+      {
+        slug: '/archive',
+        parkedId: 'archive',
+        type: '@apostrophecms/archive-page',
+        archived: true,
+        orphan: true,
+        title: 'Archive'
       }
     ]
   },
@@ -49,7 +47,11 @@ module.exports = {
   },
   async init(self) {
     self.typeChoices = self.options.types || [];
-    self.parked = self.options.minimumPark.concat(self.options.park || []);
+    // If "park" redeclares something with a parkedId present in "minimumPark",
+    // the later one should win
+    self.parked = self.options.minimumPark.concat(self.options.park || []).filter((page, i, parked) => {
+      return !parked.slice(i + 1).find(laterPage => page.parkedId === laterPage.parkedId);
+    });
     self.addManagerModal();
     self.addEditorModal();
     self.enableBrowserData();

--- a/modules/@apostrophecms/piece-page-type/index.js
+++ b/modules/@apostrophecms/piece-page-type/index.js
@@ -258,11 +258,21 @@ module.exports = {
         return self.find(req).areas(false).relationships(false);
       },
 
-      // Configure our `addUrlsToPieces` method as the `addUrls` method
-      // of the related pieces module.
+      // Associates this module with the relevant piece type module
+      // so that it knows to invoke our `addUrlsToPieces` method.
+      // Also marks the piece type as previewable.
 
       enableAddUrlsToPieces() {
-        self.pieces.setAddUrls(self.addUrlsToPieces);
+        self.pieces.addUrlsVia(self, true);
+      },
+
+      // Default implementation: we are ready to add URLs to pieces when we have
+      // at least one reachable piece page. pieceTypeName is guaranteed to always
+      // be our corresponding piece module name right now, however it is provided
+      // in case a subclass chooses to invoke `addUrlsVia` for multiple
+      // piece types
+      async readyToAddUrlsToPieces(req, pieceTypeName) {
+        return !!(await self.find(req, {}).areas(false).relationships(false).toObject());
       },
 
       // Populate `req.data.piecesFilters` with arrays of choice objects,

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -7,8 +7,7 @@ module.exports = {
     perPage: 10,
     quickCreate: true,
     previewDraft: true,
-    showCreate: true,
-    previewable: false
+    showCreate: true
     // By default there is no public REST API, but you can configure a
     // projection to enable one:
     // publicApiProjection: {
@@ -143,7 +142,6 @@ module.exports = {
     self.name = self.options.name;
     self.label = self.options.label;
     self.pluralLabel = self.options.pluralLabel;
-    self.previewable = self.options.previewable;
 
     self.composeFilters();
     self.composeColumns();
@@ -492,13 +490,8 @@ module.exports = {
       // Typically called by a piece-page-type to register itself as the
       // module providing `_url` properties to this type of piece. The addUrls
       // method will invoke the addUrlsToPieces method of that type.
-      //
-      // If previewable is true, then this means the pieces are potentially
-      // previewable ("save and preview" is a sensible operation to offer
-      // for them).
-      addUrlsVia(module, previewable) {
+      addUrlsVia(module) {
         self.addUrlsViaModule = module;
-        self.previewable = previewable;
       },
       // Implements a simple batch operation like publish or unpublish.
       // Pass `req`, the `name` of a configured batch operation, and

--- a/test/parked-pages.js
+++ b/test/parked-pages.js
@@ -1,0 +1,64 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert');
+
+let apos, apos2;
+
+describe('Parked Pages', function() {
+
+  this.timeout(t.timeout);
+
+  after(async function() {
+    await t.destroy(apos);
+    await t.destroy(apos2);
+  });
+
+  it('standard parked pages should be as expected', async function() {
+    apos = await t.create({
+      root: module,
+      modules: {}
+    });
+    const req = apos.task.getReq();
+    const home = await apos.page.find(req, { slug: '/' }).toObject();
+    assert(home);
+    assert(home.parkedId === 'home');
+    assert(home.type === '@apostrophecms/home-page');
+    const archive = await apos.page.find(req, { slug: '/archive' }).archived(true).toObject();
+    assert(archive);
+    assert(archive.parkedId === 'archive');
+    assert(archive.type === '@apostrophecms/archive-page');
+  });
+
+  it('overridden home page should work without disturbing archive', async function() {
+    apos2 = await t.create({
+      root: module,
+      modules: {
+        '@apostrophecms/page': {
+          options: {
+            park: [
+              {
+                slug: '/',
+                parkedId: 'home',
+                _defaults: {
+                  title: 'Home',
+                  type: 'default-page'
+                }
+              }
+            ]
+          }
+        },
+        'default-page': {
+          extend: '@apostrophecms/page-type'
+        }
+      }
+    });
+    const req = apos2.task.getAnonReq();
+    const home = await apos2.page.find(req, { slug: '/' }).toObject();
+    assert(home);
+    assert(home.parkedId === 'home');
+    assert(home.type === 'default-page');
+    const archive = await apos2.page.find(req, { slug: '/archive' }).archived(true).toObject();
+    assert(archive);
+    assert(archive.parkedId === 'archive');
+    assert(archive.type === '@apostrophecms/archive-page');
+  });
+});


### PR DESCRIPTION
1. Don't use `_children` in minimumPark, take advantage of the fact that the home page is the default parent of other parked pages.
2. If a parked page present in `minimumPark` is redeclared in `park` with the same `parkedId`, override the earlier definition without parking it twice.