### PR TITLE
PRO-1640 admin UI rebuilds only if package-lock.json is newer than the last bundle built. ui/src still rebuilds all the time, by design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* Corrects a bug that caused Apostrophe to rebuild the admin UI on every nodemon restart, which led to excessive wait times to test new code. Now this happens only when `package-lock.json` has been modified (i.e. you installed a new module that might contain new Apostrophe admin UI code). If you are actively developing Apostrophe admin UI code, you can opt into rebuilding all the time with the `APOS_DEV=1` environment variable. In any case, `ui/src` is always rebuilt in a dev environment.
+
 ## 3.0.1 - 2021-06-17
 
 ### Fixes

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -75,7 +75,6 @@ module.exports = {
           for (const [ name, options ] of Object.entries(self.builds)) {
             // If the option is not present always rebuild everything
             let rebuild = argv && !argv['check-apos-build'];
-
             if (!rebuild) {
               let checkTimestamp = false;
 
@@ -91,7 +90,7 @@ module.exports = {
                 }
 
                 if (!process.env.APOS_DEV) {
-                  checkTimestamp = await fs.pathExists(`${bundleDir}/${name}-only-timestamp.txt`);
+                  checkTimestamp = await fs.pathExists(`${bundleDir}/${name}-build-timestamp.txt`);
                 }
 
                 if (checkTimestamp) {
@@ -424,7 +423,7 @@ module.exports = {
           }
 
           async function lockFileIsNewer(name) {
-            const timestamp = fs.readFileSync(`${bundleDir}/${name}-only-timestamp.txt`, 'utf8');
+            const timestamp = fs.readFileSync(`${bundleDir}/${name}-build-timestamp.txt`, 'utf8');
             let pkgStats;
 
             if (await fs.pathExists(`${self.apos.rootDir}/package-lock.json`)) {


### PR DESCRIPTION
This fixes a regression in formerly working logic for this.