### PR TITLE
don't allow the current locale to be selected or look like it can

### DIFF
--- a/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
+++ b/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
@@ -482,7 +482,7 @@ export default {
       this.wizard.values.toLocales.data = [ ...this.locales ];
     },
     selectLocale(locale) {
-      if (!this.isSelected(locale)) {
+      if (!this.isSelected(locale) && !this.isCurrentLocale(locale)) {
         this.wizard.values.toLocales.data.push(locale);
       }
     },
@@ -822,9 +822,12 @@ export default {
   position: relative;
   padding: 12px 35px;
   line-height: 1;
-  cursor: pointer;
 
-  &:hover {
+  &:not(.apos-current-locale) {
+    cursor: pointer;
+  }
+
+  &:not(.apos-current-locale):hover {
     background-color: var(--a-base-10);
   }
 


### PR DESCRIPTION
Resolves:
- https://linear.app/apostrophecms/issue/PRO-1828

Doesn't allow the current locale for the current document to be selected and removes styles to make it look like it can be clicked.