### PR TITLE
Set width and height from image data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * The `className` option from the widget options in a rich text area field is now also applied to the rich text editor itself, for a consistently WYSIWYG appearance when editing and when viewing. Thanks to [Max Mulatz](https://github.com/klappradla) for this contribution.
 * Adds deprecation notes to doc module `afterLoad` events, which are deprecated.
 * Removes unused `afterLogin` method in the login module.
-* Add width & height attribute to Image widget for better loading performance
+* Optionally add `dimensionAttrs` option to image widget, which sets width & height attributes to optimize for Cumulative Layout Shift.
 
 ## 3.6.0 - 2021-10-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * The `className` option from the widget options in a rich text area field is now also applied to the rich text editor itself, for a consistently WYSIWYG appearance when editing and when viewing. Thanks to [Max Mulatz](https://github.com/klappradla) for this contribution.
 * Adds deprecation notes to doc module `afterLoad` events, which are deprecated.
 * Removes unused `afterLogin` method in the login module.
+* Add width & height attribute to Image widget for better loading performance
 
 ## 3.6.0 - 2021-10-13
 

--- a/modules/@apostrophecms/image-widget/index.js
+++ b/modules/@apostrophecms/image-widget/index.js
@@ -3,7 +3,8 @@ module.exports = {
   options: {
     label: 'apostrophe:image',
     className: false,
-    icon: 'image-icon'
+    icon: 'image-icon',
+    setWidthAndHeightAttributes: false
   },
   fields: {
     add: {

--- a/modules/@apostrophecms/image-widget/index.js
+++ b/modules/@apostrophecms/image-widget/index.js
@@ -4,7 +4,7 @@ module.exports = {
     label: 'apostrophe:image',
     className: false,
     icon: 'image-icon',
-    setWidthAndHeightAttributes: false
+    dimensionAttrs: false
   },
   fields: {
     add: {

--- a/modules/@apostrophecms/image-widget/views/widget.html
+++ b/modules/@apostrophecms/image-widget/views/widget.html
@@ -4,6 +4,12 @@
   {% set className = data.manager.options.className %}
 {% endif %}
 
+{% if data.options.dimensionAttrs %}
+  {% set dimensionAttrs = data.options.dimensionAttrs %}
+{% elif data.manager.options.dimensionAttrs  %}
+  {% set dimensionAttrs = data.manager.options.dimensionAttrs  %}
+{% endif %}
+
 {% set attachment = apos.image.first(data.widget._image) %}
 
 {% if attachment %}
@@ -11,10 +17,10 @@
     srcset="{{ apos.image.srcset(attachment) }}"
     src="{{ apos.attachment.url(attachment, { size: data.options.size or 'full' }) }}"
     alt="{{ attachment._alt or '' }}"
-    {% if data.options.dimensionAttrs %}
+    {% if dimensionAttrs %}
       {% if attachment.width %} width="{{ attachment.width }}" {% endif %}
       {% if attachment.height %} height="{{ attachment.height }}" {% endif %}
-    % endif %}
+    {% endif %}
     {% if data.contextOptions and data.contextOptions.sizes %}
       sizes="{{ data.contextOptions.sizes }}"
     {% endif %}

--- a/modules/@apostrophecms/image-widget/views/widget.html
+++ b/modules/@apostrophecms/image-widget/views/widget.html
@@ -11,7 +11,7 @@
     srcset="{{ apos.image.srcset(attachment) }}"
     src="{{ apos.attachment.url(attachment, { size: data.options.size or 'full' }) }}"
     alt="{{ attachment._alt or '' }}"
-    {% if data.options.setWidthAndHeightAttributes %}
+    {% if data.options.dimensionAttrs %}
       {% if attachment.width %} width="{{ attachment.width }}" {% endif %}
       {% if attachment.height %} height="{{ attachment.height }}" {% endif %}
     % endif %}

--- a/modules/@apostrophecms/image-widget/views/widget.html
+++ b/modules/@apostrophecms/image-widget/views/widget.html
@@ -11,8 +11,8 @@
     srcset="{{ apos.image.srcset(attachment) }}"
     src="{{ apos.attachment.url(attachment, { size: data.options.size or 'full' }) }}"
     alt="{{ attachment._alt or '' }}"
-    width="{{ attachment.width }}"
-    height="{{ attachment.height }}"
+    {% if attachment.width %} width="{{ attachment.width }}" {% endif %}
+    {% if attachment.height %} height="{{ attachment.height }}" {% endif %}
     {% if data.contextOptions and data.contextOptions.sizes %}
       sizes="{{ data.contextOptions.sizes }}"
     {% endif %}

--- a/modules/@apostrophecms/image-widget/views/widget.html
+++ b/modules/@apostrophecms/image-widget/views/widget.html
@@ -11,8 +11,10 @@
     srcset="{{ apos.image.srcset(attachment) }}"
     src="{{ apos.attachment.url(attachment, { size: data.options.size or 'full' }) }}"
     alt="{{ attachment._alt or '' }}"
-    {% if attachment.width %} width="{{ attachment.width }}" {% endif %}
-    {% if attachment.height %} height="{{ attachment.height }}" {% endif %}
+    {% if data.options.setWidthAndHeightAttributes %}
+      {% if attachment.width %} width="{{ attachment.width }}" {% endif %}
+      {% if attachment.height %} height="{{ attachment.height }}" {% endif %}
+    % endif %}
     {% if data.contextOptions and data.contextOptions.sizes %}
       sizes="{{ data.contextOptions.sizes }}"
     {% endif %}

--- a/modules/@apostrophecms/image-widget/views/widget.html
+++ b/modules/@apostrophecms/image-widget/views/widget.html
@@ -11,6 +11,8 @@
     srcset="{{ apos.image.srcset(attachment) }}"
     src="{{ apos.attachment.url(attachment, { size: data.options.size or 'full' }) }}"
     alt="{{ attachment._alt or '' }}"
+    width="{{ attachment.width }}"
+    height="{{ attachment.height }}"
     {% if data.contextOptions and data.contextOptions.sizes %}
       sizes="{{ data.contextOptions.sizes }}"
     {% endif %}

--- a/modules/@apostrophecms/image-widget/views/widget.html
+++ b/modules/@apostrophecms/image-widget/views/widget.html
@@ -13,7 +13,7 @@
 {% set attachment = apos.image.first(data.widget._image) %}
 
 {% if attachment %}
-  <img{% if className %} class="{{ className }}"{% endif %}
+  <img {% if className %} class="{{ className }}"{% endif %}
     srcset="{{ apos.image.srcset(attachment) }}"
     src="{{ apos.attachment.url(attachment, { size: data.options.size or 'full' }) }}"
     alt="{{ attachment._alt or '' }}"


### PR DESCRIPTION
Hi, 

When running analysis on the bundle performance with Lighthouse, we found one of the poor metrics was not setting width & height attributes on images which resulted in long blocking time. 

<img width="982" alt="Screen Shot 2021-11-03 at 2 48 51 PM" src="https://user-images.githubusercontent.com/10966917/140072194-41ec12fd-bce6-4637-90ca-40296259e7e1.png">

See [lighthouse guide on dimensions](https://web.dev/optimize-cls/?utm_source=lighthouse&utm_medium=devtools#images-without-dimensions)

Therefore it would be great if we can set the width and height attributes on the image widget from the attachment data which we already have from the images. 
