### PR TITLE
PRO-2442: bring back nestedModuleSubdirs feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 * Temporarily removes `npm audit` from our automated tests because of a sub-dependency of vue-loader that doesn't actually cause a security vulnerability for apostrophe.
 
+### Adds
+
+* Brought back the `nestedModuleSubdirs` feature from A2, which allows modules to be nested in subdirectories if `nestedModuleSubdirs: true` is set in `app.js`. As in A2, module configuration (including activation) can also be grouped in a `modules.js` file in such subdirectories.
 
 ## 3.11.0 - 2022-01-06
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const cluster = require('cluster');
 const { cpus } = require('os');
 const process = require('process');
 const npmResolve = require('resolve');
+const glob = require('glob');
 
 let defaults = require('./defaults.js');
 
@@ -273,6 +274,21 @@ module.exports = async function(options) {
     return _module;
   }
 
+  function nestedModuleSubdirs() {
+    if (!options.nestedModuleSubdirs) {
+      return;
+    }
+    const configs = glob.sync(self.localModules + '/**/modules.js');
+    _.each(configs, function(config) {
+      try {
+        _.merge(self.options.modules, require(config));
+      } catch (e) {
+        console.error('When nestedModuleSubdirs is active, any modules.js file beneath ' + self.moogOptions.localModules + '\nmust export an object containing configuration for Apostrophe modules.\nThe file ' + config + ' did not parse.');
+        throw e;
+      }
+    });
+  }
+
   function autodetectBundles() {
     const modules = _.keys(self.options.modules);
     _.each(modules, function(name) {
@@ -406,7 +422,8 @@ module.exports = async function(options) {
       localModules: self.localModules,
       defaultBaseClass: '@apostrophecms/module',
       sections: [ 'helpers', 'handlers', 'routes', 'apiRoutes', 'restApiRoutes', 'renderRoutes', 'middleware', 'customTags', 'components', 'tasks' ],
-      unparsedSections: [ 'queries', 'extendQueries', 'icons' ]
+      unparsedSections: [ 'queries', 'extendQueries', 'icons' ],
+      nestedModuleSubdirs: self.options.nestedModuleSubdirs
     });
 
     self.synth = synth;
@@ -416,6 +433,8 @@ module.exports = async function(options) {
     self.define = self.synth.define;
     self.redefine = self.synth.redefine;
     self.create = self.synth.create;
+
+    nestedModuleSubdirs();
 
     _.each(self.options.modules, function(options, name) {
       synth.define(name, options);

--- a/test/modules/nested-module-subdirs/example1/index.js
+++ b/test/modules/nested-module-subdirs/example1/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  init(self) {
+    self.initialized = true;
+  }
+};

--- a/test/modules/nested-module-subdirs/modules.js
+++ b/test/modules/nested-module-subdirs/modules.js
@@ -1,0 +1,7 @@
+module.exports = {
+  example1: {
+    options: {
+      folderLevelOption: true
+    }
+  }
+};

--- a/test/with-nested-module-subdirs.js
+++ b/test/with-nested-module-subdirs.js
@@ -1,0 +1,32 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert');
+
+describe('With Nested Module Subdirs', function() {
+  this.timeout(t.timeout);
+
+  let apos;
+
+  after(function () {
+    return t.destroy(apos);
+  });
+
+  /// ///
+  // EXISTENCE
+  /// ///
+
+  it('should initialize', async function() {
+    apos = await t.create({
+      root: module,
+      nestedModuleSubdirs: true,
+      modules: {
+        example1: {}
+      }
+    });
+    assert(apos.modules.example1);
+    // With nestedModuleSubdirs switched on, the index.js should be found,
+    // and modules.js should be loaded
+    assert(apos.modules.example1.options.folderLevelOption);
+    assert(apos.modules.example1.initialized);
+  });
+
+});

--- a/test/without-nested-module-subdirs.js
+++ b/test/without-nested-module-subdirs.js
@@ -1,0 +1,31 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert');
+
+describe('Without Nested Module Subdirs', function() {
+  this.timeout(t.timeout);
+
+  let apos;
+
+  after(function () {
+    return t.destroy(apos);
+  });
+
+  /// ///
+  // EXISTENCE
+  /// ///
+
+  it('should initialize', async function() {
+    apos = await t.create({
+      root: module,
+      modules: {
+        example1: {}
+      }
+    });
+    assert(apos.modules.example1);
+    // Should fail because we didn't turn on nestedModuleSubdirs,
+    // so the index.js was not found and modules.js was not loaded
+    assert(!apos.modules.example1.options.folderLevelOption);
+    assert(!apos.modules.example1.initialized);
+  });
+
+});


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Brings back nestedModuleSubdirs from 2.x, including the modules.js feature, with test coverage.

## What are the specific steps to test this change?

See the unit tests. You can create a subdirectory and move some of your modules to it. Optionally you can also create a modules.js file in that subdirectory, which gets merged with the "modules" section of `app.js`.

Module names are not changed in any way by being nested in a subdirectory, it's a convenience for code organization.

Documentation PR to follow.

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [COMING] Related documentation has been updated
- [X] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
