### PR TITLE
Fix convert method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 * The `apos.util.attachmentUrl` method now works correctly. To facilitate that, `apos.uploadsUrl` is now populated browser-side at all times as the frontend logic originally expected. For backwards compatibility `apos.attachment.uploadsUrl` is still populated when logged in.
 * Widget players are now prevented from being played twice by the implementing vue component.
-* `fieldsPresent` method in doc-type was broken, looking for properties in strings and wasn't returning anything.
+* The`fieldsPresent` method that is sued with the `presentFieldsOnly` option in doc-type was broken, looking for properties in strings and wasn't returning anything.
 
 ### Changes
 * Removes Apostrophe 2 documentation and UI configuration from the `@apostrophecms/job` module. These options were not yet in use for A3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * The search field of the pieces manager modal works properly. Thanks to [Miro Yovchev](https://github.com/myovchev) for pointing out the issue and providing a solution.
+* The`fieldsPresent` method that is used with the `presentFieldsOnly` option in doc-type was broken, looking for properties in strings and wasn't returning anything.
 
 ## 3.8.0 - 2021-11-15
 
@@ -27,7 +28,6 @@
 
 * The `apos.util.attachmentUrl` method now works correctly. To facilitate that, `apos.uploadsUrl` is now populated browser-side at all times as the frontend logic originally expected. For backwards compatibility `apos.attachment.uploadsUrl` is still populated when logged in.
 * Widget players are now prevented from being played twice by the implementing vue component.
-* The`fieldsPresent` method that is sued with the `presentFieldsOnly` option in doc-type was broken, looking for properties in strings and wasn't returning anything.
 
 ### Changes
 * Removes Apostrophe 2 documentation and UI configuration from the `@apostrophecms/job` module. These options were not yet in use for A3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 * The `apos.util.attachmentUrl` method now works correctly. To facilitate that, `apos.uploadsUrl` is now populated browser-side at all times as the frontend logic originally expected. For backwards compatibility `apos.attachment.uploadsUrl` is still populated when logged in.
 * Widget players are now prevented from being played twice by the implementing vue component.
+* `fieldsPresent` method in doc-type was broken, looking for properties in strings and wasn't returning anything.
 
 ### Changes
 * Removes Apostrophe 2 documentation and UI configuration from the `@apostrophecms/job` module. These options were not yet in use for A3.

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -554,17 +554,9 @@ module.exports = {
       // taking into account issues like relationship fields keeping their data in
       // a separate ids property, etc.
       fieldsPresent(input) {
-        const schema = self.schema;
-        const output = [];
-        for (const field of schema) {
-          if (field.type.name.substring(0, 5) === '_relationship') {
-            if (_.has(input, field.idsStorage)) {
-              output.push(field.name);
-            }
-          } else {
-            output.push(field.name);
-          }
-        }
+        return self.schema
+          .filter((field) => input[field.name])
+          .map((field) => field.name);
       },
       // Returns a query that finds docs the current user can edit. Unlike
       // find(), this query defaults to including docs in the archive. Subclasses

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -545,8 +545,11 @@ module.exports = {
 
         await self.apos.schema.convert(req, schema, input, doc);
 
-        doc.copyOfId = copyOf && copyOf._id;
         if (copyOf) {
+          if (copyOf._id) {
+            doc.copyOfId = copyOf._id;
+          }
+
           self.apos.schema.regenerateIds(req, fullSchema, doc);
         }
       },

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -555,7 +555,7 @@ module.exports = {
       // a separate ids property, etc.
       fieldsPresent(input) {
         return self.schema
-          .filter((field) => input[field.name])
+          .filter((field) => _.has(input, field.name))
           .map((field) => field.name);
       },
       // Returns a query that finds docs the current user can edit. Unlike

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -1263,4 +1263,19 @@ describe('Pieces', function() {
     assert(fs.readFileSync(path.join(__dirname, 'public', resume.attachment._url), 'utf8') === fs.readFileSync(path.join(__dirname, '/public/static-test.txt'), 'utf8'));
   });
 
+  it('should convert piece keeping only the present fields', async () => {
+    const req = apos.task.getReq();
+
+    const productPiece = {
+      title: 'produce name',
+      color: 'red'
+    };
+
+    const converted = {};
+    await apos.modules.product.convert(req, productPiece, converted, { presentFieldsOnly: true });
+
+    assert(Object.keys(converted).length === 3);
+    assert(converted.title === 'product name');
+    assert(converted.color === 'red');
+  });
 });

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -1266,16 +1266,18 @@ describe('Pieces', function() {
   it('should convert a piece keeping only the present fields', async () => {
     const req = apos.task.getReq();
 
-    const productPiece = {
-      title: 'produce name',
+    const inputPiece = {
+      title: 'new product name'
+    };
+
+    const existingPiece = {
       color: 'red'
     };
 
-    const converted = {};
-    await apos.modules.product.convert(req, productPiece, converted, { presentFieldsOnly: true });
+    await apos.modules.product.convert(req, inputPiece, existingPiece, { presentFieldsOnly: true });
 
-    assert(Object.keys(converted).length === 3);
-    assert(converted.title === 'product name');
-    assert(converted.color === 'red');
+    assert(Object.keys(existingPiece).length === 2);
+    assert(existingPiece.title === 'new product name');
+    assert(existingPiece.color === 'red');
   });
 });

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -1263,7 +1263,7 @@ describe('Pieces', function() {
     assert(fs.readFileSync(path.join(__dirname, 'public', resume.attachment._url), 'utf8') === fs.readFileSync(path.join(__dirname, '/public/static-test.txt'), 'utf8'));
   });
 
-  it('should convert piece keeping only the present fields', async () => {
+  it('should convert a piece keeping only the present fields', async () => {
     const req = apos.task.getReq();
 
     const productPiece = {


### PR DESCRIPTION
[PRO-2339](https://linear.app/apostrophecms/issue/PRO-2339/fixes-the-presentfieldsonly-option-of-the-convert-method)

## Purpose
`fieldsPresent` method in doc-type was broken, looking for properties in strings and wasn't returning anything.

## How to test
Check that when calling the method `self.convert` with the option `presentFieldsOnly` set to true you're getting the right properties.