### PR TITLE
don't select the current locale when selecting all

### DIFF
--- a/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
+++ b/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
@@ -489,7 +489,7 @@ export default {
       return !!this.localized[locale.name];
     },
     selectAll() {
-      this.wizard.values.toLocales.data = [ ...this.locales ];
+      this.wizard.values.toLocales.data = this.locales.filter(locale => !this.isCurrentLocale(locale));
     },
     selectLocale(locale) {
       if (!this.isSelected(locale) && !this.isCurrentLocale(locale)) {


### PR DESCRIPTION
Resolves:
- https://linear.app/apostrophecms/issue/PRO-1955/

To test, from the Localize Wizard click Select All above the search box. The current locale should not be added to the list of selected locales.