### PR TITLE
#1920 bc for old __ helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * There is a locale switcher for editors.
 * There is a backend route to accept a new locale on switch.
 * A `req.clone(properties)` method is now available. This creates a clone of the `req` object, optionally passing in an object of properties to be set. The use of `req.clone` ensures the new object supports `req.get` and other methods of a true `req` object. This technique is mainly used to obtain a new request object with the same privileges but a different mode or locale, i.e. `mode: 'published'`.
+* Fallback wrappers are provided for the `req.__()`, `res.__()` and `__()` localization helpers, which were never official or documented in 3.x but may be in use in projects ported from 2.x. These wrappers do not localize but do output the input they are given along with a developer warning. You should migrate them to use `req.t()` (in server-side javascript) or `__t()` (Nunjucks templates).
 
 ### Fixes
 

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -171,6 +171,14 @@ module.exports = {
             lng: req.locale
           });
         };
+        req.__ = key => {
+          self.apos.util.warnDevOnce('old-i18n-req-helper', stripIndent`
+            The req.__() and res.__() functions are deprecated and do not localize in A3.
+            Use req.t instead.
+          `);
+          return key;
+        };
+        req.res.__ = req.__;
         return next();
       }
     };

--- a/modules/@apostrophecms/task/index.js
+++ b/modules/@apostrophecms/task/index.js
@@ -14,6 +14,7 @@
 /* eslint-disable no-console */
 
 const _ = require('lodash');
+const { stripIndent } = require('common-tags');
 
 module.exports = {
   options: { alias: 'task' },
@@ -212,8 +213,16 @@ module.exports = {
               ...req,
               ...properties
             };
+          },
+          __(key) {
+            self.apos.util.warnDevOnce('old-i18n-req-helper', stripIndent`
+              The req.__() and res.__() functions are deprecated and do not localize in A3.
+              Use req.t instead.
+            `);
+            return key;
           }
         };
+        req.res.__ = req.__;
         const { role, ..._properties } = options || {};
         Object.assign(req, _properties);
         self.apos.i18n.setPrefixUrls(req);

--- a/modules/@apostrophecms/template/index.js
+++ b/modules/@apostrophecms/template/index.js
@@ -30,6 +30,7 @@ const dayjs = require('dayjs');
 const qs = require('qs');
 const Promise = require('bluebird');
 const path = require('path');
+const { stripIndent } = require('common-tags');
 
 module.exports = {
   options: { alias: 'template' },
@@ -281,7 +282,13 @@ module.exports = {
 
         args.apos = self.templateApos;
         args.__t = req.t;
-
+        args.__ = key => {
+          self.apos.util.warnDevOnce('old-i18n-nunjucks-helper', stripIndent`
+            The __() Nunjucks helper is deprecated and does not localize in A3.
+            Use __t() instead.
+          `);
+          return key;
+        };
         if (type === 'file') {
           let finalName = s;
           if (!finalName.match(/\.\w+$/)) {

--- a/modules/@apostrophecms/template/lib/custom-tags/render.js
+++ b/modules/@apostrophecms/template/lib/custom-tags/render.js
@@ -1,4 +1,5 @@
 const util = require('util');
+
 module.exports = (self) => {
   // Create the render input object, used to parse the fragment source
   function createRenderInput(info) {
@@ -100,7 +101,7 @@ module.exports = (self) => {
       const req = context.env.opts.req;
       const env = self.getEnv(req, context.env.opts.module);
       input.apos = self.templateApos;
-      input.__ = req.res.__;
+
       // attach the render caller as a function
       // it's just a string, but we keep
       // the convention from the macro `call`


### PR DESCRIPTION
Very basic fallback to just outputting the key given (which in 2.x practice is probably the English text) and warning the developer. These were never official in 3.x but from some recent correspondence it's clear they could be encountered, so let's not crash.