### PR TITLE
Bypasses field validation if the field is conditionally hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * `css-loader` now ignores `url()` in css files inside `assets` so that paths are left intact, i.e. `url(/images/file.svg)` will now find a static file at `/public/images/file.svg` (static assets in `/public` are served by `express.static`). Thanks to Matic Tersek.
 * Restored support for clicking on a "foreign" area, i.e. an area displayed on the page whose content comes from a piece, in order to edit it in an appropriate way.
 * Apostrophe module aliases and the data attached to them are now visible immediately to `ui/src/index.js` JavaScript code, i.e. you can write `apos.alias` where `alias` matches the `alias` option configured for that module. Previously one had to write `apos.modules['module-name']` or wait until next tick. However, note that most modules do not push any data to the browser when a user is not logged in. You can do so in a custom module by calling `self.enableBrowserData('public')` from `init` and implementing or extending the `getBrowserData(req)` method (note that page, piece and widget types already have one, so it is important to extend in those cases).
+* If a field is conditional (using an `if` option), is required, but the condition has not been met, it no longer throws a validation error.
 
 ### Changes
 

--- a/modules/@apostrophecms/permission/ui/apos/components/AposInputRole.vue
+++ b/modules/@apostrophecms/permission/ui/apos/components/AposInputRole.vue
@@ -126,7 +126,6 @@ export default {
       const list = document.createElement('ul');
       const intro = document.createElement('p');
       const followUp = document.createElement('p');
-      const link = document.createElement('a');
       intro.appendChild(document.createTextNode(this.$t('apostrophe:piecePermissionsIntro')));
       followUp.appendChild(document.createTextNode(this.$t('apostrophe:piecePermissionsPieceTypeList')));
       html.appendChild(intro);
@@ -137,7 +136,10 @@ export default {
         list.appendChild(li);
       });
       html.appendChild(list);
-      return { content: html, localize: false };
+      return {
+        content: html,
+        localize: false
+      };
     },
     validate(value) {
       if (this.field.required && !value.length) {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
@@ -11,6 +11,7 @@
         v-show="displayComponent(field.name)"
         v-model="fieldState[field.name]"
         :following-values="followingValues[field.name]"
+        :conditional="conditionalFields[field.name]"
         :is="fieldComponentMap[field.type]"
         :field="fields[field.name].field"
         :modifiers="fields[field.name].modifiers"

--- a/modules/@apostrophecms/schema/ui/apos/mixins/AposInputMixin.js
+++ b/modules/@apostrophecms/schema/ui/apos/mixins/AposInputMixin.js
@@ -22,6 +22,10 @@ export default {
       type: Object,
       required: false
     },
+    conditional: {
+      type: Boolean,
+      required: false
+    },
     triggerValidation: {
       type: Boolean,
       default: false
@@ -117,10 +121,12 @@ export default {
     // You must supply the validate method. It receives the
     // internal representation used for editing (a string, for instance)
     validateAndEmit () {
-      const error = this.validate(this.next);
+      // If the field is conditional and isn't shown, disregard any errors.
+      const error = this.conditional === false ? false
+        : this.validate(this.next);
       this.$emit('input', {
         data: error ? this.next : this.convert(this.next),
-        error: this.validate(this.next)
+        error
       });
     },
     watchValue () {


### PR DESCRIPTION
Fixes a bug where conditional and required fields that had not had their condition met where throwing `'required'` errors in the UI.

So in this scenario, if the `radioFields` was left null (or not `med`) the `colorField`  was throwing an error. No more.

```
      radioFields: {
        label: 'Radio',
        type: 'radio',
        choices: [
          {
            label: 'Small',
            value: 'small'
          },
          {
            label: 'Medium',
            value: 'med'
          },
          {
            label: 'Big',
            value: 'big'
          }
        ]
      },
      colorField: {
        type: 'color',
        label: 'Color',
        required: true,
        if: {
          radioFields: 'med'
        }
      },
```