### PR TITLE
Pass className option to rich text widget editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 ### Changes
 
-In 3.x, `relationship` fields have an optional `builders` property, which replaces `filters` from 2.x, and within that an optional `project` property, which replaces `projection` from 2.x (to match MongoDB's `cursor.project`). Prior to this release leaving the old syntax in place could lead to severe performance problems due to a lack of projections. Starting with this release the 2.x syntax results in an error at startup to help the developer correct their code.
+* In 3.x, `relationship` fields have an optional `builders` property, which replaces `filters` from 2.x, and within that an optional `project` property, which replaces `projection` from 2.x (to match MongoDB's `cursor.project`). Prior to this release leaving the old syntax in place could lead to severe performance problems due to a lack of projections. Starting with this release the 2.x syntax results in an error at startup to help the developer correct their code.
+* The `className` option from the widget options in a rich text area field is now also applied to the rich text editor itself.
 
 ## 3.6.0 - 2021-10-13
 

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -26,7 +26,7 @@
       </AposContextMenuDialog>
     </bubble-menu>
     <div class="apos-rich-text-editor__editor" :class="editorModifiers">
-      <editor-content :editor="editor" :class="moduleOptions.className" />
+      <editor-content :editor="editor" :class="editorOptions.className" />
     </div>
     <div class="apos-rich-text-editor__editor_after" :class="editorModifiers">
       {{ $t('apostrophe:emptyRichTextWidget') }}
@@ -101,6 +101,9 @@ export default {
         ? activeOptions.toolbar : this.defaultOptions.toolbar;
 
       activeOptions.styles = this.enhanceStyles(activeOptions.styles || this.defaultOptions.styles);
+
+      activeOptions.className = (activeOptions.className !== undefined)
+        ? activeOptions.className : this.moduleOptions.className;
 
       return activeOptions;
     },


### PR DESCRIPTION
Hi 👋 

First off: thanks a million for your work and efforts on this project - you're doing an awesome job 💚 

### Problem 🧱

We are currently using v3 of Apostrophe CMS in one of our projects (really neat so far 💯), making use of several custom widgets containing rich text area fields. On our rich text areas, we use the `className` option to style the outer HTML element as described [in the docs](https://v3.docs.apostrophecms.org/guide/core-widgets.html#setting-a-css-class-on-core-widgets). This works perfectly fine for the "presentation" mode of the content 👍.

However, in the "edit" mode, those classes specified via the area options are not applied to the `div` element that wraps the rich text editor. Instead the editor has _"only"_ the classes configured via the `className` option on the module level (the "global" setting so to say). This is quite irritating for our editors: the rich text areas look completely different while editing, compared to what users of the page see later...

The docs state:

> There are two options to set classes on core widgets. You can add a className option to either the widget module or the widget options in an area field. […] If both are set, the className property on the area configuration will be used.

Reading ☝️ it felt a bit inconsistent to ignore this order in edit mode.

### Changes ✨

This PR updates the rich text widget editor to also take into account that a `className` option may appear on both, the module as well as the widget level. Similar to how the rich text area is rendered on the public page, the setting on the widget level takes precedence. Similar as before, the classes set via the `className` option are set on the outer `div` element wrapping the editor content.

### Checklist ✔

- [x] Link to the related issue with requirements and/or clearly describe 1) what problem this solves and 2) the requirements to review it against.
- [x] Update the `CHANGELOG.md` file with the added feature or fix. If there is not yet a heading for an upcoming release, add one following the established pattern.
- [x] Keep the pull request minimal! Break large updates into separate pull requests for individual features/fixes whenever possible. Small requests get reviewed more quickly.
- [x] All tests must pass, including the linters. Run `npm run lint` to test code linting independently.

Does that work for you? I'm happy to adjust this PR in any way you want - just tell me what you need 💚 

_(Having the `className` option apply in edit mode would make life a lot easier on our side 🧘)_

Cheers 👋 