### PR TITLE
PRO-2370 underline works properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * `slug` type fields can now have an empty string or `null` as their `def` value without the string `'none'` populating automatically.
+* The `underline` feature works properly in tiptap toolbar configuration.
 
 ### Changes
 

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -250,7 +250,8 @@ module.exports = {
           codeBlock: [
             'pre',
             'code'
-          ]
+          ],
+          underline: [ 'u' ]
         };
         for (const item of options.toolbar || []) {
           if (simple[item]) {

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -44,6 +44,7 @@ import StarterKit from '@tiptap/starter-kit';
 import TextAlign from '@tiptap/extension-text-align';
 import Highlight from '@tiptap/extension-highlight';
 import TextStyle from '@tiptap/extension-text-style';
+import Underline from '@tiptap/extension-underline';
 export default {
   name: 'AposRichTextWidgetEditor',
   components: {
@@ -181,7 +182,8 @@ export default {
           types: [ 'heading', 'paragraph' ]
         }),
         Highlight,
-        TextStyle
+        TextStyle,
+        Underline
       ].concat(this.aposTiptapExtensions)
     });
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@tiptap/extension-link": "^2.0.0-beta.17",
     "@tiptap/extension-text-align": "^2.0.0-beta.17",
     "@tiptap/extension-text-style": "^2.0.0-beta.13",
-    "@tiptap/extension-underline": "^2.0.0-beta.14",
+    "@tiptap/extension-underline": "^2.0.0-beta.22",
     "@tiptap/starter-kit": "^2.0.0-beta.75",
     "@tiptap/vue-2": "^2.0.0-beta.34",
     "autoprefixer": "^10.2.4",


### PR DESCRIPTION
Needed to install the appropriate tiptap extension and add the `u` tag to the sanitizeHtml options computation.