### PR TITLE
PRO-1671 PRO-2178 PRO-2179

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 * Fixes README Node version requirement (Node 12+).
+* Users can now activate the built-in date and time editing popups of modern browsers when using the `date` and `time` schema field types.
 
 ### Changes
 

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
@@ -73,10 +73,6 @@ export default {
     icon () {
       if (this.error) {
         return 'circle-medium-icon';
-      } else if (this.field.type === 'date') {
-        return 'calendar-icon';
-      } else if (this.field.type === 'time') {
-        return 'clock-icon';
       } else if (this.field.icon) {
         return this.field.icon;
       } else {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputString.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputString.vue
@@ -71,10 +71,6 @@ export default {
     icon () {
       if (this.error) {
         return 'circle-medium-icon';
-      } else if (this.field.type === 'date') {
-        return 'calendar-icon';
-      } else if (this.field.type === 'time') {
-        return 'clock-icon';
       } else if (this.field.icon) {
         return this.field.icon;
       } else {
@@ -207,9 +203,6 @@ export default {
     // height of date/time input is slightly larger than others due to the browser spinner ui
     height: 46px;
     padding-right: 40px;
-    &::-webkit-calendar-picker-indicator {
-      background: none;
-    }
   }
   .apos-input--date {
     &::-webkit-clear-button {


### PR DESCRIPTION
To see that all three issues are fixed, you'll have to npm link my branch of launder, unless that merges by the time you read this.

Per discussion I did not attempt to editorialize on how exactly the browers display their date and time control icons. I just got us out of the way so they can be clicked on.