### PR TITLE
PRO-2422 fix console error when switching page type immediately after clicking New Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* Fixes a bug where changing the page type immediately after clicking "New Page" would produce a console error. In general, areas now correctly handle their value being changed to `null` by the parent schema after initial startup of the `AposInputArea` component.
+
 ## 3.11.0 - 2022-01-06
 
 ### Adds

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArea.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArea.vue
@@ -39,11 +39,7 @@ export default {
   mixins: [ AposInputMixin ],
   data () {
     return {
-      next: this.value.data || {
-        metaType: 'area',
-        _id: cuid(),
-        items: []
-      },
+      next: this.value.data || this.getEmptyValue(),
       error: false,
       // This is just meant to be sufficient to prevent unintended collisions
       // in the UI between id attributes
@@ -66,6 +62,17 @@ export default {
     }
   },
   methods: {
+    getEmptyValue() {
+      return {
+        metaType: 'area',
+        _id: cuid(),
+        items: []
+      };
+    },
+    watchValue () {
+      this.error = this.value.error;
+      this.next = this.value.data || this.getEmptyValue();
+    },
     validate(value) {
       if (this.field.required) {
         if (!value.items.length) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Currently if you click "New Page" and then immediately switch page types without touching anything else, you get a console error, which is alarming although so far we have not identified any functional consequences. If there are any this could be turned into a hotfix release, otherwise it'll just come out normally. I've asked the client who reported it to clarify if there is a functional issue or not.

## What are the specific steps to test this change?

* Click "new page" in a3-boilerplate
* Without touching anything else, try to change the page type
* You should not get a console error with this fix in place

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [N/A] Related documentation has been updated
- [X] Related tests have been updated (I gave Alex a note to make sure changing page types is part of his QA process going forward)

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
