### PR TITLE
don't show the switcher when there's only one locale

### DIFF
--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -5,7 +5,7 @@
       <div class="apos-admin-bar__row">
         <AposLogoPadless class="apos-admin-bar__logo" />
         <TheAposAdminBarMenu :items="items" />
-        <TheAposAdminBarLocale />
+        <TheAposAdminBarLocale v-if="hasLocales()" />
         <TheAposAdminBarUser class="apos-admin-bar__user" />
       </div>
       <TheAposContextBar @mounted="setSpacer" />
@@ -35,6 +35,9 @@ export default {
       window.apos.adminBar.height = this.$refs.adminBar.offsetHeight;
       this.$refs.spacer.style.height = `${this.$refs.adminBar.offsetHeight}px`;
       apos.bus.$emit('admin-menu-height-changed');
+    },
+    hasLocales() {
+      return Object.keys(window.apos.i18n.locales).length > 1;
     }
   }
 };


### PR DESCRIPTION
Resolves
- https://linear.app/apostrophecms/issue/PRO-1986

To test, remove configuration for i18n in your demo app.js. The locale switcher should not display.