### PR TITLE
Fixes trustproxy option reference in i18n

### DIFF
--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -503,7 +503,7 @@ module.exports = {
         // For bc, req.baseUrl is always set, to a best guess if baseUrl is not configured.
         // When falling back, req.hostname is used if trustProxy is active, otherwise the
         // Host header to allow port numbers in dev
-        const host = (self.options.trustProxy && req.get('X-Forwarded-Host')) ? req.hostname : req.get('Host');
+        const host = (self.apos.modules['@apostrophecms/express'].trustProxy && req.get('X-Forwarded-Host')) ? req.hostname : req.get('Host');
         req.baseUrl = self.apos.page.getBaseUrl(req) || `${req.protocol}://${host}`;
         req.baseUrlWithPrefix = `${self.apos.page.getBaseUrl(req)}${self.apos.prefix}`;
         req.absoluteUrl = req.baseUrlWithPrefix + req.url;


### PR DESCRIPTION
Was previously not pointing to the right module for the trustProxy option.