### PR TITLE
Walks back AposButton label change

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarLocale.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarLocale.vue
@@ -77,10 +77,7 @@ export default {
   computed: {
     button() {
       return {
-        label: {
-          phrase: window.apos.i18n.locale,
-          localize: false
-        },
+        label: window.apos.i18n.locale,
         icon: 'chevron-down-icon',
         modifiers: [ 'icon-right', 'no-motion' ],
         type: 'quiet'

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarUser.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarUser.vue
@@ -33,10 +33,7 @@ export default {
   computed: {
     button() {
       return {
-        label: {
-          phrase: this.user.title || '',
-          localize: false
-        },
+        label: this.user.title || '',
         icon: 'chevron-down-icon',
         modifiers: [ 'icon-right', 'no-motion' ],
         type: 'quiet'

--- a/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
@@ -55,7 +55,7 @@ export default {
   name: 'AposButton',
   props: {
     label: {
-      type: [ String, Object ],
+      type: String,
       default: 'apostrophe:provideButtonLabel'
     },
     interpolate: {


### PR DESCRIPTION
A change was made to AposButton.vue in #3321 to accept an object with `phrase` and `localize` properties. Those properties were not actually used, so the two components using this new prop option did not have visible labels.