### PR TITLE
emit and handle etags

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * Adds possibility for modules to [extend the webpack configuration](https://v3.docs.apostrophecms.org/guide/webpack.html).
 * Adds possibility for modules to [add extra frontend bundles for scss and js](https://v3.docs.apostrophecms.org/guide/webpack.html). This is useful when the `ui/src` build would otherwise be very large due to code used on rarely accessed pages.
 * Loads the right bundles on the right pages depending on the page template and the loaded widgets. Logged-in users have all the bundles on every page, because they might introduce widgets at any time.
-* Implement custom ETags emission. It allows caching of pages and pieces, using a cache invalidation mechanism that takes into account related (and reverse related) documents updates, thanks to backlinks mentioned above. For now, only single pages and pieces benefit from the ETags caching system (pages' and pieces' `getOne` REST API route, and regular pages).
+* Implement custom ETags emission. It allows caching of pages and pieces, using a cache invalidation mechanism that takes into account related (and reverse related) documents updates, thanks to backlinks mentioned above. For now, only single pages and pieces benefit from the ETags caching system (pages' and pieces' `getOne` REST API route, and regular served pages).
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Adds possibility for modules to [add extra frontend bundles for scss and js](https://v3.docs.apostrophecms.org/guide/webpack.html). This is useful when the `ui/src` build would otherwise be very large due to code used on rarely accessed pages.
 * Loads the right bundles on the right pages depending on the page template and the loaded widgets. Logged-in users have all the bundles on every page, because they might introduce widgets at any time.
 * Fixes deprecation warnings displayed after running `npm install`, for dependencies that are directly included by this package.
+* Implement custom ETags emission allowing caching of pages and pieces, using a cache invalidation mechanism that takes into account related (and reverse related) documents updates, thanks to backlinks mentioned above.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Adds possibility for modules to [extend the webpack configuration](https://v3.docs.apostrophecms.org/guide/webpack.html).
 * Adds possibility for modules to [add extra frontend bundles for scss and js](https://v3.docs.apostrophecms.org/guide/webpack.html). This is useful when the `ui/src` build would otherwise be very large due to code used on rarely accessed pages.
 * Loads the right bundles on the right pages depending on the page template and the loaded widgets. Logged-in users have all the bundles on every page, because they might introduce widgets at any time.
+* Fixes deprecation warnings displayed after running `npm install`, for dependencies that are directly included by this package.
 * Implement custom ETags emission. It allows caching of pages and pieces, using a cache invalidation mechanism that takes into account related (and reverse related) documents updates, thanks to backlinks mentioned above. For now, only single pages and pieces benefit from the ETags caching system (pages' and pieces' `getOne` REST API route, and regular served pages).
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@
 * Adds possibility for modules to [add extra frontend bundles for scss and js](https://v3.docs.apostrophecms.org/guide/webpack.html). This is useful when the `ui/src` build would otherwise be very large due to code used on rarely accessed pages.
 * Loads the right bundles on the right pages depending on the page template and the loaded widgets. Logged-in users have all the bundles on every page, because they might introduce widgets at any time.
 * Fixes deprecation warnings displayed after running `npm install`, for dependencies that are directly included by this package.
-* Implement custom ETags emission. It allows caching of pages and pieces, using a cache invalidation mechanism that takes into account related (and reverse related) documents updates, thanks to backlinks mentioned above. For now, only single pages and pieces benefit from the ETags caching system (pages' and pieces' `getOne` REST API route, and regular served pages).
+* Implement custom ETags emission when `etags` cache option is enabled. [See the documentation for more information](https://v3.docs.apostrophecms.org/guide/caching.html).  
+It allows caching of pages and pieces, using a cache invalidation mechanism that takes into account related (and reverse related) document updates, thanks to backlinks mentioned above.  
+Note that for now, only single pages and pieces benefit from the ETags caching system (pages' and pieces' `getOne` REST API route, and regular served pages).  
+The cache of an index page corresponding to the type of a piece that was just saved will automatically be invalidated. However, please consider that it won't be effective when a related piece is saved, therefore the cache will automatically be invalidated _after_ the cache lifetime set in `maxAge` cache option.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,7 @@
 * Adds possibility for modules to [extend the webpack configuration](https://v3.docs.apostrophecms.org/guide/webpack.html).
 * Adds possibility for modules to [add extra frontend bundles for scss and js](https://v3.docs.apostrophecms.org/guide/webpack.html). This is useful when the `ui/src` build would otherwise be very large due to code used on rarely accessed pages.
 * Loads the right bundles on the right pages depending on the page template and the loaded widgets. Logged-in users have all the bundles on every page, because they might introduce widgets at any time.
-* Fixes deprecation warnings displayed after running `npm install`, for dependencies that are directly included by this package.
-* Implement custom ETags emission allowing caching of pages and pieces, using a cache invalidation mechanism that takes into account related (and reverse related) documents updates, thanks to backlinks mentioned above.
+* Implement custom ETags emission. It allows caching of pages and pieces, using a cache invalidation mechanism that takes into account related (and reverse related) documents updates, thanks to backlinks mentioned above. For now, only single pages and pieces benefit from the ETags caching system (pages' and pieces' `getOne` REST API route, and regular pages).
 
 ### Fixes
 

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -129,10 +129,10 @@ module.exports = {
             });
           }
 
-          if (doc._parentPage) {
+          if (doc._parentSlug) {
             // Update piece index page's cache field
             await self.apos.doc.db.updateOne({
-              slug: doc._parentPage,
+              slug: doc._parentSlug,
               aposLocale: { $in: [ doc.aposLocale, null ] }
             }, {
               $set: { cacheInvalidatedAt: doc.updatedAt }

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -120,9 +120,19 @@ module.exports = {
           }
 
           if (doc.relatedReverseIds && doc.relatedReverseIds.length) {
-            // - Update related reverse docs' cache field
+            // Update related reverse docs' cache field
             await self.apos.doc.db.updateMany({
               aposDocId: { $in: doc.relatedReverseIds },
+              aposLocale: { $in: [ doc.aposLocale, null ] }
+            }, {
+              $set: { cacheInvalidatedAt: doc.updatedAt }
+            });
+          }
+
+          if (doc._parentUrl) {
+            // Update piece index page's cache field
+            await self.apos.doc.db.updateOne({
+              slug: doc._parentUrl,
               aposLocale: { $in: [ doc.aposLocale, null ] }
             }, {
               $set: { cacheInvalidatedAt: doc.updatedAt }

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -94,7 +94,7 @@ module.exports = {
   handlers(self) {
     return {
       beforeSave: {
-        async updateBacklinks(req, doc) {
+        async updateCacheFields(req, doc) {
           const relatedDocsIds = self.getRelatedDocsIds(req, doc);
 
           // Remove all references to the doc
@@ -102,7 +102,8 @@ module.exports = {
             relatedReverseIds: { $in: [ doc.aposDocId ] },
             aposLocale: { $in: [ doc.aposLocale, null ] }
           }, {
-            $pull: { relatedReverseIds: doc.aposDocId }
+            $pull: { relatedReverseIds: doc.aposDocId },
+            $set: { cacheInvalidatedAt: doc.updatedAt }
           });
 
           if (!relatedDocsIds.length) {
@@ -114,7 +115,8 @@ module.exports = {
             aposDocId: { $in: relatedDocsIds },
             aposLocale: { $in: [ doc.aposLocale, null ] }
           }, {
-            $push: { relatedReverseIds: doc.aposDocId }
+            $push: { relatedReverseIds: doc.aposDocId },
+            $set: { cacheInvalidatedAt: doc.updatedAt }
           });
         },
         prepareForStorage(req, doc) {

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -129,10 +129,10 @@ module.exports = {
             });
           }
 
-          if (doc._parentUrl) {
+          if (doc._parentPage) {
             // Update piece index page's cache field
             await self.apos.doc.db.updateOne({
-              slug: doc._parentUrl,
+              slug: doc._parentPage,
               aposLocale: { $in: [ doc.aposLocale, null ] }
             }, {
               $set: { cacheInvalidatedAt: doc.updatedAt }

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -918,6 +918,7 @@ module.exports = {
         // Setting it this way rather than setting it to published.updatedAt
         // guarantees no small discrepancy breaking equality comparisons
         draft.updatedAt = draft.lastPublishedAt;
+        draft.cacheInvalidatedAt = draft.lastPublishedAt;
         draft.updatedBy = published.updatedBy;
         draft = await self.update(req.clone({
           mode: 'draft'

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -95,12 +95,7 @@ module.exports = {
     return {
       beforeSave: {
         async updateCacheField(req, doc) {
-          console.log(' --- updateCacheField');
-
           const relatedDocsIds = self.getRelatedDocsIds(req, doc);
-
-          console.log('relatedDocsIds', relatedDocsIds);
-          console.log('doc.relatedReverseIds', doc.relatedReverseIds);
 
           // - Remove current doc reference from docs that include it
           // - Update these docs' cache field

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -34,6 +34,7 @@ module.exports = {
     self.apos.isNew = await self.detectNew();
     await self.createIndexes();
     self.addLegacyMigrations();
+    self.addCacheFieldMigration();
   },
   restApiRoutes(self) {
     return {
@@ -198,7 +199,9 @@ module.exports = {
             }
           });
           if (options.setUpdatedAtAndBy !== false) {
-            doc.updatedAt = new Date();
+            const date = new Date();
+            doc.updatedAt = date;
+            doc.cacheInvalidatedAt = date;
             doc.updatedBy = req.user ? {
               _id: req.user._id,
               title: req.user.title || null,
@@ -1156,6 +1159,18 @@ module.exports = {
             }
           }
         }
+      },
+      // Add the "cacheInvalidatedAt" field to the documents that do not have it yet,
+      // and set it to equal doc.updatedAt.
+      setCacheField() {
+        return self.apos.migration.eachDoc({ cacheInvalidatedAt: { $exists: 0 } }, 5, async doc => {
+          await self.apos.doc.db.updateOne({ _id: doc._id }, {
+            $set: { cacheInvalidatedAt: doc.updatedAt }
+          });
+        });
+      },
+      addCacheFieldMigration() {
+        self.apos.migration.add('add-cache-invalidated-at-field', self.setCacheField);
       },
       ...require('./lib/legacy-migrations')(self)
     };

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -175,11 +175,8 @@ module.exports = {
       routeWrappers: {
         apiRoutes(name, fn) {
           return async function(req, res) {
-            console.log('--- apiRoutes');
             try {
               const result = await fn(req);
-              console.log('result', result);
-              console.log('res.statusCode', res.statusCode);
 
               if (req.method === 'GET' && req.user) {
                 res.header('Cache-Control', 'no-store');
@@ -189,7 +186,6 @@ module.exports = {
               const statusCode = res.statusCode === 304 ? 304 : 200;
 
               res.status(statusCode);
-              console.log('res.statusCode', res.statusCode);
               res.send(result);
             } catch (err) {
               return self.routeSendError(req, err);
@@ -480,15 +476,11 @@ module.exports = {
       },
 
       constructETag(req, doc) {
-        console.log(' --- constructETag');
-
         const context = doc || req.data.piece || req.data.page;
 
         if (!context || !context.cacheInvalidatedAt) {
           return null;
         }
-
-        console.log('context.cacheInvalidatedAt', context.cacheInvalidatedAt);
 
         const releaseId = self.apos.asset.getReleaseId();
         const cacheInvalidatedAtTimestamp = (new Date(context.cacheInvalidatedAt)).getTime();
@@ -497,29 +489,19 @@ module.exports = {
       },
 
       sendETag(req, doc) {
-        console.log(' --- sendETag');
-
         const eTagValue = self.constructETag(req, doc);
 
         if (eTagValue) {
-          console.log('ETag', eTagValue);
-          console.log('');
           req.res.header('ETag', eTagValue);
         }
       },
 
       doesETagMatch(req, doc) {
-        console.log(' --- doesETagMatch');
-
         if (!req.headers || !req.headers['if-none-match']) {
           return false;
         }
 
         const eTagValue = self.constructETag(req, doc);
-
-        console.log('req.headers[if-none-match]', req.headers['if-none-match']);
-        console.log('req.headers[\'if-none-match\'].split(\',\').includes(eTagValue)', req.headers['if-none-match'].split(',').includes(eTagValue));
-        console.log('');
 
         return eTagValue && req.headers['if-none-match'].split(',').includes(eTagValue);
       },

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -473,8 +473,13 @@ module.exports = {
       },
 
       emitETag(req, doc) {
+        console.log(' --- emitETag');
+        // TODO: fix undefined req.data.piece
+        // console.log('req.data.piece', req.data.piece);
+
         const context = doc || req.data.piece || req.data.page;
-        if (!context) {
+        // console.log('context', context);
+        if (!context || !context.cacheInvalidatedAt) {
           return;
         }
 
@@ -482,7 +487,9 @@ module.exports = {
         const cacheInvalidatedAtTimestamp = (new Date(context.cacheInvalidatedAt)).getTime();
         const eTagValue = `"${releaseId}:${cacheInvalidatedAtTimestamp}"`;
 
+        console.log('context.cacheInvalidatedAt', context.cacheInvalidatedAt);
         console.log('ETag', eTagValue);
+        console.log('');
 
         req.res.header('ETag', eTagValue);
       },

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -492,29 +492,21 @@ module.exports = {
       },
 
       setETag(req, eTagParts) {
-        console.log('sendETag', eTagParts.join(':'));
-        console.log('=======>');
-
         req.res.header('ETag', eTagParts.join(':'));
       },
 
       checkETag(req, doc, maxAge) {
         const eTagParts = self.generateETagParts(req, doc);
-        console.log('eTagParts', eTagParts);
 
         if (!eTagParts || !self.isSafeToCache(req)) {
           return false;
         }
 
-        console.log('req.headers[\'if-none-match\']', req.headers['if-none-match']);
         const clientETagParts = req.headers['if-none-match'] ? req.headers['if-none-match'].split(':') : [];
         const doesETagMatch = clientETagParts[0] === eTagParts[0] && clientETagParts[1] === eTagParts[1];
 
         const now = Date.now();
         const clientETagAge = (now - clientETagParts[2]) / 1000;
-
-        console.log('clientETagAge', clientETagAge);
-        console.log('maxAge', maxAge);
 
         if (!doesETagMatch || clientETagAge > maxAge) {
           self.setETag(req, [ ...eTagParts, now ]);

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -472,6 +472,21 @@ module.exports = {
         req.res.header('Cache-Control', cacheControlValue);
       },
 
+      emitETag(req, doc) {
+        const context = doc || req.data.piece || req.data.page;
+        if (!context) {
+          return;
+        }
+
+        const releaseId = self.apos.asset.getReleaseId();
+        const cacheInvalidatedAtTimestamp = (new Date(context.cacheInvalidatedAt)).getTime();
+        const eTagValue = `"${releaseId}:${cacheInvalidatedAtTimestamp}"`;
+
+        console.log('ETag', eTagValue);
+
+        req.res.header('ETag', eTagValue);
+      },
+
       // Call from init once if this module implements the `getBrowserData` method.
       // The data returned by `getBrowserData(req)` will then be available on
       // `apos.modules['your-module-name']` in the browser.

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -473,8 +473,6 @@ module.exports = {
       },
 
       emitETag(req, doc) {
-        console.log(' --- emitETag');
-
         const context = doc || req.data.piece || req.data.page;
         if (!context || !context.cacheInvalidatedAt) {
           return;
@@ -483,10 +481,6 @@ module.exports = {
         const releaseId = self.apos.asset.getReleaseId();
         const cacheInvalidatedAtTimestamp = (new Date(context.cacheInvalidatedAt)).getTime();
         const eTagValue = `"${releaseId}:${cacheInvalidatedAtTimestamp}"`;
-
-        console.log('context.cacheInvalidatedAt', context.cacheInvalidatedAt);
-        console.log('ETag', eTagValue);
-        console.log('');
 
         req.res.header('ETag', eTagValue);
       },

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -474,11 +474,8 @@ module.exports = {
 
       emitETag(req, doc) {
         console.log(' --- emitETag');
-        // TODO: fix undefined req.data.piece
-        // console.log('req.data.piece', req.data.piece);
 
         const context = doc || req.data.piece || req.data.page;
-        // console.log('context', context);
         if (!context || !context.cacheInvalidatedAt) {
           return;
         }

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -185,7 +185,10 @@ module.exports = {
                 res.header('Cache-Control', 'no-store');
               }
 
-              res.status(200);
+              // Keep "304 Not Modified" status if previously set
+              const statusCode = res.statusCode === 304 ? 304 : 200;
+
+              res.status(statusCode);
               console.log('res.statusCode', res.statusCode);
               res.send(result);
             } catch (err) {

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -2136,7 +2136,10 @@ database.`);
               _id: null
             });
           } else {
-            query.project(self.options.publicApiProjection);
+            query.project({
+              ...self.options.publicApiProjection,
+              cacheInvalidatedAt: 1
+            });
           }
         }
         return query;

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -183,7 +183,9 @@ module.exports = {
             self.sendETag(req, result);
 
             if (self.doesETagMatch(req, result)) {
-              console.log('304');
+              req.res.status(304);
+
+              // Stop and send an empty body since the cached response will be used
               return {};
             }
           }

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -1396,7 +1396,14 @@ database.`);
       },
 
       shouldSendUnmodifiedResponse(req) {
-        if (!self.options.cache || !self.options.cache.page || !self.options.cache.page.maxAge || !req.headers || !req.headers['if-none-match']) {
+        if (
+          !self.options.cache ||
+          !self.options.cache.page ||
+          !self.options.cache.page.maxAge ||
+          !req.data.page ||
+          !req.data.page.cacheInvalidatedAt ||
+          !req.headers ||
+          !req.headers['if-none-match']) {
           return false;
         }
 
@@ -1405,9 +1412,11 @@ database.`);
 
         const expectedETag = `"${releaseId}:${cacheInvalidatedAtTimestamp}"`;
 
+        console.log(' --- shouldSendUnmodifiedResponse');
         console.log('req.headers[if-none-match]', req.headers['if-none-match']);
         console.log('expectedETag', expectedETag);
         console.log('req.headers[\'if-none-match\'].split(\',\').includes(expectedETag)', req.headers['if-none-match'].split(',').includes(expectedETag));
+        console.log('');
 
         return req.headers['if-none-match'].split(',').includes(expectedETag);
       },
@@ -1428,7 +1437,8 @@ database.`);
         // TODO: stop render at the right place
         if (self.shouldSendUnmodifiedResponse(req)) {
           console.log('304');
-          req.res.statusCode = 304;
+          // Express automatically sets 304
+          // req.res.statusCode = 304;
         }
 
         try {

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -1394,38 +1394,10 @@ database.`);
         const pages = Array.isArray(pageOrPages) ? pageOrPages : [ pageOrPages ];
         self.parked = self.parked.concat(pages);
       },
-
-      shouldSendUnmodifiedResponse(req) {
-        if (
-          !self.options.cache ||
-          !self.options.cache.page ||
-          !self.options.cache.page.maxAge ||
-          !req.data.page ||
-          !req.data.page.cacheInvalidatedAt ||
-          !req.headers ||
-          !req.headers['if-none-match']) {
-          return false;
-        }
-
-        const releaseId = self.apos.asset.getReleaseId();
-        const cacheInvalidatedAtTimestamp = (new Date(req.data.page.cacheInvalidatedAt)).getTime();
-
-        const expectedETag = `"${releaseId}:${cacheInvalidatedAtTimestamp}"`;
-
-        console.log(' --- shouldSendUnmodifiedResponse');
-        console.log('req.headers[if-none-match]', req.headers['if-none-match']);
-        console.log('expectedETag', expectedETag);
-        console.log('req.headers[\'if-none-match\'].split(\',\').includes(expectedETag)', req.headers['if-none-match'].split(',').includes(expectedETag));
-        console.log('');
-
-        return req.headers['if-none-match'].split(',').includes(expectedETag);
-      },
-
       // Route that serves pages. See afterInit in
       // index.js for the wildcard argument and the app.get call
       async serve(req, res) {
         req.deferWidgetLoading = true;
-
         try {
           await self.serveGetPage(req);
           await self.emit('serve', req);

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -1418,8 +1418,8 @@ database.`);
           self.sendETag(req);
 
           if (self.doesETagMatch(req)) {
-            console.log('304');
-            return req.res.sendStatus(304);
+            // Stop there and send a 304 status code; the cached response will be used
+            return res.sendStatus(304);
           }
         }
 

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -179,12 +179,11 @@ module.exports = {
           const result = await self.getRestQuery(req).and(criteria).toObject();
 
           if (self.options.cache && self.options.cache.api && self.options.cache.api.maxAge) {
-            self.setMaxAge(req, self.options.cache.api.maxAge);
-            self.sendETag(req, result);
+            const { maxAge } = self.options.cache.api;
 
-            if (self.doesETagMatch(req, result)) {
-              req.res.status(304);
-
+            if (!self.options.cache.etags) {
+              self.setMaxAge(req, maxAge);
+            } else if (self.checkETag(req, result, maxAge)) {
               // Stop and send an empty body since the cached response will be used
               return {};
             }
@@ -1414,10 +1413,11 @@ database.`);
         }
 
         if (self.options.cache && self.options.cache.page && self.options.cache.page.maxAge) {
-          self.setMaxAge(req, self.options.cache.page.maxAge);
-          self.sendETag(req);
+          const { maxAge } = self.options.cache.page;
 
-          if (self.doesETagMatch(req)) {
+          if (!self.options.cache.etags) {
+            self.setMaxAge(req, maxAge);
+          } else if (self.checkETag(req, undefined, maxAge)) {
             // Stop there and send a 304 status code; the cached response will be used
             return res.sendStatus(304);
           }

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -184,7 +184,6 @@ module.exports = {
             if (!self.options.cache.etags) {
               self.setMaxAge(req, maxAge);
             } else if (self.checkETag(req, result, maxAge)) {
-              // Stop and send an empty body since the cached response will be used
               return {};
             }
           }

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -180,7 +180,12 @@ module.exports = {
 
           if (self.options.cache && self.options.cache.api && self.options.cache.api.maxAge) {
             self.setMaxAge(req, self.options.cache.api.maxAge);
-            self.emitETag(req, result);
+            self.sendETag(req, result);
+
+            if (self.doesETagMatch(req, result)) {
+              console.log('304');
+              return {};
+            }
           }
 
           if (!result) {
@@ -1408,7 +1413,12 @@ database.`);
 
         if (self.options.cache && self.options.cache.page && self.options.cache.page.maxAge) {
           self.setMaxAge(req, self.options.cache.page.maxAge);
-          self.emitETag(req);
+          self.sendETag(req);
+
+          if (self.doesETagMatch(req)) {
+            console.log('304');
+            return req.res.sendStatus(304);
+          }
         }
 
         try {

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -1434,11 +1434,9 @@ database.`);
           return await self.serve500Error(req, err);
         }
 
-        // TODO: stop render at the right place
-        if (self.shouldSendUnmodifiedResponse(req)) {
-          console.log('304');
-          // Express automatically sets 304
-          // req.res.statusCode = 304;
+        if (self.options.cache && self.options.cache.page && self.options.cache.page.maxAge) {
+          self.setMaxAge(req, self.options.cache.page.maxAge);
+          self.emitETag(req);
         }
 
         try {
@@ -1466,11 +1464,6 @@ database.`);
         await self.emit('serveQuery', query);
         req.data.bestPage = await query.toObject();
         self.evaluatePageMatch(req);
-
-        if (self.options.cache && self.options.cache.page && self.options.cache.page.maxAge) {
-          self.setMaxAge(req, self.options.cache.page.maxAge);
-          self.emitETag(req);
-        }
       },
       // Normalize req.slug to account for unneeded trailing whitespace,
       // trailing slashes other than the root, and double slash based open

--- a/modules/@apostrophecms/piece-page-type/index.js
+++ b/modules/@apostrophecms/piece-page-type/index.js
@@ -241,7 +241,7 @@ module.exports = {
           if (parentPage) {
             piece._url = self.buildUrl(req, parentPage, piece);
             piece._parentUrl = parentPage._url;
-            piece._parentPage = parentPage.slug;
+            piece._parentSlug = parentPage.slug;
           }
         });
       },

--- a/modules/@apostrophecms/piece-page-type/index.js
+++ b/modules/@apostrophecms/piece-page-type/index.js
@@ -241,6 +241,7 @@ module.exports = {
           if (parentPage) {
             piece._url = self.buildUrl(req, parentPage, piece);
             piece._parentUrl = parentPage._url;
+            piece._parentPage = parentPage.slug;
           }
         });
       },

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -918,7 +918,10 @@ module.exports = {
               _id: null
             });
           } else if (!query.state.project) {
-            query.project(self.options.publicApiProjection);
+            query.project({
+              ...self.options.publicApiProjection,
+              cacheInvalidatedAt: 1
+            });
           }
         }
         return query;

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -216,12 +216,11 @@ module.exports = {
           const doc = await self.getRestQuery(req).and({ _id }).toObject();
 
           if (self.options.cache && self.options.cache.api && self.options.cache.api.maxAge) {
-            self.setMaxAge(req, self.options.cache.api.maxAge);
-            self.sendETag(req, doc);
+            const { maxAge } = self.options.cache.api;
 
-            if (self.doesETagMatch(req, doc)) {
-              req.res.status(304);
-
+            if (!self.options.cache.etags) {
+              self.setMaxAge(req, maxAge);
+            } else if (self.checkETag(req, doc, maxAge)) {
               // Stop and send an empty body since the cached response will be used
               return {};
             }

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -201,7 +201,7 @@ module.exports = {
             result.counts = query.get('countsResults');
           }
 
-          if (self.options.cache && self.options.cache.api) {
+          if (self.options.cache && self.options.cache.api && self.options.cache.api.maxAge) {
             self.setMaxAge(req, self.options.cache.api.maxAge);
           }
 
@@ -215,8 +215,9 @@ module.exports = {
           self.publicApiCheck(req);
           const doc = await self.getRestQuery(req).and({ _id }).toObject();
 
-          if (self.options.cache && self.options.cache.api) {
+          if (self.options.cache && self.options.cache.api && self.options.cache.api.maxAge) {
             self.setMaxAge(req, self.options.cache.api.maxAge);
+            self.emitETag(req, doc);
           }
 
           if (!doc) {

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -220,7 +220,9 @@ module.exports = {
             self.sendETag(req, doc);
 
             if (self.doesETagMatch(req, doc)) {
-              console.log('304');
+              req.res.status(304);
+
+              // Stop and send an empty body since the cached response will be used
               return {};
             }
           }

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -221,7 +221,6 @@ module.exports = {
             if (!self.options.cache.etags) {
               self.setMaxAge(req, maxAge);
             } else if (self.checkETag(req, doc, maxAge)) {
-              // Stop and send an empty body since the cached response will be used
               return {};
             }
           }

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -217,7 +217,12 @@ module.exports = {
 
           if (self.options.cache && self.options.cache.api && self.options.cache.api.maxAge) {
             self.setMaxAge(req, self.options.cache.api.maxAge);
-            self.emitETag(req, doc);
+            self.sendETag(req, doc);
+
+            if (self.doesETagMatch(req, doc)) {
+              console.log('304');
+              return {};
+            }
           }
 
           if (!doc) {

--- a/test/docs.js
+++ b/test/docs.js
@@ -300,7 +300,7 @@ describe('Docs', function() {
     assert(doc.slug.match(/^one\d+$/));
   });
 
-  it('should add the aposDocId to the related documents\' relatedReverseIds field', async () => {
+  it('should add the aposDocId to the related documents\' relatedReverseIds field and update their `cacheInvalidatedAt` field', async () => {
     const object = {
       aposDocId: 'paul',
       aposLocale: 'en:published',
@@ -315,7 +315,7 @@ describe('Docs', function() {
       _friends: [ { _id: 'carl:en:published' }, { _id: 'larry:en:published' } ]
     };
 
-    await apos.doc.insert(apos.task.getReq(), object);
+    const response = await apos.doc.insert(apos.task.getReq(), object);
 
     const carlDoc = await apos.doc.db.findOne({
       slug: 'carl',
@@ -329,9 +329,11 @@ describe('Docs', function() {
 
     assert(carlDoc.relatedReverseIds.length === 1);
     assert(carlDoc.relatedReverseIds[0] === 'paul');
+    assert(carlDoc.cacheInvalidatedAt.getTime() === response.updatedAt.getTime());
 
     assert(larryDoc.relatedReverseIds.length === 1);
     assert(larryDoc.relatedReverseIds[0] === 'paul');
+    assert(larryDoc.cacheInvalidatedAt.getTime() === response.updatedAt.getTime());
   });
 
   it('should not allow you to call the insert method if you are not an admin', async function() {
@@ -420,7 +422,7 @@ describe('Docs', function() {
     assert(counts.Lori === 2);
   });
 
-  it('should remove the aposDocId from the related documents\' relatedReverseIds field', async () => {
+  it('should remove the aposDocId from the related documents\' relatedReverseIds field and update their `cacheInvalidatedAt` field', async () => {
     const paulDoc = await apos.doc.db.findOne({
       slug: 'paul',
       aposLocale: 'en:published'
@@ -433,7 +435,7 @@ describe('Docs', function() {
       _friends: [ { _id: 'larry:en:published' } ]
     };
 
-    await apos.doc.update(apos.task.getReq(), object);
+    const response = await apos.doc.update(apos.task.getReq(), object);
 
     const carlDoc = await apos.doc.db.findOne({
       slug: 'carl',
@@ -446,9 +448,11 @@ describe('Docs', function() {
     });
 
     assert(carlDoc.relatedReverseIds.length === 0);
+    assert(carlDoc.cacheInvalidatedAt.getTime() === response.updatedAt.getTime());
 
     assert(larryDoc.relatedReverseIds.length === 1);
     assert(larryDoc.relatedReverseIds[0] === 'paul');
+    assert(larryDoc.cacheInvalidatedAt.getTime() === response.updatedAt.getTime());
   });
 
   it('should not allow you to call the update method if you are not an admin', async function() {
@@ -775,8 +779,8 @@ describe('Docs', function() {
       _id: `${response.aposDocId}:en:draft`
     });
 
-    assert(response.cacheInvalidatedAt.toString() === response.updatedAt.toString());
-    assert(draft.cacheInvalidatedAt.toString() === draft.updatedAt.toString());
+    assert(response.cacheInvalidatedAt.getTime() === response.updatedAt.getTime());
+    assert(draft.cacheInvalidatedAt.getTime() === draft.updatedAt.getTime());
   });
 
 });

--- a/test/docs.js
+++ b/test/docs.js
@@ -523,7 +523,7 @@ describe('Docs', function() {
       lastName: 'Lee',
       age: 30,
       alive: false,
-      _parentUrl: '/parent/new-page'
+      _parentPage: '/parent/new-page'
     };
 
     await apos.doc.insert(apos.task.getReq(), page);

--- a/test/docs.js
+++ b/test/docs.js
@@ -31,6 +31,20 @@ describe('Docs', function() {
               }
             }
           }
+        },
+        '@apostrophecms/page': {
+          options: {
+            park: [],
+            types: [
+              {
+                name: 'test-page',
+                label: 'Test Page'
+              }
+            ]
+          }
+        },
+        'test-page': {
+          extend: '@apostrophecms/page-type'
         }
       }
     });
@@ -489,6 +503,38 @@ describe('Docs', function() {
     });
 
     assert(johnDoc.cacheInvalidatedAt.getTime() === response.updatedAt.getTime());
+  });
+
+  it('should update the pieces parent page\'s `cacheInvalidatedAt` field', async () => {
+    const page = {
+      slug: '/parent/new-page',
+      visibility: 'public',
+      type: 'test-page',
+      title: 'New Page'
+    };
+
+    const object = {
+      aposDocId: 'bruce',
+      aposLocale: 'en:published',
+      slug: 'bruce',
+      visibility: 'public',
+      type: 'test-people',
+      firstName: 'Bruce',
+      lastName: 'Lee',
+      age: 30,
+      alive: false,
+      _parentUrl: '/parent/new-page'
+    };
+
+    await apos.doc.insert(apos.task.getReq(), page);
+    const response = await apos.doc.insert(apos.task.getReq(), object);
+
+    const pageDoc = await apos.doc.db.findOne({
+      slug: '/parent/new-page',
+      aposLocale: 'en:published'
+    });
+
+    assert(pageDoc.cacheInvalidatedAt.getTime() === response.updatedAt.getTime());
   });
 
   it('should not allow you to call the update method if you are not an admin', async function() {

--- a/test/docs.js
+++ b/test/docs.js
@@ -523,7 +523,7 @@ describe('Docs', function() {
       lastName: 'Lee',
       age: 30,
       alive: false,
-      _parentPage: '/parent/new-page'
+      _parentSlug: '/parent/new-page'
     };
 
     await apos.doc.insert(apos.task.getReq(), page);

--- a/test/pages-public-api.js
+++ b/test/pages-public-api.js
@@ -82,6 +82,26 @@ describe('Pages Public API', function() {
     assert(response2.headers['cache-control'] === undefined);
   });
 
+  it('should not set a "max-age" cache-control value when retrieving a single page, when "etags" cache option is set, with a public API projection', async () => {
+    apos.page.options.publicApiProjection = {
+      title: 1,
+      _url: 1
+    };
+    apos.page.options.cache = {
+      api: {
+        maxAge: 1111
+      },
+      etags: true
+    };
+
+    const response1 = await apos.http.get('/api/v1/@apostrophecms/page', { fullResponse: true });
+    const response2 = await apos.http.get(`/api/v1/@apostrophecms/page/${response1.body._id}`, { fullResponse: true });
+
+    assert(response2.headers['cache-control'] === undefined);
+
+    delete apos.page.options.cache;
+  });
+
   it('should set a "max-age" cache-control value when retrieving pages, with a public API projection', async () => {
     apos.page.options.publicApiProjection = {
       title: 1,

--- a/test/pages-public-api.js
+++ b/test/pages-public-api.js
@@ -122,7 +122,7 @@ describe('Pages Public API', function() {
     delete apos.page.options.cache;
   });
 
-  it('should set an etag when retrieving a single page', async () => {
+  it('should set a custom etag when retrieving a single page', async () => {
     apos.page.options.publicApiProjection = {
       title: 1,
       _url: 1

--- a/test/pages-public-api.js
+++ b/test/pages-public-api.js
@@ -121,4 +121,28 @@ describe('Pages Public API', function() {
 
     delete apos.page.options.cache;
   });
+
+  it('should set an etag when retrieving a single page', async () => {
+    apos.page.options.publicApiProjection = {
+      title: 1,
+      _url: 1
+    };
+    apos.page.options.cache = {
+      api: {
+        maxAge: 1111
+      },
+      etags: true
+    };
+
+    const response1 = await apos.http.get('/api/v1/@apostrophecms/page', { fullResponse: true });
+    const response2 = await apos.http.get(`/api/v1/@apostrophecms/page/${response1.body._id}`, { fullResponse: true });
+
+    const eTagParts = response2.headers.etag.split(':');
+
+    assert(eTagParts[0] === apos.asset.getReleaseId());
+    assert(eTagParts[1] === (new Date(response2.body.cacheInvalidatedAt)).getTime().toString());
+    assert(eTagParts[2]);
+
+    delete apos.page.options.cache;
+  });
 });

--- a/test/pages.js
+++ b/test/pages.js
@@ -503,6 +503,24 @@ describe('Pages', function() {
     assert(response2.headers['cache-control'] === undefined);
   });
 
+  it('should not set a cache-control value when retrieving a single page, when "etags" cache option is set', async () => {
+    apos.page.options.cache = {
+      page: {
+        maxAge: 5555
+      },
+      api: {
+        maxAge: 5555
+      },
+      etags: true
+    };
+
+    const response = await apos.http.get(`/api/v1/@apostrophecms/page/${homeId}`, { fullResponse: true });
+
+    assert(response.headers['cache-control'] === undefined);
+
+    delete apos.page.options.cache;
+  });
+
   it('should not set a cache-control value when retrieving pages, when "api" cache option is not set', async () => {
     apos.page.options.cache = {
       page: {

--- a/test/pages.js
+++ b/test/pages.js
@@ -662,6 +662,20 @@ describe('Pages', function() {
     delete apos.page.options.cache;
   });
 
+  it('should not set a cache-control value when serving a page, when "etags" cache option is set', async () => {
+    apos.page.options.cache = {
+      page: {
+        maxAge: 4444
+      },
+      etags: true
+    };
+    const response = await apos.http.get('/', { fullResponse: true });
+
+    assert(response.headers['cache-control'] === undefined);
+
+    delete apos.page.options.cache;
+  });
+
   it('should set a cache-control value when serving a page, when "page" cache option is set', async () => {
     apos.page.options.cache = {
       page: {
@@ -689,6 +703,24 @@ describe('Pages', function() {
 
     assert(eTagParts[0] === apos.asset.getReleaseId());
     assert(eTagParts[1] === (new Date(response.body.cacheInvalidatedAt)).getTime().toString());
+    assert(eTagParts[2]);
+
+    delete apos.page.options.cache;
+  });
+
+  it('should set a custom etag when serving a single page', async () => {
+    apos.page.options.cache = {
+      page: {
+        maxAge: 4444
+      },
+      etags: true
+    };
+    const response = await apos.http.get('/', { fullResponse: true });
+
+    const eTagParts = response.headers.etag.split(':');
+
+    assert(eTagParts[0] === apos.asset.getReleaseId());
+    assert(eTagParts[1]);
     assert(eTagParts[2]);
 
     delete apos.page.options.cache;

--- a/test/pages.js
+++ b/test/pages.js
@@ -708,7 +708,7 @@ describe('Pages', function() {
     delete apos.page.options.cache;
   });
 
-  it('should set a custom etag when serving a single page', async () => {
+  it('should set a custom etag when serving a page', async () => {
     apos.page.options.cache = {
       page: {
         maxAge: 4444
@@ -722,6 +722,110 @@ describe('Pages', function() {
     assert(eTagParts[0] === apos.asset.getReleaseId());
     assert(eTagParts[1]);
     assert(eTagParts[2]);
+
+    delete apos.page.options.cache;
+  });
+
+  it('should return a 304 status code when requesting a page with a matching etag', async () => {
+    apos.page.options.cache = {
+      page: {
+        maxAge: 4444
+      },
+      etags: true
+    };
+
+    const response1 = await apos.http.get('/', { fullResponse: true });
+    const response2 = await apos.http.get('/', {
+      fullResponse: true,
+      headers: {
+        'if-none-match': response1.headers.etag
+      }
+    });
+
+    assert(response1.status === 200);
+    assert(response1.body);
+
+    assert(response2.status === 304);
+    assert(response2.body === '');
+
+    // Same ETag should be sent again to the client
+    assert(response1.headers.etag === response2.headers.etag);
+
+    delete apos.page.options.cache;
+  });
+
+  it('should not return a 304 status code when requesting a page that has been edited', async () => {
+    apos.page.options.cache = {
+      page: {
+        maxAge: 4444
+      },
+      etags: true
+    };
+
+    const response1 = await apos.http.get('/', { fullResponse: true });
+
+    const pageDoc = await apos.doc.db.findOne({
+      slug: '/',
+      aposLocale: 'en:published'
+    });
+
+    // Edit homepage, this should invalidate its cache,
+    // so requesting it again should not return a 304 status code
+    const pageUpdateResponse = await apos.doc.update(apos.task.getReq(), {
+      ...pageDoc,
+      title: 'Home edited'
+    });
+
+    const response2 = await apos.http.get('/', {
+      fullResponse: true,
+      headers: {
+        'if-none-match': response1.headers.etag
+      }
+    });
+
+    const eTag1Parts = response1.headers.etag.split(':');
+    const eTag2Parts = response2.headers.etag.split(':');
+
+    assert(response1.status === 200);
+    assert(response1.body);
+
+    assert(response2.status === 200);
+    assert(response2.body);
+
+    // New ETag has been generated, with the new value of the edited homepage's `cacheInvalidatedAt` field...
+    assert(eTag2Parts[1] === (new Date(pageUpdateResponse.cacheInvalidatedAt)).getTime().toString());
+    // ...and a new timestamp
+    assert(eTag2Parts[2] !== eTag1Parts[2]);
+
+    delete apos.page.options.cache;
+  });
+
+  it('should not return a 304 status code when requesting a page after the max-age period', async () => {
+    apos.page.options.cache = {
+      page: {
+        maxAge: 4444
+      },
+      etags: true
+    };
+
+    const response1 = await apos.http.get('/', { fullResponse: true });
+
+    const eTagParts = response1.headers.etag.split(':');
+    const outOfDateETagParts = [ ...eTagParts ];
+    outOfDateETagParts[2] = Number(outOfDateETagParts[2]) - 4445000; // 1s outdated
+
+    const response2 = await apos.http.get('/', {
+      fullResponse: true,
+      headers: {
+        'if-none-match': outOfDateETagParts.join(':')
+      }
+    });
+
+    assert(response1.status === 200);
+    assert(response1.body);
+
+    assert(response2.status === 200);
+    assert(response2.body);
 
     delete apos.page.options.cache;
   });

--- a/test/pages.js
+++ b/test/pages.js
@@ -675,4 +675,23 @@ describe('Pages', function() {
     delete apos.page.options.cache;
   });
 
+  it('should set an etag when retrieving a single page', async () => {
+    apos.page.options.cache = {
+      api: {
+        maxAge: 1111
+      },
+      etags: true
+    };
+
+    const response = await apos.http.get(`/api/v1/@apostrophecms/page/${homeId}`, { fullResponse: true });
+
+    const eTagParts = response.headers.etag.split(':');
+
+    assert(eTagParts[0] === apos.asset.getReleaseId());
+    assert(eTagParts[1] === (new Date(response.body.cacheInvalidatedAt)).getTime().toString());
+    assert(eTagParts[2]);
+
+    delete apos.page.options.cache;
+  });
+
 });

--- a/test/pieces-public-api.js
+++ b/test/pieces-public-api.js
@@ -128,7 +128,7 @@ describe('Pieces Public API', function() {
     delete apos.thing.options.cache;
   });
 
-  it('should set an etag when retrieving a single piece', async () => {
+  it('should set a custom etag when retrieving a single piece', async () => {
     apos.thing.options.publicApiProjection = {
       title: 1,
       _url: 1

--- a/test/pieces-public-api.js
+++ b/test/pieces-public-api.js
@@ -91,6 +91,23 @@ describe('Pieces Public API', function() {
     assert(response2.headers['cache-control'] === undefined);
   });
 
+  it('should not set a "max-age" cache-control value when retrieving a single piece, when "etags" cache option is set, with a public API projection', async () => {
+    apos.thing.options.publicApiProjection = {
+      title: 1,
+      _url: 1
+    };
+    apos.thing.options.cache = {
+      api: {
+        maxAge: 2222
+      },
+      etags: true
+    };
+
+    const response = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });
+
+    assert(response.headers['cache-control'] === undefined);
+  });
+
   it('should set a "max-age" cache-control value when retrieving pieces, with a public API projection', async () => {
     apos.thing.options.publicApiProjection = {
       title: 1,

--- a/test/pieces-public-api.js
+++ b/test/pieces-public-api.js
@@ -128,4 +128,27 @@ describe('Pieces Public API', function() {
     delete apos.thing.options.cache;
   });
 
+  it('should set an etag when retrieving a single piece', async () => {
+    apos.thing.options.publicApiProjection = {
+      title: 1,
+      _url: 1
+    };
+    apos.thing.options.cache = {
+      api: {
+        maxAge: 1111
+      },
+      etags: true
+    };
+
+    const response = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });
+
+    const eTagParts = response.headers.etag.split(':');
+
+    assert(eTagParts[0] === apos.asset.getReleaseId());
+    assert(eTagParts[1] === (new Date(response.body.cacheInvalidatedAt)).getTime().toString());
+    assert(eTagParts[2]);
+
+    delete apos.thing.options.cache;
+  });
+
 });

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -1315,6 +1315,19 @@ describe('Pieces', function() {
     assert(response2.headers['cache-control'] === undefined);
   });
 
+  it('should not set a cache-control value when retrieving a single piece, when "etags" cache option is set', async () => {
+    apos.thing.options.cache = {
+      api: {
+        maxAge: 5555
+      },
+      etags: true
+    };
+
+    const response = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });
+
+    assert(response.headers['cache-control'] === undefined);
+  });
+
   it('should not set a cache-control value when retrieving pieces, when "api" cache option is not set', async () => {
     apos.thing.options.cache = {
       page: {

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -1437,4 +1437,23 @@ describe('Pieces', function() {
 
     delete apos.thing.options.cache;
   });
+
+  it('should set an etag when retrieving a single piece', async () => {
+    apos.thing.options.cache = {
+      api: {
+        maxAge: 1111
+      },
+      etags: true
+    };
+
+    const response = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });
+
+    const eTagParts = response.headers.etag.split(':');
+
+    assert(eTagParts[0] === apos.asset.getReleaseId());
+    assert(eTagParts[1] === (new Date(response.body.cacheInvalidatedAt)).getTime().toString());
+    assert(eTagParts[2]);
+
+    delete apos.thing.options.cache;
+  });
 });

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -1457,6 +1457,113 @@ describe('Pieces', function() {
     delete apos.thing.options.cache;
   });
 
+  it('should return a 304 status code when retrieving a piece with a matching etag', async () => {
+    apos.thing.options.cache = {
+      api: {
+        maxAge: 1111
+      },
+      etags: true
+    };
+
+    const response1 = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });
+    const response2 = await apos.http.get('/api/v1/thing/testThing:en:published', {
+      fullResponse: true,
+      headers: {
+        'if-none-match': response1.headers.etag
+      }
+    });
+
+    assert(response1.status === 200);
+    assert(response1.body);
+
+    assert(response2.status === 304);
+    assert(response2.body === '');
+
+    // Same ETag should be sent again to the client
+    assert(response1.headers.etag === response2.headers.etag);
+
+    delete apos.thing.options.cache;
+  });
+
+  it('should not return a 304 status code when retrieving a piece that has been edited', async () => {
+    apos.thing.options.cache = {
+      api: {
+        maxAge: 1111
+      },
+      etags: true
+    };
+
+    const response1 = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });
+
+    const pieceDoc = await apos.doc.db.findOne({
+      aposDocId: 'testThing',
+      aposLocale: 'en:published'
+    });
+
+    // Edit piece, this should invalidate its cache,
+    // so requesting it again should not return a 304 status code
+    const pieceUpdateResponse = await apos.doc.update(apos.task.getReq(), pieceDoc);
+
+    const response2 = await apos.http.get('/api/v1/thing/testThing:en:published', {
+      fullResponse: true,
+      headers: {
+        'if-none-match': response1.headers.etag
+      }
+    });
+
+    const eTag1Parts = response1.headers.etag.split(':');
+    const eTag2Parts = response2.headers.etag.split(':');
+
+    assert(response1.status === 200);
+    assert(response1.body);
+
+    assert(response2.status === 200);
+    assert(response2.body);
+
+    // New ETag has been generated, with the new value of the edited piece's `cacheInvalidatedAt` field...
+    assert(eTag2Parts[1] === pieceUpdateResponse.cacheInvalidatedAt.getTime().toString());
+    // ...and a new timestamp
+    assert(eTag2Parts[2] !== eTag1Parts[2]);
+
+    delete apos.thing.options.cache;
+  });
+
+  it('should not return a 304 status code when retrieving a piece after the max-age period', async () => {
+    apos.thing.options.cache = {
+      api: {
+        maxAge: 4444
+      },
+      etags: true
+    };
+
+    const response1 = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });
+
+    const eTagParts = response1.headers.etag.split(':');
+    const outOfDateETagParts = [ ...eTagParts ];
+    outOfDateETagParts[2] = Number(outOfDateETagParts[2]) - (4444 + 1) * 1000; // 1s outdated
+
+    const response2 = await apos.http.get('/api/v1/thing/testThing:en:published', {
+      fullResponse: true,
+      headers: {
+        'if-none-match': outOfDateETagParts.join(':')
+      }
+    });
+
+    const eTag1Parts = response1.headers.etag.split(':');
+    const eTag2Parts = response2.headers.etag.split(':');
+
+    assert(response1.status === 200);
+    assert(response1.body);
+
+    assert(response2.status === 200);
+    assert(response2.body);
+
+    // New timestamp
+    assert(eTag1Parts[2] !== eTag2Parts[2]);
+
+    delete apos.thing.options.cache;
+  });
+
   it('should not set a custom etag when retrieving a single piece, when user is connected', async () => {
     apos.thing.options.cache = {
       api: {


### PR DESCRIPTION
[PRO-2576](https://linear.app/apostrophecms/issue/PRO-2576/caching-emit-etags-for-the-context-document-and-invalidate-them-based)

## Summary

Emit `ETags` that are used to cache pages and pieces.

When the `Etag` value of a doc is unchanged, the client will use the cached version version of the page or REST GET response (of a single piece or page, i.e: `getOne()`).

`ETags` value rely on the `cacheInvalidatedAt` docs field, which is updated every time the doc or one of its related docs is updated (thanks to backlinks: the `relatedReverseIds` field).
The related docs of a doc have also their `cacheInvalidatedAt` field updated, when the doc is updated

## What are the specific steps to test this change?

First, ensure that HTTP cache is not disabled:

![image](https://user-images.githubusercontent.com/8301962/160863837-3bcbb9ff-a88f-4e6b-98e5-fbed5e3125b2.png)

**Pages**

- In private window tabs, go to:
  - the GET REST API route of the homepage (`/api/v1/@apostrophecms/page/<homepage-id>`)
  - the homepage (`/`)

- Refresh the pages above, you should get a `304` status code, with the `ETag` response header matching the `If-None-Match` request header:

![image](https://user-images.githubusercontent.com/8301962/160864542-b63157c6-0cd1-4114-a45d-9327775e0800.png)

- In a non-private window, login to the website and edit the homepage
- Go back to the private window tabs and refresh the pages, you should have a `200` status code, with a mismatch between `ETag` response header and `If-None-Match` request header (ETag has changed), and of course your change ("edit 4" --> "edit 5" in this example):

![image](https://user-images.githubusercontent.com/8301962/160864939-b4b859ae-10d1-4979-9438-a28a5e55930b.png)

- Refresh the pages, you should have the `304` status code back, and the `ETag` header equaling the `If-None-Match` one.

**Pieces**

In a project using apostrophe, create pieces of 2 piece types that are related, like an `article` piece that has a relationship with a `topic` piece type.

Example:

`Article 1` has 2 related topics, `Article 2` only has one:

```
Article 1 -> Topic 1
          -> Topic 2

Article 2 -> Topic 2
```

- In private window tabs, go to:
  - the GET REST API route of the `Article 1` (eg: `/api/v1/article/<article-1-id>`)
  - the piece page of `Article 1` (eg: `/articles/<article-1-slug>`)
  - the GET REST API route of the `Topic 1` and `Topic 2` (eg: `/api/v1/topic/<topic-x-id>`)
  - the piece page of `Topic 1` and `Topic 2` (eg: `/topics/<topic-x-slug>`)

- Refresh the pages above, you should get a `304` status code, with the `ETag` response header matching the `If-None-Match` request header:

![image](https://user-images.githubusercontent.com/8301962/160859889-721ecd2e-06cf-4215-affb-2bceaed1d9bc.png)

- In a non-private window, login to the website and edit `Article 1`
- Go back to the private window tabs and refresh the pages, you should have a `200` status code, with a mismatch between `ETag` response header and `If-None-Match` request header (ETag has changed), **for `Article 1`, `Topic 1` and `Topic 2` pages**:

![image](https://user-images.githubusercontent.com/8301962/160861147-1f95571a-f473-42c5-9c71-a4fc01849733.png)

- Refresh the pages, you should have the `304` status code back, and the `ETag` header equaling the `If-None-Match` one.

- ☝️ Run the same tests as above but this time, edit `Topic 1` or `Topic 2`, not `Article 1` directly
  - 👉  If you edit `Topic 1`, then only `Topic 1` and `Article 1` should have their cache invalidated
  - 👉  If you edit `Topic 2`, then `Topic 1`, `Article 1` and `Article 2` should have their cache invalidated

- Editing a piece should invalidate the cache of the piece index page
- After the max-age period set in the cache config, the cache should be invalidated automatically and the response status code should be 200.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
