### PR TITLE
Extend Tiptap2 TextStyles to accept all spans, not just ones with `style` attrs

### DIFF
--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/TextStyle.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/TextStyle.js
@@ -1,0 +1,8 @@
+import TextStyle from '@tiptap/extension-text-style';
+export default (options) => {
+  return TextStyle.extend({
+    parseHTML() {
+      return [ 'span' ];
+    }
+  });
+};

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/TextStyle.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/TextStyle.js
@@ -2,7 +2,9 @@ import TextStyle from '@tiptap/extension-text-style';
 export default (options) => {
   return TextStyle.extend({
     parseHTML() {
-      return [ 'span' ];
+      return [
+        { tag: 'span' }
+      ];
     }
   });
 };


### PR DESCRIPTION
- Currently spans without style attrs get parsed out on tiptap remount, modify the extension to return all spans