### PR TITLE
fix overlap

### DIFF
--- a/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
+++ b/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
@@ -893,6 +893,7 @@ export default {
 
 .apos-locale-to-localize {
   @include type-small;
+  display: inline-block;
   position: relative;
   overflow: hidden;
   padding: 10px 20px;


### PR DESCRIPTION
Resolves:
- https://linear.app/apostrophecms/issue/PRO-1933

To test, select a couple locales in the localize modal. On the last step ensure the text doesn't overlap.