### PR TITLE
PRO-2641: fix float field value typing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * Documentation of obsolete options has been removed.
 * Dead code relating to activating in-context widget editors have been removed. They are always active and have been for some time. In the future they might be swapped in on scroll, but there will never be a need to swap them in "on click."
+* Fixes float field UI bug that transforms the value to integer when there is no field error and the first number after the decimal is `0`.
 
 ## 3.17.0 (2022-03-31)
 

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputString.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputString.vue
@@ -172,6 +172,14 @@ export default {
         if ((s == null) || (s === '')) {
           return s;
         } else {
+          // The native parse float converts 3.0 to 3 and makes
+          // next to become integer. In theory we don't need parseFloat
+          // as the value is natively guarded by the browser 'number' type.
+          // However we need a float value sent to the backend
+          // and we force that when focus is lost.
+          if (this.focus && (`${s}`.match(/\.[0]*$/))) {
+            return s;
+          }
           return parseFloat(s);
         }
       } else {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputString.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputString.vue
@@ -177,7 +177,7 @@ export default {
           // as the value is natively guarded by the browser 'number' type.
           // However we need a float value sent to the backend
           // and we force that when focus is lost.
-          if (this.focus && (`${s}`.match(/\.[0]*$/))) {
+          if (this.focus && `${s}`.match(/\.[0]*$/)) {
             return s;
           }
           return parseFloat(s);


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

If a field of type float has max value set to 4, then:
- when typing 3.01 the value becomes 31 
- when typing 42.01 the value is as expected 42.01

The bug occurs when there is no error and the first number after the decimal (.) is `0`.

Closes PRO-2641.

## What are the specific steps to test this change?
Passing UI tests.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

