### PR TITLE
oembed field fixes

### DIFF
--- a/modules/@apostrophecms/oembed-field/ui/apos/components/AposInputOembed.vue
+++ b/modules/@apostrophecms/oembed-field/ui/apos/components/AposInputOembed.vue
@@ -136,9 +136,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .apos-input--oembed {
-    margin-bottom: $spacing-double;
-  }
   .apos-input__embed {
     ::v-deep iframe {
       max-width: 100%;

--- a/modules/@apostrophecms/oembed-field/ui/apos/components/AposInputOembed.vue
+++ b/modules/@apostrophecms/oembed-field/ui/apos/components/AposInputOembed.vue
@@ -38,7 +38,7 @@ export default {
   emits: [ 'return' ],
   data () {
     return {
-      next: (this.value && this.value.data !== undefined)
+      next: (this.value && this.value.data)
         ? this.value.data : {},
       oembedResult: {},
       dynamicRatio: '',
@@ -69,6 +69,11 @@ export default {
     validate(value) {
       if (value == null || value.url === null) {
         value = {};
+      }
+
+      if (!value.url && !this.field.required) {
+        // field is now empty and not required, not an error
+        return false;
       }
 
       if (


### PR DESCRIPTION
Fixes two bugs in oembed fields
- Detecting existing field values was getting tripped up between `null` and `undefined`. If our content has an existing oembed value we know it will be an object so we don't have to be so careful as to what to expect
- the field's validation didn't account for filling in a field and then manually clearing it. A newly-empty oembed string field always produced an error and blocked save.