### PR TITLE
Fix rendering of field help html

### DIFF
--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputWrapper.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputWrapper.vue
@@ -36,7 +36,7 @@
         <p
           v-if="(field.help || field.htmlHelp) && !displayOptions.helpTooltip"
           class="apos-field__help"
-          v-html="$t(field.help || field.htmlHelp)"
+          v-html="$t(field.help) || field.htmlHelp"
         />
         <slot name="additional" />
       </div>


### PR DESCRIPTION
You can see in the diff that we are using html strings as translation keys. But unfortunately it looks like we can't feasibly use html strings as translation keys since html often contains colons (`:`), and i18next treats colons in translation keys as a "namespace separator" ("char to split namespace from key"). [See nsSeparator in docs.](https://www.i18next.com/overview/configuration-options#:~:text=this%20to%20false.-,nsSeparator,-%27%3A%27)

![image](https://user-images.githubusercontent.com/3198597/139218701-8e514009-bd98-452c-a9e3-9c244e63a323.png)

Beyond `field.htmlHelp`, we will also have problems if `field.help` contains a colon.

TODO:
- [ ] Add entry to changelog