### PR TITLE
call crop route when saving editor modal

### DIFF
--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -183,14 +183,18 @@ module.exports = {
         crop: [
           self.canUpload,
           async function (req) {
+            console.log('CROP ROUTE');
             const _id = self.apos.launder.id(req.body._id);
             const { crop } = req.body;
+            console.log('_id', _id);
+            console.log('crop', crop);
 
             if (!_id || !crop || typeof crop !== 'object' || Array.isArray(crop)) {
               throw self.apos.error('invalid');
             }
 
             const sanitizedCrop = self.sanitizeCrop(crop);
+            console.log('sanitizedCrop', sanitizedCrop);
 
             if (!sanitizedCrop) {
               throw self.apos.error('invalid');
@@ -461,6 +465,7 @@ module.exports = {
       },
       async crop(req, _id, crop) {
         const info = await self.db.findOne({ _id });
+        console.log('info', info);
 
         if (!info) {
           throw self.apos.error('notfound');

--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -183,18 +183,14 @@ module.exports = {
         crop: [
           self.canUpload,
           async function (req) {
-            console.log('CROP ROUTE');
             const _id = self.apos.launder.id(req.body._id);
             const { crop } = req.body;
-            console.log('_id', _id);
-            console.log('crop', crop);
 
             if (!_id || !crop || typeof crop !== 'object' || Array.isArray(crop)) {
               throw self.apos.error('invalid');
             }
 
             const sanitizedCrop = self.sanitizeCrop(crop);
-            console.log('sanitizedCrop', sanitizedCrop);
 
             if (!sanitizedCrop) {
               throw self.apos.error('invalid');
@@ -465,7 +461,6 @@ module.exports = {
       },
       async crop(req, _id, crop) {
         const info = await self.db.findOne({ _id });
-        console.log('info', info);
 
         if (!info) {
           throw self.apos.error('notfound');

--- a/modules/@apostrophecms/image-widget/index.js
+++ b/modules/@apostrophecms/image-widget/index.js
@@ -18,28 +18,24 @@ module.exports = {
         fields: {
           add: {
             top: {
-              type: 'integer',
-              label: 'top'
+              type: 'integer'
             },
             left: {
-              type: 'integer',
-              label: 'left'
+              type: 'integer'
             },
             width: {
               type: 'integer',
-              label: 'width'
+              label: 'W'
             },
             height: {
               type: 'integer',
-              label: 'height'
+              label: 'H'
             },
             x: {
-              type: 'integer',
-              label: 'x'
+              type: 'integer'
             },
             y: {
-              type: 'integer',
-              label: 'y'
+              type: 'integer'
             }
           }
         }

--- a/modules/@apostrophecms/image-widget/index.js
+++ b/modules/@apostrophecms/image-widget/index.js
@@ -18,22 +18,28 @@ module.exports = {
         fields: {
           add: {
             top: {
-              type: 'integer'
+              type: 'integer',
+              label: 'top'
             },
             left: {
-              type: 'integer'
+              type: 'integer',
+              label: 'left'
             },
             width: {
-              type: 'integer'
+              type: 'integer',
+              label: 'width'
             },
             height: {
-              type: 'integer'
+              type: 'integer',
+              label: 'height'
             },
             x: {
-              type: 'integer'
+              type: 'integer',
+              label: 'x'
             },
             y: {
-              type: 'integer'
+              type: 'integer',
+              label: 'y'
             }
           }
         }

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageRelationshipEditor.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageRelationshipEditor.vue
@@ -63,6 +63,10 @@ export default {
     title: {
       type: String,
       required: true
+    },
+    id: {
+      type: String,
+      required: true
     }
   },
   emits: [ 'modal-result', 'safe-close' ],
@@ -99,16 +103,9 @@ export default {
   },
   methods: {
     async submit() {
-      console.log('this.$vnode.key', this.$vnode.key);
-      console.log('this', this);
-      console.log('this.docFields', this.docFields);
-      console.log('this.docFields.data', this.docFields.data);
-      console.log('this.schema', this.schema);
-      console.log('this.original', this.original);
       await apos.http.post(`${apos.attachment.action}/crop`, {
         body: {
-          // TODO: retrieve attachment actual id
-          _id: 'cl1ncr3kr0167m0gfhlpe9ptm',
+          _id: this.id,
           crop: this.docFields.data
         }
       });

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageRelationshipEditor.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageRelationshipEditor.vue
@@ -99,6 +99,19 @@ export default {
   },
   methods: {
     async submit() {
+      console.log('this.$vnode.key', this.$vnode.key);
+      console.log('this', this);
+      console.log('this.docFields', this.docFields);
+      console.log('this.docFields.data', this.docFields.data);
+      console.log('this.schema', this.schema);
+      console.log('this.original', this.original);
+      await apos.http.post(`${apos.attachment.action}/crop`, {
+        body: {
+          // TODO: retrieve attachment actual id
+          _id: 'cl1ncr3kr0167m0gfhlpe9ptm',
+          crop: this.docFields.data
+        }
+      });
       this.$emit('modal-result', this.docFields.data);
       this.modal.showModal = false;
     },

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -206,6 +206,7 @@ export default {
 
       const result = await apos.modal.execute(editor, {
         schema: this.field.schema,
+        id: item._id,
         title: item.title,
         value: item._fields
       });

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -206,7 +206,7 @@ export default {
 
       const result = await apos.modal.execute(editor, {
         schema: this.field.schema,
-        id: item._id,
+        id: item.attachment._id,
         title: item.title,
         value: item._fields
       });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

[PRO-2680](https://linear.app/apostrophecms/issue/PRO-2680/actual-cropped-images-are-generated-when-the-cropping-modal-is-saved)

## Summary

Call `/attachment/crop` route when `AposImageRelationshipEditor` modale is saved.

## What are the specific steps to test this change?

- add an image 

<img width="330" alt="image" src="https://user-images.githubusercontent.com/8301962/162175169-f11768e2-0ad3-4b2d-80ee-d7671d510de9.png">

- click on "Image Adjustments"

<img width="456" alt="image" src="https://user-images.githubusercontent.com/8301962/162175783-6e8b85e2-7847-4cfb-aa82-7df0736d58df.png">

- enter cropping data manually

<img width="909" alt="image" src="https://user-images.githubusercontent.com/8301962/162175879-0762ddb2-ea20-4159-9fec-0b37c5f59432.png">

- save the modal

- verify appropriate image filenames and sizes appear in public/uploads/attachments after cropping

<img width="602" alt="image" src="https://user-images.githubusercontent.com/8301962/162175979-fdd25432-88cc-46bc-8407-117a773b11d2.png">


## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
