### PR TITLE
PRO-1535: relationship subfields working in expanded chooser (manager view), also fixed initialization with support for defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Relationship subfields can now be edited when selecting in the full "manage view" browser, as well as in the compact relationship field view which worked previously.
 * A console warning when editing subfields for a new relationship was fixed.
 * Relationship subfields now respect the `def` property.
+* Relationship subfields are restored if you deselect a document and then reselect it within a single editing experience, i.e. accidentally deselect and immediately reselect, for instance.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 * Reverse relationships work properly for published documents.
 * Relationship subfields are now loaded properly when `reverseOf` is used.
+* Relationship subfields can now be edited when selecting in the full "manage view" browser, as well as in the compact relationship field view which worked previously.
+* A console warning when editing subfields for a new relationship was fixed.
+* Relationship subfields now respect the `def` property.
 
 ### Changes
 

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
@@ -14,7 +14,14 @@ export default {
       // as initially checked.
       checked: Array.isArray(this.chosen) ? this.chosen.map(item => item._id)
         : [],
-      checkedDocs: Array.isArray(this.chosen) ? klona(this.chosen) : []
+      checkedDocs: Array.isArray(this.chosen) ? klona(this.chosen) : [],
+      // Remember relationship subfield values even if a document
+      // is temporarily deselected, easing the user's pain if they
+      // inadvertently deselect something for a moment
+      subfields: Object.fromEntries((this.chosen || [])
+        .filter(doc => doc._fields)
+        .map(doc => [ doc._id, doc._fields ])
+      )
     };
   },
   props: {
@@ -86,7 +93,17 @@ export default {
         this.generateUi();
       }
     },
-    checked () {
+    checkedDocs(after, before) {
+      for (const doc of before) {
+        this.subfields[doc._id] = doc._fields;
+      }
+      for (const doc of after) {
+        if (this.subfields[doc._id] && !Object.keys(doc._fields || {}).length) {
+          doc._fields = this.subfields[doc._id];
+        }
+      }
+    },
+    checked() {
       this.updateCheckedDocs();
     }
   },

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
@@ -49,7 +49,9 @@
           <AposSlatList
             class="apos-pieces-manager__relationship__items"
             @input="setCheckedDocs"
+            @item-clicked="editRelationship"
             :value="checkedDocs"
+            :has-relationship-schema="!!(relationshipField && relationshipField.schema)"
           />
         </div>
       </AposModalRail>
@@ -351,6 +353,20 @@ export default {
         headers = headers.filter(h => h.component !== 'AposCellLabels');
       }
       return headers;
+    },
+    async editRelationship(item) {
+      const result = await apos.modal.execute('AposRelationshipEditor', {
+        schema: this.relationshipField.schema,
+        title: item.title,
+        value: item._fields
+      });
+      if (result) {
+        const index = this.checkedDocs.findIndex(_item => _item._id === item._id);
+        this.$set(this.checkedDocs, index, {
+          ...this.checkedDocs[index],
+          _fields: result
+        });
+      }
     }
   }
 };

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
@@ -249,15 +249,6 @@ export default {
         // Cancel clicked
         return;
       }
-      if (this.relationshipField) {
-        if (!this.checked.includes(doc._id)) {
-          doc._fields = doc._fields || {};
-          // Must push to checked docs or it will try to do it for us
-          // and not include _fields
-          this.checkedDocs.push(doc);
-          this.checked.push(doc._id);
-        }
-      }
     },
     async finishSaved() {
       await this.getPieces();

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposRelationshipEditor.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposRelationshipEditor.vue
@@ -40,6 +40,7 @@
 <script>
 import AposModifiedMixin from 'Modules/@apostrophecms/ui/mixins/AposModifiedMixin';
 import { detectDocChange } from 'Modules/@apostrophecms/schema/lib/detectChange';
+import { klona } from 'klona';
 
 export default {
   name: 'AposRelationshipEditor',
@@ -55,7 +56,9 @@ export default {
     },
     value: {
       type: Object,
-      required: true
+      default() {
+        return null;
+      }
     },
     title: {
       type: String,
@@ -69,7 +72,13 @@ export default {
       original: this.value,
       docFields: {
         data: {
-          ...this.value
+          ...((this.value != null) ? this.value :
+            Object.fromEntries(
+              this.schema.map(field =>
+                [ field.name, (field.def !== undefined) ? klona(field.def) : null ]
+              )
+            )
+          )
         },
         hasErrors: false
       },

--- a/modules/@apostrophecms/schema/ui/apos/lib/detectChange.js
+++ b/modules/@apostrophecms/schema/ui/apos/lib/detectChange.js
@@ -6,6 +6,15 @@
 import { isEqual } from 'lodash';
 
 export function detectDocChange(schema, v1, v2, options = {}) {
+  // Handle null docs
+  if (!v1) {
+    // If there is no v1 then it's a change if there is a v2
+    return !!v2;
+  }
+  if (!v2) {
+    // If there is no v2 then it's a change if there was a v1
+    return !!v1;
+  }
   if (options.differences) {
     const differences = [];
     schema.forEach(field => {
@@ -16,7 +25,7 @@ export function detectDocChange(schema, v1, v2, options = {}) {
     return differences;
   } else {
     return schema.some(field => {
-      return detectFieldChange(field, v1[field.name], v2[field.name]);
+      return (!v1 !== !v2) || detectFieldChange(field, v1[field.name], v2[field.name]);
     });
   }
 }

--- a/modules/@apostrophecms/schema/ui/apos/lib/detectChange.js
+++ b/modules/@apostrophecms/schema/ui/apos/lib/detectChange.js
@@ -25,7 +25,7 @@ export function detectDocChange(schema, v1, v2, options = {}) {
     return differences;
   } else {
     return schema.some(field => {
-      return (!v1 !== !v2) || detectFieldChange(field, v1[field.name], v2[field.name]);
+      return detectFieldChange(field, v1[field.name], v2[field.name]);
     });
   }
 }


### PR DESCRIPTION
* Relationship subfields can now be edited when selecting in the full "manage view" browser, as well as in the compact relatio
nship field view which worked previously.
* A console warning when editing subfields for a new relationship was fixed.
* Relationship subfields now respect the `def` property (there was no real previous implementation of initializing the object, with or without defaults, so no reason not to do it right the first time).