### PR TITLE
PRO-1679 lint for missing export default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Changes
 
 * Deprecates `self.renderPage` method for removal in next major version.
+* Since `ui/src/index.js` files must export a function to avoid a browser error in production which breaks the website experience, we now detect this at startup and throw a more helpful error to prevent a last-minute discovery in production.
 
 ## 3.0.1 - 2021-06-17
 

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -188,7 +188,8 @@ module.exports = {
             if (options.index) {
               indexJsImports = getImports(source, 'index.js', {
                 invokeApps: true,
-                importSuffix: 'App'
+                importSuffix: 'App',
+                requireDefaultExport: true
               });
               indexSassImports = getImports(source, 'index.scss', {
                 importSuffix: 'Stylesheet'
@@ -396,6 +397,16 @@ module.exports = {
             };
 
             components.forEach((component, i) => {
+              if (options.requireDefaultExport) {
+                if (!fs.readFileSync(component, 'utf8').match(/export[\s\n]+default/)) {
+                  throw new Error(stripIndent`
+                    The file ${component} does not have a default export.
+
+                    Any ui/src/index.js file that does not have a function as
+                    its default export will cause the build to fail in production.
+                  `);
+                }
+              }
               const jsFilename = JSON.stringify(component);
               const name = require('path').basename(component).replace(/\.\w+/, '') + (options.invokeApps ? `_${i}` : '');
               const jsName = JSON.stringify(name);


### PR DESCRIPTION
Since `ui/src/index.js` files must export a function to avoid a browser error in production which breaks the website experience, we now detect this at startup and throw a more helpful error to prevent a last-minute discovery in production.

This is not perfect, in particular we could look more specifically for the export being a function, but I don't want to mess this up by failing to think about cases that are valid but use different syntax. Making sure "export default" exists should cover 99% of likely developer errors on this point.