### PR TITLE
PRO-2500 tweaks

### DIFF
--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -552,7 +552,7 @@ module.exports = {
         const { earlyRequirements, lateRequirements } = self.filterRequirements();
         for (const [ name, requirement ] of Object.entries(earlyRequirements)) {
           try {
-            await requirement.verify(req);
+            await requirement.verify(req, req.body.requirements && req.body.requirements[name]);
           } catch (e) {
             e.data = e.data || {};
             e.data.requirement = name;

--- a/modules/@apostrophecms/login/ui/apos/components/TheAposLogin.vue
+++ b/modules/@apostrophecms/login/ui/apos/components/TheAposLogin.vue
@@ -41,6 +41,7 @@
                     :is="requirement.component"
                     v-bind="getRequirementProps(requirement.name)"
                     @done="requirementDone(requirement, $event)"
+                    @block="requirementBlock(requirement)"
                   />
                 </template>
                 <!-- TODO -->
@@ -269,6 +270,11 @@ export default {
       // TODO handle situation where user should be sent somewhere other than homepage.
       // Redisplay homepage with editing interface
       location.assign(`${apos.prefix}/`);
+    },
+    async requirementBlock(requirementBlock) {
+      const requirement = this.requirements.find(requirement => requirement.name === requirementBlock.name);
+      requirement.done = false;
+      requirement.value = undefined;
     },
     async requirementDone(requirementDone, value) {
       const requirement = this.requirements.find(requirement => requirement.name === requirementDone.name);


### PR DESCRIPTION

## Summary

* beforeSubmit requirements take a data arg too, for consistency
* block events are implemented for beforeSubmit requirements, because there is no other way to say "hang on not ready" in a beforeSubmit requirement (we don't need this feature for the other phases)

## What are the specific steps to test this change?

Use the `login-requirements` branch of `testbed`. If you clear the "fake captcha" field, the login button disables. Also the field still works (showing I handled the new data arg right).

However see my notes about issues with doing that with `npm link` wieh the login-totp module, that's why it's in there as a proper github dependency on the right branch.

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [Opened Separate Ticket] Related documentation has been updated 
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
