### PR TITLE
PRO-1739 fixed foreign area editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Rich Text widgets now instantiate with a valid element from the `styles` option rather than always starting with an unclassed `<p>` tag.
 * Fixes a bug where having no project modules directory would throw an error. This is primarily a concern for module unit tests where there are no additional modules involved.
 * `css-loader` now ignores `url()` in css files inside `assets` so that paths are left intact, i.e. `url(/images/file.svg)` will now find a static file at `/public/images/file.svg` (static assets in `/public` are served by `express.static`). Thanks to Matic Tersek.
+* Restored support for clicking on a "foreign" area, i.e. an area displayed on the page whose content comes from a piece, in order to edit it in an appropriate way.
 
 ### Changes
 
@@ -19,6 +20,7 @@
 
 * If `options.testModule` on the app is a string it will be used as an npm namespace when creating a symlink test module.
 * Rich Text widget's styles support a `def` property for specifying the default style the editor should instantiate with.
+* A more helpful error message if a field of type `area` is missing its `options` property.
 
 ## 3.4.1 - 2021-09-13
 

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const deep = require('deep-get-set');
+const { stripIndent } = require('common-tags');
 
 // An area is a series of zero or more widgets, in which users can add
 // and remove widgets and drag them to reorder them. This module implements
@@ -131,6 +132,14 @@ module.exports = {
         const field = self.apos.schema.getFieldById(area._fieldId);
 
         const options = field.options;
+        if (!options) {
+          throw new Error(stripIndent`
+            The area field ${field.name} has no options property.
+
+            You probably forgot to nest the widgets property
+            in an options property.
+          `);
+        }
         _.each(options.widgets, function (options, name) {
           const manager = self.widgetManagers[name];
           if (manager) {

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -38,11 +38,19 @@ module.exports = {
   restApiRoutes(self) {
     return {
       // GET /api/v1/@apostrophecms/doc/_id supports only the universal query
-      // features, but works for any document type, Simplifies browser-side
-      // logic for redirects to foreign documents; the frontend only has to
+      // features, but works for any document type. Simplifies browser-side
+      // logic for redirects to foreign documents. The frontend only has to
       // know the doc _id.
+      //
+      // Since this API is solely for editing purposes you will receive
+      // a 404 if you request a document you cannot edit.
       async getOne(req, _id) {
-        return self.find(req, { _id }).toObject();
+        _id = self.apos.i18n.inferIdLocaleAndMode(req, _id);
+        const doc = await self.find(req, { _id }).permission('edit').toObject();
+        if (!doc) {
+          throw self.apos.error('notfound');
+        }
+        return doc;
       }
     };
   },


### PR DESCRIPTION
Also added a decent error message when you forget to nest `widgets` in `options`, because that was making it painful to test the other thing.