### PR TITLE
3.0: fix field label typo

### DIFF
--- a/modules/@apostrophecms/user/index.js
+++ b/modules/@apostrophecms/user/index.js
@@ -54,7 +54,7 @@ module.exports = {
       add: {
         title: {
           type: 'string',
-          label: 'Dislay Name',
+          label: 'Display Name',
           required: true
         },
         slug: {


### PR DESCRIPTION
There is a field typo in the `user` module, reported by @kimsmouter 
My most significant yet apos contribution :)

I suppose it doesn't need a special CHANGELOG entry? If it needs indeed, let me know.