### PR TITLE
PRO-1536 select all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixes
 
+* Fixes bug in the "select all" relationship chooser UI where it selected unpublished items.
+
+## UNRELEASED
+
+### Fixes
+
 * Addresses the page jump when using the in-context undo/redo feature. The page will immediately return users to their origin scroll position after the content refreshes.
 * Resolves slug-related bug when switching between images in the archived view of the media manager. The slug field was not taking into account the double slug prefix case.
 * Fixes migration task crash when parking new page. Thanks to [Miro Yovchev](https://www.corllete.com/) for this fix.

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
@@ -122,7 +122,9 @@ export default {
     selectAll() {
       if (!this.checked.length) {
         this.items.forEach((item) => {
-          if (this.relationshipField && this.relationshipErrors === 'max') {
+          const relationshipsMaxed = this.relationshipField && this.maxReached();
+
+          if (relationshipsMaxed || !item.lastPublishedAt) {
             return;
           }
 


### PR DESCRIPTION
The relationship chooser previously selected draft items with the "select all" button. This fixes that and improves the max limit handling.