### PR TITLE
DCAD-1089: correct status code for template error page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+## Fixes
+
+* The template error page was returning a 200 status code. It now correctly returns a 500 status code.
+
 ## 2.220.4 (2021-08-03)
 
 ## Fixes

--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -721,7 +721,9 @@ module.exports = {
         self.apos.utils.error(':: ' + now + ': ' + type + ' error at ' + req.url);
         self.apos.utils.error('Current user: ' + (req.user ? req.user.username : 'none'));
         self.apos.utils.error(e);
-        req.statusCode = 500;
+        // It is too late for req.statusCode, which is processed
+        // before sendPage is invoked
+        req.res.statusCode = 500;
         return self.render(req, 'templateError');
       }
     };


### PR DESCRIPTION
This can be QA'd by throwing an unclosed `{%` at the top of `home.html` in enterprise testbed. The resulting error page should have a 500 status code.