### PR TITLE
temporarily remove text align controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,12 @@
 
 ### Adds
 
-- Rich text editor adds support for text align controls as part of the upgrade to tiptap 2.x beta (see "changes").
 - Added the `ignoreUnusedFolderWarning` option for modules that intentionally might not be activated or inherited from in a particular startup.
-
+- Better explanation of how to replace macros with fragments, in particular how to call the fragments with `{% render fragmentName(args) %}`.
 
 ### Security Fixes
 
 The `nlbr` and `nlp` Nunjucks filters marked their output as safe to preserve the tags that they added, without first escaping their input, creating a CSRF risk. These filters have been updated to escape their input unless it has already been marked safe. No code changes are required to templates whose input to the filter is intended as plaintext, however if you were intentionally leveraging this bug to output unescaped HTML markup you will need to make sure your input is free of CSRF risks and then use the `| safe` filter before the `| nlbr` or `| nlp` filter.
-
-### Adds
-
-Better explanation of how to replace macros with fragments, in particular how to call the fragments with `{% render fragmentName(args) %}`.
 
 ### Fixes
 

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -122,38 +122,38 @@ module.exports = {
         label: 'Redo',
         icon: 'redo-icon'
       },
-      alignLeft: {
-        component: 'AposTiptapButton',
-        label: 'Align Left',
-        icon: 'format-align-left-icon',
-        command: 'setTextAlign',
-        commandParameters: 'left',
-        isActive: { textAlign: 'left' }
-      },
-      alignCenter: {
-        component: 'AposTiptapButton',
-        label: 'Align Center',
-        icon: 'format-align-center-icon',
-        command: 'setTextAlign',
-        commandParameters: 'center',
-        isActive: { textAlign: 'center' }
-      },
-      alignRight: {
-        component: 'AposTiptapButton',
-        label: 'Align Right',
-        icon: 'format-align-right-icon',
-        command: 'setTextAlign',
-        commandParameters: 'right',
-        isActive: { textAlign: 'right' }
-      },
-      alignJustify: {
-        component: 'AposTiptapButton',
-        label: 'Align Justify',
-        icon: 'format-align-justify-icon',
-        command: 'setTextAlign',
-        commandParameters: 'justify',
-        isActive: { textAlign: 'justify' }
-      },
+      // alignLeft: {
+      //   component: 'AposTiptapButton',
+      //   label: 'Align Left',
+      //   icon: 'format-align-left-icon',
+      //   command: 'setTextAlign',
+      //   commandParameters: 'left',
+      //   isActive: { textAlign: 'left' }
+      // },
+      // alignCenter: {
+      //   component: 'AposTiptapButton',
+      //   label: 'Align Center',
+      //   icon: 'format-align-center-icon',
+      //   command: 'setTextAlign',
+      //   commandParameters: 'center',
+      //   isActive: { textAlign: 'center' }
+      // },
+      // alignRight: {
+      //   component: 'AposTiptapButton',
+      //   label: 'Align Right',
+      //   icon: 'format-align-right-icon',
+      //   command: 'setTextAlign',
+      //   commandParameters: 'right',
+      //   isActive: { textAlign: 'right' }
+      // },
+      // alignJustify: {
+      //   component: 'AposTiptapButton',
+      //   label: 'Align Justify',
+      //   icon: 'format-align-justify-icon',
+      //   command: 'setTextAlign',
+      //   commandParameters: 'justify',
+      //   isActive: { textAlign: 'justify' }
+      // },
       highlight: {
         component: 'AposTiptapButton',
         label: 'Mark',

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -122,6 +122,8 @@ module.exports = {
         label: 'Redo',
         icon: 'redo-icon'
       },
+      // Disabled until sanitize-html is auto configured to save style properties
+      // when align controls are present
       // alignLeft: {
       //   component: 'AposTiptapButton',
       //   label: 'Align Left',


### PR DESCRIPTION
remove text alignment controls until sanihtml can be auto configured to save style properties.