### PR TITLE
PRO-2173 Properly displays UI strings with colons.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* UI strings that are not registered localization keys will now display properly when they contain a colon (`:`). These were previously interpreted as i18next namespace/key pairs and the "namespace" portion was left out.
+
 ## 3.11.0 - 2022-01-06
 
 ### Adds

--- a/modules/@apostrophecms/ui/ui/apos/lib/i18next.js
+++ b/modules/@apostrophecms/ui/ui/apos/lib/i18next.js
@@ -26,6 +26,15 @@ export default {
       },
       appendNamespaceToMissingKey: true,
       parseMissingKeyHandler (key) {
+        // We include namespaces with unrecognized l10n keys using
+        // `appendNamespaceToMissingKey: true`. This passes strings containing
+        // colons that were never meant to be localized through to the UI.
+        //
+        // Strings that do not include colons ("Content area") are given the
+        // default namespace by i18next ("translation," by default). Here we
+        // check if the key starts with that default namespace, meaning it
+        // belongs to no other registered namespace, then remove that default
+        // namespace before passing this through to be processed and displayed.
         if (key.startsWith(`${this.defaultNS[0]}:`)) {
           return key.slice(this.defaultNS[0].length + 1);
         } else {

--- a/modules/@apostrophecms/ui/ui/apos/lib/i18next.js
+++ b/modules/@apostrophecms/ui/ui/apos/lib/i18next.js
@@ -23,6 +23,14 @@ export default {
       debug: i18n.debug,
       interpolation: {
         escapeValue: false
+      },
+      appendNamespaceToMissingKey: true,
+      parseMissingKeyHandler (key) {
+        if (key.startsWith(`${this.defaultNS[0]}:`)) {
+          return key.slice(this.defaultNS[0].length + 1);
+        } else {
+          return key;
+        }
       }
     });
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Closes #3475 
Closes PRO-2173

## What are the specific steps to test this change?

Use `htmlHelp` help text on a doc type field, such as:
```
htmlHelp: 'This link to the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea" target="_blank">MDN textarea reference</a> should display properly.',
```

In the main branch this will only display the part after the colon. With this branch it will display that properly as HTML with a link. 


## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
