### PR TITLE
PRO-1949: relax the absolute URL thing to the previous standard if there are no locales with hostnames

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ workflows:
   version: 2
   build:
     jobs:
+      - build-node14-mongo5
       - build-node14-mongo44
       - build-node14-mongo42
       - build-node12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,26 @@
 version: 2
 jobs:
+  build-node14-mongo5:
+    docker:
+      - image: circleci/node:14-browsers
+      - image: mongo:5.0
+    steps:
+      - checkout
+      - run:
+          name: update-npm
+          command: 'sudo npm install -g npm@7'
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+          name: install-npm-wee
+          command: npm install
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+      - run:
+          name: test
+          command: npm test
   build-node14-mongo44:
     docker:
       - image: circleci/node:14-browsers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Fixes the display of inline range inputs, notably broken when using Palette
 * Fixes occasional unique key errors from migrations when attempting to start up again with a site that experienced a startup failure before inserting its first document.
 * Requires that locale names begin with a letter character to ensure order when looping over the object entries.
+* Unit tests pass in MongoDB 5.x.
 
 ## 3.1.3 - 2021-07-16
 

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -340,7 +340,7 @@ module.exports = {
           // We are experiencing what may be a mongodb bug in which these indexes
           // have different weights than expected and the createIndex call fails.
           // If this happens drop and recreate the text index
-          if (e.toString().match(/with different options/)) {
+          if (e.toString().match(/different options/)) {
             self.apos.util.warn('Text index has unexpected weights or other misconfiguration, reindexing');
             await self.db.dropIndex('highSearchText_text_lowSearchText_text_title_text_searchBoost_text');
             return await attempt();

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -34,6 +34,7 @@ module.exports = {
     self.debug = process.env.APOS_DEBUG_I18N ? true : self.options.debug;
     self.show = process.env.APOS_SHOW_I18N ? true : self.options.show;
     self.locales = self.getLocales();
+    self.hostnamesInUse = Object.values(self.locales).find(locale => locale.hostname);
     self.defaultLocale = self.options.defaultLocale || Object.keys(self.locales)[0];
 
     Object.keys(self.locales).forEach(key => {
@@ -509,18 +510,26 @@ module.exports = {
         );
       },
       setPrefixUrls(req) {
-        // For bc, req.baseUrl is always set, to a best guess if baseUrl is not configured.
-        //
         // In a production-like environment, use req.hostname, otherwise the Host header
         // to allow port numbers in dev.
         //
         // Watch out for modules that won't be set up if this is an afterInit task in an
         // early module like the asset module
         const host = (process.env.NODE_ENV === 'production') ? req.hostname : req.get('Host');
-        req.baseUrl = (self.apos.page && self.apos.page.getBaseUrl(req)) || `${req.protocol}://${host}`;
+        const fallbackBaseUrl = `${req.protocol}://${host}`;
+        if (self.hostnamesInUse) {
+          req.baseUrl = (self.apos.page && self.apos.page.getBaseUrl(req)) || fallbackBaseUrl;
+        } else {
+          req.baseUrl = self.apos.page && self.apos.page.getBaseUrl(req);
+        }
         req.baseUrlWithPrefix = `${req.baseUrl}${self.apos.prefix}`;
         req.absoluteUrl = req.baseUrlWithPrefix + req.url;
         req.prefix = `${req.baseUrlWithPrefix}${self.locales[req.locale].prefix || ''}`;
+        if (!req.baseUrl) {
+          // Always set for bc, but in the absence of locale hostnames we
+          // set it later so it is not part of req.prefix
+          req.baseUrl = fallbackBaseUrl;
+        }
       },
       // Returns an Express route suitable for use in a module
       // like a piece type or the page module. The returned route will


### PR DESCRIPTION
A bc break otherwise. Also fix mongo 5.x detection of a certain edge case.
