### PR TITLE
Webpack css loader config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fixes moog error messages to reflect the recommended pattern of customization functions only taking `self` as an argument.
 * Rich Text widgets now instantiate with a valid element from the `styles` option rather than always starting with an unclassed `<p>` tag.
 * Fixes a bug where having no project modules directory would throw an error. This is primarily a concern for module unit tests where there are no additional modules involved.
+* `css-loader` now ignores `url()` in css files inside `assets` so webpack handles path resolution in them.
 
 ### Changes
 

--- a/modules/@apostrophecms/asset/lib/webpack/src/webpack.scss.js
+++ b/modules/@apostrophecms/asset/lib/webpack/src/webpack.scss.js
@@ -9,8 +9,11 @@ module.exports = (options, apos) => {
           use: [
             // Instead of style-loader, to avoid FOUC
             MiniCssExtractPlugin.loader,
-            // Parses CSS imports
-            'css-loader',
+            // Parses CSS imports and make css-loader ignore urls. Urls will still be handled by webpack
+            {
+              loader: 'css-loader',
+              options: { url: false }
+            },
             // Provides autoprefixing
             {
               loader: 'postcss-loader',


### PR DESCRIPTION
We are solving an issue where `css-loader` is trying to parse `url()` inside `modules/@apostrophecms/assets`. This is to no avail as webpack is the one that should compile paths. 

Solution established with @boutell 
