### PR TITLE
PRO-1853 module aliases now available when ui/src logic starts up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Rich Text widgets now instantiate with a valid element from the `styles` option rather than always starting with an unclassed `<p>` tag.
 * Fixes a bug where having no project modules directory would throw an error. This is primarily a concern for module unit tests where there are no additional modules involved.
 * `css-loader` now ignores `url()` in css files inside `assets` so that paths are left intact, i.e. `url(/images/file.svg)` will now find a static file at `/public/images/file.svg` (static assets in `/public` are served by `express.static`). Thanks to Matic Tersek.
+* Apostrophe module aliases and the data attached to them are now visible immediately to `ui/src/index.js` JavaScript code, i.e. you can write `apos.alias` where `alias` matches the `alias` option configured for that module. Previously one had to write `apos.modules['module-name']` or wait until next tick. However, note that most modules do not push any data to the browser when a user is not logged in. You can do so in a custom module by calling `self.enableBrowserData('public')` from `init` and implementing or extending the `getBrowserData(req)` method (note that page, piece and widget types already have one, so it is important to extend in those cases).
 
 ### Changes
 

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -580,7 +580,14 @@ module.exports = {
             if (data) {
               document.body.removeAttribute('data-apos');
             }
-          })();
+            if (window.apos.modules) {
+              for (const module of Object.values(window.apos.modules)) {
+                if (module.alias) {
+                  window.apos[module.alias] = module;
+                }
+              }
+            }
+        })();
         `;
         self.builds = {
           src: {
@@ -632,13 +639,6 @@ module.exports = {
             prologue: stripIndent`
               import 'Modules/@apostrophecms/ui/scss/global/import-all.scss';
               import Vue from 'Modules/@apostrophecms/ui/lib/vue';
-              if (window.apos.modules) {
-                for (const module of Object.values(window.apos.modules)) {
-                  if (module.alias) {
-                    window.apos[module.alias] = module;
-                  }
-                }
-              }
               window.apos.bus = new Vue();
             `,
             // Load only in browsers that support ES6 modules

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -446,7 +446,7 @@ module.exports = {
       // By default browser data is pushed only for the `apos` scene, so public
       // site pages will not be cluttered with it, except on the /login page and
       // other pages that opt into the `apos` scene. If `scene` is set to `public`
-      // then the data is available al the time.
+      // then the data is available all the time.
       //
       // Be sure to use `extendMethods` when implementing `getBrowserData`
       // as your base class may also implement `getBrowserData`.


### PR DESCRIPTION
@stuartromanek pointed out that aliases didn't work in `ui/src/index.js` files, at least not until next tick. Now they are initialized earlier to save hassle.

In the changelog I couldn't help writing a note explaining when this even makes sense to try to use and how, a lil' bit. Bea, feel free to steal this for a doc page on the topic...