### PR TITLE
PRO-2255 Adds the audit step of testing back in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Adds deprecation note to `__testDefaults` option. It is not in use, but removing would be a minor BC break we don't need to make.
 * Allows test modules to use a custom port as an option on the `@apostrophecms/express` module.
 * Removes the code base pull request template to instead inherit the organization-level template.
+* Adds `npm audit` back to the test scripts.
 
 ## 3.10.0 - 2021-12-22
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "pretest": "npm run lint",
     "test": "nyc --reporter=html mocha -t 10000",
+    "posttest": "npm audit",
     "lint": "eslint . && node scripts/lint-i18n"
   },
   "repository": {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Resolves PRO-2255

## What are the specific steps to test this change?

Run `npm test` and it should include an auditing step at the end.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [x] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
