### PR TITLE
Fixes bug preventing nested batch operations from running

### DIFF
--- a/modules/@apostrophecms/modal/ui/apos/components/AposDocsManagerToolbar.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposDocsManagerToolbar.vue
@@ -39,7 +39,7 @@
           }"
           :disabled="!checkedCount"
           :menu="operations"
-          @item-clicked="beginOperation"
+          @item-clicked="(a) => beginGroupedOperation(a, operations)"
         />
       </div>
     </template>
@@ -213,18 +213,10 @@ export default {
     registerPageChange(pageNum) {
       this.$emit('page-change', pageNum);
     },
-    async beginOperation(action) {
-      let op = this.batchOperations.find(o => o.action === action);
+    async beginGroupedOperation(action, operations) {
+      const operation = operations.find(o => o.action === action);
 
-      if (!op) {
-        this.batchOperations.forEach(group => {
-          if (!op && group.operations) {
-            op = group.operations.find(o => o.action === action);
-          }
-        });
-      }
-
-      await this.confirmOperation(op);
+      await this.confirmOperation(operation);
     },
     async confirmOperation ({
       modalOptions = {}, action, operations, label, ...rest

--- a/modules/@apostrophecms/modal/ui/apos/components/AposDocsManagerToolbar.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposDocsManagerToolbar.vue
@@ -27,7 +27,7 @@
           :icon="icon"
           :disabled="!checkedCount"
           type="outline"
-          @click="operationModal({ action, label, ...rest })"
+          @click="confirmOperation({ action, label, ...rest })"
         />
         <AposContextMenu
           v-else
@@ -39,7 +39,7 @@
           }"
           :disabled="!checkedCount"
           :menu="operations"
-          @item-clicked="(action) => operationModal({ action, operations, label, ...rest })"
+          @item-clicked="beginOperation"
         />
       </div>
     </template>
@@ -125,9 +125,7 @@ export default {
     'filter',
     'search',
     'page-change',
-    'batch',
-    // TEMP
-    'start-job'
+    'batch'
   ],
   data() {
     return {
@@ -215,7 +213,20 @@ export default {
     registerPageChange(pageNum) {
       this.$emit('page-change', pageNum);
     },
-    async operationModal ({
+    async beginOperation(action) {
+      let op = this.batchOperations.find(o => o.action === action);
+
+      if (!op) {
+        this.batchOperations.forEach(group => {
+          if (!op && group.operations) {
+            op = group.operations.find(o => o.action === action);
+          }
+        });
+      }
+
+      await this.confirmOperation(op);
+    },
+    async confirmOperation ({
       modalOptions = {}, action, operations, label, ...rest
     }) {
       const {


### PR DESCRIPTION
In the case of grouped/nested batch operations, the properties on line 42 were mostly from the _group_, not the individual action. We need to find the action within the group. No changelog since this fixes an unreleased feature.

----------------
Please ensure your pull request follows these guidelines:

- [x] Link to the related issue with requirements and/or clearly describe 1) what problem this solves and 2) the requirements to review it against.
- [ ] Update the `CHANGELOG.md` file with the added feature or fix. If there is not yet a heading for an upcoming release, add one following the established pattern.
- [x] Keep the pull request minimal! Break large updates into separate pull requests for individual features/fixes whenever possible. Small requests get reviewed more quickly.
- [ ] All tests must pass, including the linters. Run `npm run lint` to test code linting independently.

Thanks for contributing!