### PR TITLE
passing unit test showing that two modules can contribute separate languages to the same i18n namespace

### DIFF
--- a/test/i18n.js
+++ b/test/i18n.js
@@ -19,6 +19,13 @@ describe('static i18n', function() {
           options: {
             l10n: {}
           }
+        },
+        'apostrophe-fr': {
+          options: {
+            l10n: {
+              ns: 'apostrophe'
+            }
+          }
         }
       }
     });
@@ -32,6 +39,15 @@ describe('static i18n', function() {
 
   it('should localize default namespace phrases contributed by a project level module', function() {
     assert.strictEqual(apos.task.getReq().t('projectLevelPhrase'), 'Project Level Phrase');
+  });
+
+  it('should merge translations in different languages of the same phrases from @apostrophecms/i18n and a different module', function() {
+    assert.strictEqual(apos.task.getReq().t('apostrophe:alignCenter'), 'Align Center');
+  });
+
+  it('should merge translations in different languages of the same phrases from @apostrophecms/i18n and a different module', function() {
+    // je suis désolé re: Google Translate-powered French test, feel free to PR better example
+    assert.strictEqual(apos.task.getReq({ locale: 'fr' }).t('apostrophe:alignCenter'), 'Aligner Le Centre');
   });
 
 });

--- a/test/modules/apostrophe-fr/l10n/fr.json
+++ b/test/modules/apostrophe-fr/l10n/fr.json
@@ -1,0 +1,3 @@
+{
+  "alignCenter": "Aligner Le Centre"
+}


### PR DESCRIPTION
No changelog entry because it's just a unit test of functionality that's being announced already in the changelog.