### PR TITLE
PRO-1621: when pushing a secondary context document (such as palette) draft mode should always be entered, as worked in the past before 3.0.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * Corrects a bug that caused Apostrophe to rebuild the admin UI on every nodemon restart, which led to excessive wait times to test new code. Now this happens only when `package-lock.json` has been modified (i.e. you installed a new module that might contain new Apostrophe admin UI code). If you are actively developing Apostrophe admin UI code, you can opt into rebuilding all the time with the `APOS_DEV=1` environment variable. In any case, `ui/src` is always rebuilt in a dev environment.
+* Pushing a secondary context document now always results in entry to draft mode, as intended.
 
 ### Changes
 

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
@@ -225,6 +225,7 @@ export default {
       this.undone = [];
       await this.setContext({
         doc,
+        mode: 'draft',
         navigate: false
       });
       // So that on-page areas react like foreign areas while


### PR DESCRIPTION
There is even logic for this but it got thrown off by later logic examining the document itself. Simple to fix by passing the intended mode to `setContext`.