### PR TITLE
3.0: [UI] fix AposCellDate typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+
+### Fixes
+* Fixes AposCellDate to show correct month on Apostrophe UI list view
+
 ### Changes
 * Bolsters the CSS that backs Apostrophe UI's typography to help prevent unintended style leaks at project-level code.
 

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellDate.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellDate.vue
@@ -27,7 +27,7 @@ export default {
         // We're not sure what this is, but it's not a date.
         return value;
       }
-      const month = d.getMonth();
+      const month = d.getMonth() + 1;
       const date = d.getDate();
       const year = d.getFullYear();
       let hour = d.getHours();


### PR DESCRIPTION
AposCellDate component should increment the month value when formatting because the value is zero-based.