### PR TITLE
PRO-2096 fix webpack fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Pinned dependency on `vue-material-design-icons` to fix `apos-build.js` build error in production.
 * The file size of uploaded media is visible again when selected in the editor, and media information such as upload date, dimensions and file size is now properly localized.
 * Fixes moog error messages to reflect the recommended pattern of customization functions only taking `self` as an argument.
 * Rich Text widgets now instantiate with a valid element from the `styles` option rather than always starting with an unclassed `<p>` tag.

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "vue": "^2.6.14",
     "vue-click-outside-element": "^1.0.13",
     "vue-loader": "^15.9.6",
-    "vue-material-design-icons": "^4.9.0",
+    "vue-material-design-icons": "~4.12.1",
     "vue-style-loader": "^4.1.2",
     "vue-template-compiler": "^2.6.14",
     "vuedraggable": "^2.24.3",


### PR DESCRIPTION
In a3-demo webpack simply fails to build `apos-build.js`, with no error, when `NODE_ENV=production` unless I pin `vue-material-design-icons` to the previous minor version. I took a look and it's basically a whole lot more icons, I really don't know how that could cause webpack to silently fail to produce an output file, but there you are.
