### PR TITLE
Update CI badge URL to point to correct image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Unit Tests](https://github.com/github/docs/actions/workflows/main.yml/badge.svg)
+![Unit Tests](https://github.com/apostrophecms/apostrophe/actions/workflows/main.yml/badge.svg)
 [![Chat on Discord](https://img.shields.io/discord/517772094482677790.svg)](https://chat.apostrophecms.org)
 
 <p align="center">


### PR DESCRIPTION
As documented in [this](https://stackoverflow.com/questions/70269088/how-do-i-produce-a-status-that-can-be-displayed-via-the-badge-from-a-github-acti) Stack Overflow post, the URL for the status badge was incorrect.

This PR updates the URL to match the project.