### PR TITLE
fix #3667

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.14.1 (2022-02-25)
+
+* Hotfix: fixed a bug in which replication across locales did not work properly for parked pages configured via the `_children` feature. A one-time migration is included to reconnect improperly replicated versions of the same parked pages. This runs automatically, no manual action is required. Thanks to [justyna1](https://github.com/justyna13) for identifying the issue.
+
 ## 3.14.0 (2022-02-22)
 
 ### Adds

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -1005,10 +1005,12 @@ module.exports = {
       async replicate() {
         const localeNames = Object.keys(self.apos.i18n.locales);
         const criteria = [];
-        for (const parked of self.apos.page.parked) {
+        self.apos.page.parked.forEach(pushParkedPageAndParkedChildren);
+        function pushParkedPageAndParkedChildren(page) {
           criteria.push({
-            parkedId: parked.parkedId
+            parkedId: page.parkedId
           });
+          (page._children || []).forEach(pushParkedPageAndParkedChildren);
         }
         const pieceModules = Object.values(self.apos.modules).filter(module => self.apos.instanceOf(module, '@apostrophecms/piece-type') && module.options.replicate);
         for (const module of pieceModules) {

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -2196,10 +2196,7 @@ database.`);
               $exists: 1
             }
           }).toArray();
-          let locales = Object.keys(self.apos.i18n.locales);
-          if (locales[0] !== self.apos.i18n.defaultLocale) {
-            locales = [ self.apos.i18n.defaultLocale, ...locales.filter(locale => locale !== self.apos.i18n.defaultLocale) ];
-          }
+          let locales = [ self.apos.i18n.defaultLocale, ... Object.keys(self.apos.i18n.locales) ];
           const parkedIds = [ ...new Set(parkedPages.map(page => page.parkedId)) ];
           for (const parkedId of parkedIds) {
             let aposDocId;

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -2196,7 +2196,7 @@ database.`);
               $exists: 1
             }
           }).toArray();
-          let locales = [ self.apos.i18n.defaultLocale, ... Object.keys(self.apos.i18n.locales) ];
+          const locales = [ self.apos.i18n.defaultLocale, ...Object.keys(self.apos.i18n.locales) ];
           const parkedIds = [ ...new Set(parkedPages.map(page => page.parkedId)) ];
           for (const parkedId of parkedIds) {
             let aposDocId;

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -2201,10 +2201,8 @@ database.`);
             locales = [ self.apos.i18n.defaultLocale, ...locales.filter(locale => locale !== self.apos.i18n.defaultLocale) ];
           }
           const parkedIds = [ ...new Set(parkedPages.map(page => page.parkedId)) ];
-          console.log('>>', locales);
           for (const parkedId of parkedIds) {
             let aposDocId;
-            console.log(parkedId);
             for (const locale of locales) {
               for (const mode of [ 'draft', 'published' ]) {
                 const page = parkedPages.find(page => (page.parkedId === parkedId) && (page.aposLocale === `${locale}:${mode}`));
@@ -2218,7 +2216,6 @@ database.`);
                     await self.apos.doc.db.removeOne({
                       _id: page._id
                     });
-                    console.log(`${page.slug} ${page._id} ${aposDocId}:${locale}:${mode}`);
                     await self.apos.doc.db.insertOne({
                       ...page,
                       _id: `${aposDocId}:${locale}:${mode}`,

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -59,6 +59,7 @@ module.exports = {
     self.addEditorModal();
     self.enableBrowserData();
     self.addLegacyMigrations();
+    self.addMisreplicatedParkedPagesMigration();
     await self.createIndexes();
   },
   restApiRoutes(self) {
@@ -2187,7 +2188,50 @@ database.`);
           }
         }
       },
-      ...require('./lib/legacy-migrations')(self)
+      ...require('./lib/legacy-migrations')(self),
+      addMisreplicatedParkedPagesMigration() {
+        self.apos.migration.add('misreplicated-parked-pages', async () => {
+          const parkedPages = await self.apos.doc.db.find({
+            parkedId: {
+              $exists: 1
+            }
+          }).toArray();
+          let locales = Object.keys(self.apos.i18n.locales);
+          if (locales[0] !== self.apos.i18n.defaultLocale) {
+            locales = [ self.apos.i18n.defaultLocale, ...locales.filter(locale => locale !== self.apos.i18n.defaultLocale) ];
+          }
+          const parkedIds = [ ...new Set(parkedPages.map(page => page.parkedId)) ];
+          console.log('>>', locales);
+          for (const parkedId of parkedIds) {
+            let aposDocId;
+            console.log(parkedId);
+            for (const locale of locales) {
+              for (const mode of [ 'draft', 'published' ]) {
+                const page = parkedPages.find(page => (page.parkedId === parkedId) && (page.aposLocale === `${locale}:${mode}`));
+                if (!page) {
+                  continue;
+                }
+                if (!aposDocId) {
+                  aposDocId = page.aposDocId;
+                } else {
+                  if (page.aposDocId !== aposDocId) {
+                    await self.apos.doc.db.removeOne({
+                      _id: page._id
+                    });
+                    console.log(`${page.slug} ${page._id} ${aposDocId}:${locale}:${mode}`);
+                    await self.apos.doc.db.insertOne({
+                      ...page,
+                      _id: `${aposDocId}:${locale}:${mode}`,
+                      aposDocId,
+                      path: page.path.replace(page.aposDocId, aposDocId)
+                    });
+                  }
+                }
+              }
+            }
+          }
+        });
+      }
     };
   },
   helpers(self) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {

--- a/test/parked-pages.js
+++ b/test/parked-pages.js
@@ -1,7 +1,36 @@
 const t = require('../test-lib/test.js');
 const assert = require('assert');
 
-let apos, apos2;
+let apos, apos2, apos3, apos4, apos5, apos6;
+
+const park2 = [
+  {
+    slug: '/',
+    parkedId: 'home',
+    _defaults: {
+      title: 'Home',
+      type: 'default-page'
+    },
+    _children: [
+      {
+        slug: '/default1',
+        parkedId: 'default1',
+        _defaults: {
+          type: 'default-page',
+          title: 'Default 1'
+        }
+      },
+      {
+        slug: '/default2',
+        parkedId: 'default2',
+        _defaults: {
+          type: 'default-page',
+          title: 'Default 2'
+        }
+      }
+    ]
+  }
+];
 
 describe('Parked Pages', function() {
 
@@ -10,12 +39,21 @@ describe('Parked Pages', function() {
   after(async function() {
     await t.destroy(apos);
     await t.destroy(apos2);
+    await t.destroy(apos3);
+    await t.destroy(apos4);
+    await t.destroy(apos5);
+    await t.destroy(apos6);
   });
 
-  it('standard parked pages should be as expected', async function() {
+  it('standard and custom parked pages should be as expected', async function() {
+    this.timeout(20000);
     apos = await t.create({
       root: module,
-      modules: {}
+      modules: {
+        'default-page': {
+          extend: '@apostrophecms/page-type'
+        }
+      }
     });
     const req = apos.task.getReq();
     const home = await apos.page.find(req, { slug: '/' }).toObject();
@@ -29,21 +67,13 @@ describe('Parked Pages', function() {
   });
 
   it('overridden home page should work without disturbing archive', async function() {
+    this.timeout(20000);
     apos2 = await t.create({
       root: module,
       modules: {
         '@apostrophecms/page': {
           options: {
-            park: [
-              {
-                slug: '/',
-                parkedId: 'home',
-                _defaults: {
-                  title: 'Home',
-                  type: 'default-page'
-                }
-              }
-            ]
+            park: park2
           }
         },
         'default-page': {}
@@ -58,5 +88,246 @@ describe('Parked Pages', function() {
     assert(archive);
     assert(archive.parkedId === 'archive');
     assert(archive.type === '@apostrophecms/archive-page');
+    await apos2.db.collection('verify').insertOne({
+      checkSameDb: true
+    });
+  });
+
+  it('all pages should have consistent aposDocId across draft and published', async function() {
+    this.timeout(20000);
+    await validate(apos2, [ '/', '/archive', '/default1', '/default2' ]);
+  });
+
+  it('third apos object should park a third child correctly when spinning up later on existing db', async function() {
+    this.timeout(20000);
+    apos3 = await t.create({
+      root: module,
+      modules: {
+        '@apostrophecms/page': {
+          options: {
+            park: [
+              ...park2,
+              {
+                slug: '/default3',
+                parkedId: 'default3',
+                _defaults: {
+                  type: 'default-page',
+                  title: 'Default 3'
+                }
+              }
+            ]
+          }
+        },
+        'default-page': {}
+      },
+      shortName: apos2.options.shortName
+    });
+    // prove apos2 and apos3 are talking to the same db and it hasn't been erased
+    assert(await apos3.db.collection('verify').findOne({
+      checkSameDb: true
+    }));
+  });
+
+  it('all pages should have consistent aposDocId across draft and published', async function() {
+    await validate(apos3, [ '/', '/archive', '/default1', '/default2', '/default3' ]);
+    // Should be same db, make sure of that
+    await validate(apos2, [ '/', '/archive', '/default1', '/default2', '/default3' ]);
+  });
+
+  it('nested parked children work', async function() {
+    this.timeout(20000);
+    apos4 = await t.create({
+      root: module,
+      modules: {
+        '@apostrophecms/page': {
+          options: {
+            park: [
+              ...park2,
+              {
+                slug: '/default3',
+                parkedId: 'default3',
+                _defaults: {
+                  type: 'default-page',
+                  title: 'Default 3'
+                },
+                _children: [
+                  {
+                    slug: '/default3/child1',
+                    parkedId: 'default3child1',
+                    _defaults: {
+                      type: 'default-page',
+                      title: 'Default 3 Child 1'
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        'default-page': {}
+      },
+      shortName: apos2.options.shortName
+    });
+    await validate(apos4, [ '/', '/archive', '/default1', '/default2', '/default3', '/default3/child1' ]);
+  });
+
+  it('nested parked children work across locales if locales are added later', async function() {
+    this.timeout(20000);
+    apos5 = await t.create({
+      root: module,
+      modules: {
+        '@apostrophecms/i18n': {
+          options: {
+            locales: {
+              en: {
+                label: 'English',
+                hostname: 'en'
+              },
+              fr: {
+                label: 'French',
+                hostname: 'fr'
+              }
+            }
+          }
+        },
+        '@apostrophecms/page': {
+          options: {
+            park: [
+              ...park2,
+              {
+                slug: '/default3',
+                parkedId: 'default3',
+                _defaults: {
+                  type: 'default-page',
+                  title: 'Default 3'
+                },
+                _children: [
+                  {
+                    slug: '/default3/child1',
+                    parkedId: 'default3child1',
+                    _defaults: {
+                      type: 'default-page',
+                      title: 'Default 3 Child 1'
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        'default-page': {}
+      },
+      shortName: apos4.options.shortName
+    });
+    await validate(apos5, [ '/', '/archive', '/default1', '/default2', '/default3', '/default3/child1' ]);
   });
 });
+
+it('nested parked children work across locales if locales are present from the start', async function() {
+  this.timeout(20000);
+  apos6 = await t.create({
+    root: module,
+    modules: {
+      '@apostrophecms/i18n': {
+        options: {
+          locales: {
+            en: {
+              label: 'English',
+              hostname: 'en'
+            },
+            fr: {
+              label: 'French',
+              hostname: 'fr'
+            }
+          }
+        }
+      },
+      '@apostrophecms/page': {
+        options: {
+          park: [
+            ...park2,
+            {
+              slug: '/default3',
+              parkedId: 'default3',
+              _defaults: {
+                type: 'default-page',
+                title: 'Default 3'
+              },
+              _children: [
+                {
+                  slug: '/default3/child1',
+                  parkedId: 'default3child1',
+                  _defaults: {
+                    type: 'default-page',
+                    title: 'Default 3 Child 1'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      'default-page': {}
+    }
+  });
+  await validate(apos6, [ '/', '/archive', '/default1', '/default2', '/default3', '/default3/child1' ]);
+});
+
+async function validate(apos, expected) {
+  const locales = Object.keys(apos.i18n.locales);
+  const slugs = await apos.doc.db.distinct('slug', {
+    slug: /^\//
+  });
+  slugs.sort();
+  assert.deepStrictEqual(slugs, expected);
+  const pages = await apos.doc.db.find({
+    slug: /^\//
+  }).toArray();
+  assert(pages.length === slugs.length * 2 * locales.length);
+  for (const slug of slugs) {
+    const matches = pages.filter(page => page.slug === slug);
+    matches.sort((p1, p2) => {
+      if (p1.aposLocale < p2.aposLocale) {
+        return -1;
+      } else if (p1.aposLocale > p2.aposLocale) {
+        return 1;
+      } else {
+        return 0;
+      }
+    });
+    assert.strictEqual(matches.length, 2 * locales.length);
+    let i = 0;
+    let aposDocId;
+    for (const locale of locales) {
+      const draft = i;
+      const published = i + 1;
+      assert.strictEqual(matches[draft].aposLocale, `${locale}:draft`);
+      assert.strictEqual(matches[published].aposLocale, `${locale}:published`);
+      assert(matches[draft].aposDocId);
+      assert.strictEqual(matches[draft].aposDocId, matches[published].aposDocId);
+      if (!aposDocId) {
+        aposDocId = matches[draft].aposDocId;
+      } else {
+        assert.strictEqual(matches[draft].aposDocId, aposDocId);
+      }
+      assert.strictEqual(matches[draft]._id, `${aposDocId}:${locale}:draft`);
+      assert.strictEqual(matches[published]._id, `${aposDocId}:${locale}:published`);
+      i += 2;
+    }
+  }
+  const home = await apos.page.find(apos.task.getReq(), {
+    slug: '/'
+  }).children({
+    depth: 2
+  }).toObject();
+  const children = expected.filter(slug => slug.startsWith('/default') && !slug.match(/\/.*\//));
+  assert.deepStrictEqual(home._children.map(child => child.slug), children);
+  const grandkids = expected.filter(slug => slug.match(/\/.*\//));
+  for (const grandkid of grandkids) {
+    const parentSlug = grandkid.replace(/\/[^/]+$/, '');
+    const parent = home._children.find(child => child.slug === parentSlug);
+    assert(parent);
+    assert(parent._children);
+    assert(parent._children.find(child => child.slug === grandkid));
+  }
+}


### PR DESCRIPTION
Also the needed migration resolves a different one-off problem for an enterprise client. Try to prevent the one-off from recurring with better locking

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

* Fixes a nasty bug where use of `_children` with parked pages broke replication in multi-locale websites.
* Introduces tons of tests to make sure we avoid regressions in the parked page logic.
* The necessary migration also resolves a once-seen problem where the draft and published aposDocIds were not in sync on a single-locale site for a parked page. But we have been unable to replicate that problem on a new site or via highly creative unit tests. So there could be more work later if it ever recurs and we nail down the cause.
* Wraps a lock around more of the startup logic to further reduce the risk of race conditions.

## What are the specific steps to test this change?

Sync down WL, npm run dev, the sandbox site works now. (I tested this, you don't have to, we will validate it on the demo after merge.)

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [X] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
