### PR TITLE
Pro 2506 Pro 2585 modules webpack section

### DIFF
--- a/index.js
+++ b/index.js
@@ -291,11 +291,11 @@ module.exports = async function(options) {
           ${self.localModules}
 
           must export an object containing configuration for Apostrophe modules.
-          
+
           The file:
-          
+
           ${config}
-          
+
           did not parse.
         `);
         throw e;
@@ -441,7 +441,8 @@ module.exports = async function(options) {
         'queries',
         'extendQueries',
         'icons',
-        'i18n'
+        'i18n',
+        'webpack'
       ]
     });
 

--- a/lib/moog.js
+++ b/lib/moog.js
@@ -134,7 +134,20 @@ module.exports = function(options) {
     self.options.sections = self.options.sections || [];
     self.options.unparsedSections = self.options.unparsedSections || [];
 
-    const validKeys = [ '__meta', 'options', 'cascades', 'beforeSuperClass', 'init', 'afterAllSections', 'extend', 'improve', 'methods', 'extendMethods', 'instantiate', 'bundle' ]
+    const validKeys = [
+      '__meta',
+      'options',
+      'cascades',
+      'beforeSuperClass',
+      'init',
+      'afterAllSections',
+      'extend',
+      'improve',
+      'methods',
+      'extendMethods',
+      'instantiate',
+      'bundle'
+    ]
       .concat(self.options.sections)
       .concat(self.options.sections.map(getExtendKey))
       .concat(self.options.unparsedSections)

--- a/modules/@apostrophecms/asset/lib/webpack/utils.js
+++ b/modules/@apostrophecms/asset/lib/webpack/utils.js
@@ -1,0 +1,47 @@
+const { merge: webpackMerge } = require('webpack-merge');
+
+module.exports = {
+  checkModulesWebpackConfig(modules, t) {
+    const allowedProperties = [ 'extensions', 'bundles' ];
+
+    for (const mod of Object.values(modules)) {
+      const webpackConfig = mod.__meta.webpack[mod.__meta.name];
+
+      if (!webpackConfig) {
+        continue;
+      }
+
+      if (
+        typeof webpackConfig !== 'object' ||
+        webpackConfig === null ||
+        Array.isArray(webpackConfig) ||
+        Object.keys(webpackConfig).some((prop) => !allowedProperties.includes(prop))
+      ) {
+        const error = t('apostrophe:assetWebpackConfigWarning', {
+          module: mod.__meta.name
+        });
+
+        throw new Error(error);
+      }
+    }
+  },
+  mergeWebpackConfigs (modules, config) {
+    const extensions = Object.values(modules).reduce((acc, mod) => {
+      const { name, webpack } = mod.__meta;
+
+      if (
+        !webpack[name] ||
+        !webpack[name].extensions
+      ) {
+        return acc;
+      }
+
+      return {
+        ...acc,
+        ...webpack[name].extensions
+      };
+    }, {});
+
+    return webpackMerge(config, ...Object.values(extensions));
+  }
+};

--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -30,6 +30,7 @@
   "areYouSure": "Are You Sure?",
   "assetTypeBuildComplete": "👍 {{ label }} is complete!",
   "assetTypeBuilding": "🧑‍💻 Building the {{ label }}...",
+  "assetWebpackConfigWarning": "⚠️ In the module {{ module }}, your webpack config is incorrect. It must be an object and should contain only two properties extensions and bundles.",
   "back": "Back",
   "backToHome": "Back to Home",
   "basics": "Basics",

--- a/test/assets.js
+++ b/test/assets.js
@@ -1,6 +1,73 @@
 const t = require('../test-lib/test.js');
 const assert = require('assert');
+const path = require('path');
+const {
+  checkModulesWebpackConfig,
+  mergeWebpackConfigs
+} = require('../modules/@apostrophecms/asset/lib/webpack/utils');
+const webpackBaseConfig = require('../modules/@apostrophecms/asset/lib/webpack/src/webpack.config');
+
 let apos;
+
+const modules = {
+  '@apostrophecms/i18n': {
+    options: {
+      locales: {
+        en: {}
+      }
+    }
+  },
+  mod1: {
+    extend: '@apostrophecms/module',
+    webpack: {
+      extensions: {
+        ext1: {
+          rules: [
+            {
+              test: /\.ext1$/,
+              loader: 'ext1-loader',
+              options: { sourceMap: true }
+            }
+          ]
+        },
+        ext2: {
+          rules: [
+            {
+              test: /\.ext2$/,
+              loader: 'ext2-loader',
+              options: { sourceMap: true }
+            }
+          ]
+        }
+      }
+    }
+  },
+  mod2: {
+    extend: '@apostrophecms/module',
+    webpack: {
+      extensions: {
+        ext1: {
+          rules: [
+            {
+              test: /\.ext1$/,
+              loader: 'ext1-loader',
+              options: { sourceMap: false }
+            }
+          ]
+        }
+      }
+    }
+  }
+};
+
+const badModules = {
+  ...modules,
+  badModules: {
+    webpack: {
+      badprop: {}
+    }
+  }
+};
 
 describe('Assets', function() {
 
@@ -12,7 +79,8 @@ describe('Assets', function() {
 
   it('should should exist on the apos object', async function() {
     apos = await t.create({
-      root: module
+      root: module,
+      modules
     });
     assert(apos.asset);
   });
@@ -20,5 +88,61 @@ describe('Assets', function() {
   it('should serve static files', async function() {
     const text = await apos.http.get('/static-test.txt');
     assert(text.match(/served/));
+  });
+
+  it('should check that webpack configs in modules are well formatted', async function () {
+    const [ valid, err ] = check(apos.modules, apos.task.getReq().t);
+
+    assert(valid);
+    assert(!err);
+
+    await t.destroy(apos);
+
+    apos = await t.create({
+      root: module,
+      modules: badModules
+    });
+
+    const [ valid2, err2 ] = check(apos.modules, apos.task.getReq().t);
+
+    assert(!valid2);
+    assert(err2);
+
+    await t.destroy(apos);
+
+    apos = await t.create({
+      root: module,
+      modules
+    });
+
+    function check (modules, t) {
+      try {
+        checkModulesWebpackConfig(modules, t);
+
+        return [ true, false ];
+      } catch (err) {
+        return [ false, err ];
+      }
+    }
+  });
+
+  it('shoud merge webpack configs from modules with the Apostrophe one', async function () {
+    const buildPath = (p) => {
+      return path.join(process.cwd(), p);
+    };
+
+    const webpackInstanceConfig = webpackBaseConfig({
+      importFile: buildPath('apos-build/default/src-import.js'),
+      modulesDir: buildPath('apos-build/default/src/modules'),
+      outputPath: buildPath('public/apos-frontend/default'),
+      outputFilename: 'src-build.js'
+    }, apos);
+
+    const mergedConfig = mergeWebpackConfigs(apos.modules, webpackInstanceConfig);
+
+    const ext1Loaders = mergedConfig.rules.filter((rule) => rule.loader === 'ext1-loader');
+    assert(ext1Loaders.length === 1);
+    assert(ext1Loaders[0].options.sourceMap === false);
+    assert(mergedConfig.rules);
   });
 });


### PR DESCRIPTION
[PRO-2506](https://linear.app/apostrophecms/issue/PRO-2506/implement-new-module-format-section-for-configuring-bundles-required)
[PRO-2585](https://linear.app/apostrophecms/issue/PRO-2585/as-a-developer-i-can-contribute-custom-webpack-configuration-via-any)

## Summary
* Accepts webpack configs from modules
* Check that this config is well formatted.
* If two modules with the same config name, with take only the latest to merge it with the main config
* Tests added for the two utils methods.

## What are the specific steps to test this change?

> 1. `npm link` Apostrophe this branch into a project like testbed.
> 2. Add webpack configs in your modules and check there are added to the main config
> 3. It should throw error if a webpack module section is not an object or contain other properties than `bundles` and `extensions`.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [X] Related tests have been updated
