### PR TITLE
move etags as a sub property of api and page cache options

### DIFF
--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -181,7 +181,7 @@ module.exports = {
           if (self.options.cache && self.options.cache.api && self.options.cache.api.maxAge) {
             const { maxAge } = self.options.cache.api;
 
-            if (!self.options.cache.etags) {
+            if (!self.options.cache.api.etags) {
               self.setMaxAge(req, maxAge);
             } else if (self.checkETag(req, result, maxAge)) {
               return {};
@@ -1414,7 +1414,7 @@ database.`);
         if (self.options.cache && self.options.cache.page && self.options.cache.page.maxAge) {
           const { maxAge } = self.options.cache.page;
 
-          if (!self.options.cache.etags) {
+          if (!self.options.cache.page.etags) {
             self.setMaxAge(req, maxAge);
           } else if (self.checkETag(req, undefined, maxAge)) {
             // Stop there and send a 304 status code; the cached response will be used

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -218,7 +218,7 @@ module.exports = {
           if (self.options.cache && self.options.cache.api && self.options.cache.api.maxAge) {
             const { maxAge } = self.options.cache.api;
 
-            if (!self.options.cache.etags) {
+            if (!self.options.cache.api.etags) {
               self.setMaxAge(req, maxAge);
             } else if (self.checkETag(req, doc, maxAge)) {
               return {};

--- a/test/pages-public-api.js
+++ b/test/pages-public-api.js
@@ -89,9 +89,9 @@ describe('Pages Public API', function() {
     };
     apos.page.options.cache = {
       api: {
-        maxAge: 1111
-      },
-      etags: true
+        maxAge: 1111,
+        etags: true
+      }
     };
 
     const response1 = await apos.http.get('/api/v1/@apostrophecms/page', { fullResponse: true });
@@ -129,9 +129,9 @@ describe('Pages Public API', function() {
     };
     apos.page.options.cache = {
       api: {
-        maxAge: 1111
-      },
-      etags: true
+        maxAge: 1111,
+        etags: true
+      }
     };
 
     const response1 = await apos.http.get('/api/v1/@apostrophecms/page', { fullResponse: true });

--- a/test/pages.js
+++ b/test/pages.js
@@ -505,13 +505,10 @@ describe('Pages', function() {
 
   it('should not set a cache-control value when retrieving a single page, when "etags" cache option is set', async () => {
     apos.page.options.cache = {
-      page: {
-        maxAge: 5555
-      },
       api: {
-        maxAge: 5555
-      },
-      etags: true
+        maxAge: 5555,
+        etags: true
+      }
     };
 
     const response = await apos.http.get(`/api/v1/@apostrophecms/page/${homeId}`, { fullResponse: true });
@@ -665,9 +662,9 @@ describe('Pages', function() {
   it('should not set a cache-control value when serving a page, when "etags" cache option is set', async () => {
     apos.page.options.cache = {
       page: {
-        maxAge: 4444
-      },
-      etags: true
+        maxAge: 4444,
+        etags: true
+      }
     };
     const response = await apos.http.get('/', { fullResponse: true });
 
@@ -692,9 +689,9 @@ describe('Pages', function() {
   it('should set a custom etag when retrieving a single page', async () => {
     apos.page.options.cache = {
       api: {
-        maxAge: 1111
-      },
-      etags: true
+        maxAge: 1111,
+        etags: true
+      }
     };
 
     const response = await apos.http.get(`/api/v1/@apostrophecms/page/${homeId}`, { fullResponse: true });
@@ -711,9 +708,9 @@ describe('Pages', function() {
   it('should return a 304 status code when retrieving a page with a matching etag', async () => {
     apos.page.options.cache = {
       api: {
-        maxAge: 1111
-      },
-      etags: true
+        maxAge: 1111,
+        etags: true
+      }
     };
 
     const response1 = await apos.http.get(`/api/v1/@apostrophecms/page/${homeId}`, { fullResponse: true });
@@ -739,9 +736,9 @@ describe('Pages', function() {
   it('should not return a 304 status code when retrieving a page that has been edited', async () => {
     apos.page.options.cache = {
       api: {
-        maxAge: 1111
-      },
-      etags: true
+        maxAge: 1111,
+        etags: true
+      }
     };
 
     const response1 = await apos.http.get(`/api/v1/@apostrophecms/page/${homeId}`, { fullResponse: true });
@@ -782,9 +779,9 @@ describe('Pages', function() {
   it('should not return a 304 status code when retrieving a page after the max-age period', async () => {
     apos.page.options.cache = {
       api: {
-        maxAge: 4444
-      },
-      etags: true
+        maxAge: 4444,
+        etags: true
+      }
     };
 
     const response1 = await apos.http.get(`/api/v1/@apostrophecms/page/${homeId}`, { fullResponse: true });
@@ -818,9 +815,9 @@ describe('Pages', function() {
   it('should set a custom etag when serving a page', async () => {
     apos.page.options.cache = {
       page: {
-        maxAge: 4444
-      },
-      etags: true
+        maxAge: 4444,
+        etags: true
+      }
     };
     const response = await apos.http.get('/', { fullResponse: true });
 
@@ -836,9 +833,9 @@ describe('Pages', function() {
   it('should return a 304 status code when requesting a page with a matching etag', async () => {
     apos.page.options.cache = {
       page: {
-        maxAge: 4444
-      },
-      etags: true
+        maxAge: 4444,
+        etags: true
+      }
     };
 
     const response1 = await apos.http.get('/', { fullResponse: true });
@@ -864,9 +861,9 @@ describe('Pages', function() {
   it('should not return a 304 status code when requesting a page that has been edited', async () => {
     apos.page.options.cache = {
       page: {
-        maxAge: 4444
-      },
-      etags: true
+        maxAge: 4444,
+        etags: true
+      }
     };
 
     const response1 = await apos.http.get('/', { fullResponse: true });
@@ -907,9 +904,9 @@ describe('Pages', function() {
   it('should not return a 304 status code when requesting a page with an outdated release id', async () => {
     apos.page.options.cache = {
       page: {
-        maxAge: 4444
-      },
-      etags: true
+        maxAge: 4444,
+        etags: true
+      }
     };
 
     const response1 = await apos.http.get('/', { fullResponse: true });
@@ -943,9 +940,9 @@ describe('Pages', function() {
   it('should not return a 304 status code when requesting a page after the max-age period', async () => {
     apos.page.options.cache = {
       page: {
-        maxAge: 4444
-      },
-      etags: true
+        maxAge: 4444,
+        etags: true
+      }
     };
 
     const response1 = await apos.http.get('/', { fullResponse: true });
@@ -979,9 +976,9 @@ describe('Pages', function() {
   it('should not set a custom etag when retrieving a single page, when user is connected', async () => {
     apos.page.options.cache = {
       api: {
-        maxAge: 4444
-      },
-      etags: true
+        maxAge: 4444,
+        etags: true
+      }
     };
 
     const jar = apos.http.jar();
@@ -1011,9 +1008,9 @@ describe('Pages', function() {
   it('should not set a custom etag when retrieving a single page, when user is connected using an api key', async () => {
     apos.page.options.cache = {
       api: {
-        maxAge: 4444
-      },
-      etags: true
+        maxAge: 4444,
+        etags: true
+      }
     };
 
     const response = await apos.http.get(`/api/v1/@apostrophecms/page/${homeId}?apiKey=${apiKey}`, { fullResponse: true });

--- a/test/pieces-public-api.js
+++ b/test/pieces-public-api.js
@@ -98,9 +98,9 @@ describe('Pieces Public API', function() {
     };
     apos.thing.options.cache = {
       api: {
-        maxAge: 2222
-      },
-      etags: true
+        maxAge: 2222,
+        etags: true
+      }
     };
 
     const response = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });
@@ -135,9 +135,9 @@ describe('Pieces Public API', function() {
     };
     apos.thing.options.cache = {
       api: {
-        maxAge: 1111
-      },
-      etags: true
+        maxAge: 1111,
+        etags: true
+      }
     };
 
     const response = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -1318,9 +1318,9 @@ describe('Pieces', function() {
   it('should not set a cache-control value when retrieving a single piece, when "etags" cache option is set', async () => {
     apos.thing.options.cache = {
       api: {
-        maxAge: 5555
-      },
-      etags: true
+        maxAge: 5555,
+        etags: true
+      }
     };
 
     const response = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });
@@ -1441,9 +1441,9 @@ describe('Pieces', function() {
   it('should set a custom etag when retrieving a single piece', async () => {
     apos.thing.options.cache = {
       api: {
-        maxAge: 1111
-      },
-      etags: true
+        maxAge: 1111,
+        etags: true
+      }
     };
 
     const response = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });
@@ -1460,9 +1460,9 @@ describe('Pieces', function() {
   it('should return a 304 status code when retrieving a piece with a matching etag', async () => {
     apos.thing.options.cache = {
       api: {
-        maxAge: 1111
-      },
-      etags: true
+        maxAge: 1111,
+        etags: true
+      }
     };
 
     const response1 = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });
@@ -1488,9 +1488,9 @@ describe('Pieces', function() {
   it('should not return a 304 status code when retrieving a piece that has been edited', async () => {
     apos.thing.options.cache = {
       api: {
-        maxAge: 1111
-      },
-      etags: true
+        maxAge: 1111,
+        etags: true
+      }
     };
 
     const response1 = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });
@@ -1531,9 +1531,9 @@ describe('Pieces', function() {
   it('should not return a 304 status code when retrieving a piece after the max-age period', async () => {
     apos.thing.options.cache = {
       api: {
-        maxAge: 4444
-      },
-      etags: true
+        maxAge: 4444,
+        etags: true
+      }
     };
 
     const response1 = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });
@@ -1567,9 +1567,9 @@ describe('Pieces', function() {
   it('should not set a custom etag when retrieving a single piece, when user is connected', async () => {
     apos.thing.options.cache = {
       api: {
-        maxAge: 3333
-      },
-      etags: true
+        maxAge: 3333,
+        etags: true
+      }
     };
 
     await apos.http.post('/api/v1/@apostrophecms/login/login', {
@@ -1597,9 +1597,9 @@ describe('Pieces', function() {
   it('should not set a custom etag when retrieving a single piece, when user is connected using an api key', async () => {
     apos.thing.options.cache = {
       api: {
-        maxAge: 3333
-      },
-      etags: true
+        maxAge: 3333,
+        etags: true
+      }
     };
 
     const response = await apos.http.get(`/api/v1/thing/testThing:en:published?apiKey=${apiKey}`, { fullResponse: true });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

In addition to #3692, give the possibility to set etags cache option for `api` _**and/or**_ `page` cache options, rather than setting it globally for `api` **_and_** `page` cache options.

## What are the specific steps to test this change?

See #3692 

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [x] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated --> _no need_
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
