### PR TITLE
Brings back aposcelldate changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,12 @@
 ## Unreleased
 
 ### Fixes
+* Fixes AposCellDate to show correct month on Apostrophe UI list view
+* Fixes migration task crash when parking new page. Thanks to [Miro Yovchev](https://www.corllete.com/) for this fix.
 
 ### Changes
 
 * Bolsters the CSS that backs Apostrophe UI's typography to help prevent unintended style leaks at project-level code.
-
-### Fixes
-
-* Fixes migration task crash when parking new page. Thanks to [Miro Yovchev](https://www.corllete.com/) for this fix.
 
 ## 3.2.0 - 2021-08-13
 


### PR DESCRIPTION
A changelog entry looks to have been accidentally deleted in a merge in #3317