### PR TITLE
PRO-2060: a fix introduced in 3.3.1 revealed broken render-widget logic that was getting by due to the bug fixed in 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Unlocalized piece types, such as users, may now be selected as part of a relationship when browsing.
 * Unpublished localized piece types may not be selected via the autocomplete feature of the relationship input field, which formerly ignored this requirement, although the browse button enforced it.
 * The server-side JavaScript and REST APIs to delete pieces now work properly for pieces that are not subject to either localization or draft/published workflow at all the (`localize: false` option). UI for this is under discussion, this is just a bug fix for the back end feature which already existed.
+* Starting in version 3.3.1, a newly added image widget did not display its image until the page was refreshed. This has been fixed.
 
 ### Adds
 

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -52,6 +52,9 @@ module.exports = {
           widget = await sanitize(widget);
           widget._edit = true;
           widget._docId = _docId;
+          // So that carrying out relationship loading again can yield results
+          // (the idsStorage must be populated as if we were saving)
+          self.apos.schema.prepareForStorage(req, widget);
           await load();
           return render();
           async function sanitize(widget) {

--- a/modules/@apostrophecms/image-widget/views/widget.html
+++ b/modules/@apostrophecms/image-widget/views/widget.html
@@ -5,6 +5,7 @@
 {% endif %}
 
 {% set attachment = apos.image.first(data.widget._image) %}
+
 {% if attachment %}
   <img{% if className %} class="{{ className }}"{% endif %}
     srcset="{{ apos.image.srcset(attachment) }}"


### PR DESCRIPTION
render-widget essentially simulates saving the widget so that the loaders can function properly on it. But this simulation was incomplete. Specifically we did not call the method to populate the idsStorage before saving, so upon calling the loaders the image widget's relationship with images was empty.

This bug slid by until 3.3.1 because of a separate bug in which the relate() method didn't replace any existing relationship data when reloading it but rather just appended, which created a major performance issue for an enterprise client, necessitating a hotfix.

As we see here however full QA is always a good idea, even for a hotfix, particularly if it touches on deeper functionality and not a single piece of UI.