### PR TITLE
Adds a field option to put a field last in its group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Adds
 
-* Adds a `last` option to fields. Setting `last: true` on a field puts that field at the end of the field's group order (unless more than one field has that option active).
+* Adds a `last` option to fields. Setting `last: true` on a field puts that field at the end of the field's widget order. If more than one field has that option active the true last item will depend on general field registration order. If the field is ordered with the `fields.order` array, that specified order will take precedence.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Adds
+
+* Adds a `last` option to fields. Setting `last: true` on a field puts that field at the end of the field's group order (unless more than one field has that option active).
+
 ## 3.9.0 - 2021-12-08
 
 ### Adds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Adds
 
-* Adds a `last` option to fields. Setting `last: true` on a field puts that field at the end of the field's widget order. If more than one field has that option active the true last item will depend on general field registration order. If the field is ordered with the `fields.order` array, that specified order will take precedence.
+* Adds a `last` option to fields. Setting `last: true` on a field puts that field at the end of the field's widget order. If more than one field has that option active the true last item will depend on general field registration order. If the field is ordered with the `fields.order` array or field group ordering, those specified orders will take precedence.
 
 ### Changes
 

--- a/lib/moog.js
+++ b/lib/moog.js
@@ -179,17 +179,42 @@ module.exports = function(options) {
               ...properties.add
             };
           }
+
+          const lastFields = Object.entries(that[cascade])
+            .filter(([ field, val ]) => val.last === true)
+            .map(([ field, val ]) => field);
+
           if (properties.remove) {
             for (const field of properties.remove) {
               delete that[cascade][field];
             }
           }
           if (properties.order) {
+            // 1. Ordered fields
+            // 2. Other fields not marked as last
+            // 3. Fields marked as last
             that[cascade] = Object.fromEntries([
               ...properties.order.map(field => [ field, that[cascade][field] ]),
-              ...Object.keys(that[cascade]).filter(field => !properties.order.includes[field]).map(field => [ field, that[cascade][field] ])
+              ...Object.keys(that[cascade])
+                .filter(field => {
+                  return !properties.order.includes(field) &&
+                    !lastFields.includes(field);
+                })
+                .map(field => [ field, that[cascade][field] ]),
+              ...lastFields.filter(field => !properties.order.includes(field))
+                .map(field => [ field, that[cascade][field] ])
+            ]);
+          } else if (lastFields.length > 0) {
+            // 1. Fields not marked as last
+            // 2. Fields marked as last
+            that[cascade] = Object.fromEntries([
+              ...Object.keys(that[cascade])
+                .filter(field => !lastFields.includes(field))
+                .map(field => [ field, that[cascade][field] ]),
+              ...lastFields.map(field => [ field, that[cascade][field] ])
             ]);
           }
+
           if (properties.group) {
             const groups = klona(that[`${cascade}Groups`]);
             for (const value of Object.values(properties.group)) {

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1224,18 +1224,6 @@ module.exports = {
         // loop over any groups and orders we want to respect
         _.each(groups, function (group) {
 
-          group.fields.sort((a, b) => {
-            const fieldA = schema.find(f => f.name === a);
-            const fieldB = schema.find(f => f.name === b);
-            if (!fieldA || !fieldB) {
-              return 0;
-            }
-
-            return fieldA.last === true && fieldB.last === true ? 0
-              : !fieldA.last && !fieldB.last ? 0
-                : fieldA.last === true ? 1 : -1;
-          });
-
           _.each(group.fields, function (field) {
             // find the field we are ordering
             let f = _.find(schema, { name: field });

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1217,12 +1217,26 @@ module.exports = {
 
         // all fields in the schema will end up in this variable
         let newSchema = [];
+
         // loop over any groups and orders we want to respect
         _.each(groups, function (group) {
+
+          group.fields.sort((a, b) => {
+            const fieldA = schema.find(f => f.name === a);
+            const fieldB = schema.find(f => f.name === b);
+            if (!fieldA || !fieldB) {
+              return 0;
+            }
+
+            return fieldA.last === true && fieldB.last === true ? 0
+              : !fieldA.last && !fieldB.last ? 0
+                : fieldA.last === true ? 1 : -1;
+          });
 
           _.each(group.fields, function (field) {
             // find the field we are ordering
             let f = _.find(schema, { name: field });
+
             if (!f) {
               // May have already been migrated due to subclasses re-grouping fields
               f = _.find(newSchema, { name: field });
@@ -1242,6 +1256,7 @@ module.exports = {
               if (fIndex !== -1) {
                 newSchema.splice(fIndex, 1);
               }
+
               newSchema.push(f);
 
               // remove the field from the old schema, if that is where we got it from

--- a/test/moog.js
+++ b/test/moog.js
@@ -284,6 +284,54 @@ describe('moog', function() {
       assert(myObject.fieldsGroups.basics.fields.includes('five'));
     });
 
+    it('should order fields with the last option unless the order array overrides', async function() {
+      const moog = require('../lib/moog.js')({});
+
+      moog.define('unorderedObject', {
+        cascades: [ 'fields' ],
+        fields: {
+          add: {
+            first: { type: 'string' },
+            last: {
+              type: 'string',
+              last: true
+            },
+            second: { type: 'string' },
+            third: { type: 'string' }
+          }
+        }
+      });
+
+      moog.define('orderedObject', {
+        cascades: [ 'fields' ],
+        fields: {
+          add: {
+            first: { type: 'string' },
+            last: {
+              type: 'string',
+              last: true
+            },
+            second: { type: 'string' },
+            third: { type: 'string' }
+          },
+          order: [ 'last', 'third', 'second', 'first' ]
+        }
+      });
+      const unordered = await moog.create('unorderedObject', {});
+      assert(unordered);
+      assert(Object.keys(unordered.fields)[0] === 'first');
+      assert(Object.keys(unordered.fields)[1] === 'second');
+      assert(Object.keys(unordered.fields)[2] === 'third');
+      assert(Object.keys(unordered.fields)[3] === 'last');
+
+      const ordered = await moog.create('orderedObject', {});
+      assert(ordered);
+      assert(Object.keys(ordered.fields)[0] === 'last');
+      assert(Object.keys(ordered.fields)[1] === 'third');
+      assert(Object.keys(ordered.fields)[2] === 'second');
+      assert(Object.keys(ordered.fields)[3] === 'first');
+    });
+
     // ==================================================
     // `redefine` AND `isDefined`
     // ==================================================

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -257,9 +257,39 @@ describe('Schemas', function() {
     };
     const schema = apos.schema.compose(options);
     assert(schema.length === 2);
+    // console.info('0️⃣', schema);
     assert(schema[0].name === 'name');
     assert(schema[1].name === 'variety');
     assert(_.keys(schema[1].choices).length === 3);
+  });
+
+  it('should place a "last" field last', () => {
+    const options = {
+      addFields: [
+        {
+          name: 'firstField',
+          type: 'string',
+          label: 'First Field'
+        },
+        {
+          name: 'lastField',
+          type: 'string',
+          label: 'Final Field',
+          last: true
+        },
+        {
+          name: 'secondField',
+          type: 'string',
+          label: 'Second Field'
+        }
+      ]
+    };
+    const schema = apos.schema.compose(options);
+    assert(schema.length === 3);
+    // console.info('1️⃣', schema);
+    assert(schema[0].name === 'firstField');
+    assert(schema[1].name === 'secondField');
+    assert(schema[2].name === 'lastField');
   });
 
   it('should compose a schema for a complex real world case correctly', function() {

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -262,34 +262,6 @@ describe('Schemas', function() {
     assert(_.keys(schema[1].choices).length === 3);
   });
 
-  it('should place a "last" field last', () => {
-    const options = {
-      addFields: [
-        {
-          name: 'firstField',
-          type: 'string',
-          label: 'First Field'
-        },
-        {
-          name: 'lastField',
-          type: 'string',
-          label: 'Final Field',
-          last: true
-        },
-        {
-          name: 'secondField',
-          type: 'string',
-          label: 'Second Field'
-        }
-      ]
-    };
-    const schema = apos.schema.compose(options);
-    assert(schema.length === 3);
-    assert(schema[0].name === 'firstField');
-    assert(schema[1].name === 'secondField');
-    assert(schema[2].name === 'lastField');
-  });
-
   it('should compose a schema for a complex real world case correctly', function() {
     const schema = apos.schema.compose(realWorldCase);
     assert(schema);

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -257,7 +257,6 @@ describe('Schemas', function() {
     };
     const schema = apos.schema.compose(options);
     assert(schema.length === 2);
-    // console.info('0️⃣', schema);
     assert(schema[0].name === 'name');
     assert(schema[1].name === 'variety');
     assert(_.keys(schema[1].choices).length === 3);
@@ -286,7 +285,6 @@ describe('Schemas', function() {
     };
     const schema = apos.schema.compose(options);
     assert(schema.length === 3);
-    // console.info('1️⃣', schema);
     assert(schema[0].name === 'firstField');
     assert(schema[1].name === 'secondField');
     assert(schema[2].name === 'lastField');


### PR DESCRIPTION
We didn't have a way to put fields at the end of a widget's schema UI since we can't put them in their own group. This new field option, `last: true` puts the field at the end of its group (for any schema). This is especially useful for improving modules, which don't know the rest of the schema to do reordering. This also parallels the similar field group option.

-------------------

Please ensure your pull request follows these guidelines:

- [x] Link to the related issue with requirements and/or clearly describe 1) what problem this solves and 2) the requirements to review it against.
- [x] Update the `CHANGELOG.md` file with the added feature or fix. If there is not yet a heading for an upcoming release, add one following the established pattern.
- [x] Keep the pull request minimal! Break large updates into separate pull requests for individual features/fixes whenever possible. Small requests get reviewed more quickly.
- [x] All tests must pass, including the linters. Run `npm run lint` to test code linting independently.

Thanks for contributing!