### PR TITLE
Avoid 500 error when field is hidden and required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+## Fixes
+
+* Avoid 500 errors when `joinByOne` field is hidden and required.
+
 ## 2.220.6 (2021-09-13)
 
 ## Security

--- a/lib/modules/apostrophe-doc-type-manager/lib/routes.js
+++ b/lib/modules/apostrophe-doc-type-manager/lib/routes.js
@@ -63,7 +63,14 @@ module.exports = function(self, options) {
       convert: function(callback) {
         // For purposes of previewing, it's OK to ignore readOnly so we can tell which
         // inputs are plausible
-        return self.apos.schemas.convert(req, [ _.omit(field, 'readOnly') ], 'form', input, receptacle, callback);
+        return self.apos.schemas.convert(
+          req,
+          [_.omit(field, ['readOnly', 'required', 'min', 'max'])],
+          'form',
+          input,
+          receptacle,
+          callback
+        );
       },
       join: function(callback) {
         return self.apos.schemas.join(req, [ field ], receptacle, true, callback);

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -2673,57 +2673,63 @@ module.exports = {
     // reasonable values for certain properties, such as the `idField` property
     // of a `joinByOne` field, or the `label` property of anything.
 
-    self.validate = function(schema, options) {
+    self.validate = function (schema, options) {
       // Infinite recursion prevention
-      if (self.validatedSchemas[options.type + ':' + options.subtype]) {
-        return;
-      }
-      self.validatedSchemas[options.type + ':' + options.subtype] = true;
       var unarranged = [];
-      _.each(schema, function(field) {
-        var fieldType = self.fieldTypes[field.type];
-        if (!fieldType) {
-          fail('Unknown schema field type.');
-        }
-        if (!field.name) {
-          fail('name property is missing.');
-        }
-        if ((!field.label) && (!field.contextual)) {
-          field.label = _.startCase(field.name.replace(/^_/, ''));
-        }
-        if (fieldType.validate) {
-          fieldType.validate(field, options, warn, fail, schema);
-        }
-        // If at least one field is in a non-default group and this one is in the
-        // default group, complain about halfassed grouping. The "Info" tab indicates
-        // insufficient UX consideration, unless it contains all the fields, which
-        // usually indicates a simple array schema that does not need any groups.
-        // Don't ding the developer for things that aren't their fault and are
-        // probably not that obnoxious in practice, like the withTags field of all
-        // pieces-pages, which is usually alone in the default group.
-        if (
-          field.group &&
-            (!field.contextual) &&
-            (field.name !== 'withTags') &&
-            (!field.type.match(/Reverse$/)) &&
-            (field.group.name === 'default') &&
-            (_.find(schema, function(field) {
-              return (field.group) && (field.group.name !== 'default');
-            }))) {
-          unarranged.push(field);
-        }
-        function fail(s) {
-          throw new Error(format(s));
-        }
-        function warn(s) {
-          self.apos.utils.warnDev(format(s));
-        }
-        function format(s) {
-          return '\n⚠️  ' + options.type + ' ' + options.subtype + ', field name ' + field.name + ':\n\n' + s + '\n';
+      _.each(schema, function (field) {
+        const key = `${options.type}:${options.subtype}.${field.name}`;
+
+        if (!self.validatedSchemas[key]) {
+          self.validatedSchemas[key] = true;
+          self.validateField(field, options, schema, unarranged);
         }
       });
+
       if (unarranged.length) {
         self.apos.utils.warnDevOnce('unarranged-fields', '\n⚠️ ' + options.type + ' ' + options.subtype + ' contains unarranged field(s): ' + _.pluck(unarranged, 'name').join(', ') + '.\nArrange all of your fields with arrangeFields, using meaningful group labels.\nhttps://apos.dev/arrange-fields');
+      }
+    };
+
+    self.validateField = function (field, options, schema, unarranged) {
+      var fieldType = self.fieldTypes[field.type];
+      if (!fieldType) {
+        fail('Unknown schema field type.');
+      }
+      if (!field.name) {
+        fail('name property is missing.');
+      }
+      if ((!field.label) && (!field.contextual)) {
+        field.label = _.startCase(field.name.replace(/^_/, ''));
+      }
+      if (fieldType.validate) {
+        fieldType.validate(field, options, warn, fail, schema);
+      }
+      // If at least one field is in a non-default group and this one is in the
+      // default group, complain about halfassed grouping. The "Info" tab indicates
+      // insufficient UX consideration, unless it contains all the fields, which
+      // usually indicates a simple array schema that does not need any groups.
+      // Don't ding the developer for things that aren't their fault and are
+      // probably not that obnoxious in practice, like the withTags field of all
+      // pieces-pages, which is usually alone in the default group.
+      if (
+        field.group &&
+        (!field.contextual) &&
+        (field.name !== 'withTags') &&
+        (!field.type.match(/Reverse$/)) &&
+        (field.group.name === 'default') &&
+        (_.find(schema, function (field) {
+          return (field.group) && (field.group.name !== 'default');
+        }))) {
+        unarranged.push(field);
+      }
+      function fail(s) {
+        throw new Error(format(s));
+      }
+      function warn(s) {
+        self.apos.utils.warnDev(format(s));
+      }
+      function format(s) {
+        return '\n⚠️  ' + options.type + ' ' + options.subtype + ', field name ' + field.name + ':\n\n' + s + '\n';
       }
     };
 

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -2673,10 +2673,10 @@ module.exports = {
     // reasonable values for certain properties, such as the `idField` property
     // of a `joinByOne` field, or the `label` property of anything.
 
-    self.validate = function (schema, options) {
+    self.validate = function(schema, options) {
       // Infinite recursion prevention
-      var unarranged = [];
-      _.each(schema, function (field) {
+      const unarranged = [];
+      _.each(schema, function(field) {
         const key = `${options.type}:${options.subtype}.${field.name}`;
 
         if (!self.validatedSchemas[key]) {
@@ -2690,7 +2690,7 @@ module.exports = {
       }
     };
 
-    self.validateField = function (field, options, schema, unarranged) {
+    self.validateField = function(field, options, schema, unarranged) {
       var fieldType = self.fieldTypes[field.type];
       if (!fieldType) {
         fail('Unknown schema field type.');
@@ -2717,7 +2717,7 @@ module.exports = {
         (field.name !== 'withTags') &&
         (!field.type.match(/Reverse$/)) &&
         (field.group.name === 'default') &&
-        (_.find(schema, function (field) {
+        (_.find(schema, function(field) {
           return (field.group) && (field.group.name !== 'default');
         }))) {
         unarranged.push(field);


### PR DESCRIPTION
[SUP-155](https://apostrophecms.atlassian.net/browse/SUP-155)

## Purpose
When opening a modal, some 500 errors was popping about some `joinByOne` fields that are required, even if these fields are hidden. This behavior has been fixed in the PR.

## How to test
Create a simple widgets that have a `joinByOne` field that can be hidden by a select field with a `showFields` property. If the `joinByOne` field is hidden, even if it's empty, it should never throw a 500 error.