### PR TITLE
Fix from QA: public bundle should not receive apos UI build

### DIFF
--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -417,12 +417,15 @@ module.exports = {
             const jsNoModules = `${scene}-nomodule-bundle.js`;
             const css = `${scene}-bundle.css`;
             writeAssetFile({
+              scene,
               filePath: jsModules
             });
             writeAssetFile({
+              scene,
               filePath: jsNoModules
             });
             writeAssetFile({
+              scene,
               filePath: css,
               checkForFile: true
             });
@@ -431,14 +434,15 @@ module.exports = {
           }
 
           function writeAssetFile ({
-            filePath, checkForFile = false
+            scene, filePath, checkForFile = false
           }) {
             const [ _ext, fileExt ] = filePath.match(/\.(\w+)$/);
             const filterBuilds = ({
-              outputs, condition
+              scenes, outputs, condition
             }) => {
               return outputs.includes(fileExt) &&
-                (!condition || condition === 'module');
+                (!condition || condition === 'module') &&
+                scenes.includes(scene);
             };
 
             const filesContent = Object.entries(self.builds)


### PR DESCRIPTION
## Summary

The code to check whether a build is relevant to a scene was lost in the transition to extra bundles. I brought that logic back.

## What are the specific steps to test this change?

"npm run dev" while logged out on the testbed. Without this fix you get a console error from Apos UI code.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
