### PR TITLE
Updates oembetter and cheerio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * Corrects a bug that caused Apostrophe to rebuild the admin UI on every nodemon restart, which led to excessive wait times to test new code. Now this happens only when `package-lock.json` has been modified (i.e. you installed a new module that might contain new Apostrophe admin UI code). If you are actively developing Apostrophe admin UI code, you can opt into rebuilding all the time with the `APOS_DEV=1` environment variable. In any case, `ui/src` is always rebuilt in a dev environment.
+* Updates `cheerio` and `oembetter` versions to resolve vulnerability warnings.
 
 ### Changes
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {
-    "pretest": "npm run lint",
+    "pretest": "npm run lint && npm audit",
     "test": "nyc --reporter=html mocha",
     "lint": "eslint ."
   },
@@ -42,7 +42,7 @@
     "body-parser": "^1.18.2",
     "boring": "^1.1.1",
     "broadband": "^1.1.0",
-    "cheerio": "^0.22.0",
+    "cheerio": "^1.0.0-rc.10",
     "common-tags": "^1.8.0",
     "connect-mongo": "^3.0.0",
     "connect-multiparty": "^2.1.1",
@@ -77,7 +77,7 @@
     "node-fetch": "^2.6.1",
     "nodemailer": "^6.6.1",
     "nunjucks": "^3.2.1",
-    "oembetter": "^1.0.0",
+    "oembetter": "^1.0.1",
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",
     "path-to-regexp": "^1.8.0",

--- a/test/widgets.js
+++ b/test/widgets.js
@@ -1,6 +1,5 @@
 const t = require('../test-lib/test.js');
 const assert = require('assert');
-// const cheerio = require('cheerio');
 
 let apos;
 


### PR DESCRIPTION
This will get us passing npm audit. This requires https://github.com/apostrophecms/oembetter/pull/16 to be merged and published.