### PR TITLE
Pro 2490 cache on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * To reduce complications for those implementing caching strategies, the CSRF protection cookie now contains a simple constant string, and is not recorded in `req.session`. This is acceptable because the real purpose of the CSRF check is simply to verify that the browser has sent the cookie at all, which it will not allow a cross-origin script to do.
 * As a result of the above, a session cookie is not generated and sent at all unless `req.session` is actually used or a user logs in. Again, this reduces complications for those implementing caching strategies.
 * When logging out, the session cookie is now cleared in the browser. Formerly the session was destroyed on the server side only, which was sufficient for security purposes but could create caching issues.
+* Uses `express-cache-on-demand` lib to make similar and concurrent requests on pieces and pages faster.
 
 ### Fixes
 

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const expressCacheOnDemand = require('express-cache-on-demand')(); C;
+const expressCacheOnDemand = require('express-cache-on-demand')();
 
 module.exports = {
   extend: '@apostrophecms/doc-type',

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const cacheOnDemand = require('express-cache-on-demand')();
+const expressCacheOnDemand = require('express-cache-on-demand')(); C;
 
 module.exports = {
   extend: '@apostrophecms/doc-type',
@@ -171,7 +171,7 @@ module.exports = {
 
     return {
       getAll: [
-        ...enableCacheOnDemand ? [ cacheOnDemand ] : [],
+        ...enableCacheOnDemand ? [ expressCacheOnDemand ] : [],
         async (req) => {
           self.publicApiCheck(req);
           const query = self.getRestQuery(req);
@@ -204,7 +204,7 @@ module.exports = {
         }
       ],
       getOne: [
-        ...enableCacheOnDemand ? [ cacheOnDemand ] : [],
+        ...enableCacheOnDemand ? [ expressCacheOnDemand ] : [],
         async (req, _id) => {
           _id = self.inferIdLocaleAndMode(req, _id);
           self.publicApiCheck(req);

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-promise": "^5.1.0",
     "express": "^4.16.4",
     "express-bearer-token": "^2.4.0",
+    "express-cache-on-demand": "^1.0.2",
     "express-session": "^1.17.1",
     "form-data": "^4.0.0",
     "fs-extra": "^7.0.1",


### PR DESCRIPTION
[PRO-2490](https://linear.app/apostrophecms/issue/PRO-2490/integrate-the-express-cache-on-demand-middleware-in-a3-core)

## Summary

Adds Express cache on deman on get routes for pieces and pages (getOne / getAll). Also on the main route for rendering pages.

Has been tested with refactored `cache-on-demand` and `express-cache-on-demand`. See these PRs:
* [cache-on-demand](https://github.com/apostrophecms/cache-on-demand/pull/2)
* [express-cache-on-demand](https://github.com/apostrophecms/express-cache-on-demand/pull/5)

⚠️ This one should wait that both above have been merged and released.

Tested with 50 concurrent users and 200 reps, on benchmark mode (so without delays between requests), we can see an obvious difference on the Elapsed time, an average of 20 seconds (even more on the example) of difference between requests with cache on demand and without.
![image](https://user-images.githubusercontent.com/17548370/154071345-c17ee6fa-cdea-4303-9753-13154eabebb2.png)

![image](https://user-images.githubusercontent.com/17548370/154071366-e4595f02-c2f1-499d-b9bd-afec2fb5cdde.png)


## What are the specific steps to test this change?

> 1. Can be tested with the PRs above on testbed
> 2. Run the project and run siege on pages.

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated (Will be done in A3-docs)
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
