### PR TITLE
PRO-2502: Resolve _urls by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * Documentation of obsolete options has been removed.
 * Dead code relating to activating in-context widget editors have been removed. They are always active and have been for some time. In the future they might be swapped in on scroll, but there will never be a need to swap them in "on click."
+* Fixes `_urls` not added on attachment fields when pieces API index is requested (#3643)
 
 ## 3.17.0 (2022-03-31)
 

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1519,7 +1519,7 @@ module.exports = {
         // `apos.attachment.all` method. Used by our REST APIs.
 
         attachments: {
-          def: false,
+          def: true,
           after(results) {
             const attachments = query.get('attachments');
 

--- a/test/pieces-public-api.js
+++ b/test/pieces-public-api.js
@@ -1,5 +1,7 @@
 const t = require('../test-lib/test.js');
 const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
 
 let apos;
 
@@ -31,6 +33,12 @@ describe('Pieces Public API', function() {
               foo: {
                 label: 'Foo',
                 type: 'string'
+              },
+              _image: {
+                label: 'Image',
+                type: 'relationship',
+                withType: '@apostrophecms/image',
+                max: 1
               }
             }
           }
@@ -151,4 +159,80 @@ describe('Pieces Public API', function() {
     delete apos.thing.options.cache;
   });
 
+  it('should resolve _urls for image attachments', async () => {
+    // Reproduces https://github.com/apostrophecms/apostrophe/issues/3643
+    // Create piece with image
+    await await apos.doc.db.deleteMany({ type: 'thing' });
+    const req = apos.task.getReq();
+    await wipeUploads();
+    const attachment = await upload('upload_image.png');
+    const image = await apos.image.insert(req, {
+      type: '@apostrophecms/image',
+      slug: 'image-1',
+      visibility: 'public',
+      attachment
+    });
+    await apos.thing.insert(req, {
+      ...testThing,
+      _id: 'testThingAttachment:en:published',
+      title: 'Hello Image',
+      _image: [ image ]
+    });
+    apos.thing.options.publicApiProjection = {
+      title: 1,
+      _url: 1,
+      _image: 1
+    };
+
+    // Test
+    const response = await apos.http.get('/api/v1/thing');
+    assert(response);
+    assert.strictEqual(response.results.length, 1);
+
+    const [ img ] = response.results[0]._image;
+    assert(img);
+    const att = img.attachment;
+    assert(att);
+    assert(att._urls);
+    assert(Object.keys(att._urls).length > 0);
+  });
+
 });
+
+// HELPERS
+const uploadSource = path.join(__dirname, '/data/upload_tests/');
+
+async function wipeUploads() {
+  deleteFolderRecursive(path.join(__dirname, '/public/uploads'));
+  await await apos.doc.db.deleteMany({ type: '@apostrophecms/image' });
+  return apos.db.collection('aposAttachments').deleteMany({});
+
+  function deleteFolderRecursive (path) {
+    let files = [];
+    if (fs.existsSync(path)) {
+      files = fs.readdirSync(path);
+      files.forEach(function(file, index) {
+        const curPath = path + '/' + file;
+        if (fs.lstatSync(curPath).isDirectory()) { // recurse
+          deleteFolderRecursive(curPath);
+        } else { // delete file
+          fs.unlinkSync(curPath);
+        }
+      });
+      fs.rmdirSync(path);
+    }
+  }
+}
+
+async function upload(filename) {
+  const info = await apos.attachment.insert(apos.task.getReq(), {
+    name: filename,
+    path: uploadSource + filename
+  });
+  // make sure it exists in mongo
+  const result = await apos.db.collection('aposAttachments').findOne({
+    _id: info._id
+  });
+  assert(result);
+  return result;
+}

--- a/test/pieces-public-api.js
+++ b/test/pieces-public-api.js
@@ -159,7 +159,7 @@ describe('Pieces Public API', function() {
     delete apos.thing.options.cache;
   });
 
-  it('should resolve _urls for image attachments', async () => {
+  it('should resolve _urls for image attachments', async function () {
     // Reproduces https://github.com/apostrophecms/apostrophe/issues/3643
     // Create piece with image
     await await apos.doc.db.deleteMany({ type: 'thing' });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Resolve attachment owned `_urls` for API calls.

Closes #3643 
Closes PRO-2502
Related to https://github.com/apostrophecms/apostrophe/pull/3525

## What are the specific steps to test this change?
Attachment URLs are computed by default.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

