### PR TITLE
PRO-1670 parked defaults

### DIFF
--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -520,17 +520,13 @@ module.exports = {
 
       async convert(req, input, doc, options = {
         presentFieldsOnly: false,
-        copyingId: false,
-        isPage: false
+        copyingId: false
       }) {
-        let fullSchema;
+        const fullSchema = self.apos.doc.getManager(options.type || self.name)
+          .allowedSchema(req, doc);
         let schema;
         let copyOf;
-        if (options.isPage) {
-          fullSchema = self.apos.page.allowedSchema(req, doc);
-        } else {
-          fullSchema = self.apos.doc.getManager(options.type || self.name).allowedSchema(req);
-        }
+
         if (options.presentFieldsOnly) {
           schema = self.apos.schema.subset(fullSchema, self.fieldsPresent(input));
         } else {

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -520,11 +520,17 @@ module.exports = {
 
       async convert(req, input, doc, options = {
         presentFieldsOnly: false,
-        copyingId: false
+        copyingId: false,
+        isPage: false
       }) {
-        const fullSchema = self.apos.doc.getManager(options.type || self.name).allowedSchema(req);
+        let fullSchema;
         let schema;
         let copyOf;
+        if (options.isPage) {
+          fullSchema = self.apos.page.allowedSchema(req, doc);
+        } else {
+          fullSchema = self.apos.doc.getManager(options.type || self.name).allowedSchema(req);
+        }
         if (options.presentFieldsOnly) {
           schema = self.apos.schema.subset(fullSchema, self.fieldsPresent(input));
         } else {
@@ -540,13 +546,14 @@ module.exports = {
             ...input
           };
         }
+
         await self.apos.schema.convert(req, schema, input, doc);
+
         doc.copyOfId = copyOf && copyOf._id;
         if (copyOf) {
           self.apos.schema.regenerateIds(req, fullSchema, doc);
         }
       },
-
       // Return the names of all schema fields present in the `input` object,
       // taking into account issues like relationship fields keeping their data in
       // a separate ids property, etc.

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -520,13 +520,17 @@ module.exports = {
 
       async convert(req, input, doc, options = {
         presentFieldsOnly: false,
-        copyingId: false
+        copyingId: false,
+        isPage: false
       }) {
-        const fullSchema = self.apos.doc.getManager(options.type || self.name)
-          .allowedSchema(req, doc);
+        let fullSchema;
         let schema;
         let copyOf;
-
+        if (options.isPage) {
+          fullSchema = self.apos.page.allowedSchema(req, doc);
+        } else {
+          fullSchema = self.apos.doc.getManager(options.type || self.name).allowedSchema(req);
+        }
         if (options.presentFieldsOnly) {
           schema = self.apos.schema.subset(fullSchema, self.fieldsPresent(input));
         } else {

--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -292,6 +292,7 @@
   "saveDraftAndPreviewDescription": "Save as a draft and preview the {{ typeLabel }}.",
   "savingDocument": "Saving document...",
   "searchDocType": "Search {{ type }}",
+  "searchLabel": "Search Page",
   "searchLocales": "Search Locales",
   "searchLocalesPlaceholder": "Search locales...",
   "select": "Select",

--- a/modules/@apostrophecms/page-type/index.js
+++ b/modules/@apostrophecms/page-type/index.js
@@ -215,6 +215,10 @@ module.exports = {
   },
   methods(self) {
     return {
+      // Given a page and its parent (if any), returns a schema that  is
+      // filtered appropriately to that page's type, taking into account whether
+      // the page is new, whether it is parked, and the parent's allowed subpage
+      // types.
       allowedSchema(req, page = {}, parentPage = {}) {
         let schema = self.schema;
 

--- a/modules/@apostrophecms/page-type/index.js
+++ b/modules/@apostrophecms/page-type/index.js
@@ -215,45 +215,6 @@ module.exports = {
   },
   methods(self) {
     return {
-      allowedSchema(req, page = {}, parentPage = {}) {
-        let schema = self.schema;
-
-        const typeField = _.find(schema, { name: 'type' });
-        if (typeField) {
-          const allowed = self.apos.page.allowedChildTypes(parentPage);
-          // For a preexisting page, we can't forbid the type it currently has
-          if (page._id && !_.includes(allowed, page.type)) {
-            allowed.unshift(page.type);
-          }
-          typeField.choices = _.map(allowed, function (name) {
-            return {
-              value: name,
-              label: getLabel(name)
-            };
-          });
-        }
-        if (page._id) {
-          // Preexisting page
-          schema = self.apos.page.addApplyToSubpagesToSchema(schema);
-          schema = self.apos.page.removeParkedPropertiesFromSchema(page, schema);
-        }
-        return schema;
-        function getLabel(name) {
-          const choice = _.find(self.apos.page.typeChoices, { name: name });
-          let label = choice && choice.label;
-          if (!label) {
-            const manager = self.apos.doc.getManager(name);
-            if (!manager) {
-              throw new Error(`There is no page type ${name} but it is configured in the types option`);
-            }
-            label = manager.label;
-          }
-          if (!label) {
-            label = name;
-          }
-          return label;
-        }
-      },
       dispatchAll() {
         self.dispatch('/', req => self.setTemplate(req, 'page'));
       },

--- a/modules/@apostrophecms/page-type/index.js
+++ b/modules/@apostrophecms/page-type/index.js
@@ -215,10 +215,6 @@ module.exports = {
   },
   methods(self) {
     return {
-      // Given a page and its parent (if any), returns a schema that  is
-      // filtered appropriately to that page's type, taking into account whether
-      // the page is new, whether it is parked, and the parent's allowed subpage
-      // types.
       allowedSchema(req, page = {}, parentPage = {}) {
         let schema = self.schema;
 

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -228,7 +228,8 @@ module.exports = {
           }
           await manager.convert(req, input, page, {
             onlyPresentFields: true,
-            copyingId
+            copyingId,
+            isPage: true
           });
           await self.insert(req, targetPage._id, position, page, { lock: false });
           return self.findOneForEditing(req, { _id: page._id }, { attachments: true });
@@ -287,9 +288,12 @@ module.exports = {
               force
             });
           }
+
           self.enforceParkedProperties(req, page, input);
-          await manager.convert(req, input, page);
+
+          await manager.convert(req, input, page, { isPage: true });
           await self.update(req, page);
+
           if (input._targetId) {
             const targetId = self.apos.launder.string(input._targetId);
             const position = self.apos.launder.string(input._position);
@@ -745,7 +749,7 @@ database.`);
         _.assign(browserOptions, _.pick(self.options, 'batchOperations'));
         _.defaults(browserOptions, {
           label: 'apostrophe:page',
-          pluralLabel: 'Pages',
+          pluralLabel: 'apostrophe:pages',
           components: {}
         });
         _.defaults(browserOptions.components, {

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -2062,10 +2062,8 @@ database.`);
           await change(req, page, data);
         }
       },
-      // Given a page and its parent (if any), returns a schema that
-      // is filtered appropriately to that page's type, taking into
-      // account whether the page is new and the parent's allowed
-      // subpage types
+      // Backward compatible method following moving this to page-type module.
+      // This page module method may be deprecated in the next major version.
       allowedSchema(req, page, parentPage) {
         return self.apos.doc.getManager(page.type)
           .allowedSchema(req, page, parentPage);

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -2062,8 +2062,10 @@ database.`);
           await change(req, page, data);
         }
       },
-      // Backward compatible method following moving this to page-type module.
-      // This page module method may be deprecated in the next major version.
+      // Given a page and its parent (if any), returns a schema that
+      // is filtered appropriately to that page's type, taking into
+      // account whether the page is new and the parent's allowed
+      // subpage types
       allowedSchema(req, page, parentPage) {
         return self.apos.doc.getManager(page.type)
           .allowedSchema(req, page, parentPage);

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -732,7 +732,7 @@ database.`);
         }
         self.apos.schema.implementPatchOperators(input, page);
         const parentPage = page._ancestors.length && page._ancestors[page._ancestors.length - 1];
-        const schema = self.apos.schema.subsetSchemaForPatch(self.allowedSchema(req, {
+        const schema = self.apos.schema.subsetSchemaForPatch(manager.allowedSchema(req, {
           ...page,
           type: manager.name
         }, parentPage), input);
@@ -2067,42 +2067,8 @@ database.`);
       // account whether the page is new and the parent's allowed
       // subpage types
       allowedSchema(req, page, parentPage) {
-        let schema = self.apos.doc.getManager(page.type).allowedSchema(req);
-        const typeField = _.find(schema, { name: 'type' });
-        if (typeField) {
-          const allowed = self.allowedChildTypes(parentPage);
-          // For a preexisting page, we can't forbid the type it currently has
-          if (page._id && !_.includes(allowed, page.type)) {
-            allowed.unshift(page.type);
-          }
-          typeField.choices = _.map(allowed, function (name) {
-            return {
-              value: name,
-              label: getLabel(name)
-            };
-          });
-        }
-        if (page._id) {
-          // Preexisting page
-          schema = self.addApplyToSubpagesToSchema(schema);
-          schema = self.removeParkedPropertiesFromSchema(page, schema);
-        }
-        return schema;
-        function getLabel(name) {
-          const choice = _.find(self.typeChoices, { name: name });
-          let label = choice && choice.label;
-          if (!label) {
-            const manager = self.apos.doc.getManager(name);
-            if (!manager) {
-              throw new Error(`There is no page type ${name} but it is configured in the types option`);
-            }
-            label = manager.label;
-          }
-          if (!label) {
-            label = name;
-          }
-          return label;
-        }
+        return self.apos.doc.getManager(page.type)
+          .allowedSchema(req, page, parentPage);
       },
       getRestQuery(req) {
         const query = self.find(req).ancestors(true).children(true).applyBuildersSafely(req.query);

--- a/modules/@apostrophecms/search/index.js
+++ b/modules/@apostrophecms/search/index.js
@@ -50,8 +50,8 @@ module.exports = {
   extend: '@apostrophecms/page-type',
   options: {
     alias: 'search',
-    name: '@apostrophecms/search',
-    perPage: 10
+    perPage: 10,
+    label: 'apostrophe:searchLabel'
   },
   init(self) {
 


### PR DESCRIPTION
Since pages were using the regular doc-type `allowedSchema` method they didn't get the parked page checks. So when a page was parked and we tried to edit it there were opportunities to fail, including if we were updating a page whose type was not in the main array of selectable types.