### PR TITLE
Supports adding a test module namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Fixes
 
-* The file size of uploaded media is visible again when selected in the editor, and media information such as upload date, dimensions and file size is now properly localized. 
+* The file size of uploaded media is visible again when selected in the editor, and media information such as upload date, dimensions and file size is now properly localized.
+
+### Adds
+
+* If `options.testModule` on the app is a string it will be used as an npm namespace when creating a symlink test module.
 
 ## 3.4.1 - 2021-09-13
 

--- a/index.js
+++ b/index.js
@@ -254,6 +254,8 @@ module.exports = async function(options) {
   // when options.testModule is true. There must be a
   // test/ or tests/ subdir of the module containing
   // a test.js file that runs under mocha via devDependencies.
+  // If `options.testModule` is a string it will be used as a
+  // namespace for the test module.
 
   function testModule() {
     if (!options.testModule) {
@@ -278,8 +280,8 @@ module.exports = async function(options) {
       throw new Error('Test file must be in test/ or tests/ subdirectory of module');
     }
     if (!fs.existsSync(testDir + '/node_modules')) {
-      fs.mkdirSync(testDir + '/node_modules');
-      fs.symlinkSync(moduleDir, testDir + '/node_modules/' + require('path').basename(moduleDir), 'dir');
+      fs.mkdirSync(testDir + '/node_modules' + addAposIfApos(options.testModule), { recursive: true });
+      fs.symlinkSync(moduleDir, testDir + '/node_modules' + addAposIfApos(options.testModule) + '/' + require('path').basename(moduleDir), 'dir');
     }
 
     // Not quite superfluous: it'll return self.root, but
@@ -296,6 +298,10 @@ module.exports = async function(options) {
           throw new Error('mocha does not seem to be running, is this really a test?');
         }
       }
+    }
+
+    function addAposIfApos (testType) {
+      return typeof testType === 'string' ? `/${testType}` : '';
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -279,9 +279,17 @@ module.exports = async function(options) {
     if (testDir === moduleDir) {
       throw new Error('Test file must be in test/ or tests/ subdirectory of module');
     }
+
+    const pkgName = require(`${moduleDir}/package.json`).name;
+    let pkgNamespace = '';
+    if (pkgName.includes('/')) {
+      const parts = pkgName.split('/');
+      pkgNamespace = '/' + parts.slice(0, parts.length - 1).join('/');
+    }
+
     if (!fs.existsSync(testDir + '/node_modules')) {
-      fs.mkdirSync(testDir + '/node_modules' + addDirNamespace(options.testModule), { recursive: true });
-      fs.symlinkSync(moduleDir, testDir + '/node_modules' + addDirNamespace(options.testModule) + '/' + require('path').basename(moduleDir), 'dir');
+      fs.mkdirSync(testDir + '/node_modules' + pkgNamespace, { recursive: true });
+      fs.symlinkSync(moduleDir, testDir + '/node_modules/' + pkgName, 'dir');
     }
 
     // Not quite superfluous: it'll return self.root, but
@@ -298,10 +306,6 @@ module.exports = async function(options) {
           throw new Error('mocha does not seem to be running, is this really a test?');
         }
       }
-    }
-
-    function addDirNamespace (testType) {
-      return typeof testType === 'string' ? `/${testType}` : '';
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -280,8 +280,8 @@ module.exports = async function(options) {
       throw new Error('Test file must be in test/ or tests/ subdirectory of module');
     }
     if (!fs.existsSync(testDir + '/node_modules')) {
-      fs.mkdirSync(testDir + '/node_modules' + addAposIfApos(options.testModule), { recursive: true });
-      fs.symlinkSync(moduleDir, testDir + '/node_modules' + addAposIfApos(options.testModule) + '/' + require('path').basename(moduleDir), 'dir');
+      fs.mkdirSync(testDir + '/node_modules' + addDirNamespace(options.testModule), { recursive: true });
+      fs.symlinkSync(moduleDir, testDir + '/node_modules' + addDirNamespace(options.testModule) + '/' + require('path').basename(moduleDir), 'dir');
     }
 
     // Not quite superfluous: it'll return self.root, but
@@ -300,7 +300,7 @@ module.exports = async function(options) {
       }
     }
 
-    function addAposIfApos (testType) {
+    function addDirNamespace (testType) {
       return typeof testType === 'string' ? `/${testType}` : '';
     }
   }


### PR DESCRIPTION
The existing tests didn't support official Apostrophe modules well since they created a symlink test node module named after the package directory. A3 modules do not include the namespace in the package directory typically. This supports adding the namespace for a test module.

In our official modules in packages like `form` or `seo` we would use `testModule: '@apostrophecms'` on test apps to namespace the symlink.