### PR TITLE
PRO-2510 allow npm installed frontend dependencies of npm linked modules to work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Full support for the `object` field type, which works much like `array` but stores just one sub-object as a property, rather than an array of objects.
 * To help find documents that reference related ones via `relationship` fields, implement backlinks of related documents by adding a `relatedReverseIds` field to them and keeping it up to date.
 
+### Fixes
+
+* Apostrophe's webpack build now works properly when developing code that imports module-specific npm dependencies from `ui/src` or `ui/apos` when using `npm link` to develop the module in question.
+
 # 3.16.1 (2022-03-21)
 
 ### Fixes

--- a/modules/@apostrophecms/asset/lib/webpack/apos/webpack.config.js
+++ b/modules/@apostrophecms/asset/lib/webpack/apos/webpack.config.js
@@ -47,11 +47,11 @@ module.exports = ({
         Modules: path.resolve(modulesDir)
       },
       modules: [
-        // TODO change this if we decide to namespace the
-        // apostrophe module itself
+        'node_modules',
         `${apos.npmRootDir}/node_modules/apostrophe/node_modules`,
         `${apos.npmRootDir}/node_modules`
-      ]
+      ],
+      symlinks: false
     },
     stats: 'verbose',
     plugins: process.env.APOS_BUNDLE_ANALYZER ? [ new BundleAnalyzerPlugin() ] : []

--- a/modules/@apostrophecms/asset/lib/webpack/src/webpack.config.js
+++ b/modules/@apostrophecms/asset/lib/webpack/src/webpack.config.js
@@ -41,7 +41,9 @@ module.exports = ({
     },
     resolveLoader: {
       extensions: [ '*', '.js' ],
-      modules: [ 'node_modules' ]
+      // Make sure css-loader and postcss-loader can always be found, even
+      // if npm didn't hoist them
+      modules: [ 'node_modules', 'node_modules/apostrophe/node_modules' ]
     },
     resolve: {
       extensions: [ '*', '.js' ],
@@ -50,11 +52,13 @@ module.exports = ({
         Modules: path.resolve(modulesDir)
       },
       modules: [
+        'node_modules',
         `${apos.npmRootDir}/node_modules`,
         // Make sure core-js and regenerator-runtime can always be found, even
         // if npm didn't hoist them
         `${apos.npmRootDir}/node_modules/apostrophe/node_modules`
-      ]
+      ],
+      symlinks: false
     },
     stats: 'verbose',
     plugins: process.env.APOS_BUNDLE_ANALYZER ? [ new BundleAnalyzerPlugin() ] : []


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

It is now possible to use `npm link` to develop a module like `@apostrophecms/login-totp` that imports its own npm dependencies from frontend `ui/apos` or `ui/src` code.

In addition, apostrophe itself can be brought into a project with `npm link` without an error about failure to resolve `css-loader`, even if `css-loader` is not currently in project-level node_modules.

Of course, the module-level dependencies must be present in the npm linked module (I think npm link enforces that, but just to be clear).

## What are the specific steps to test this change?

Using up to date npm, you should be able to git clone and npm install testbed, then git clone and npm install `@apostrophecms/login-totp`, then run `npm link` in the login-totp folder, then run `npm link @apostrophecms/login-totp` in the testbed folder.

After these steps `npm run dev` should work properly.

npm linking `apostrophe` into `testbed` in the usual way should also work with no complaints about `css-loader` during `npm run dev`.

Note that this issue appears to be much more severe in npm 7 and 8, so if you are still using npm 6 you may be less familiar with it (but it can still happen).

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
