### PR TITLE
Ensures a style for empty rich text widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * The search field of the pieces manager modal works properly. Thanks to [Miro Yovchev](https://github.com/myovchev) for pointing out the issue and providing a solution.
+* Fixes a bug in `AposRichTextWidgetEditor.vue` when a rich text widget was specifically configured with an empty array as the `styles` option. In that case a new empty rich text widget will initiate with an empty paragraph tag.
 
 ## 3.8.0 - 2021-11-15
 

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -100,7 +100,9 @@ export default {
       activeOptions.toolbar = (activeOptions.toolbar !== undefined)
         ? activeOptions.toolbar : this.defaultOptions.toolbar;
 
-      activeOptions.styles = this.enhanceStyles(activeOptions.styles || this.defaultOptions.styles);
+      activeOptions.styles = this.enhanceStyles(
+        (activeOptions.styles.length && activeOptions.styles) ||
+        this.defaultOptions.styles);
 
       activeOptions.className = (activeOptions.className !== undefined)
         ? activeOptions.className : this.moduleOptions.className;
@@ -118,6 +120,7 @@ export default {
         // the text align control will not work until the user manually
         // applies a style or refreshes the page
         const defaultStyle = this.editorOptions.styles.find(style => style.def);
+
         const _class = defaultStyle.class ? ` class="${defaultStyle.class}"` : '';
         return `<${defaultStyle.tag}${_class}></${defaultStyle.tag}>`;
       } else {


### PR DESCRIPTION
@myovchev reported a bug where the component would crash the UI when a rich text widget was configured with an empty styles array: 

```
  {
    className: 'smr-widget smr-widget--rich-text',
    toolbar: [
      'bold',
      'italic',
      'strike',
      'link'
    ],
    styles: []
  }
```

In this case the RTE widget component will treat this as if there was no `styles` configuration. The particular configuration pattern is no longer necessary since the toolbar does not have a `styles` button included. No styles will display. This may not have been the case in early versions of Apostrophe.

Please ensure your pull request follows these guidelines:

- [x] Link to the related issue with requirements and/or clearly describe 1) what problem this solves and 2) the requirements to review it against.
- [x] Update the `CHANGELOG.md` file with the added feature or fix. If there is not yet a heading for an upcoming release, add one following the established pattern.
- [x] Keep the pull request minimal! Break large updates into separate pull requests for individual features/fixes whenever possible. Small requests get reviewed more quickly.
- [x] All tests must pass, including the linters. Run `npm run lint` to test code linting independently.

Thanks for contributing!