### PR TITLE
Keep Add Content controls accessible when widgets are focused

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -384,9 +384,9 @@ export default {
       }
       if (!this.focused) {
         this.state.labels.show = false;
+        this.state.add.top.show = false;
+        this.state.add.bottom.show = false;
       }
-      this.state.add.top.show = false;
-      this.state.add.bottom.show = false;
     },
 
     focus(e) {
@@ -396,8 +396,8 @@ export default {
       this.focused = true;
       this.state.container.focus = true;
       this.state.controls.show = true;
-      this.state.add.top.show = false;
-      this.state.add.bottom.show = false;
+      this.state.add.top.show = true;
+      this.state.add.bottom.show = true;
       this.state.labels.show = true;
       document.addEventListener('click', this.unfocus);
     },


### PR DESCRIPTION
We originally hid the Add Content buttons when a widget was focused to separate the concepts of 'adding content to an area' from 'editing the settings of an individual widget' but this felt like it was getting in the way more than guiding the editor, especially when they tried to use the breadcrumb UI for wayfinding (using the breadcrumbs focuses the parent widget, which would hide the Add Content UI, only providing half the utility).

This helps to alleviate scenarios like #3388 