### PR TITLE
PRO-1900: localize modal should actually localize, part 1: just the page itself

### DIFF
--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -737,7 +737,6 @@ module.exports = {
         if (!existing) {
           if (self.apos.page.isPage(draft)) {
             if (!draft.level) {
-              console.log('replicating home page for first time');
               // Replicating the home page for the first time
               return self.apos.doc.insert(toReq, {
                 ...data,
@@ -751,7 +750,6 @@ module.exports = {
                 parkedId: draft.parkedId
               });
             } else {
-              console.log('inserting non home');
               // A page that is not the home page, being replicated for the first time
               return actionModule.insert(toReq,
                 draft.aposLastTargetId.replace(`:${draft.aposLocale}`, `:${toLocale}:draft`),
@@ -774,7 +772,6 @@ module.exports = {
             });
           }
         } else {
-          console.log('updating');
           const update = {
             ...existing,
             ...data,

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -737,6 +737,7 @@ module.exports = {
         if (!existing) {
           if (self.apos.page.isPage(draft)) {
             if (!draft.level) {
+              console.log('replicating home page for first time');
               // Replicating the home page for the first time
               return self.apos.doc.insert(toReq, {
                 ...data,
@@ -750,6 +751,7 @@ module.exports = {
                 parkedId: draft.parkedId
               });
             } else {
+              console.log('inserting non home');
               // A page that is not the home page, being replicated for the first time
               return actionModule.insert(toReq,
                 draft.aposLastTargetId.replace(`:${draft.aposLocale}`, `:${toLocale}:draft`),
@@ -772,16 +774,15 @@ module.exports = {
             });
           }
         } else {
+          console.log('updating');
           const update = {
+            ...existing,
             ...data,
+            _id: toId,
             aposDocId: draft.aposDocId,
             aposLocale: `${toLocale}:draft`,
-            _id: toId
+            metaType: 'doc'
           };
-          if (self.apos.page.isPage(draft)) {
-            update.parked = draft.parked;
-            update.parkedId = draft.parkedId;
-          }
           return actionModule.update(toReq, update);
         }
       },

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -272,11 +272,11 @@ module.exports = {
         }
       },
       getBrowserData(req) {
-        const i18n = {};
-        for (const [ name, options ] of Object.entries(self.namespaces)) {
-          if (options.browser) {
-            i18n[name] = self.i18next.getResourceBundle(req.locale, name);
-          }
+        const i18n = {
+          [req.locale]: self.getBrowserBundles(req.locale)
+        };
+        if (req.locale !== self.defaultLocale) {
+          i18n[self.defaultLocale] = self.getBrowserBundles(self.defaultLocale);
         }
         const result = {
           i18n,
@@ -288,6 +288,15 @@ module.exports = {
           action: self.action
         };
         return result;
+      },
+      getBrowserBundles(locale) {
+        const i18n = {};
+        for (const [ name, options ] of Object.entries(self.namespaces)) {
+          if (options.browser) {
+            i18n[name] = self.i18next.getResourceBundle(locale, name);
+          }
+        }
+        return i18n;
       },
       getLocales() {
         const locales = self.options.locales || {

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -147,11 +147,18 @@ module.exports = {
           const localeReq = req.clone({
             locale: sanitizedLocale
           });
-          self.apos.i18n.setPrefixUrls(localeReq);
+          self.setPrefixUrls(localeReq);
           if (_id) {
             doc = await self.apos.doc.find(localeReq, {
               aposDocId: _id.split(':')[0]
             }).toObject();
+            if (!doc) {
+              const publishedLocaleReq = localeReq.clone({ mode: 'draft' });
+              self.setPrefixUrls(publishedLocaleReq);
+              doc = await self.apos.doc.find(publishedLocaleReq, {
+                aposDocId: _id.split(':')[0]
+              }).toObject();
+            }
           }
           if (!sanitizedLocale) {
             throw self.apos.error('invalid');

--- a/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
+++ b/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
@@ -40,7 +40,7 @@
             </h2>
           </header>
 
-          <form class="apos-wizard__form" @submit.prevent="submit">
+          <form class="apos-wizard__form" @submit.prevent>
             <fieldset
               v-if="isStep(0)"
               class="apos-wizard__step apos-wizard__step-0"
@@ -218,6 +218,7 @@
             v-if="isStep(wizard.sections.length - 1)"
             type="primary"
             label="apostrophe:localizeContent"
+            @click="submit"
           />
           <AposButton
             v-else
@@ -409,8 +410,18 @@ export default {
       }
       return classes;
     },
-    submit() {
-      console.log('Submitting...', this.wizard.values);
+    async submit() {
+      // Leaving this until we finish implementing the rest of the operations
+      console.log('Submitting...', JSON.stringify(this.wizard.values, null, '  '));
+      for (const locale of this.wizard.values.toLocales.data) {
+        apos.http.post(`${this.action}/${this.doc._id}/localize`, {
+          body: {
+            toLocale: locale.name
+          },
+          busy: true
+        });
+      }
+      this.close();
     }
   }
 };

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -28,9 +28,9 @@
               </div>
               <h2 :id="id" class="apos-modal__heading">
                 <span v-if="modal.a11yTitle" class="apos-sr-only">
-                  {{ modal.a11yTitle }}
+                  {{ $t(modal.a11yTitle) }}
                 </span>
-                {{ modalTitle }}
+                {{ $t(modalTitle) }}
               </h2>
               <div class="apos-modal__controls--primary" v-if="hasPrimaryControls">
                 <slot name="primaryControls" />

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -715,6 +715,7 @@ database.`);
           throw self.apos.error('invalid');
         }
         self.apos.schema.implementPatchOperators(input, page);
+        console.log('***', page);
         const parentPage = page._ancestors.length && page._ancestors[page._ancestors.length - 1];
         const schema = self.apos.schema.subsetSchemaForPatch(self.allowedSchema(req, {
           ...page,
@@ -1460,7 +1461,8 @@ database.`);
                 0: req.path
               },
               query: req.query,
-              mode: 'draft'
+              mode: 'draft',
+              locale: req.locale
             });
             await self.serveGetPage(testReq);
             await self.emit('serve', testReq);

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -715,7 +715,6 @@ database.`);
           throw self.apos.error('invalid');
         }
         self.apos.schema.implementPatchOperators(input, page);
-        console.log('***', page);
         const parentPage = page._ancestors.length && page._ancestors[page._ancestors.length - 1];
         const schema = self.apos.schema.subsetSchemaForPatch(self.allowedSchema(req, {
           ...page,

--- a/modules/@apostrophecms/ui/ui/apos/lib/i18next.js
+++ b/modules/@apostrophecms/ui/ui/apos/lib/i18next.js
@@ -17,8 +17,13 @@ export default {
       debug: i18n.debug
     });
 
-    for (const [ ns, phrases ] of Object.entries(i18n.i18n)) {
+    for (const [ ns, phrases ] of Object.entries(i18n.i18n[i18n.locale])) {
       i18next.addResourceBundle(i18n.locale, ns, phrases, true, true);
+    }
+    if (i18n.locale !== i18n.defaultLocale) {
+      for (const [ ns, phrases ] of Object.entries(i18n.i18n[i18n.defaultLocale])) {
+        i18next.addResourceBundle(i18n.defaultLocale, ns, phrases, true, true);
+      }
     }
 
     Vue.prototype.$t = (phrase, options) => {

--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -661,6 +661,7 @@ module.exports = {
         } else if (object.metaType === 'object') {
           return self.apos.schema.getArrayManager(object.scopedObjectName);
         } else {
+          self.apos.util.error(object);
           throw new Error('Unsupported metaType in getManagerOf:', object);
         }
       },

--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -661,8 +661,7 @@ module.exports = {
         } else if (object.metaType === 'object') {
           return self.apos.schema.getArrayManager(object.scopedObjectName);
         } else {
-          self.apos.util.error(object);
-          throw new Error('Unsupported metaType in getManagerOf:', object);
+          throw new Error(`Unsupported metaType in getManagerOf: ${object.metaType}`);
         }
       },
       // fetch the value at the given path from the object or


### PR DESCRIPTION
The basics of localizing a page are working (not related documents yet). I fixed some bugs and oversights to get us there at a decent level for a demo:

* Localization API preserves non-schema properties when updating an existing page or piece (overwriting existing English with French). Without this the page tree breaks.
* Static i18n fallback works properly for browser-side UI (Vue). This requires that we push both locales to the browser when the active locale is not the default locale.
* Localized more titles.
