### PR TITLE
Removes util.indexBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changes
 
 * Temporarily removes `npm audit` from our automated tests because of a sub-dependency of vue-loader that doesn't actually cause a security vulnerability for apostrophe.
+* Removes the `@apostrophecms/util` module template helper `indexBy`, which was using a lodash method not included in lodash v4.
 
 
 ## 3.11.0 - 2022-01-06

--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -936,15 +936,6 @@ module.exports = {
         });
       },
 
-      // If propertyName is _id, then the keys in the returned
-      // object will be the ids of each object in arr,
-      // and the values will be the corresponding objects.
-      // You may index by any property name.
-
-      indexBy: function(arr, propertyName) {
-        return _.indexBy(arr, propertyName);
-      },
-
       // Find all the array elements, if any, that have the specified value for
       // the specified property.
 
@@ -1061,11 +1052,14 @@ module.exports = {
 
         function groupByArray(items, arrayName) {
           const results = {};
+          // looping over each item in the original array
           _.each(items, function(item) {
+            // looping over each item in the array within the top level item
             _.each(item[arrayName] || [], function(inner) {
               if (!results[inner]) {
                 results[inner] = [];
               }
+              // grouping top level items on the sub properties
               results[inner].push(item);
             });
           });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Removes a utility template helper that would be throwing an error if used. indexBy is not included in lodash 4, which A3 uses.

## What are the specific steps to test this change?

No testing needed. You can test `indexBy` in the `main` branch to confirm it throws an error.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
