### PR TITLE
PRO-1397 dont try to switch to the utility group on error, not a 'real' group

### DIFF
--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -521,7 +521,11 @@ export default {
             field = this.schema.filter(item => {
               return item.name === tabKey;
             })[0];
-            this.switchPane(field.group.name);
+
+            if (field.group.name !== 'utility') {
+              this.switchPane(field.group.name);
+            }
+
             this.getAposSchema(field).scrollFieldIntoView(field.name);
           }
         }


### PR DESCRIPTION
trying to switch to the utility rail on error hides all tab content in the main body