### PR TITLE
PRO-1907 Defensive driving: clean up before inserting migrations into a "new" database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fixes the broken text alignment in rich text widgets.
 * Adds a missing npm dependency on `chokidar`, which Apostrophe and Nunjucks use for template refreshes. In most environments this worked anyway due to an indirect dependency via the `sass` module, but for stability Apostrophe should depend directly on any npm module it uses.
 * Fixes the display of inline range inputs, notably broken when using Palette
+* Fixes occasional unique key errors from migrations when attempting to start up again with a site that experienced a startup failure before inserting its first document.
 
 ## 3.1.3 - 2021-07-16
 

--- a/modules/@apostrophecms/migration/index.js
+++ b/modules/@apostrophecms/migration/index.js
@@ -238,6 +238,11 @@ module.exports = {
             // it requires no migrations. Mark them all as "done" but note
             // that they were skipped, just in case we decide that's an issue later
             const at = new Date();
+            // Just in case the db has no documents but did
+            // start to run migrations on a previous attempt,
+            // which causes an occasional unique key error if not
+            // corrected for here
+            await self.db.removeMany({});
             await self.db.insertMany(self.migrations.map(migration => ({
               _id: migration.name,
               at,


### PR DESCRIPTION
This was causing serious demo grief, but has also caused surprise unique key errors from the migrations module during ordinary dev.