### PR TITLE
Fixes the changelog from previous commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Removes a lodash wrapper around `@apostrophecms/express` `bodyParser.json` options that prevented adding custom options to the body parser.
 * Uses `req.clone` consistently when creating a new `req` object with a different mode or locale for localization purposes, etc.
+* Fixes bug in the "select all" relationship chooser UI where it selected unpublished items.
 
 ## 3.3.1 - 2021-09-01
 
@@ -16,12 +17,6 @@
 * Do not crash on startup if users have a relationship to another type. This was caused by the code that checks whether any users exist to present a warning to developers. That code was running too early for relationships to work due to event timing issues.
 
 ## 3.3.0 - 2021-08-30
-
-### Fixes
-
-* Fixes bug in the "select all" relationship chooser UI where it selected unpublished items.
-
-## UNRELEASED
 
 ### Fixes
 


### PR DESCRIPTION
Fixes a break in the timeline from #3363 being registered early and merged late.