### PR TITLE
Lints locale names to start with alpha character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Adds a missing npm dependency on `chokidar`, which Apostrophe and Nunjucks use for template refreshes. In most environments this worked anyway due to an indirect dependency via the `sass` module, but for stability Apostrophe should depend directly on any npm module it uses.
 * Fixes the display of inline range inputs, notably broken when using Palette
 * Fixes occasional unique key errors from migrations when attempting to start up again with a site that experienced a startup failure before inserting its first document.
+* Requires that locale names begin with a letter character to ensure order when looping over the object entries.
 
 ## 3.1.3 - 2021-07-16
 

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -35,6 +35,12 @@ module.exports = {
     self.show = process.env.APOS_SHOW_I18N ? true : self.options.show;
     self.locales = self.getLocales();
     self.defaultLocale = self.options.defaultLocale || Object.keys(self.locales)[0];
+
+    Object.keys(self.locales).forEach(key => {
+      if (typeof key !== 'string' || !key.match(/^[a-zA-Z]/)) {
+        throw self.apos.error('invalid', 'Locale names must begin with a non-numeric, "word" character (a-z or A-Z)');
+      }
+    });
     // Make sure we have our own instance to avoid conflicts with other apos objects
     self.i18next = i18next.createInstance({
       fallbackLng: self.defaultLocale,
@@ -365,8 +371,11 @@ module.exports = {
         const hostname = req.hostname;
         let best = false;
         for (const [ name, options ] of Object.entries(self.locales)) {
-          const matchedHostname = options.hostname ? (hostname === options.hostname.split(':')[0]) : null;
-          const matchedPrefix = options.prefix ? ((req.path === options.prefix) || req.path.startsWith(options.prefix + '/')) : null;
+          const matchedHostname = options.hostname
+            ? (hostname === options.hostname.split(':')[0]) : null;
+          const matchedPrefix = options.prefix
+            ? ((req.path === options.prefix) || req.path.startsWith(options.prefix + '/'))
+            : null;
           if (options.hostname && options.prefix) {
             if (matchedHostname && matchedPrefix) {
               // Best possible match


### PR DESCRIPTION
Lints locale names to start with an alphabetic character. This is primarily to further ensure that the `Object.entries` loops maintain order. Apparently numbers as object keys can take precedence in some environments. https://2ality.com/2015/10/property-traversal-order-es6.html