### PR TITLE
Have the `type` visible in case the warning apears

### DIFF
--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -63,7 +63,7 @@ module.exports = {
         const doc = (docOrType && docOrType._id) ? docOrType : null;
         const manager = type && self.apos.doc.getManager(type);
         if (type && !manager) {
-          self.apos.util.warn(`A permission.can() call was made with a type that has no manager: ${type}`);
+          self.apos.util.warn('A permission.can() call was made with a type that has no manager:', type);
           return false;
         }
         if (action === 'view') {


### PR DESCRIPTION
Have the type clearly displayed, instead of `[Object Object]`

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

When the error appears, the type is not displayed in the console. Only `[Object Object]` is shown.

## What are the specific steps to test this change?

See issue #3626 for repro steps.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [x] Related tests have been updated **(Not sure about that)**
