### PR TITLE
PRO-2406 Registers the default namespace in the UI i18n instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* Registers the default namespace in the Vue instance of i18n, fixing a lack of support for un-namespaced l10n keys in the UI.
+
 ## 3.12.0 - 2022-01-21
 
 ### Adds

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -47,6 +47,7 @@ module.exports = {
     }
   },
   async init(self) {
+    self.defaultNamespace = 'default';
     self.namespaces = {};
     self.debug = process.env.APOS_DEBUG_I18N ? true : self.options.debug;
     self.show = process.env.APOS_SHOW_I18N ? true : self.options.show;
@@ -84,7 +85,7 @@ module.exports = {
         // Nunjucks and Vue will already do this
         escapeValue: false
       },
-      defaultNS: 'default',
+      defaultNS: self.defaultNamespace,
       debug: self.debug
     });
     if (self.show) {
@@ -540,6 +541,7 @@ module.exports = {
           i18n,
           locale: req.locale,
           defaultLocale: self.defaultLocale,
+          defaultNamespace: self.defaultNamespace,
           locales: self.locales,
           debug: self.debug,
           show: self.show,

--- a/modules/@apostrophecms/ui/ui/apos/lib/i18next.js
+++ b/modules/@apostrophecms/ui/ui/apos/lib/i18next.js
@@ -25,13 +25,14 @@ export default {
         escapeValue: false
       },
       appendNamespaceToMissingKey: true,
+      defaultNS: [ apos.i18n.defaultNamespace ],
       parseMissingKeyHandler (key) {
         // We include namespaces with unrecognized l10n keys using
         // `appendNamespaceToMissingKey: true`. This passes strings containing
         // colons that were never meant to be localized through to the UI.
         //
         // Strings that do not include colons ("Content area") are given the
-        // default namespace by i18next ("translation," by default). Here we
+        // default namespace by i18next ("default," in Apostrophe). Here we
         // check if the key starts with that default namespace, meaning it
         // belongs to no other registered namespace, then remove that default
         // namespace before passing this through to be processed and displayed.


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Closes PRO-2406, supporting l10n keys in the UI without a namespace.

## What are the specific steps to test this change?

1. Use the testbed project branch PRO-2406-l10n, or register a l10n key for a piece type pluralLabel option. Previously the admin bar UI would display the l10n key, not its value.
2. Check the admin bar UI to make sure no l10n keys are showing instead of their values.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
