### PR TITLE
PRO-1877 fix duplicte bug, clear clipboard on paste

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -286,6 +286,7 @@ export default {
     },
     async copy(i) {
       apos.area.widgetClipboard.set(this.next[i]);
+      console.log(this.next[i]);
       apos.notify('Widget copied to clipboard', {
         type: 'success',
         icon: 'content-copy-icon',
@@ -357,17 +358,16 @@ export default {
     // Regenerate all array item, area and widget ids so they are considered
     // new. Useful when copying a widget with nested content.
     regenerateIds(schema, object) {
+      object._id = cuid();
       for (const field of schema) {
         if (field.type === 'array') {
           for (const item of (object[field.name] || [])) {
-            item._id = cuid();
             this.regenerateIds(field.schema, item);
           }
         } else if (field.type === 'area') {
           if (object[field.name]) {
             object[field.name]._id = cuid();
             for (const item of (object[field.name].items || [])) {
-              item._id = cuid();
               const schema = apos.modules[apos.area.widgetManagers[item.type]].schema;
               this.regenerateIds(schema, item);
             }
@@ -398,6 +398,8 @@ export default {
       clipboard
     }) {
       if (clipboard) {
+        // clear clipboard after paste
+        apos.area.widgetClipboard.set(null);
         this.regenerateIds(apos.modules[apos.area.widgetManagers[clipboard.type]].schema, clipboard);
         return this.insert({
           widget: clipboard,
@@ -493,28 +495,6 @@ export default {
         return null;
       } else {
         return this.renderings[widget._id];
-      }
-    },
-    // Regenerate all array item, area and widget ids so they are considered
-    // new. Useful when copying an entire nested widget.
-    regenerateIds(schema, doc) {
-      doc._id = cuid();
-      for (const field of schema) {
-        if (field.type === 'array') {
-          for (const item of (doc[field.name] || [])) {
-            this.regenerateIds(field.schema, item);
-          }
-        } else if (field.type === 'area') {
-          if (doc[field.name]) {
-            doc[field.name]._id = cuid();
-            for (const item of (doc[field.name].items || [])) {
-              const schema = apos.area.widgetManagers[item.type].schema;
-              this.regenerateIds(schema, item);
-            }
-          }
-        }
-        // We don't want to regenerate attachment ids. They correspond to
-        // actual files, and the reference count will update automatically
       }
     }
   }

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -286,7 +286,6 @@ export default {
     },
     async copy(i) {
       apos.area.widgetClipboard.set(this.next[i]);
-      console.log(this.next[i]);
       apos.notify('Widget copied to clipboard', {
         type: 'success',
         icon: 'content-copy-icon',

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -23,12 +23,12 @@
         @click="$emit('cut')"
         tooltip="Cut"
       />
-      <AposButton
+      <!-- <AposButton
         v-bind="copyButton"
         v-if="!foreign"
         @click="$emit('copy')"
         tooltip="Copy"
-      />
+      /> -->
       <AposButton
         v-if="!foreign"
         :disabled="disabled || maxReached"


### PR DESCRIPTION
## Bug
- There were conflicting versions of the method `regenerateIds` which was causing a bug in both Duplicate and clipboard paste.

## Improvement
- In demo prep and testing with Alex we decided to clear the clipboard contents on paste, as it felt strange to have the very specific duplication follow you around forever in areas.
- Hide Copy button for now. Between Duplicate and Cut/Paste, Copy felt like a confusing use case. Something to revisit, potentially with some improved widget control bar UI