### PR TITLE
Remove lodash wrapper around bodyParser.json options override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Resolves slug-related bug when switching between images in the archived view of the media manager. The slug field was not taking into account the double slug prefix case.
 * Fixes migration task crash when parking new page. Thanks to [Miro Yovchev](https://www.corllete.com/) for this fix.
 * Fixes incorrect month name in `AposCellDate`, which can be optionally used in manage views of pieces. Thanks to [Miro Yovchev](https://www.corllete.com/) for this fix.
+* Removes a lodash wrapper around `@apostrophecms/express` `bodyParser.json` options that prevented adding custom options to the body parser.
 
 ### Adds
 

--- a/modules/@apostrophecms/express/index.js
+++ b/modules/@apostrophecms/express/index.js
@@ -341,7 +341,7 @@ module.exports = {
       }),
       bodyParserJson: bodyParser.json({
         limit: '16mb',
-        ..._(self.options.bodyParser && self.options.bodyParser.json)
+        ...(self.options.bodyParser && self.options.bodyParser.json)
       })
     };
   },


### PR DESCRIPTION
`bodyParser.json` options passed to `@apostrophecms/express` are currently ignored because they are being wrapped by lodash before spread. This change should fix it. cf #3369