### PR TITLE
PRO-2357 fix "cannot set headers"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 * Fully removes references to the A2 `self.partial` module method. It appeared only once outside of comments, but was not actually used by the UI. The `self.render` method should be used for simple template rendering.
-* No more "cannot set headers after they are sent" messages when handling URLs with extra trailing slashes.
+* No more "cannot set headers after they are sent to the client" and "req.res.redirect not defined" messages when handling URLs with extra trailing slashes.
 
 ## 3.8.1 - 2021-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * Fully removes references to the A2 `self.partial` module method. It appeared only once outside of comments, but was not actually used by the UI. The `self.render` method should be used for simple template rendering.
+* No more "cannot set headers after they are sent" messages when handling URLs with extra trailing slashes.
 
 ## 3.8.1 - 2021-11-23
 

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -1365,7 +1365,6 @@ database.`);
       // Route that serves pages. See afterInit in
       // index.js for the wildcard argument and the app.get call
       async serve(req, res) {
-        const superEnd = req.res.end;
         req.deferWidgetLoading = true;
         try {
           await self.serveGetPage(req);

--- a/modules/@apostrophecms/task/index.js
+++ b/modules/@apostrophecms/task/index.js
@@ -172,11 +172,6 @@ module.exports = {
       // and unit tests. The `req` object returned is a mockup of a true Express
       // `req` object.
       //
-      // The `req.res` property is similarly a mockup of a true Express `res` object
-      // with some basic support for operations such as `res.redirect`, which results
-      // in setting the `req.res.redirectedTo` property, and reading the status code
-      // that would have been sent, which is available as `req.res.statusCode`.
-      //
       // An `options` object may be passed. If `options.role` is set,
       // it may be `anon` (no role and no req.user), `guest`, `contributor`,
       // `editor`, or `admin`. For bc reasons, it defaults to `admin`.
@@ -196,43 +191,9 @@ module.exports = {
             }
           }),
           res: {
-            statusCode: 200,
-            headers: {},
-            endHandlers: [],
-            status(code) {
-              req.res.statusCode = code;
-              return req.res;
-            },
-            on(name, fn) {
-              if (name !== 'end') {
-                throw new Error(`Unsupported event name in task req: ${name}`);
-              }
-              req.res.endHandlers.push(fn);
-            },
-            end() {
-              req.res.emit('end');
-              for (const fn of req.res.endHandlers) {
-                fn();
-              }
-              req.res.endHandlers = [];
-            },
-            send(data) {
-              req.res.send();
-            },
             redirect(url) {
               req.res.redirectedTo = url;
-              req.res.end();
-            },
-            set(name, value) {
-              req.res.headers[name.toLowerCase()] = value;
-            },
-            // Express loves aliases
-            setHeader(name, value) {
-              req.res.set(name, value);
-            },
-            header(name, value) {
-              req.res.set(name, value);
-            },
+            }
           },
           t(key, options = {}) {
             return self.apos.i18n.i18next.t(key, {


### PR DESCRIPTION
No more "cannot set headers after they are sent to the client" and "req.res.redirect not defined" messages when handling URLs with extra trailing slashes.