### PR TITLE
Fixes field group merging label loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Piece types with relationships to multiple other piece types may now be configured in any order, relative to the other piece types. This sometimes appeared to be a bug in reverse relationships.
 * Code at the project level now overrides code found in modules that use `improve` for the same module name. For example, options set by the `@apostrophecms/seo-global` improvement that ships with `@apostrophecms/seo` can now be overridden at project level by `/modules/@apostrophecms/global/index.js` in the way one would expect.
 * Array input component edit button label is now propertly localized.
+* Fixes field group cascade merging, using the original group label if none is given in the new field group configuration.
 
 ### Changes
 

--- a/lib/moog.js
+++ b/lib/moog.js
@@ -211,6 +211,7 @@ module.exports = function(options) {
             for (const [ key, value ] of Object.entries(properties.group)) {
               if (groups[key] && Array.isArray(groups[key].fields)) {
                 value.fields = groups[key].fields.concat(value.fields);
+                value.label = value.label || groups[key].label;
               }
             }
 


### PR DESCRIPTION
In the previous release we supported field group cascading, but you'd lose the label if you didn't add it again in the latter module configurations. This maintains the original label if no new one is given.