### PR TITLE
req.clone is available, and used where mission critical, for localeReq. A separate ticket is open to use req.clone consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * There is a bare bones, unstyled locale switcher (so far, will update this entry).
 * There is a backend route to accept a new locale on switch, on refresh you currently have a 404, but we'll fix this when we do replication in content localization.
 * We ditched the i18next middleware in favor of simpler i18next-based middleware better for our needs.
+* A `req.clone(properties)` method is now available. This creates a clone of the `req` object, optionally passing in an object of properties to be set. The use of `req.clone` ensures the new object supports `req.get` and other methods of a true `req` object. This technique is mainly used to obtain a new request object with the same privileges but a different mode or locale, i.e. `mode: 'published'`.
 
 ### Fixes
 

--- a/modules/@apostrophecms/express/index.js
+++ b/modules/@apostrophecms/express/index.js
@@ -225,6 +225,17 @@ module.exports = {
         url: '/api/v1',
         middleware: cors()
       },
+      attachUtilityMethods(req, res, next) {
+        // We apply the super pattern variously to res.redirect,
+        // make sure the original version is always available
+        res.rawRedirect = res.redirect;
+        // Convenient way to make a new req object with
+        // some tweaked properties
+        req.clone = (properties = {}) => {
+          return self.apos.util.cloneReq(req, properties);
+        };
+        return next();
+      },
       createDataAndGuards(req, res, next) {
         if (!req.data) {
           req.data = {};

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -144,12 +144,9 @@ module.exports = {
           const sanitizedLocale = self.sanitizeLocaleName(req.body.locale);
           const _id = self.apos.launder.id(req.body.contextDocId);
           let doc;
-          const localeReq = {
-            ...req,
-            locale: sanitizedLocale,
-            // A getter on the original, so won't clone on its own
-            protocol: req.protocol
-          };
+          const localeReq = req.clone({
+            locale: sanitizedLocale
+          });
           self.apos.i18n.setPrefixUrls(localeReq);
           if (_id) {
             doc = await self.apos.doc.find(localeReq, {

--- a/modules/@apostrophecms/task/index.js
+++ b/modules/@apostrophecms/task/index.js
@@ -206,7 +206,13 @@ module.exports = {
           locale: self.apos.argv.locale || self.apos.modules['@apostrophecms/i18n'].defaultLocale,
           mode: 'published',
           aposNeverLoad: {},
-          aposStack: []
+          aposStack: [],
+          clone(properties = {}) {
+            return {
+              ...req,
+              ...properties
+            };
+          }
         };
         const { role, ..._properties } = options || {};
         Object.assign(req, _properties);

--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -776,6 +776,19 @@ module.exports = {
         const result = await fn();
         req.aposStack.pop();
         return result;
+      },
+      // Returns a new `req` object with the properties of the original plus any
+      // in the optional `properties` parameter. Used when a request object
+      // with one change is desired, such as `mode: 'published'`. Avoids
+      // the need to push and pop properties of the original `req`.
+      // Also available as `req.clone(properties = {})`.
+      cloneReq(req, properties = {}) {
+        // Express and Node.js offer no official constructor for a req object.
+        // But a plain object "clone" only takes us so far because we need
+        // access to things like `req.get`. Solution: ask `Object.create` to
+        // create a new object with the same prototype as `req`, then copy the
+        // own properties of `req` into the new object.
+        return Object.assign(Object.create(Object.getPrototypeOf(req)), req, properties);
       }
     };
   },

--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -788,7 +788,12 @@ module.exports = {
         // access to things like `req.get`. Solution: ask `Object.create` to
         // create a new object with the same prototype as `req`, then copy the
         // own properties of `req` into the new object.
-        return Object.assign(Object.create(Object.getPrototypeOf(req)), req, properties);
+        const result = Object.assign(Object.create(Object.getPrototypeOf(req)), req, properties);
+        // Must have its own clone function or we can't clone two levels deep
+        result.clone = (properties = {}) => {
+          return self.apos.util.cloneReq(result, properties);
+        };
+        return result;
       }
     };
   },


### PR DESCRIPTION
Cloning `req` naively yields an object with no `get` method, which is an issue for code that calls `req.get`. Opening separate ticket to replace *all* naive `{ ...req, ...}` clones of req with calls to this method.