### PR TITLE
handle max-age cache-control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Adds
 
 * `data-apos-test=""` selectors for certain elements frequently selected in QA tests, such as `data-apos-test="adminBar"`.
+* Offer a simple way to set a Cache-Control max-age for Apostrophe page and GET REST API responses for pieces and pages.
 
 ## 3.15.0 (2022-03-02)
 

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -446,6 +446,24 @@ module.exports = {
         );
       },
 
+      setMaxAge(req, maxAge, exceptions = []) {
+        if (typeof maxAge !== 'number') {
+          self.apos.util.warnDev('"maxAge" property must be defined as a number in the module cache option');
+          return;
+        }
+
+        // TODO: handle exceptions here?
+        // or directly in the piece-type module (calling this "parent" setMaxAge)
+
+        // TODO: handle user and session
+
+        console.log(req.user);
+        console.log(req.session);
+        console.log('maxAge', maxAge);
+
+        req.res.header('Cache-Control', `max-age=${maxAge}`);
+      },
+
       // Call from init once if this module implements the `getBrowserData` method.
       // The data returned by `getBrowserData(req)` will then be available on
       // `apos.modules['your-module-name']` in the browser.

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -464,7 +464,12 @@ module.exports = {
         const isSafeToCache = !req.user && isSessionClearForCaching;
         const cacheControlValue = isSafeToCache ? `max-age=${maxAge}` : 'no-store';
 
-        req.res.header('Cache-Control', cacheControlValue);
+        // When serving a page for a connected user, `req.res.header` gets undefined sometimes, somehow.
+        // The Cache-Control value will still be set to "no-cache" (equivalent to "no-store")
+        // by the admin-bar module, so the result will be the same.
+        if (req.res.header) {
+          req.res.header('Cache-Control', cacheControlValue);
+        }
       },
 
       // Call from init once if this module implements the `getBrowserData` method.

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -446,13 +446,7 @@ module.exports = {
         );
       },
 
-      setCacheControl(req) {
-        if (!self.options.cache || !(self.options.cache.api || self.options.cache.page)) {
-          return;
-        }
-
-        const { maxAge } = self.options.cache[self.__meta.name === 'page' ? 'page' : 'api'];
-
+      setCacheControl(req, maxAge) {
         if (typeof maxAge !== 'number') {
           self.apos.util.warnDev(`"maxAge" property must be defined as a number in the "${self.__meta.name}" module's cache options"`);
           return;

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -446,7 +446,13 @@ module.exports = {
         );
       },
 
-      setCacheControl(req, maxAge) {
+      setCacheControl(req) {
+        if (!self.options.cache || !(self.options.cache.api || self.options.cache.page)) {
+          return;
+        }
+
+        const { maxAge } = self.options.cache[self.__meta.name === 'page' ? 'page' : 'api'];
+
         if (typeof maxAge !== 'number') {
           self.apos.util.warnDev(`"maxAge" property must be defined as a number in the "${self.__meta.name}" module's cache options"`);
           return;
@@ -463,13 +469,6 @@ module.exports = {
         );
         const isSafeToCache = !req.user && isSessionClearForCaching;
         const cacheControlValue = isSafeToCache ? `max-age=${maxAge}` : 'no-store';
-
-        console.log('-----------------');
-        console.log('req.user', Boolean(req.user));
-        console.log('isSessionClearForCaching', isSessionClearForCaching);
-        console.log('isSafeToCache', isSafeToCache);
-        console.log('cacheControlValue', cacheControlValue);
-        console.log('-----------------');
 
         req.res.header('Cache-Control', cacheControlValue);
       },

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -180,15 +180,11 @@ module.exports = {
               const result = await fn(req);
 
               const setCacheControl = () => {
-                if (self.options.cache && self.options.cache.api && self.cacheApiRoutesExceptions) {
-                  console.log('self.cacheApiRoutesExceptions', self.cacheApiRoutesExceptions, self.cacheApiRoutesExceptions.some(routePattern => req.url.match(routePattern)));
-                }
-
                 const shouldNotCacheThisRoute =
                   self.cacheApiRoutesExceptions &&
                   self.cacheApiRoutesExceptions.some(routePattern => req.url.match(routePattern));
 
-                console.log('shouldNotCacheThisRoute', shouldNotCacheThisRoute);
+                console.log('apiRoutes - shouldNotCacheThisRoute', shouldNotCacheThisRoute);
 
                 if (
                   !self.options.cache ||
@@ -197,7 +193,13 @@ module.exports = {
                 ) {
                   return;
                 }
-                console.log('routeWrappers -> apiRoutes', name);
+
+                console.log(
+                  'apiRoutes - self.cacheApiRoutesExceptions',
+                  self.cacheApiRoutesExceptions,
+                  self.cacheApiRoutesExceptions.some(routePattern => req.url.match(routePattern))
+                );
+                console.log('---');
 
                 self.setCacheControl(req, self.options.cache.api.maxAge);
               };
@@ -466,9 +468,7 @@ module.exports = {
       // that point.
 
       async sendPage(req, template, data) {
-        // console.log('sendPage - before', req.res.getHeader('Cache-Control'));
         await self.apos.page.emit('beforeSend', req);
-        // console.log('sendPage - after', req.res.getHeader('Cache-Control'));
         await self.apos.area.loadDeferredWidgets(req);
         req.res.send(
           await self.apos.template.renderPageForModule(req, template, data, self)
@@ -720,11 +720,7 @@ module.exports = {
             return;
           }
 
-          // console.log(self.__meta.name, 'exceptions', self.options.cache.api.exceptions);
-
           self.cacheApiRoutesExceptions = [];
-
-          console.log(self.options.cache.api.exceptions);
 
           if (!_.isArray(self.options.cache.api.exceptions)) {
             self.apos.util.warnDev(`"exceptions" property must be defined as an array in the "${self.__meta.name}" module's cache options"`);
@@ -739,7 +735,7 @@ module.exports = {
             .map(exception => self.getRouteUrl(exception))
             .map(url => minimatch.makeRe(url));
 
-          console.log('self.cacheApiRoutesExceptions', self.cacheApiRoutesExceptions);
+          console.log('compileCacheApiRoutesExceptions - self.cacheApiRoutesExceptions', self.cacheApiRoutesExceptions);
           console.log('---');
         }
       },

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -26,7 +26,6 @@
 // logged in.
 
 const _ = require('lodash');
-const minimatch = require('minimatch');
 
 module.exports = {
 
@@ -178,34 +177,6 @@ module.exports = {
           return async function(req, res) {
             try {
               const result = await fn(req);
-
-              const setCacheControl = () => {
-                const shouldNotCacheThisRoute =
-                  self.cacheApiRoutesExceptions &&
-                  self.cacheApiRoutesExceptions.some(routePattern => req.url.match(routePattern));
-
-                console.log('apiRoutes - shouldNotCacheThisRoute', shouldNotCacheThisRoute);
-
-                if (
-                  !self.options.cache ||
-                  !self.options.cache.api ||
-                  shouldNotCacheThisRoute
-                ) {
-                  return;
-                }
-
-                console.log(
-                  'apiRoutes - self.cacheApiRoutesExceptions',
-                  self.cacheApiRoutesExceptions,
-                  self.cacheApiRoutesExceptions.some(routePattern => req.url.match(routePattern))
-                );
-                console.log('---');
-
-                self.setCacheControl(req, self.options.cache.api.maxAge);
-              };
-
-              setCacheControl();
-
               res.status(200);
               res.send(result);
             } catch (err) {
@@ -710,33 +681,6 @@ module.exports = {
           if (self.apos.template) {
             self.apos.template.addHelpersForModule(self, self.__helpers);
           }
-        },
-        compileCacheApiRoutesExceptions() {
-          if (
-            !self.options.cache ||
-            !self.options.cache.api ||
-            !self.options.cache.api.exceptions
-          ) {
-            return;
-          }
-
-          self.cacheApiRoutesExceptions = [];
-
-          if (!_.isArray(self.options.cache.api.exceptions)) {
-            self.apos.util.warnDev(`"exceptions" property must be defined as an array in the "${self.__meta.name}" module's cache options"`);
-            return;
-          }
-
-          // TODO: factorize with csrfExceptions logic?
-          // TODO: handle module alias in getRouteUrl?
-          //   In order to have: [ /^(?:\/api\/v1\/page\/custom-route)$/ ]
-          //   rather than:      [ /^(?:\/api\/v1\/@apostrophecms\/page\/custom-route)$/ ]
-          self.cacheApiRoutesExceptions = self.options.cache.api.exceptions
-            .map(exception => self.getRouteUrl(exception))
-            .map(url => minimatch.makeRe(url));
-
-          console.log('compileCacheApiRoutesExceptions - self.cacheApiRoutesExceptions', self.cacheApiRoutesExceptions);
-          console.log('---');
         }
       },
       '@apostrophecms/express:compileRoutes': {

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -464,12 +464,7 @@ module.exports = {
         const isSafeToCache = !req.user && isSessionClearForCaching;
         const cacheControlValue = isSafeToCache ? `max-age=${maxAge}` : 'no-store';
 
-        // When serving a page for a connected user, `req.res.header` gets undefined sometimes, somehow.
-        // The Cache-Control value will still be set to "no-cache" (equivalent to "no-store")
-        // by the admin-bar module, so the result will be the same.
-        if (req.res.header) {
-          req.res.header('Cache-Control', cacheControlValue);
-        }
+        req.res.header('Cache-Control', cacheControlValue);
       },
 
       // Call from init once if this module implements the `getBrowserData` method.

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -1415,6 +1415,10 @@ database.`);
         await self.emit('serveQuery', query);
         req.data.bestPage = await query.toObject();
         self.evaluatePageMatch(req);
+
+        if (self.options.cache && self.options.cache.page) {
+          self.setMaxAge(req, self.options.cache.page.maxAge);
+        }
       },
       // Normalize req.slug to account for unneeded trailing whitespace,
       // trailing slashes other than the root, and double slash based open
@@ -2093,6 +2097,11 @@ database.`);
             query.project(self.options.publicApiProjection);
           }
         }
+
+        if (self.options.cache && self.options.cache.api) {
+          self.setMaxAge(req, self.options.cache.api.maxAge);
+        }
+
         return query;
       },
       // Returns a query that finds pages the current user can edit. Unlike

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -119,6 +119,10 @@ module.exports = {
               project: self.getAllProjection()
             }).toObject();
 
+            if (self.options.cache && self.options.cache.api) {
+              self.setCacheControl(req, self.options.cache.api.maxAge);
+            }
+
             if (!page) {
               throw self.apos.error('notfound');
             }
@@ -137,6 +141,11 @@ module.exports = {
             }
           } else {
             const result = await self.getRestQuery(req).and({ level: 0 }).toObject();
+
+            if (self.options.cache && self.options.cache.api) {
+              self.setCacheControl(req, self.options.cache.api.maxAge);
+            }
+
             if (!result) {
               throw self.apos.error('notfound');
             }
@@ -168,6 +177,11 @@ module.exports = {
           self.publicApiCheck(req);
           const criteria = self.getIdCriteria(_id);
           const result = await self.getRestQuery(req).and(criteria).toObject();
+
+          if (self.options.cache && self.options.cache.api) {
+            self.setCacheControl(req, self.options.cache.api.maxAge);
+          }
+
           if (!result) {
             throw self.apos.error('notfound');
           }

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -119,9 +119,7 @@ module.exports = {
               project: self.getAllProjection()
             }).toObject();
 
-            if (self.options.cache && self.options.cache.api) {
-              self.setCacheControl(req, self.options.cache.api.maxAge);
-            }
+            self.setCacheControl(req);
 
             if (!page) {
               throw self.apos.error('notfound');
@@ -142,9 +140,7 @@ module.exports = {
           } else {
             const result = await self.getRestQuery(req).and({ level: 0 }).toObject();
 
-            if (self.options.cache && self.options.cache.api) {
-              self.setCacheControl(req, self.options.cache.api.maxAge);
-            }
+            self.setCacheControl(req);
 
             if (!result) {
               throw self.apos.error('notfound');
@@ -178,9 +174,7 @@ module.exports = {
           const criteria = self.getIdCriteria(_id);
           const result = await self.getRestQuery(req).and(criteria).toObject();
 
-          if (self.options.cache && self.options.cache.api) {
-            self.setCacheControl(req, self.options.cache.api.maxAge);
-          }
+          self.setCacheControl(req);
 
           if (!result) {
             throw self.apos.error('notfound');
@@ -1429,10 +1423,7 @@ database.`);
         await self.emit('serveQuery', query);
         req.data.bestPage = await query.toObject();
         self.evaluatePageMatch(req);
-
-        if (self.options.cache && self.options.cache.page) {
-          self.setCacheControl(req, self.options.cache.page.maxAge);
-        }
+        self.setCacheControl(req);
       },
       // Normalize req.slug to account for unneeded trailing whitespace,
       // trailing slashes other than the root, and double slash based open

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -1415,6 +1415,10 @@ database.`);
         await self.emit('serveQuery', query);
         req.data.bestPage = await query.toObject();
         self.evaluatePageMatch(req);
+
+        if (self.options.cache && self.options.cache.page) {
+          self.setCacheControl(req, self.options.cache.page.maxAge);
+        }
       },
       // Normalize req.slug to account for unneeded trailing whitespace,
       // trailing slashes other than the root, and double slash based open
@@ -1584,12 +1588,6 @@ database.`);
         // have editing privileges on the page
         if (req.query.pageInformation === 'json' && args.page && args.page._edit) {
           return req.res.send(args.page);
-        }
-
-        // Set cache-control here in order to give the chance to override it
-        // in `sendPage` or in a "beforeSend" event handler.
-        if (providePage && self.options.cache && self.options.cache.page) {
-          self.setCacheControl(req, self.options.cache.page.maxAge);
         }
 
         return self.sendPage(req, req.template, args);

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -119,7 +119,9 @@ module.exports = {
               project: self.getAllProjection()
             }).toObject();
 
-            self.setCacheControl(req);
+            if (self.options.cache && self.options.cache.api) {
+              self.setCacheControl(req, self.options.cache.api.maxAge);
+            }
 
             if (!page) {
               throw self.apos.error('notfound');
@@ -140,7 +142,9 @@ module.exports = {
           } else {
             const result = await self.getRestQuery(req).and({ level: 0 }).toObject();
 
-            self.setCacheControl(req);
+            if (self.options.cache && self.options.cache.api) {
+              self.setCacheControl(req, self.options.cache.api.maxAge);
+            }
 
             if (!result) {
               throw self.apos.error('notfound');
@@ -174,7 +178,9 @@ module.exports = {
           const criteria = self.getIdCriteria(_id);
           const result = await self.getRestQuery(req).and(criteria).toObject();
 
-          self.setCacheControl(req);
+          if (self.options.cache && self.options.cache.api) {
+            self.setCacheControl(req, self.options.cache.api.maxAge);
+          }
 
           if (!result) {
             throw self.apos.error('notfound');
@@ -1423,7 +1429,10 @@ database.`);
         await self.emit('serveQuery', query);
         req.data.bestPage = await query.toObject();
         self.evaluatePageMatch(req);
-        self.setCacheControl(req);
+
+        if (self.options.cache && self.options.cache.page) {
+          self.setCacheControl(req, self.options.cache.page.maxAge);
+        }
       },
       // Normalize req.slug to account for unneeded trailing whitespace,
       // trailing slashes other than the root, and double slash based open

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -1603,7 +1603,6 @@ database.`);
         if (req.query.pageInformation === 'json' && args.page && args.page._edit) {
           return req.res.send(args.page);
         }
-
         return self.sendPage(req, req.template, args);
       },
       // In the event of an error during the beforeSend event or the

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -491,11 +491,11 @@ module.exports = {
   handlers(self) {
     return {
       beforeSend: {
-        async handlerName(req) {
-          console.log('beforeSend - before', req.res.getHeader('Cache-Control'));
-          req.res.header('Cache-Control', 1234);
-          console.log('beforeSend - after', req.res.getHeader('Cache-Control'));
-        },
+        // async handlerName(req) {
+        //   console.log('beforeSend - before', req.res.getHeader('Cache-Control'));
+        //   req.res.header('Cache-Control', 1234);
+        //   console.log('beforeSend - after', req.res.getHeader('Cache-Control'));
+        // },
         async addLevelAttributeToBody(req) {
           // Add level as a data attribute on the body tag
           // The admin bar uses this to stay open if configured by the user

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -491,11 +491,6 @@ module.exports = {
   handlers(self) {
     return {
       beforeSend: {
-        // async handlerName(req) {
-        //   console.log('beforeSend - before', req.res.getHeader('Cache-Control'));
-        //   req.res.header('Cache-Control', 1234);
-        //   console.log('beforeSend - after', req.res.getHeader('Cache-Control'));
-        // },
         async addLevelAttributeToBody(req) {
           // Add level as a data attribute on the body tag
           // The admin bar uses this to stay open if configured by the user
@@ -1420,10 +1415,6 @@ database.`);
         await self.emit('serveQuery', query);
         req.data.bestPage = await query.toObject();
         self.evaluatePageMatch(req);
-
-        // if (self.options.cache && self.options.cache.page) {
-        //   self.setCacheControl(req, self.options.cache.page.maxAge);
-        // }
       },
       // Normalize req.slug to account for unneeded trailing whitespace,
       // trailing slashes other than the root, and double slash based open
@@ -2109,11 +2100,6 @@ database.`);
             query.project(self.options.publicApiProjection);
           }
         }
-
-        // if (self.options.cache && self.options.cache.api) {
-        //   self.setCacheControl(req, self.options.cache.api.maxAge);
-        // }
-
         return query;
       },
       // Returns a query that finds pages the current user can edit. Unlike
@@ -2249,25 +2235,6 @@ database.`);
       }
     };
   },
-  // extendMethods(self) {
-  //   return {
-  //     routeWrappers: {
-  //       apiRoutes(_super, name, fn) {
-  //         return async function(req, res) {
-  //           if (!self.options.cache || !self.options.cache.api) {
-  //             return _super(name, fn)(req, res);
-  //           }
-
-  //           console.log('PAGE: child routeWrappers -> apiRoutes', name);
-
-  //           self.setCacheControl(req, self.options.cache.api.maxAge);
-
-  //           return _super(name, fn)(req, res);
-  //         };
-  //       }
-  //     }
-  //   };
-  // },
   helpers(self) {
     return {
       isAncestorOf: function (possibleAncestorPage, ofPage) {

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -911,10 +911,6 @@ module.exports = {
           }
         }
 
-        if (self.options.cache && self.options.cache.api) {
-          self.setMaxAge(req, self.options.cache.api.maxAge);
-        }
-
         return query;
       },
       // Throws a `notfound` exception if a public API projection is
@@ -973,6 +969,23 @@ module.exports = {
       find(_super, req, criteria, projection) {
         return _super(req, criteria, projection).defaultSort(self.options.sort || { updatedAt: -1 });
       }
+      // routeWrappers: {
+      //   apiRoutes(_super, name, fn) {
+      //     return async function(req, res) {
+      //       if (!self.options.cache || !self.options.cache.api) {
+      //         return _super(name, fn)(req, res);
+      //       }
+
+      //       // TODO: handle exceptions here
+
+      //       console.log('PIECE TYPE: child routeWrappers -> apiRoutes', name);
+
+      //       self.setCacheControl(req, self.options.cache.api.maxAge);
+
+      //       return _super(name, fn)(req, res);
+      //     };
+      //   }
+      // }
     };
   },
   tasks(self) {

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -201,7 +201,9 @@ module.exports = {
             result.counts = query.get('countsResults');
           }
 
-          self.setCacheControl(req);
+          if (self.options.cache && self.options.cache.api) {
+            self.setCacheControl(req, self.options.cache.api.maxAge);
+          }
 
           return result;
         }
@@ -213,7 +215,9 @@ module.exports = {
           self.publicApiCheck(req);
           const doc = await self.getRestQuery(req).and({ _id }).toObject();
 
-          self.setCacheControl(req);
+          if (self.options.cache && self.options.cache.api) {
+            self.setCacheControl(req, self.options.cache.api.maxAge);
+          }
 
           if (!doc) {
             throw self.apos.error('notfound');

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -910,6 +910,11 @@ module.exports = {
             query.project(self.options.publicApiProjection);
           }
         }
+
+        if (self.options.cache && self.options.cache.api) {
+          self.setMaxAge(req, self.options.cache.api.maxAge);
+        }
+
         return query;
       },
       // Throws a `notfound` exception if a public API projection is

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -201,9 +201,7 @@ module.exports = {
             result.counts = query.get('countsResults');
           }
 
-          if (self.options.cache && self.options.cache.api) {
-            self.setCacheControl(req, self.options.cache.api.maxAge);
-          }
+          self.setCacheControl(req);
 
           return result;
         }
@@ -215,9 +213,7 @@ module.exports = {
           self.publicApiCheck(req);
           const doc = await self.getRestQuery(req).and({ _id }).toObject();
 
-          if (self.options.cache && self.options.cache.api) {
-            self.setCacheControl(req, self.options.cache.api.maxAge);
-          }
+          self.setCacheControl(req);
 
           if (!doc) {
             throw self.apos.error('notfound');

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -200,6 +200,11 @@ module.exports = {
           if (query.get('countsResults')) {
             result.counts = query.get('countsResults');
           }
+
+          if (self.options.cache && self.options.cache.api) {
+            self.setCacheControl(req, self.options.cache.api.maxAge);
+          }
+
           return result;
         }
       ],
@@ -209,6 +214,11 @@ module.exports = {
           _id = self.inferIdLocaleAndMode(req, _id);
           self.publicApiCheck(req);
           const doc = await self.getRestQuery(req).and({ _id }).toObject();
+
+          if (self.options.cache && self.options.cache.api) {
+            self.setCacheControl(req, self.options.cache.api.maxAge);
+          }
+
           if (!doc) {
             throw self.apos.error('notfound');
           }

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -910,7 +910,6 @@ module.exports = {
             query.project(self.options.publicApiProjection);
           }
         }
-
         return query;
       },
       // Throws a `notfound` exception if a public API projection is
@@ -969,23 +968,6 @@ module.exports = {
       find(_super, req, criteria, projection) {
         return _super(req, criteria, projection).defaultSort(self.options.sort || { updatedAt: -1 });
       }
-      // routeWrappers: {
-      //   apiRoutes(_super, name, fn) {
-      //     return async function(req, res) {
-      //       if (!self.options.cache || !self.options.cache.api) {
-      //         return _super(name, fn)(req, res);
-      //       }
-
-      //       // TODO: handle exceptions here
-
-      //       console.log('PIECE TYPE: child routeWrappers -> apiRoutes', name);
-
-      //       self.setCacheControl(req, self.options.cache.api.maxAge);
-
-      //       return _super(name, fn)(req, res);
-      //     };
-      //   }
-      // }
     };
   },
   tasks(self) {

--- a/modules/@apostrophecms/task/index.js
+++ b/modules/@apostrophecms/task/index.js
@@ -193,6 +193,12 @@ module.exports = {
           res: {
             redirect(url) {
               req.res.redirectedTo = url;
+            },
+            header(key, value) {
+              req.res.headers = {
+                ...(req.res.headers || {}),
+                [key]: value
+              };
             }
           },
           t(key, options = {}) {

--- a/test/pages-public-api.js
+++ b/test/pages-public-api.js
@@ -98,5 +98,7 @@ describe('Pages Public API', function() {
 
     assert(response1.headers['cache-control'] === 'max-age=1111');
     assert(response2.headers['cache-control'] === 'max-age=1111');
+
+    delete apos.page.options.cache;
   });
 });

--- a/test/pages-public-api.js
+++ b/test/pages-public-api.js
@@ -68,4 +68,35 @@ describe('Pages Public API', function() {
     // But projection did apply
     assert(!home.searchSummary);
   });
+
+  it('should not set a "max-age" cache-control value when retrieving pages, when cache option is not set, with a public API projection', async () => {
+    apos.page.options.publicApiProjection = {
+      title: 1,
+      _url: 1
+    };
+
+    const response1 = await apos.http.get('/api/v1/@apostrophecms/page', { fullResponse: true });
+    const response2 = await apos.http.get(`/api/v1/@apostrophecms/page/${response1.body._id}`, { fullResponse: true });
+
+    assert(response1.headers['cache-control'] === undefined);
+    assert(response2.headers['cache-control'] === undefined);
+  });
+
+  it('should set a "max-age" cache-control value when retrieving pages, with a public API projection', async () => {
+    apos.page.options.publicApiProjection = {
+      title: 1,
+      _url: 1
+    };
+    apos.page.options.cache = {
+      api: {
+        maxAge: 1111
+      }
+    };
+
+    const response1 = await apos.http.get('/api/v1/@apostrophecms/page', { fullResponse: true });
+    const response2 = await apos.http.get(`/api/v1/@apostrophecms/page/${response1.body._id}`, { fullResponse: true });
+
+    assert(response1.headers['cache-control'] === 'max-age=1111');
+    assert(response2.headers['cache-control'] === 'max-age=1111');
+  });
 });

--- a/test/pages.js
+++ b/test/pages.js
@@ -515,6 +515,8 @@ describe('Pages', function() {
 
     assert(response1.headers['cache-control'] === undefined);
     assert(response2.headers['cache-control'] === undefined);
+
+    delete apos.page.options.cache;
   });
 
   it('should set a "max-age" cache-control value when retrieving pieces, when "api" cache option is set', async () => {
@@ -529,6 +531,8 @@ describe('Pages', function() {
 
     assert(response1.headers['cache-control'] === 'max-age=4444');
     assert(response2.headers['cache-control'] === 'max-age=4444');
+
+    delete apos.page.options.cache;
   });
 
   it('should set a "no-store" cache-control value when retrieving pages, when "api" cache option is set, when user is connected', async () => {
@@ -569,6 +573,8 @@ describe('Pages', function() {
 
     assert(response1.headers['cache-control'] === 'no-store');
     assert(response2.headers['cache-control'] === 'no-store');
+
+    delete apos.page.options.cache;
   });
 
   it('should set a "no-store" cache-control value when retrieving pages, when "api" cache option is set, when user is connected using an api key', async () => {
@@ -583,6 +589,8 @@ describe('Pages', function() {
 
     assert(response1.headers['cache-control'] === 'no-store');
     assert(response2.headers['cache-control'] === 'no-store');
+
+    delete apos.page.options.cache;
   });
 
   it('should not set a cache-control value when serving a page, when cache option is not set', async () => {
@@ -600,6 +608,8 @@ describe('Pages', function() {
     const response = await apos.http.get('/', { fullResponse: true });
 
     assert(response.headers['cache-control'] === undefined);
+
+    delete apos.page.options.cache;
   });
 
   it('should set a cache-control value when serving a page, when "page" cache option is set', async () => {
@@ -611,6 +621,8 @@ describe('Pages', function() {
     const response = await apos.http.get('/', { fullResponse: true });
 
     assert(response.headers['cache-control'] === 'max-age=5555');
+
+    delete apos.page.options.cache;
   });
 
 });

--- a/test/pieces-public-api.js
+++ b/test/pieces-public-api.js
@@ -107,6 +107,8 @@ describe('Pieces Public API', function() {
 
     assert(response1.headers['cache-control'] === 'max-age=2222');
     assert(response2.headers['cache-control'] === 'max-age=2222');
+
+    delete apos.thing.options.cache;
   });
 
 });

--- a/test/pieces-public-api.js
+++ b/test/pieces-public-api.js
@@ -78,4 +78,35 @@ describe('Pieces Public API', function() {
     assert(!response.results[0].foo);
   });
 
+  it('should not set a "max-age" cache-control value when retrieving pieces, when cache option is not set, with a public API projection', async () => {
+    apos.thing.options.publicApiProjection = {
+      title: 1,
+      _url: 1
+    };
+
+    const response1 = await apos.http.get('/api/v1/thing', { fullResponse: true });
+    const response2 = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });
+
+    assert(response1.headers['cache-control'] === undefined);
+    assert(response2.headers['cache-control'] === undefined);
+  });
+
+  it('should set a "max-age" cache-control value when retrieving pieces, with a public API projection', async () => {
+    apos.thing.options.publicApiProjection = {
+      title: 1,
+      _url: 1
+    };
+    apos.thing.options.cache = {
+      api: {
+        maxAge: 2222
+      }
+    };
+
+    const response1 = await apos.http.get('/api/v1/thing', { fullResponse: true });
+    const response2 = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });
+
+    assert(response1.headers['cache-control'] === 'max-age=2222');
+    assert(response2.headers['cache-control'] === 'max-age=2222');
+  });
+
 });

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -1280,4 +1280,83 @@ describe('Pieces', function() {
     assert(existingPiece.title === 'new product name');
     assert(existingPiece.color === 'red');
   });
+
+  it('should not set a cache-control value when retrieving pieces, when cache option is not set', async () => {
+    const response1 = await apos.http.get('/api/v1/thing', { fullResponse: true });
+    const response2 = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });
+
+    assert(response1.headers['cache-control'] === undefined);
+    assert(response2.headers['cache-control'] === undefined);
+  });
+
+  it('should not set a cache-control value when retrieving pieces, when "api" cache option is not set', async () => {
+    apos.thing.options.cache = {
+      page: {
+        maxAge: 5555
+      }
+    };
+
+    const response1 = await apos.http.get('/api/v1/thing', { fullResponse: true });
+    const response2 = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });
+
+    assert(response1.headers['cache-control'] === undefined);
+    assert(response2.headers['cache-control'] === undefined);
+  });
+
+  it('should set a "max-age" cache-control value when retrieving pieces, when "api" cache option is set', async () => {
+    apos.thing.options.cache = {
+      api: {
+        maxAge: 3333
+      }
+    };
+
+    const response1 = await apos.http.get('/api/v1/thing', { fullResponse: true });
+    const response2 = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });
+
+    assert(response1.headers['cache-control'] === 'max-age=3333');
+    assert(response2.headers['cache-control'] === 'max-age=3333');
+  });
+
+  it('should set a "no-store" cache-control value when retrieving pieces, when "api" cache option is set, when user is connected', async () => {
+    apos.thing.options.cache = {
+      api: {
+        maxAge: 3333
+      }
+    };
+
+    await apos.http.post('/api/v1/@apostrophecms/login/login', {
+      body: {
+        username: 'admin',
+        password: 'admin',
+        session: true
+      },
+      jar
+    });
+
+    const response1 = await apos.http.get('/api/v1/thing', {
+      fullResponse: true,
+      jar
+    });
+    const response2 = await apos.http.get('/api/v1/thing/testThing:en:published', {
+      fullResponse: true,
+      jar
+    });
+
+    assert(response1.headers['cache-control'] === 'no-store');
+    assert(response2.headers['cache-control'] === 'no-store');
+  });
+
+  it('should set a "no-store" cache-control value when retrieving pieces, when "api" cache option is set, when user is connected using an api key', async () => {
+    apos.thing.options.cache = {
+      api: {
+        maxAge: 3333
+      }
+    };
+
+    const response1 = await apos.http.get(`/api/v1/thing?apiKey=${apiKey}`, { fullResponse: true });
+    const response2 = await apos.http.get(`/api/v1/thing/testThing:en:published?apiKey=${apiKey}`, { fullResponse: true });
+
+    assert(response1.headers['cache-control'] === 'no-store');
+    assert(response2.headers['cache-control'] === 'no-store');
+  });
 });

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -1301,6 +1301,8 @@ describe('Pieces', function() {
 
     assert(response1.headers['cache-control'] === undefined);
     assert(response2.headers['cache-control'] === undefined);
+
+    delete apos.thing.options.cache;
   });
 
   it('should set a "max-age" cache-control value when retrieving pieces, when "api" cache option is set', async () => {
@@ -1315,6 +1317,8 @@ describe('Pieces', function() {
 
     assert(response1.headers['cache-control'] === 'max-age=3333');
     assert(response2.headers['cache-control'] === 'max-age=3333');
+
+    delete apos.thing.options.cache;
   });
 
   it('should set a "no-store" cache-control value when retrieving pieces, when "api" cache option is set, when user is connected', async () => {
@@ -1344,6 +1348,8 @@ describe('Pieces', function() {
 
     assert(response1.headers['cache-control'] === 'no-store');
     assert(response2.headers['cache-control'] === 'no-store');
+
+    delete apos.thing.options.cache;
   });
 
   it('should set a "no-store" cache-control value when retrieving pieces, when "api" cache option is set, when user is connected using an api key', async () => {
@@ -1358,5 +1364,7 @@ describe('Pieces', function() {
 
     assert(response1.headers['cache-control'] === 'no-store');
     assert(response2.headers['cache-control'] === 'no-store');
+
+    delete apos.thing.options.cache;
   });
 });


### PR DESCRIPTION
[PRO-2573/](https://linear.app/apostrophecms/issue/PRO-2573/caching-offer-a-simple-way-to-set-max-age-for-apostrophe-page-and-get)

## Summary

Add the simple way to cache pages and pieces responses.

## What are the specific steps to test this change?

- Add the following config (diff below) to a project using A3, and `npm link` `apostrophe` (on the `2573-max-age` branch)


```diff 
diff --git a/modules/@apostrophecms/express/index.js b/modules/@apostrophecms/express/index.js
index 819359f..f2c0ac2 100644
--- a/modules/@apostrophecms/express/index.js
+++ b/modules/@apostrophecms/express/index.js
@@ -10,6 +10,10 @@ module.exports = {
           role: 'admin'
         }
       }
-      : null
+      : {
+        myapikey: {
+          role: 'admin'
+        }
+      }
   }
 };
diff --git a/modules/@apostrophecms/page/index.js b/modules/@apostrophecms/page/index.js
index 6580174..fe2ebbc 100644
--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -31,6 +31,18 @@ module.exports = {
         title: 'Search',
         type: '@apostrophecms/search'
       }
-    ]
+    ],
+    publicApiProjection: {
+      title: 1,
+      _url: 1
+    },
+    cache: {
+      api: {
+        maxAge: 3000
+      },
+      page: {
+        maxAge: 6000
+      }
+    }
   }
 };
diff --git a/modules/topic/index.js b/modules/topic/index.js
index 5982eb5..becd771 100644
--- a/modules/topic/index.js
+++ b/modules/topic/index.js
@@ -2,7 +2,16 @@ module.exports = {
   extend: '@apostrophecms/piece-type',
   options: {
     label: 'testNs:topicLabel',
-    pluralLabel: 'testNs:topicPlural'
+    pluralLabel: 'testNs:topicPlural',
+    publicApiProjection: {
+      title: 1,
+      _url: 1
+    },
+    cache: {
+      api: {
+        maxAge: 2000
+      }
+    }
   },
   i18n: {
     testNs: {
```

- Run the project and check that the different scenarios match with the ones described in the [issue](https://linear.app/apostrophecms/issue/PRO-2573/caching-offer-a-simple-way-to-set-max-age-for-apostrophe-page-and-get), for pieces and pages using the REST API, and pages using the regular routing

<img width="1333" alt="image" src="https://user-images.githubusercontent.com/8301962/157671290-44137b38-2751-486d-a8d7-8547fb96f7ae.png">

- Removing the cache config (`api`, `page`, or the whole `cache` config) should not add the `cache-control` value in the HTTP response

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
