### PR TITLE
PRO-1790 accomodations for inline micro range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fixes the `toolbarToAllowedStyles` method in the rich text widget, which was not returning any configuration.
 * Fixes the broken text alignment in rich text widgets.
 * Adds a missing npm dependency on `chokidar`, which Apostrophe and Nunjucks use for template refreshes. In most environments this worked anyway due to an indirect dependency via the `sass` module, but for stability Apostrophe should depend directly on any npm module it uses.
+* Fixes the display of inline range inputs, notably broken when using Palette
 
 ## 3.1.3 - 2021-07-16
 

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRange.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRange.vue
@@ -265,10 +265,10 @@ export default {
   }
 
   .apos-range__input:focus::-ms-fill-lower {
-    background: var(--a-base-7);;
+    background: var(--a-base-7);
   }
 
   .apos-range__input:focus::-ms-fill-upper {
-    background: var(--a-base-7);;
+    background: var(--a-base-7);
   }
 </style>

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputWrapper.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputWrapper.vue
@@ -222,6 +222,25 @@ export default {
   .apos-field__info {
     margin-right: 4%;
   }
+  &.apos-field--range {
+    display: block;
+    .apos-range__input {
+      margin: 5px 0 0;
+    }
+    .apos-range__scale {
+      margin-top: 0;
+    }
+    .apos-range__value {
+      padding-top: 9px;
+    }
+    .apos-field__info {
+      margin: 0 0 5px;
+    }
+    .apos-field__info,
+    .apos-input-wrapper {
+      width: 100%;
+    }
+  }
 }
 
 </style>

--- a/modules/@apostrophecms/ui/ui/apos/scss/global/_inputs.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/_inputs.scss
@@ -120,6 +120,13 @@
       white-space: nowrap;
     }
   }
+  &.apos-field--range {
+    .apos-range__input::-webkit-slider-thumb,
+    .apos-range__input::-moz-range-thumb {
+      width: 10px;
+      height: 10px;
+    }
+  }
 }
 
 .apos-input-wrapper {


### PR DESCRIPTION
sister PR in `@apostrophecms-pro/palette` completes the lewk
https://github.com/apostrophecms/palette/pull/26