### PR TITLE
only stretch the modal body when we have a footer

### DIFF
--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalBody.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalBody.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="apos-modal__body">
+  <div class="apos-modal__body" :class="{ 'apos-modal__body--flex': hasSlot('footer') }">
     <div class="apos-modal__body-inner">
       <div v-if="hasSlot('bodyHeader')" class="apos-modal__body-header">
         <slot name="bodyHeader" />
@@ -27,14 +27,21 @@ export default {
 
 <style lang="scss" scoped>
 .apos-modal__body {
+  overflow-y: auto;
+  padding: 20px;
+}
+
+.apos-modal__body--flex {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-}
+  overflow-y: initial;
+  padding: 0;
 
-.apos-modal__body-inner {
-  overflow-y: auto;
-  padding: 20px;
+  .apos-modal__body-inner {
+    overflow-y: auto;
+    padding: 20px;
+  }
 }
 
 .apos-modal__main--no-rails .apos-modal__body {


### PR DESCRIPTION
Fixes:
- https://linear.app/apostrophecms/issue/PRO-1948/media-manager-layout-is-disrupted-when-uploading

Original change was made to match the design of the new wizard. Wasn't anticipating this change messing other things up but it did... This ensure's we only stretch it when we add a footer in the body. ( The standard modal footer can't be broken up like the visuals for the wizard. )