### PR TITLE
dont show related options on confirm screen if current page doesn't have any related docs

### DIFF
--- a/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
+++ b/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
@@ -276,7 +276,11 @@ export default {
               // exist, as the user might opt in step three
               // to express an interest in previously
               // replicated related docs
-              return this.allRelatedDocs.length > 0;
+              const hasRelated = this.allRelatedDocs.length > 0;
+              if (!hasRelated) {
+                this.wizard.values.toLocalize.data = 'thisDoc';
+              }
+              return hasRelated;
             }
           },
           selectLocales: {


### PR DESCRIPTION
Resolves:
- https://linear.app/apostrophecms/issue/PRO-1955

To test, try to localize a page without any related documents. You should be bumped by default to the Select Locales option. After clicking Next, you should be able to confirm your selections but not see any of the options for related documents.