### PR TITLE
Fixes the batch operation button labels

### DIFF
--- a/modules/@apostrophecms/modal/ui/apos/components/AposDocsManagerToolbar.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposDocsManagerToolbar.vue
@@ -22,7 +22,7 @@
       >
         <AposButton
           v-if="!operations"
-          label="label"
+          :label="label"
           :icon-only="true"
           :icon="icon"
           :disabled="!checkedCount"


### PR DESCRIPTION
This label prop was using the actual string "label" since it wasn't using v-bind/`:`