### PR TITLE
fix devDependencies and provide coverage (forward port from moog-require)

### DIFF
--- a/lib/moog-require.js
+++ b/lib/moog-require.js
@@ -169,7 +169,7 @@ module.exports = function(options) {
     // module unless we verify it is a real project-level dependency
     if (!self.validPackages) {
       const info = JSON.parse(fs.readFileSync(`${path.dirname(self.root.filename)}/package.json`, 'utf8'));
-      self.validPackages = new Set([ ...Object.keys(info.dependencies || {}), Object.keys(info.devDependencies || {}) ]);
+      self.validPackages = new Set([ ...Object.keys(info.dependencies || {}), ...Object.keys(info.devDependencies || {}) ]);
     }
     if (!self.validPackages.has(type)) {
       return null;

--- a/test-lib/test.js
+++ b/test-lib/test.js
@@ -16,9 +16,11 @@ fs.writeFileSync(packageJson, `
 {
   "name": "test",
   "dependencies": {
-    "apostrophe": "^3.0.0",
+    "apostrophe": "^3.0.0"
+  },
+  "devDependencies": {
     "test-bundle": {}
-  }
+    }
 }`);
 
 module.exports = require('./util.js');


### PR DESCRIPTION
The fix for ignoring transitive dependencies as apostrophe modules didn't work for devDependencies. Fixed that and provided coverage. `apostrophe` does count as a valid test, as it loads as an ordinary bundle and no tests pass if that doesn't work.