### PR TITLE
 PRO-1114 Updates cascade grouping to combine like-named groups' fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Fixes
 
-* The file size of uploaded media is visible again when selected in the editor, and media information such as upload date, dimensions and file size is now properly localized. 
+* The file size of uploaded media is visible again when selected in the editor, and media information such as upload date, dimensions and file size is now properly localized.
+
+### Changes
+
+* Cascade grouping (e.g., grouping fields) will now concatenate a group's field name array with the field name array of an existing group of the same name. Put simply, if a new piece module adds their custom fields to a `basics` group, that field will be added to the default `basics` group fields. Previously the new group would have replaced the old, leaving inherited fields in the "Ungrouped" section.
 
 ## 3.4.1 - 2021-09-13
 

--- a/lib/moog.js
+++ b/lib/moog.js
@@ -192,17 +192,24 @@ module.exports = function(options) {
           }
           if (properties.group) {
             const groups = klona(that[`${cascade}Groups`]);
-            for (const value of Object.values(properties.group)) {
+            for (const [ key, value ] of Object.entries(properties.group)) {
               for (const field of value.fields || []) {
-                for (const value of Object.values(groups)) {
-                  if (value.fields) {
-                    if (value.fields.includes(field)) {
-                      value.fields = value.fields.filter(_field => _field !== field);
+                // Remove fields from existing groups if they're added to a new
+                // group.
+                for (const val of Object.values(groups)) {
+                  if (val.fields) {
+                    if (val.fields.includes(field)) {
+                      val.fields = val.fields.filter(_field => _field !== field);
                     }
                   }
                 }
               }
+              // Combine groups of the same name
+              if (groups[key] && Array.isArray(groups[key].fields)) {
+                value.fields = groups[key].fields.concat(value.fields);
+              }
             }
+
             that[`${cascade}Groups`] = {
               ...groups,
               ...klona(properties.group)

--- a/lib/moog.js
+++ b/lib/moog.js
@@ -192,7 +192,7 @@ module.exports = function(options) {
           }
           if (properties.group) {
             const groups = klona(that[`${cascade}Groups`]);
-            for (const [ key, value ] of Object.entries(properties.group)) {
+            for (const value of Object.values(properties.group)) {
               for (const field of value.fields || []) {
                 // Remove fields from existing groups if they're added to a new
                 // group.
@@ -204,7 +204,11 @@ module.exports = function(options) {
                   }
                 }
               }
-              // Combine groups of the same name
+            }
+
+            // Combine groups of the same name now that inherited groups are
+            // filtered
+            for (const [ key, value ] of Object.entries(properties.group)) {
               if (groups[key] && Array.isArray(groups[key].fields)) {
                 value.fields = groups[key].fields.concat(value.fields);
               }

--- a/test/moog.js
+++ b/test/moog.js
@@ -237,6 +237,53 @@ describe('moog', function() {
       assert(myObject.extended(5) === 20);
     });
 
+    it('should support inheriting field group fields rather than requiring all fields to be restated', async function() {
+      const moog = require('../lib/moog.js')({});
+
+      moog.define('myObject', {
+        cascades: [ 'fields' ],
+        fields: {
+          add: {
+            one: { type: 'string' },
+            two: { type: 'string' },
+            three: { type: 'string' }
+          },
+          group: {
+            basics: {
+              fields: [ 'one', 'two', 'three' ]
+            }
+          }
+        }
+      });
+
+      moog.define('myObject', {
+        fields: {
+          add: {
+            four: { type: 'string' },
+            five: { type: 'string' }
+          },
+          group: {
+            basics: {
+              fields: [ 'four', 'five' ]
+            },
+            other: {
+              fields: [ 'one' ]
+            }
+          }
+        }
+      });
+
+      const myObject = await moog.create('myObject', {});
+      assert(myObject);
+      assert(myObject.fieldsGroups);
+      assert(!myObject.fieldsGroups.basics.fields.includes('one'));
+      assert(myObject.fieldsGroups.other.fields.includes('one'));
+      assert(myObject.fieldsGroups.basics.fields.includes('two'));
+      assert(myObject.fieldsGroups.basics.fields.includes('three'));
+      assert(myObject.fieldsGroups.basics.fields.includes('four'));
+      assert(myObject.fieldsGroups.basics.fields.includes('five'));
+    });
+
     // ==================================================
     // `redefine` AND `isDefined`
     // ==================================================


### PR DESCRIPTION
I couldn't let this go anymore. Seems like a simple fix for a big quality of life improvement. Devs no longer need to know what the inherited fields in a group are.