### PR TITLE
api keys and bearer tokens should beat session cookies when both are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Adds
 
+* API keys and bearer tokens "win" over session cookies when both are present. Since API keys and bearer tokens are explicitly added to the request at hand, it never makes sense to ignore them in favor of a cookie, which is implicit. This also simplifies automated testing with Cypress.
 * `data-apos-test=""` selectors for certain elements frequently selected in QA tests, such as `data-apos-test="adminBar"`.
 
 ## 3.15.0 (2022-03-02)

--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -789,7 +789,12 @@ module.exports = {
       },
       passportSession: {
         before: '@apostrophecms/i18n',
-        middleware: self.passport.session()
+        middleware: (() => {
+          // Wrap the passport middleware so that if the apikey or bearer token
+          // middleware already supplied req.user, that wins (explicit wins over implicit)
+          const passportSession = self.passport.session();
+          return (req, res, next) => req.user ? next() : passportSession(req, res, next);
+        })()
       },
       honorLoginInvalidBefore: {
         before: '@apostrophecms/i18n',

--- a/test/modules/@apostrophecms/home-page/views/page.html
+++ b/test/modules/@apostrophecms/home-page/views/page.html
@@ -2,7 +2,7 @@
 <h4>Home Page Template</h4>
 {# This is necessary to the login.js tests. -Tom #}
 {% if data.user %}
-  logged in
+  logged in as {{ data.user.title }}
 {% else %}
   logged out
 {% endif %}


### PR DESCRIPTION
…

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

API keys and bearer tokens beat session cookies if both are present. Explicit should beat implicit. Needed for cypress tests.

## What are the specific steps to test this change?

See `test/login.js` which covers this (last test in file). Also general logged-in functionality should continue to work properly and no other tests should break.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [X] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
