### PR TITLE
Removes a defunct jqtree method; tidies code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * Removes an unused method, `mapMongoIdToJqtreeId`, that was used in A2 but is no longer relevant.
+* Removes deprecated and non-functional steps from the `edit` method in the `AposDocsManager.vue` component.
 
 ## 3.1.0 - 2021-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+
+* Removes an unused method, `mapMongoIdToJqtreeId`, that was used in A2 but is no longer relevant.
+
 ## 3.1.0 - 2021-06-30
 
 ### Fixes

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -93,7 +93,8 @@ module.exports = {
           return {
             // For consistency with the pieces REST API we
             // use a results property when returning a flat list
-            results: await self.getRestQuery(req).limit(10).relationships(false).areas(false).toArray()
+            results: await self.getRestQuery(req).limit(10).relationships(false)
+              .areas(false).toArray()
           };
         }
 
@@ -1777,15 +1778,6 @@ database.`);
         if (!count) {
           throw 'No page with that slug was found.';
         }
-      },
-      // Routes use this to convert _id to id for the
-      // convenience of jqtree
-      mapMongoIdToJqtreeId(changed) {
-        return _.map(changed, function (change) {
-          change.id = change._id;
-          delete change._id;
-          return change;
-        });
       },
       // Invoked by the @apostrophecms/version module.
       //

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
@@ -240,14 +240,12 @@ export default {
       } else {
         moduleName = this.moduleName;
       }
-      const doc = await apos.modal.execute(apos.modules[moduleName].components.editorModal, {
+
+      await apos.modal.execute(apos.modules[moduleName].components.editorModal, {
         moduleName,
         docId: piece && piece._id,
         filterValues: this.filterValues
       });
-      if (!doc) {
-        // Cancel clicked
-      }
     },
     async finishSaved() {
       await this.getPieces();

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
@@ -247,7 +247,6 @@ export default {
       });
       if (!doc) {
         // Cancel clicked
-        return;
       }
     },
     async finishSaved() {

--- a/modules/@apostrophecms/video-widget/ui/src/index.js
+++ b/modules/@apostrophecms/video-widget/ui/src/index.js
@@ -57,7 +57,8 @@ export default () => {
           if (result.width && result.height) {
             inner.style.width = '100%';
             resizeVideo(inner);
-            // If we need to iniitally size the video, also resize it on window resize.
+            // If we need to initially size the video, also resize it on window
+            // resize.
             window.addEventListener('resize', resizeHandler);
           } else {
             // No, so assume the oembed HTML code is responsive.


### PR DESCRIPTION
- `mapMongoIdToJqtreeId` isn't used anymore because we don't use jqTree anymore.
- An eslint fix in `AposDocsManager.vue` since the return isn't doing anything.
- Some line break stuff since 80 character line lengths are the meaning of life.