### PR TITLE
trashes moved page if parent is trashed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+## Fixes
+
+* When moving a page, makes it trashed if its parent is trashed too.
+
 ## 2.220.9 (2022-02-04)
 
 ## Fixes

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -554,13 +554,17 @@ module.exports = function(self, options) {
         // Are we in the trashcan? Our new parent reveals that,
         // but only if trash is a place in the tree rather than a
         // simple schema field
+
+        if (parent.trash) {
+          moved.trash = true;
+        }
+
         if (!self.apos.docs.trashInSchema) {
-          if (parent.trash) {
-            moved.trash = true;
-          } else {
+          if (!parent.trash) {
             delete moved.trash;
           }
         }
+
         return self.update(req, moved, callback);
       }
       function updateDescendants(callback) {

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -559,10 +559,8 @@ module.exports = function(self, options) {
           moved.trash = true;
         }
 
-        if (!self.apos.docs.trashInSchema) {
-          if (!parent.trash) {
-            delete moved.trash;
-          }
+        if (!self.apos.docs.trashInSchema && !parent.trash) {
+          delete moved.trash;
         }
 
         return self.update(req, moved, callback);


### PR DESCRIPTION
[PRO-2366/](https://linear.app/apostrophecms/issue/PRO-2366/[michelin-reported]-pages-not-listingshowing-in-page-tree-on-target)

## Summary

Since a page cannot be `trash: false` if its parent is trashed, makes the moved page trash if its parent is in every cases.

## What are the specific steps to test this change?

> 1. Export a not trashed page to another locale where its parent is trashed
> 2. Make sure the moved page is trashed.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

