### PR TITLE
PRO-1892 img slug shenanigans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* Resolves slug-related bug when switching between images in the archived view of the media manager. The slug field was not taking into account the double slug prefix case.
+
 ## 3.2.0 - 2021-08-13
 
 ### Fixes

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -26,7 +26,7 @@ module.exports = {
         slug: {
           type: 'slug',
           label: 'Slug',
-          following: 'title',
+          following: [ 'title', 'archived' ],
           required: true
         },
         archived: {

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -104,7 +104,7 @@ module.exports = {
             }
 
             let archivePrefix;
-            const archivedRegexp = new RegExp(`^deduplicate-[a-z0-9]+-${prefix}`);
+            const archivedRegexp = new RegExp(`^deduplicate-[a-z0-9]+-${self.apos.util.regExpQuote(prefix)}`);
 
             // The doc may be going from archived to published, so it won't have
             // doc.archived === true. Remove the dedupe prefix, check the slug
@@ -391,8 +391,8 @@ module.exports = {
         });
         if (self.options.slugPrefix) {
           if (self.options.slugPrefix === 'deduplicate-') {
-            const req = self.apos.task.getReq();
-            throw self.apos.error('invalid', req.__('The deduplicate- slug is reserved.'));
+            // TODO: i18n
+            throw self.apos.error('invalid', 'The deduplicate- slug is reserved.');
           }
           const slug = self.schema.find(field => field.name === 'slug');
           if (slug) {

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -97,12 +97,27 @@ module.exports = {
           self.apos.schema.prepareForStorage(req, doc);
         },
         slugPrefix(req, doc) {
-          if (self.options.slugPrefix) {
+          const prefix = self.options.slugPrefix;
+          if (prefix) {
             if (!doc.slug) {
               doc.slug = 'none';
             }
-            if (!doc.slug.startsWith(self.options.slugPrefix)) {
-              doc.slug = `${self.options.slugPrefix}${doc.slug}`;
+
+            let archivePrefix;
+            const archivedRegexp = new RegExp(`^deduplicate-[a-z0-9]+-${prefix}`);
+
+            // The doc may be going from archived to published, so it won't have
+            // doc.archived === true. Remove the dedupe prefix, check the slug
+            // prefix, then reapply the dedupe prefix.
+            if (doc.slug.match(archivedRegexp)) {
+              archivePrefix = doc.slug.match(/^deduplicate-[a-z0-9]+-/);
+              doc.slug = doc.slug.replace(archivePrefix, '');
+            }
+            if (!doc.slug.startsWith(prefix)) {
+              doc.slug = `${prefix}${doc.slug}`;
+            }
+            if (archivePrefix) {
+              doc.slug = `${archivePrefix}${doc.slug}`;
             }
           }
         }

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -390,6 +390,10 @@ module.exports = {
           arrangeFields: self.apos.schema.groupsToArray(self.fieldsGroups)
         });
         if (self.options.slugPrefix) {
+          if (self.options.slugPrefix === 'deduplicate-') {
+            const req = self.apos.task.getReq();
+            throw self.apos.error('invalid', req.__('The deduplicate- slug is reserved.'));
+          }
           const slug = self.schema.find(field => field.name === 'slug');
           if (slug) {
             slug.prefix = self.options.slugPrefix;

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -692,7 +692,7 @@ export default {
         // As a matter of UI implementation, we know our slug input field will
         // automatically change the empty string to the prefix, so to
         // prevent a false positive for this being considered a change,
-        // do it earlier when creating a new user
+        // do it earlier when creating a new doc.
         this.original.slug = this.original.slug || slugField.def || slugField.prefix || '';
       }
       this.prepErrors();

--- a/modules/@apostrophecms/file/index.js
+++ b/modules/@apostrophecms/file/index.js
@@ -29,7 +29,7 @@ module.exports = {
         label: 'Slug',
         prefix: 'file',
         required: true,
-        following: 'title'
+        following: [ 'title', 'archived' ]
       },
       attachment: {
         type: 'attachment',

--- a/modules/@apostrophecms/image/index.js
+++ b/modules/@apostrophecms/image/index.js
@@ -34,7 +34,7 @@ module.exports = {
         label: 'Slug',
         prefix: 'image',
         required: true,
-        following: 'title'
+        following: [ 'title', 'archived' ]
       },
       attachment: {
         type: 'attachment',

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -269,6 +269,7 @@ export default {
       this.filterValues[name] = value;
       this.currentPage = 1;
 
+      this.updateEditing(null);
       await this.getMedia();
     },
     createPlaceholder(dimensions) {

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -225,7 +225,7 @@ export default {
     async updateActiveDoc(newMedia) {
       this.showReplace = false;
       this.activeMedia = klona(newMedia);
-      this.restoreOnly = this.activeMedia.archived;
+      this.restoreOnly = !!this.activeMedia.archived;
       this.original = klona(newMedia);
       this.docFields.data = klona(newMedia);
       this.generateLipKey();

--- a/modules/@apostrophecms/page-type/index.js
+++ b/modules/@apostrophecms/page-type/index.js
@@ -12,7 +12,7 @@ module.exports = {
           label: 'Slug',
           required: true,
           page: true,
-          following: 'title'
+          following: [ 'title', 'archived' ]
         },
         type: {
           type: 'select',

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -20,8 +20,8 @@ module.exports = {
       slug: {
         type: 'slug',
         label: 'Slug',
-        required: true,
-        following: 'title'
+        following: [ 'title', 'archived' ],
+        required: true
       }
     }
   },

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
@@ -207,6 +207,7 @@ export default {
     setPrefix (slug) {
       // Get a fresh clone of the slug.
       let updated = slug.slice();
+      console.info('Update 0', updated);
       const archivedRegexp = new RegExp(`^deduplicate-[a-z0-9]+-${this.prefix}`);
 
       // Prefix if the slug doesn't start with the prefix OR if its archived
@@ -230,8 +231,10 @@ export default {
           // Make sure we're not double prefixing archived slugs.
           updated = updated.startsWith(this.prefix) ? updated : this.prefix + updated;
         }
-        // Reapply the dedupe pattern if archived.
-        updated = this.isArchived ? `${archivePrefix}${updated}` : updated;
+        // Reapply the dedupe pattern if archived. If being restored from the
+        // doc editor modal it will momentarily be tracked as archived but
+        // without not have the archive prefix, so check that too.
+        updated = this.isArchived && archivePrefix ? `${archivePrefix}${updated}` : updated;
       }
       return updated;
     },

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
@@ -185,17 +185,21 @@ export default {
         }
       }
       if (!componentOnly) {
-        if (!s.startsWith(this.prefix)) {
-          if (this.prefix.startsWith(s)) {
-            // If they delete the `-`, and the prefix is `recipe-`,
-            // we want to restore `recipe-`, not set it to `recipe-recipe`
-            s = this.prefix;
-          } else {
-            s = this.prefix + s;
-          }
+        this.setPrefix(s);
+      }
+
+      return s;
+    },
+    setPrefix (slug) {
+      if (!slug.startsWith(this.prefix)) {
+        if (this.prefix.startsWith(slug)) {
+          // If they delete the `-`, and the prefix is `recipe-`,
+          // we want to restore `recipe-`, not set it to `recipe-recipe`
+          slug = this.prefix;
+        } else {
+          slug = this.prefix + slug;
         }
       }
-      return s;
     },
     async checkConflict() {
       let slug;

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
@@ -207,7 +207,6 @@ export default {
     setPrefix (slug) {
       // Get a fresh clone of the slug.
       let updated = slug.slice();
-      console.info('Update 0', updated);
       const archivedRegexp = new RegExp(`^deduplicate-[a-z0-9]+-${this.prefix}`);
 
       // Prefix if the slug doesn't start with the prefix OR if its archived

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
@@ -206,7 +206,7 @@ export default {
     },
     setPrefix (slug) {
       // Get a fresh clone of the slug.
-      let updated = slug.slice();
+      let updated = slug;
       const archivedRegexp = new RegExp(`^deduplicate-[a-z0-9]+-${this.prefix}`);
 
       // Prefix if the slug doesn't start with the prefix OR if its archived

--- a/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
@@ -172,6 +172,11 @@ export default {
         next.data._id = this.value.data._id;
         fieldState._id = { data: this.value.data._id };
       }
+      // Though not *always* in the schema, keep track of the archived status.
+      if (this.value.data.archived !== undefined) {
+        next.data.archived = this.value.data.archived;
+        fieldState.archived = { data: this.value.data.archived };
+      }
 
       this.schema.forEach(field => {
         const value = this.value.data[field.name];

--- a/modules/@apostrophecms/user/index.js
+++ b/modules/@apostrophecms/user/index.js
@@ -106,6 +106,7 @@ module.exports = {
           label: 'Basics',
           fields: [
             'title',
+            // TODO: Move slug to the utility column.
             'slug'
           ]
         },

--- a/modules/@apostrophecms/user/index.js
+++ b/modules/@apostrophecms/user/index.js
@@ -105,9 +105,7 @@ module.exports = {
         basics: {
           label: 'Basics',
           fields: [
-            'title',
-            // TODO: Move slug to the utility column.
-            'slug'
+            'title'
           ]
         },
         utility: {
@@ -115,6 +113,7 @@ module.exports = {
             'username',
             'email',
             'password',
+            'slug',
             'archived'
           ]
         },

--- a/modules/@apostrophecms/user/index.js
+++ b/modules/@apostrophecms/user/index.js
@@ -57,12 +57,6 @@ module.exports = {
           label: 'Display Name',
           required: true
         },
-        slug: {
-          type: 'slug',
-          label: 'Slug',
-          following: 'title',
-          required: true
-        },
         disabled: {
           type: 'boolean',
           label: 'Login Disabled',


### PR DESCRIPTION
Clicking between archived images triggered the "discard changes?" modal. The media manager and its ever-open editor is the only place this would really come up on its own. It came down to the slug field seeing a change in the incoming value and triggering prefix checking, but not accounting for how archived images get two prefixes: `deduplicate-[ID]-` and `image-`.

The main thing I'm only 97% sure about is how I'm regexing for the dedupe prefix. Though I think the danger might only come in if you make your slugPrefix "deduplicate-", in which case you're an agent of chaos. ... Maybe we should prevent that.

Update: I reserved the "deduplicate-" slug.