### PR TITLE
Fixes notification interpolate l10n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Future Unreleased
+
+### Fixes
+
+* Properly localizes notification message "interpolate" object values.
+
 ## Unreleased
 
 ### Adds

--- a/modules/@apostrophecms/notification/ui/apos/components/AposNotification.vue
+++ b/modules/@apostrophecms/notification/ui/apos/components/AposNotification.vue
@@ -109,8 +109,17 @@ export default {
     },
     localize(s) {
       let result;
+      let interpolate = this.notification.interpolate;
+
+      if (interpolate && Object.keys(interpolate)[0]) {
+        interpolate = Object.fromEntries(Object.entries(interpolate)
+          .map(([ key, value ]) => {
+            return [ key, this.$t(value) ];
+          }));
+      }
+
       if (this.notification.localize !== false) {
-        result = this.$t(s, this.notification.interpolate || {});
+        result = this.$t(s, interpolate || {});
       } else {
         // Any interpolation was done before insertion
         result = s;


### PR DESCRIPTION
Values in the interpolate object are not currently being localized. This handles localizing those values.