### PR TITLE
Fixes bundles contribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@
 
 * Full support for the `object` field type, which works much like `array` but stores just one sub-object as a property, rather than an array of objects.
 * To help find documents that reference related ones via `relationship` fields, implement backlinks of related documents by adding a `relatedReverseIds` field to them and keeping it up to date.
+* Adds the ability for modules to extend the webpack config as well as to add extra bundles for scss and js.
+* Loads the right bundles on the right pages depending on their config and the loaded widgets. Logged-in users have all the bundles on every page.
 
 ### Fixes
 
 * Apostrophe's webpack build now works properly when developing code that imports module-specific npm dependencies from `ui/src` or `ui/apos` when using `npm link` to develop the module in question.
+* The `es5: true` option to `@apostrophecms/asset` works again.
 
 # 3.16.1 (2022-03-21)
 
@@ -26,8 +29,6 @@
 * `data-apos-test=""` selectors for certain elements frequently selected in QA tests, such as `data-apos-test="adminBar"`.
 * Offer a simple way to set a Cache-Control max-age for Apostrophe page and GET REST API responses for pieces and pages.
 * To speed up functional tests, an `insecurePasswords` option has been added to the login module. This option is deliberately named to discourage use for any purpose other than functional tests in which repeated password hashing would unduly limit performance. Normally password hashing is intentionally difficult to slow down brute force attacks, especially if a database is compromised.
-* Adds possibility for modules to extend the webpack config as well as to add extra bundles for scss and js.
-* Loads the right bundles on the right pages depending on their config and the loaded widgets. Logged-in users have all the bundles on every page.
 
 ### Fixes
 

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -380,27 +380,27 @@ module.exports = {
             indexSass
           }) {
             fs.writeFileSync(importFile, (prologue || '') + stripIndent`
-            ${(icon && icon.importCode) || ''}
-            ${(icon && icon.registerCode) || ''}
-            ${(components && components.importCode) || ''}
-            ${(tiptap && tiptap.importCode) || ''}
-            ${(app && app.importCode) || ''}
-            ${(indexJs && indexJs.importCode) || ''}
-            ${(indexSass && indexSass.importCode) || ''}
-            ${(icon && icon.registerCode) || ''}
-            ${(components && components.registerCode) || ''}
-            ${(tiptap && tiptap.registerCode) || ''}
-          ` +
-            (app ? stripIndent`
-              setTimeout(() => {
-                ${app.invokeCode}
-              }, 0);
-            ` : '') +
-            // No delay on these, they expect to run early like ui/public code
-            // and the first ones invoked set up expected stuff like apos.http
-            (indexJs ? stripIndent`
-              ${indexJs.invokeCode}
-            ` : '')
+              ${(icon && icon.importCode) || ''}
+              ${(icon && icon.registerCode) || ''}
+              ${(components && components.importCode) || ''}
+              ${(tiptap && tiptap.importCode) || ''}
+              ${(app && app.importCode) || ''}
+              ${(indexJs && indexJs.importCode) || ''}
+              ${(indexSass && indexSass.importCode) || ''}
+              ${(icon && icon.registerCode) || ''}
+              ${(components && components.registerCode) || ''}
+              ${(tiptap && tiptap.registerCode) || ''}
+              ` +
+              (app ? stripIndent`
+                setTimeout(() => {
+                  ${app.invokeCode}
+                }, 0);
+              ` : '') +
+              // No delay on these, they expect to run early like ui/public code
+              // and the first ones invoked set up expected stuff like apos.http
+              (indexJs ? stripIndent`
+                ${indexJs.invokeCode}
+              ` : '')
             );
           }
 

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -487,16 +487,16 @@ module.exports = {
             const filesContent = Object.entries(self.builds)
               .filter(([ _, options ]) => filterBuilds(options))
               .map(([ name ]) => {
-                const builtFile = `${bundleDir}/${name}-build.${fileExt}`;
+                const file = `${bundleDir}/${name}-build.${fileExt}`;
                 const readFile = (n, f) => `/* BUILD: ${n} */\n${fs.readFileSync(f, 'utf8')}`;
 
                 if (checkForFile) {
-                  return fs.existsSync(builtFile)
-                    ? readFile(name, builtFile)
+                  return fs.existsSync(file)
+                    ? readFile(name, file)
                     : '';
                 }
 
-                return readFile(name, builtFile);
+                return readFile(name, file);
               }).join('\n');
 
             fs.writeFileSync(`${bundleDir}/${filePath}`, filesContent);

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -24,7 +24,7 @@ module.exports = {
     // builds of the ui/src browser code in each module, and serve them
     // to the appropriate browsers without overhead for modern browsers.
     // This does not attempt to compile the admin UI (ui/apos) for ES5.
-    es5: true,
+    es5: false,
     // If this option is true and process.env.NODE_ENV is not `production`,
     // the browser will refresh when the Apostrophe application
     // restarts. A useful companion to `nodemon`.

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -602,7 +602,6 @@ module.exports = {
               const jsFilename = JSON.stringify(component);
               const name = getComponentName(component, options, i);
               const jsName = JSON.stringify(name);
-
               const importCode = `
               import ${name}${options.importSuffix || ''} from ${jsFilename};
               `;

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -24,7 +24,7 @@ module.exports = {
     // builds of the ui/src browser code in each module, and serve them
     // to the appropriate browsers without overhead for modern browsers.
     // This does not attempt to compile the admin UI (ui/apos) for ES5.
-    es5: false,
+    es5: true,
     // If this option is true and process.env.NODE_ENV is not `production`,
     // the browser will refresh when the Apostrophe application
     // restarts. A useful companion to `nodemon`.

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -449,11 +449,13 @@ module.exports = {
 
               writeSceneBundle({
                 scene,
-                filePath: jsModules
+                filePath: jsModules,
+                jsCondition: 'module'
               });
               writeSceneBundle({
                 scene,
-                filePath: jsNoModules
+                filePath: jsNoModules,
+                jsCondition: 'nomodule'
               });
               writeSceneBundle({
                 scene,
@@ -471,14 +473,14 @@ module.exports = {
           }
 
           function writeSceneBundle ({
-            scene, filePath, checkForFile = false
+            scene, filePath, jsCondition, checkForFile = false
           }) {
             const [ _ext, fileExt ] = filePath.match(/\.(\w+)$/);
             const filterBuilds = ({
               scenes, outputs, condition
             }) => {
               return outputs.includes(fileExt) &&
-                (!condition || condition === 'module') &&
+                ((!condition || !jsCondition) || condition === jsCondition) &&
                 scenes.includes(scene);
             };
 

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -647,7 +647,7 @@ module.exports = {
           function getComponentName(component, { enumerateImports } = {}, i) {
             return path
               .basename(component)
-              .replace('-', '_')
+              .replace(/-/g, '_')
               .replace(/\.\w+/, '') + (enumerateImports ? `_${i}` : '');
           }
 

--- a/modules/@apostrophecms/asset/lib/webpack/src/webpack.config.js
+++ b/modules/@apostrophecms/asset/lib/webpack/src/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const merge = require('webpack-merge').merge;
 const scssTask = require('./webpack.scss');
 const es5Task = require('./webpack.es5');
+const srcBuildNames = [ 'src-build', 'src-es5-build' ];
 
 let BundleAnalyzerPlugin;
 
@@ -24,7 +25,8 @@ module.exports = ({
         importFile,
         modulesDir
       },
-      apos
+      apos,
+      srcBuildNames
     )
   );
 
@@ -42,7 +44,7 @@ module.exports = ({
     output: {
       path: outputPath,
       filename: ({ chunk }) => {
-        return chunk.name === 'src-build'
+        return srcBuildNames.includes(chunk.name)
           ? '[name].js'
           : '[name]-module-bundle.js';
       }

--- a/modules/@apostrophecms/asset/lib/webpack/src/webpack.config.js
+++ b/modules/@apostrophecms/asset/lib/webpack/src/webpack.config.js
@@ -42,7 +42,7 @@ module.exports = ({
     output: {
       path: outputPath,
       filename: ({ chunk }) => {
-        return chunk.id === 'src-build'
+        return chunk.name === 'src-build'
           ? '[name].js'
           : '[name]-module-bundle.js';
       }

--- a/modules/@apostrophecms/asset/lib/webpack/src/webpack.config.js
+++ b/modules/@apostrophecms/asset/lib/webpack/src/webpack.config.js
@@ -30,6 +30,7 @@ module.exports = ({
     )
   );
 
+  const moduleName = es5 ? 'nomodule' : 'module';
   const config = {
     entry: {
       [mainBundleName]: importFile,
@@ -46,7 +47,7 @@ module.exports = ({
       filename: ({ chunk }) => {
         return srcBuildNames.includes(chunk.name)
           ? '[name].js'
-          : '[name]-module-bundle.js';
+          : `[name]-${moduleName}-bundle.js`;
       }
     },
     resolveLoader: {

--- a/modules/@apostrophecms/asset/lib/webpack/src/webpack.config.js
+++ b/modules/@apostrophecms/asset/lib/webpack/src/webpack.config.js
@@ -74,5 +74,9 @@ module.exports = ({
     plugins: process.env.APOS_BUNDLE_ANALYZER ? [ new BundleAnalyzerPlugin() ] : []
   };
 
+  if (es5) {
+    config.output.chunkFormat = 'array-push';
+  }
+
   return merge(config, ...tasks);
 };

--- a/modules/@apostrophecms/asset/lib/webpack/src/webpack.scss.js
+++ b/modules/@apostrophecms/asset/lib/webpack/src/webpack.scss.js
@@ -41,7 +41,7 @@ module.exports = (options, apos) => {
       new MiniCssExtractPlugin({
         // Should be automatic but we wind up with main.css if we try to go with that
         filename: ({ chunk }) => {
-          return chunk.id === 'src-build'
+          return chunk.name === 'src-build'
             ? '[name].css'
             : '[name]-bundle.css';
         }

--- a/modules/@apostrophecms/asset/lib/webpack/src/webpack.scss.js
+++ b/modules/@apostrophecms/asset/lib/webpack/src/webpack.scss.js
@@ -40,7 +40,11 @@ module.exports = (options, apos) => {
     plugins: [
       new MiniCssExtractPlugin({
         // Should be automatic but we wind up with main.css if we try to go with that
-        filename: '[name].css'
+        filename: ({ chunk }) => {
+          return chunk.id === 'src-build'
+            ? '[name].css'
+            : '[name]-bundle.css';
+        }
       })
     ]
   };

--- a/modules/@apostrophecms/asset/lib/webpack/src/webpack.scss.js
+++ b/modules/@apostrophecms/asset/lib/webpack/src/webpack.scss.js
@@ -1,6 +1,6 @@
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
-module.exports = (options, apos) => {
+module.exports = (options, apos, srcBuildNames) => {
   return {
     module: {
       rules: [
@@ -41,7 +41,7 @@ module.exports = (options, apos) => {
       new MiniCssExtractPlugin({
         // Should be automatic but we wind up with main.css if we try to go with that
         filename: ({ chunk }) => {
-          return chunk.name === 'src-build'
+          return srcBuildNames.includes(chunk.name)
             ? '[name].css'
             : '[name]-bundle.css';
         }

--- a/modules/@apostrophecms/asset/lib/webpack/utils.js
+++ b/modules/@apostrophecms/asset/lib/webpack/utils.js
@@ -96,6 +96,54 @@ module.exports = {
         ...es5Bundles
       ];
     }, []);
+  },
+
+  writeBundlesImportFiles ({
+    name,
+    buildDir,
+    mainBundleName,
+    verifiedBundles,
+    getImportFileOutput,
+    writeImportFile
+  }) {
+    if (!name.includes('src')) {
+      return [];
+    }
+
+    const bundlesOutputs = Object.entries(verifiedBundles)
+      .map(([ bundleName, paths ]) => {
+        return {
+          bundleName,
+          importFile: `${buildDir}/${bundleName}-import.js`,
+          js: getImportFileOutput(paths.js, {
+            invokeApps: true,
+            enumerateImports: true,
+            requireDefaultExport: true
+          }),
+          scss: getImportFileOutput(paths.scss, {
+            enumerateImports: true,
+            importSuffix: 'Stylesheet'
+          })
+        };
+      });
+
+    for (const output of bundlesOutputs) {
+      writeImportFile({
+        importFile: output.importFile,
+        indexJs: output.js,
+        indexSass: output.scss
+      });
+    }
+
+    return bundlesOutputs.reduce((acc, { bundleName, importFile }) => {
+      return {
+        ...acc,
+        [bundleName]: {
+          import: importFile,
+          dependOn: mainBundleName
+        }
+      };
+    }, {});
   }
 };
 

--- a/modules/@apostrophecms/asset/lib/webpack/utils.js
+++ b/modules/@apostrophecms/asset/lib/webpack/utils.js
@@ -203,7 +203,7 @@ async function verifyBundlesEntryPoints (bundles) {
     };
   });
 
-  const bundlesPaths = (await Promise.all(checkPathsPromises));
+  const bundlesPaths = await Promise.all(checkPathsPromises);
 
   const packedFilesByBundle = bundlesPaths.reduce((acc, {
     bundleName, jsPath, scssPath

--- a/modules/@apostrophecms/asset/lib/webpack/utils.js
+++ b/modules/@apostrophecms/asset/lib/webpack/utils.js
@@ -62,19 +62,16 @@ module.exports = {
     };
   },
 
-  fillExtraBundles (verifiedBundles = []) {
-    const getFileName = (p) => p.substr(p.lastIndexOf('/') + 1)
-      .replace(/\.(js|scss)$/, '');
-
-    return verifiedBundles.reduce((acc, { paths }) => {
+  fillExtraBundles (verifiedBundles = {}) {
+    return Object.entries(verifiedBundles).reduce((acc, [ bundleName, { js, scss } ]) => {
       return {
         js: [
           ...acc.js,
-          ...paths.filter((p) => p.endsWith('.js')).map((p) => getFileName(p))
+          ...(js.length && !acc.js.includes(bundleName)) ? [ bundleName ] : []
         ],
         css: [
           ...acc.css,
-          ...paths.filter((p) => p.endsWith('.scss')).map((p) => getFileName(p))
+          ...(scss.length && !acc.css.includes(bundleName)) ? [ bundleName ] : []
         ]
       };
     }, {
@@ -153,17 +150,36 @@ async function verifyBundlesEntryPoints (bundles) {
 
     return {
       bundleName,
-      paths: [
-        ...jsFileExists ? [ jsPath ] : [],
-        ...scssFileExists ? [ scssPath ] : []
-      ]
+      ...jsFileExists && { jsPath: jsPath },
+      ...scssFileExists && { scssPath: scssPath }
     };
   });
 
-  const bundlesPaths = (await Promise.all(checkPathsPromises))
-    .filter((bundle) => bundle.paths.length);
+  const bundlesPaths = (await Promise.all(checkPathsPromises));
 
-  return bundlesPaths;
+  const packedFilesByBundle = bundlesPaths.reduce((acc, {
+    bundleName, jsPath, scssPath
+  }) => {
+    if (!jsPath && !scssPath) {
+      return acc;
+    }
+
+    return {
+      ...acc,
+      [bundleName]: {
+        js: [
+          ...acc[bundleName] ? acc[bundleName].js : [],
+          ...jsPath ? [ jsPath ] : []
+        ],
+        scss: [
+          ...acc[bundleName] ? acc[bundleName].scss : [],
+          ...scssPath ? [ scssPath ] : []
+        ]
+      }
+    };
+  }, {});
+
+  return packedFilesByBundle;
 };
 
 function formatConfigs (chain, webpackConfigs) {

--- a/modules/@apostrophecms/template/lib/bundlesLoader.js
+++ b/modules/@apostrophecms/template/lib/bundlesLoader.js
@@ -21,6 +21,7 @@ module.exports = (self) => {
 
     const { es5 } = self.apos.asset.options;
     const { extraBundles } = self.apos.asset;
+
     const jsMainBundle = renderMarkup({
       fileName: scene,
       ext: 'js',
@@ -63,7 +64,8 @@ module.exports = (self) => {
         extraBundles.js.includes(name) &&
           renderMarkup({
             fileName: name,
-            ext: 'js'
+            ext: 'js',
+            es5
           });
 
         const cssMarkup = stylesheetsPlaceholder &&
@@ -126,12 +128,14 @@ function loadAllBundles({
   stylesheetsPlaceholder,
   jsMainBundle,
   cssMainBundle,
-  renderMarkup
+  renderMarkup,
+  es5
 }) {
   const reduceToMarkup = (acc, bundle, ext) => {
     const bundleMarkup = renderMarkup({
       fileName: bundle.replace(`.${ext}`, ''),
-      ext
+      ext,
+      es5
     });
 
     return stripIndent`

--- a/test/assets.js
+++ b/test/assets.js
@@ -108,17 +108,13 @@ describe('Assets', function() {
     assert(extensions.ext1.resolve.alias.ext1Overriden);
     assert(extensions.ext2.resolve.alias.ext2);
 
-    assert(verifiedBundles.length === 2);
+    assert(Object.keys(verifiedBundles).length === 2);
 
-    const [ verified1, verified2 ] = verifiedBundles;
+    assert(verifiedBundles.extra.js.length === 1);
+    assert(verifiedBundles.extra.scss.length === 1);
 
-    assert(verified1.bundleName === 'extra');
-    assert(verified1.paths.length === 2);
-    assert(verified1.paths[0].endsWith('.js'));
-    assert(verified1.paths[1].endsWith('.scss'));
-
-    assert(verified2.bundleName === 'extra2');
-    assert(verified2.paths.length === 1);
+    assert(verifiedBundles.extra2.js.length === 1);
+    assert(verifiedBundles.extra2.scss.length === 0);
 
     const filled = fillExtraBundles(verifiedBundles);
 
@@ -129,8 +125,6 @@ describe('Assets', function() {
     filled.css.forEach((name) => {
       assert(expectedEntryPointsNames.css.includes(name));
     });
-
-    // await t.destroy(apos);
   });
 
   it('should build the right bundles in dev and prod modes', async function () {

--- a/test/modules/bundle-page/ui/src/extra.js
+++ b/test/modules/bundle-page/ui/src/extra.js
@@ -1,0 +1,1 @@
+export default () => {};

--- a/test/modules/bundle-widget/ui/src/extra2.js
+++ b/test/modules/bundle-widget/ui/src/extra2.js
@@ -1,0 +1,1 @@
+export default () => {};


### PR DESCRIPTION
## Summary
Fixes missing piece of the feature. Now multiple modules can contribute to the same bundle, they now export default functions. We reuse logic to write the import files.
Tweak webpack config to create bundles with the right name (`-module-bundle`) without touching the src-build bundle. and without having to copy manually our bundles...

## What are the specific steps to test this change?

Contribute to the same bundle from different modules.
You must export default function in your bundle files.
A module extending another that has a bundle will load this bundle too.
Check the order of apparition of your log adn see that the order of modules is respected.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

