### PR TITLE
fix autocomplete

### DIFF
--- a/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
+++ b/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
@@ -82,6 +82,7 @@
                 :field="searchField"
                 @input="updateFilter"
                 class="apos-locales-filter"
+                ref="searchInput"
               />
               <transition-group tag="ul" name="selected-list" class="apos-selected-locales">
                 <li
@@ -529,6 +530,12 @@ export default {
       } else if (this.isSelected(locale)) {
        this.wizard.values.toLocales.data = this.wizard.values.toLocales.data.filter(l => l !== locale);
       }
+      // Reset search filter
+      if (this.filteredLocales.length < 2) {
+        this.wizard.sections.selectLocales.filter = '';
+        this.searchValue.data = '';
+        this.$refs.searchInput.$el.querySelector('input').focus();
+      }
     },
     removeLocale(locale) {
       this.wizard.values.toLocales.data = this.wizard.values.toLocales.data.filter(
@@ -581,7 +588,7 @@ export default {
     },
     updateFilter(event) {
       if (event && event.data) {
-        wizard.sections.selectLocales.filter = event.data
+        this.wizard.sections.selectLocales.filter = event.data
       }
     },
     async submit() {


### PR DESCRIPTION
Regression: autocomplete in the locale searcher didn't work
Small UX bit around resetting the search when the remaining results are probably not actionable.