### PR TITLE
3.0: Refactor input computation and filter kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ myColorField: {
 * `data.page` and `data.contextOptions` are now available in `widget.html` templates in most cases. Specifically, they are available when loading the page, (2) when a widget has just been inserted on the page, and (3) when a widget has just been edited and saved back to the page. However, bear in mind that these parameters are never available when a widget is being edited "out of context" via "Page Settings", via the "Edit Piece" dialog box, via a dialog box for a parent widget, etc. Your templates should be written to tolerate the absence of these parameters.
 * Double slashes in the slug cannot be used to trick Apostrophe into serving as an open redirect (fix ported to 3.x from 2.92.0).
 * The global doc respects the `def` property of schema fields when first inserted at site creation time.
+* Fixed fragment keyword arguments being available when not a part of the fragment signature.
 
 ## 3.0.0-beta.3.1 - 2021-06-07
 

--- a/test/modules/fragment-all/views/fragment.html
+++ b/test/modules/fragment-all/views/fragment.html
@@ -18,6 +18,13 @@
   val_{{ fourth }}
 {% endfragment %}
 
+{% fragment printNumbers(number, one = 1, two = 2) %}
+  val_{{ number }}
+  val_{{ one }}
+  val_{{ two }}
+  val_{{ three }}
+{% endfragment %}
+
 {% fragment _print(text) %}
   {{ text }}
 {% endfragment %}

--- a/test/modules/fragment-all/views/page.html
+++ b/test/modules/fragment-all/views/page.html
@@ -38,4 +38,8 @@ Below Call Fragment
 {% render fragment.listNumbers(third = 9, 1) %}
 --endissue_3056_2--
 
+--issue_3102--
+{% render fragment.printNumbers(three = 3) %}
+--endissue_3102--
+
 {% endblock %}

--- a/test/templates.js
+++ b/test/templates.js
@@ -300,4 +300,20 @@ describe('Templates', function() {
     ]);
   });
 
+  it('should filter out unknown keyword arguments', async () => {
+    const req = apos.task.getReq();
+    const result = await apos.modules['fragment-all'].renderPage(req, 'page');
+    if (result.match(/error/)) {
+      throw result;
+    }
+
+    const data = parseOutput(result, 'issue_3102');
+    assert.deepStrictEqual(data, [
+      'val_',
+      'val_1',
+      'val_2',
+      'val_'
+    ]);
+  });
+
 });


### PR DESCRIPTION
This patch is an attempt to cleanup the fragment arguments computation logic and it solves the issue when unknown keyword arguments are being available in the fragment context.

ref #3102
