### PR TITLE
Fixes the server-side and template l10n debugging plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Fully removes references to the A2 `self.partial` module method. It appeared only once outside of comments, but was not actually used by the UI. The `self.render` method should be used for simple template rendering.
 * Fixes string interpolation for the confirmation modal when publishing a page that has an unpublished parent page.
 * No more "cannot set headers after they are sent to the client" and "req.res.redirect not defined" messages when handling URLs with extra trailing slashes.
-* Properly activates the `apostrophei18nDebugPlugin` i18next debugging plugin when using the `APOS_SHOW_I18N` environment variable. The full set of l10n emoji indicators previously available for the UI is now available for template and server-side strings.
+* Properly activates the `apostropheI18nDebugPlugin` i18next debugging plugin when using the `APOS_SHOW_I18N` environment variable. The full set of l10n emoji indicators previously available for the UI is now available for template and server-side strings.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fully removes references to the A2 `self.partial` module method. It appeared only once outside of comments, but was not actually used by the UI. The `self.render` method should be used for simple template rendering.
 * Fixes string interpolation for the confirmation modal when publishing a page that has an unpublished parent page.
 * No more "cannot set headers after they are sent to the client" and "req.res.redirect not defined" messages when handling URLs with extra trailing slashes.
+* Properly activates the `apostrophei18nDebugPlugin` i18next debugging plugin when using the `APOS_SHOW_I18N` environment variable. The full set of l10n emoji indicators previously available for the UI is now available for template and server-side strings.
 
 ### Changes
 

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -13,7 +13,7 @@ const ExpressSessionCookie = require('express-session/session/cookie');
 
 const apostropheI18nDebugPlugin = {
   type: 'postProcessor',
-  name: 'apostrophei18nDebugPlugin',
+  name: 'apostropheI18nDebugPlugin',
   process(value, key, options, translator) {
     // The key is passed as an array (theoretically to include multiple keys).
     // We confirm that and grab the primary one for comparison.
@@ -91,7 +91,7 @@ module.exports = {
     }
 
     const i18nextOptions = self.show ? {
-      postProcess: 'apostrophei18nDebugPlugin'
+      postProcess: 'apostropheI18nDebugPlugin'
     } : {};
 
     await self.i18next.init(i18nextOptions);

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -15,9 +15,25 @@ const apostropheI18nDebugPlugin = {
   type: 'postProcessor',
   name: 'apostrophei18nDebugPlugin',
   process(value, key, options, translator) {
-    // For ease of tracking down which phrases were
-    // actually passed through i18next
-    return `🌍 ${value}`;
+    // The key is passed as an array (theoretically to include multiple keys).
+    // We confirm that and grab the primary one for comparison.
+    const l10nKey = Array.isArray(key) ? key[0] : key;
+
+    if (value === l10nKey) {
+      if (l10nKey.match(/^\S+:/)) {
+        // The l10n key does not have a value assigned (or the key is
+        // actually the same as the phrase). The key seems to have a
+        // namespace, so might be from the Apostrophe UI.
+        return `❌ ${value}`;
+      } else {
+        // The l10n key does not have a value assigned (or the key is
+        // actually the same as the phrase). It is in the default namespace.
+        return `🕳 ${value}`;
+      }
+    } else {
+      // The phrase is fully localized.
+      return `🌍 ${value}`;
+    }
   }
 };
 
@@ -73,7 +89,12 @@ module.exports = {
     if (self.show) {
       self.i18next.use(apostropheI18nDebugPlugin);
     }
-    await self.i18next.init();
+
+    const i18nextOptions = self.show ? {
+      postProcess: 'apostrophei18nDebugPlugin'
+    } : {};
+
+    await self.i18next.init(i18nextOptions);
     self.addInitialResources();
     self.enableBrowserData();
   },


### PR DESCRIPTION
During documentation I noticed the server-side and template l10n strings were not debugged the same as UI strings. The plugin needed to be activated in the init method.

+++++++++++++++

Please ensure your pull request follows these guidelines:

- [x] Link to the related issue with requirements and/or clearly describe 1) what problem this solves and 2) the requirements to review it against.
- [x] Update the `CHANGELOG.md` file with the added feature or fix. If there is not yet a heading for an upcoming release, add one following the established pattern.
- [x] Keep the pull request minimal! Break large updates into separate pull requests for individual features/fixes whenever possible. Small requests get reviewed more quickly.
- [x] All tests must pass, including the linters. Run `npm run lint` to test code linting independently.

Thanks for contributing!