### PR TITLE
Fix double slash URL bug when a piece-page-type is set as the homepage.

### DIFF
--- a/modules/@apostrophecms/piece-page-type/index.js
+++ b/modules/@apostrophecms/piece-page-type/index.js
@@ -220,7 +220,7 @@ module.exports = {
         if (!page) {
           return false;
         }
-        return page._url + '/' + piece.slug;
+        return self.apos.util.addSlashIfNeeded(page._url) + piece.slug;
       },
 
       // Adds the `._url` property to all of the provided pieces,

--- a/test/pieces-page-type.js
+++ b/test/pieces-page-type.js
@@ -34,6 +34,24 @@ describe('Pieces Pages', function() {
             perPage: 10
           }
         },
+        root: {
+          extend: '@apostrophecms/piece-type',
+          options: {
+            name: 'root',
+            label: 'Root',
+            alias: 'root',
+            sort: { title: 1 }
+          }
+        },
+        'root-piece-pages': {
+          extend: '@apostrophecms/piece-page-type',
+          options: {
+            name: 'rootPiecePage',
+            label: 'Root Piece Page',
+            alias: 'rootPiecePage',
+            perPage: 10
+          }
+        },
         '@apostrophecms/page': {
           options: {
             park: [
@@ -42,6 +60,12 @@ describe('Pieces Pages', function() {
                 type: 'eventPage',
                 slug: '/events',
                 parkedId: 'events'
+              },
+              {
+                title: 'Root piece page',
+                type: 'rootPiecePage',
+                slug: '/',
+                parkedId: 'root'
               }
             ]
           }
@@ -102,6 +126,19 @@ describe('Pieces Pages', function() {
     }).toObject();
     assert(piece);
     assert((!piece._url) || (piece._url.match(/undefined/)));
+  });
+  
+  it('should not create a double-slashed _url on a piece-page-type set as the homepage', async function() {
+    const piece = await apos.doc.find(apos.task.getAnonReq(), {
+      type: 'root',
+      title: 'Root 001'
+    }, {
+      project: {
+        type: 1
+      }
+    }).toObject();
+    assert(piece);
+    assert(piece._url === '/root-001');
   });
 
   it('should correctly populate the ._url property of pieces in a docs query if _url itself is "projected"', async function() {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Closes issue #3650 by using `apos.util.addSlashIfNeeded` to correctly build URLs for all piece-page-types, even if they are at the root of the webpage.

Also added a test for it!

## What are the specific steps to test this change?

> 1. Run the website and log in as an admin
> 2. Set the homepage to a piece-page-type.
> 3. Use the _url property of a single piece in your template.
> 4. Check that the _url is `baseUrl/:slug` instead of `baseUrl//:slug`

## What kind of change does this PR introduce?

- [x] Bug fix

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated (not needed)
- [x] Related tests have been updated
