### PR TITLE
Fixes error messages to remove the options argument recommendation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixes
 
-* The file size of uploaded media is visible again when selected in the editor, and media information such as upload date, dimensions and file size is now properly localized. 
+* The file size of uploaded media is visible again when selected in the editor, and media information such as upload date, dimensions and file size is now properly localized.
+* Fixes error moog error messages to reflect the recommended pattern of customization functions only taking `self` as an argument.
 
 ## 3.4.1 - 2021-09-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 * The file size of uploaded media is visible again when selected in the editor, and media information such as upload date, dimensions and file size is now properly localized.
-* Fixes error moog error messages to reflect the recommended pattern of customization functions only taking `self` as an argument.
+* Fixes moog error messages to reflect the recommended pattern of customization functions only taking `self` as an argument.
 
 ## 3.4.1 - 2021-09-13
 

--- a/lib/moog.js
+++ b/lib/moog.js
@@ -142,8 +142,8 @@ module.exports = function(options) {
 
     const upgradeHints = {
       construct: 'in Apostrophe 3.x, "construct" has been replaced with "methods", "routes", "apiRoutes", etc.',
-      beforeConstruct: 'in Apostrophe 3.x, "beforeConstruct" has been replaced with "beforeSuperClass". It takes (self, options) and should be solely concerned with modifying the options before the base class sees them. It must be synchronous. Check out the new fields section, you might not need beforeSuperClass.',
-      afterConstruct: 'in Apostrophe 3.x, "afterConstruct" has been replaced with "init". It takes (self, options) and may be an async function.'
+      beforeConstruct: 'in Apostrophe 3.x, "beforeConstruct" has been replaced with "beforeSuperClass". It takes (self) and should be solely concerned with modifying the options before the base class sees them. It must be synchronous. Check out the new fields section, you might not need beforeSuperClass.',
+      afterConstruct: 'in Apostrophe 3.x, "afterConstruct" has been replaced with "init". It takes (self) and may be an async function.'
     };
 
     for (const step of steps) {
@@ -289,14 +289,14 @@ module.exports = function(options) {
             };
           }
           if ((typeof step[keyword]) !== 'function') {
-            throw stepError(step, `${keyword} must be a function that takes (self, options) and returns an object`);
+            throw stepError(step, `${keyword} must be a function that takes (self) and returns an object`);
           }
           _.merge(context, step[keyword](that, options));
         }
         const extend = getExtendKey(keyword);
         if (step[extend]) {
           if ((typeof step[extend]) !== 'function') {
-            throw stepError(step, `${extend} must be a function that takes (self, options) and returns an object`);
+            throw stepError(step, `${extend} must be a function that takes (self) and returns an object`);
           }
           const extensions = step[extend](that, options);
           wrap(context, extensions);


### PR DESCRIPTION
The documented recommendation is to only use `self` as an argument to customization functions. This should be reflected in error messages as well.