### PR TITLE
Disables npm audit step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 * UI strings that are not registered localization keys will now display properly when they contain a colon (`:`). These were previously interpreted as i18next namespace/key pairs and the "namespace" portion was left out.
 * Fixes a bug where changing the page type immediately after clicking "New Page" would produce a console error. In general, areas now correctly handle their value being changed to `null` by the parent schema after initial startup of the `AposInputArea` component.
 
+### Changes
+
+* Temporarily removes `npm audit` from our automated tests because of a sub-dependency of vue-loader that doesn't actually cause a security vulnerability for apostrophe.
+
+
 ## 3.11.0 - 2022-01-06
 
 ### Adds

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "pretest": "npm run lint",
     "test": "nyc --reporter=html mocha -t 10000",
-    "posttest": "npm audit",
     "lint": "eslint . && node scripts/lint-i18n"
   },
   "repository": {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

After review it is clear the sub-sub-dependency vulnerability through vue-loader (PostCSS) is not a risk in Apostrophe since access to take advantage would entail access to do much more than that. We're disabling npm audit in the tests until vue-loader and vue component-compiler-utils updates the PostCSS version ([proposed here](https://github.com/vuejs/component-compiler-utils/pull/121)).

## What are the specific steps to test this change?

Run the `npm test` command successfully.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
