### PR TITLE
3.0: fix TypeError while parking missing parked page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3 Unreleased 
+
+### Fixes
+* Fixes migration task crash when parking new page
+
 ## 3.2.0 - 2021-08-13
 
 ### Fixes

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -1711,8 +1711,9 @@ database.`);
           await self.apos.doc.db.updateOne({ _id: existing._id }, { $set: self.apos.util.clonePermanent(item) });
         }
         async function insert() {
-          const parkedDefaults = item._defaults || {};
-          delete item._defaults;
+          const parkedDefaults = { ...(item._defaults || {}) };
+          const cloned = { ...item };
+          delete cloned._defaults;
           let ordinaryDefaults;
           if (parent) {
             ordinaryDefaults = self.newChild(parent);
@@ -1727,7 +1728,7 @@ database.`);
           const _item = {
             ...ordinaryDefaults,
             ...parkedDefaults,
-            ...item
+            ...cloned
           };
           delete _item._children;
           if (!parent) {


### PR DESCRIPTION
This patch fixes a migrate task crash when new parked page is inserted.

## The problem
1. not yet existing in the DB page is available in the parked list
2. migrate task is executed
3. park sync logic is triggered on after:migrate (more than once)
4. the `implementParkOne` calls internally `insert`
5. the internal `insert` method is mutating the original parked configuration
6. on subsequent `implementParkOne` invocation, the script is crashing with error message `TypeError: Cannot read property 'slug' of undefined`

## The fix
The parked configuration is shallow cloned before processed in the internal `insert` method. No other logic is changed. 

A follow up from the PR against a stale branch #3308