### PR TITLE
PRO-2687 default relationship editor and fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# UNRELEASED
+
+### Adds
+
+* Images may now be cropped to suit a particular placement after selecting them.
+* Developers may now specify an alternate Vue component to be used for editing the subfields of relationships, either at the field level or as a default for all relationships with a particular piece type.
+
 # 3.17.0 (2022-03-31)
 
 ### Adds

--- a/modules/@apostrophecms/image-widget/index.js
+++ b/modules/@apostrophecms/image-widget/index.js
@@ -10,33 +10,10 @@ module.exports = {
     add: {
       _image: {
         type: 'relationship',
-        editor: 'AposImageRelationshipEditor',
         label: 'apostrophe:image',
         max: 1,
         required: true,
-        withType: '@apostrophecms/image',
-        fields: {
-          add: {
-            top: {
-              type: 'integer'
-            },
-            left: {
-              type: 'integer'
-            },
-            width: {
-              type: 'integer'
-            },
-            height: {
-              type: 'integer'
-            },
-            x: {
-              type: 'integer'
-            },
-            y: {
-              type: 'integer'
-            }
-          }
-        }
+        withType: '@apostrophecms/image'
       }
     }
   }

--- a/modules/@apostrophecms/image/index.js
+++ b/modules/@apostrophecms/image/index.js
@@ -28,7 +28,30 @@ module.exports = {
     showPermissions: true,
     // Images should by default be considered "related documents" when localizing
     // another document that references them
-    relatedDocument: true
+    relatedDocument: true,
+    relationshipEditor: 'AposImageRelationshipEditor',
+    relationshipFields: {
+      add: {
+        top: {
+          type: 'integer'
+        },
+        left: {
+          type: 'integer'
+        },
+        width: {
+          type: 'integer'
+        },
+        height: {
+          type: 'integer'
+        },
+        x: {
+          type: 'integer'
+        },
+        y: {
+          type: 'integer'
+        }
+      }
+    }
   },
   fields: {
     remove: [ 'visibility' ],

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1028,8 +1028,8 @@ module.exports = {
           const withTypeManager = self.apos.doc.getManager(field.withType);
           field.editor = field.editor || withTypeManager.options.relationshipEditor;
           if (!field.schema && !Array.isArray(field.withType)) {
-            const withTypeManager = self.apos.doc.getManager(field.withType);
-            const fields = withTypeManager.options.relationshipFields && withTypeManager.options.relationshipFields.add;
+            const fieldsOption = withTypeManager.options.relationshipFields;
+            const fields = fieldsOption && fieldsOption.add;
             field.fields = fields && klona(fields);
             field.schema = self.fieldsToArray(`Relationship field ${field.name}`, field.fields);
           }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

* Piece type modules may specify a default set of fields for any relationship with that type, as well as a vue component to be used to edit those fields.
* Configured that for the `@apostrophecms/image` type and removed it from the `@apostrophecms/image-widget` type, showing that custom slideshow widgets etc. will "just work" with cropping without having to think about this.

## What are the specific steps to test this change?

*For example:*

Crop an image for a particular placement in an image widget in the testbed, as per normal. Note that this works and displays the proper editor even though the configuration for that exists only in the image piece type.

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
