### PR TITLE
fixes transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixes
 
-When the home page extends `@apostrophecms/piece-page-type`, the "show page" URLs for individual pieces should not contain two slashes before the piece slug. Thanks to [Martí Bravo](https://github.com/martibravo) for the fix.
+* When the home page extends `@apostrophecms/piece-page-type`, the "show page" URLs for individual pieces should not contain two slashes before the piece slug. Thanks to [Martí Bravo](https://github.com/martibravo) for the fix.
+* Fixes transitions between login page and `afterPasswordVerified` login steps.
 
 ## 3.13.0 - 2022-02-04
 

--- a/modules/@apostrophecms/login/ui/apos/components/TheAposLogin.vue
+++ b/modules/@apostrophecms/login/ui/apos/components/TheAposLogin.vue
@@ -6,8 +6,9 @@
       :class="themeClass"
     >
       <div class="apos-login__wrapper">
-        <transition name="fade-body">
+        <transition name="fade-body" mode="out-in">
           <div
+            key="1"
             class="apos-login__upper"
             v-if="loaded && phase === 'beforeSubmit'"
           >
@@ -18,25 +19,19 @@
             />
 
             <div class="apos-login__body">
-              <form
-                @submit.prevent="submit"
-              >
+              <form @submit.prevent="submit">
                 <AposSchema
                   :schema="schema"
                   v-model="doc"
                 />
-                <!-- Do not ask these components to render without their props,
-                  v-show is not enough -->
-                <template v-if="loaded">
-                  <Component
-                    v-for="requirement in beforeSubmitRequirements"
-                    :key="requirement.name"
-                    :is="requirement.component"
-                    v-bind="getRequirementProps(requirement.name)"
-                    @done="requirementDone(requirement, $event)"
-                    @block="requirementBlock(requirement)"
-                  />
-                </template>
+                <Component
+                  v-for="requirement in beforeSubmitRequirements"
+                  :key="requirement.name"
+                  :is="requirement.component"
+                  v-bind="getRequirementProps(requirement.name)"
+                  @done="requirementDone(requirement, $event)"
+                  @block="requirementBlock(requirement)"
+                />
                 <!-- TODO -->
                 <!-- <a href="#" class="apos-login__link">Forgot Password</a> -->
                 <AposButton
@@ -53,8 +48,9 @@
             </div>
           </div>
           <div
+            key="2"
             class="apos-login__upper"
-            v-else-if="activeSoloRequirement && !fetchingRequirementProps"
+            v-else-if="activeSoloRequirement"
           >
             <TheAposLoginHeader
               :env="context.env"
@@ -64,6 +60,7 @@
             />
             <div class="apos-login__body">
               <Component
+                v-if="!fetchingRequirementProps"
                 v-bind="getRequirementProps(activeSoloRequirement.name)"
                 :is="activeSoloRequirement.component"
                 :success="activeSoloRequirement.success"
@@ -392,12 +389,11 @@ function getRequirements() {
     transition-delay: 0.6s;
   }
 
-  .fade-leave-active {
+  .fade-body-leave-active {
     transition: all 0.25s linear;
-    transition-delay: 0;
   }
 
-  .fade-body-enter-to,.fade-body-leave {
+  .fade-body-enter-to, .fade-body-leave {
     transform: translateY(0);
   }
 

--- a/test/pieces-page-type.js
+++ b/test/pieces-page-type.js
@@ -127,7 +127,7 @@ describe('Pieces Pages', function() {
     assert(piece);
     assert((!piece._url) || (piece._url.match(/undefined/)));
   });
-  
+
   it('should not create a double-slashed _url on a piece-page-type set as the homepage', async function() {
     const piece = await apos.doc.find(apos.task.getAnonReq(), {
       type: 'root',


### PR DESCRIPTION
[PRO-2515](https://linear.app/apostrophecms/issue/PRO-2515/login-transition-is-not-working-well-when-leaving)

## Summary
Fixes transitions between login steps, to transition in and out for each one.

## What are the specific steps to test this change?

*For example:*
> 1. Run a testbed project (or other) with afterPasswordVerified login steps.
> 2. Check that transitions between login pages and next steps are goind well.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated