### PR TITLE
Removes the partial method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* Fully removes references to the A2 `self.partial` module method. It appeared only once outside of comments, but was not actual used by the UI. The `self.render` method should be used for simple template rendering.
+
 ## 3.8.1 - 2021-11-23
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* Fully removes references to the A2 `self.partial` module method. It appeared only once outside of comments, but was not actual used by the UI. The `self.render` method should be used for simple template rendering.
+* Fully removes references to the A2 `self.partial` module method. It appeared only once outside of comments, but was not actually used by the UI. The `self.render` method should be used for simple template rendering.
 
 ## 3.8.1 - 2021-11-23
 

--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -230,7 +230,6 @@ module.exports = {
       addFieldType() {
         self.apos.schema.addFieldType({
           name: self.name,
-          partial: self.fieldTypePartial,
           convert: self.convert,
           index: self.index,
           register: self.register
@@ -273,9 +272,6 @@ module.exports = {
         info.used = true;
         await self.db.replaceOne({ _id: info._id }, info);
         object[field.name] = info;
-      },
-      fieldTypePartial(data) {
-        return self.partial('attachment', data);
       },
       index(value, field, texts) {
         const silent = field.silent === undefined ? true : field.silent;

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -292,10 +292,7 @@ module.exports = {
       // your version wins if it exists.
       //
       // You MUST pass req as the first argument. This allows
-      // internationalization/localization to work. If you
-      // are writing a Nunjucks helper function, use
-      // self.partial instead. This method is primarily used
-      // to implement routes that respond with HTML fragments.
+      // internationalization/localization to work.
       //
       // All properties of `data` appear in Nunjucks templates as
       // properties of the `data` object. Nunjucks helper functions

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1292,24 +1292,6 @@ module.exports = {
           return field.group && field.group.name === defaultGroup.name;
         }));
 
-        _.each(schema, function (field) {
-
-          // A field can have a custom template, which can be a
-          // template name (relative to the @apostrophecms/schema module)
-          // or a function (called to render it)
-
-          if (field.template) {
-            if (typeof field.template === 'string') {
-              field.partial = self.partialer(field.template);
-              delete field.template;
-            } else {
-              field.partial = field.template;
-              delete field.template;
-            }
-          }
-
-        });
-
         // Shallowly clone the fields. This allows modules
         // like workflow to patch schema fields of various modules
         // without inadvertently impacting other apos instances

--- a/modules/@apostrophecms/template/index.js
+++ b/modules/@apostrophecms/template/index.js
@@ -1,5 +1,5 @@
 // Implements template rendering via Nunjucks. **You should use the
-// `self.render` and `self.partial` methods of *your own* module**,
+// `self.render` method of *your own* module**,
 // which exist courtesy of [@apostrophecms/module](../@apostrophecms/module/index.html)
 // and invoke methods of this module more conveniently for you.
 //
@@ -21,7 +21,7 @@
 // you have a custom version of Nunjucks that is compatible.
 //
 // ### `viewsFolderFallback`: specifies a folder to be checked for templates
-// if they are not found in the module that called `self.render` or `self.partial`
+// if they are not found in the module that called `self.render`
 // or those it extends. This is a handy place for project-wide macro files.
 // Often set to `__dirname + '/views'` in `app.js`.
 
@@ -203,7 +203,7 @@ module.exports = {
 
       async renderForModule(req, name, data, module) {
         if (typeof req !== 'object') {
-          throw new Error('The first argument to module.render must be req. If you are trying to implement a Nunjucks helper function, use module.partial.');
+          throw new Error('The first argument to module.render must be req.');
         }
         return self.renderBody(req, 'file', name, data, module);
       },
@@ -214,7 +214,7 @@ module.exports = {
 
       async renderStringForModule(req, s, data, module) {
         if (typeof req !== 'object') {
-          throw new Error('The first argument to module.render must be req. If you are trying to implement a Nunjucks helper function, use module.partial.');
+          throw new Error('The first argument to module.render must be req.');
         }
         return self.renderBody(req, 'string', s, data, module);
       },
@@ -289,12 +289,6 @@ module.exports = {
 
         args.data = merged;
 
-        // // Allows templates to render other templates in an independent
-        // // nunjucks environment, rather than including them
-        // args.partial = function(name, data) {
-        //   return self.partialForModule(name, data, module);
-        // };
-
         if (req.data) {
           _.defaults(merged, req.data);
         }
@@ -334,7 +328,7 @@ module.exports = {
 
       // Fetch a nunjucks environment in which `include`, `extends`, etc. search
       // the views directories of the specified module and its ancestors.
-      // Typically you will call `self.render` or `self.partial` on your module
+      // Typically you will call `self.render` on your module
       // object rather than calling this directly.
       //
       // `req` is effectively here for bc purposes only. This method


### PR DESCRIPTION
This removes the deprecated A2 method `self.partial`. It was undocumented and effectively unused in A3. The only appearance in code was not actually used by the application.

Please ensure your pull request follows these guidelines:

- [x] Link to the related issue with requirements and/or clearly describe 1) what problem this solves and 2) the requirements to review it against.
- [x] Update the `CHANGELOG.md` file with the added feature or fix. If there is not yet a heading for an upcoming release, add one following the established pattern.
- [x] Keep the pull request minimal! Break large updates into separate pull requests for individual features/fixes whenever possible. Small requests get reviewed more quickly.
- [x] All tests must pass, including the linters. Run `npm run lint` to test code linting independently.

Thanks for contributing!