### PR TITLE
PRO-2601 simple selectors for QA tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Adds
+
+* `data-apos-test=""` selectors for certain elements frequently selected in QA tests, such as `data-apos-test="adminBar"`.
+
 ## 3.15.0 (2022-03-02)
 
 ### Adds

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="apos-admin-bar-wrapper" :class="themeClass">
+  <div data-apos-test="adminBar" class="apos-admin-bar-wrapper" :class="themeClass">
     <div class="apos-admin-bar-spacer" ref="spacer" />
     <nav class="apos-admin-bar" ref="adminBar">
       <div class="apos-admin-bar__row">
         <AposLogoPadless class="apos-admin-bar__logo" />
         <TheAposAdminBarMenu :items="items" />
         <TheAposAdminBarLocale v-if="hasLocales()" />
-        <TheAposAdminBarUser class="apos-admin-bar__user" />
+        <TheAposAdminBarUser data-apos-test="authenticatedUserMenuTrigger" class="apos-admin-bar__user" />
       </div>
       <TheAposContextBar @mounted="setSpacer" />
     </nav>

--- a/modules/@apostrophecms/login/ui/apos/components/TheAposLogin.vue
+++ b/modules/@apostrophecms/login/ui/apos/components/TheAposLogin.vue
@@ -2,6 +2,7 @@
   <transition name="fade-stage">
     <div
       class="apos-login apos-theme-dark"
+      data-apos-test="loginForm"
       v-show="loaded"
       :class="themeClass"
     >
@@ -35,6 +36,7 @@
                 <!-- TODO -->
                 <!-- <a href="#" class="apos-login__link">Forgot Password</a> -->
                 <AposButton
+                  data-apos-test="loginSubmit"
                   :busy="busy"
                   :disabled="disabled"
                   type="primary"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -16,6 +16,7 @@
       <!-- TODO refactor buttons to take a single config obj -->
       <AposButton
         class="apos-context-menu__btn"
+        data-apos-test="contextMenuTrigger"
         @click.stop="buttonClicked($event)"
         v-bind="button"
         :state="buttonState"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
@@ -19,7 +19,7 @@
           <AposContextMenuItem
             v-for="item in menu"
             :key="item.action"
-            :data-apos-test="item.action"
+            :data-apos-test-context-menu-item="item.action"
             :menu-item="item"
             @clicked="menuItemClicked"
             :open="isOpen"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
@@ -19,6 +19,7 @@
           <AposContextMenuItem
             v-for="item in menu"
             :key="item.action"
+            :data-apos-test="item.action"
             :menu-item="item"
             @clicked="menuItemClicked"
             :open="isOpen"


### PR DESCRIPTION
These should allow you to get very close to what you asked for. To avoid pushing props too deeply there are some cases where you'll need a simple descendant selector too. For the username and password fields, use the existing `data-apos-field` selectors as a starting point to reach those fields by name.