### PR TITLE
1973 focal point

### DIFF
--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -145,6 +145,7 @@
   "filterByTag": "Filter by Tag",
   "filterResultsByType": "Filter Results By Type",
   "findOrAddTag": "Find an existing tag or add a new one",
+  "focalPoint": "Select a focal point for this image",
   "globalDocLabel": "Global Content",
   "goToPage": "Go to page {{ page }}",
   "guest": "Guest",

--- a/modules/@apostrophecms/i18n/i18n/es.json
+++ b/modules/@apostrophecms/i18n/i18n/es.json
@@ -138,6 +138,7 @@
   "filterByTag": "Filtrar por Etiqueta",
   "filterResultsByType": "Filtrar Resultados por Tipo",
   "findOrAddTag": "Encuentrar una etiqueta o añadir una etiqueta nueva",
+  "focalPoint": "Seleccione un punto focal para esta imagen",
   "globalDocLabel": "Contenido Global",
   "goToPage": "Ir a página {{ page }}",
   "guest": "Invitado",

--- a/modules/@apostrophecms/i18n/i18n/pt-BR.json
+++ b/modules/@apostrophecms/i18n/i18n/pt-BR.json
@@ -138,6 +138,7 @@
   "filterByTag": "Filtrar por Tag",
   "filterResultsByType": "Filtrar Resultados por Tipo",
   "findOrAddTag": "Encontre uma tag existente ou adicione uma nova",
+  "focalPoint": "Selecione um ponto focal para esta imagem",
   "globalDocLabel": "Conteúdo Global",
   "goToPage": "Ir para página {{ page }}",
   "guest": "Convidado",

--- a/modules/@apostrophecms/i18n/i18n/sk.json
+++ b/modules/@apostrophecms/i18n/i18n/sk.json
@@ -142,6 +142,7 @@
   "filterByTag": "Filtrovať podľa značky",
   "filterResultsByType": "Filtrovať výsledky podľa typu",
   "findOrAddTag": "Nájdite existujúcu značku alebo pridajte novú",
+  "focalPoint": "Vyberte ohnisko pre tento obrázok",
   "globalDocLabel": "Globálny obsah",
   "goToPage": "Ísť na stranu {{ page }}",
   "guest": "Hosť",

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -125,9 +125,6 @@ export default {
       document.addEventListener('mouseup', this.closeDragElement);
     },
     elementDrag(event) {
-      // TODO: break this function down
-      const { focalPoint } = this.$refs;
-
       event.preventDefault();
 
       this.dragAndDrop.pos1 = this.dragAndDrop.pos3 - event.clientX;
@@ -135,34 +132,7 @@ export default {
       this.dragAndDrop.pos3 = event.clientX;
       this.dragAndDrop.pos4 = event.clientY;
 
-      const focalPointLeft = focalPoint.offsetLeft - this.dragAndDrop.pos1;
-      const focalPointTop = focalPoint.offsetTop - this.dragAndDrop.pos2;
-
-      // TODO: get element only once!
-      const stencilElement = document.querySelector('[data-stencil]');
-      const stencilStyle = window.getComputedStyle(stencilElement);
-
-      // TODO: use something compatible, not WebKitCSSMatrix (DOMMatrixReadOnly? no because Internet Exp, regular style.transform?, getComputedStyle()?)
-      const matrix = new window.WebKitCSSMatrix(stencilStyle.transform);
-      const stencilTranslateX = matrix.m41;
-      const stencilTranslateY = matrix.m42;
-      const stencilWidth = stencilElement.clientWidth;
-      const stencilHeight = stencilElement.clientHeight;
-
-      const focalPointHalfWidth = (focalPoint.clientWidth + focalPoint.clientLeft * 2) / 2;
-      const focalPointHalfHeight = (focalPoint.clientHeight + focalPoint.clientTop * 2) / 2;
-
-      if (
-        focalPointLeft < stencilTranslateX - focalPointHalfWidth ||
-        focalPointTop < stencilTranslateY - focalPointHalfHeight ||
-        focalPointLeft > stencilTranslateX - focalPointHalfWidth + stencilWidth ||
-        focalPointTop > stencilTranslateY - focalPointHalfHeight + stencilHeight
-      ) {
-        return;
-      }
-
-      focalPoint.style.left = `${focalPointLeft}px`;
-      focalPoint.style.top = `${focalPointTop}px`;
+      this.setFocalPointCoordinates();
     },
     closeDragElement() {
       const { focalPoint } = this.$refs;
@@ -170,6 +140,44 @@ export default {
       focalPoint.style.cursor = 'grab';
       document.removeEventListener('mousemove', this.elementDrag);
       document.removeEventListener('mouseup', this.closeDragElement);
+    },
+    setFocalPointCoordinates () {
+      const { focalPoint } = this.$refs;
+
+      const focalPointCoordinates = {
+        left: focalPoint.offsetLeft - this.dragAndDrop.pos1,
+        top: focalPoint.offsetTop - this.dragAndDrop.pos2
+      };
+
+      const stencilCoordinates = this.getStencilCoordinates();
+
+      const focalPointHalfWidth = (focalPoint.clientWidth + focalPoint.clientLeft * 2) / 2;
+      const focalPointHalfHeight = (focalPoint.clientHeight + focalPoint.clientTop * 2) / 2;
+
+      if (
+        focalPointCoordinates.left < stencilCoordinates.left - focalPointHalfWidth ||
+        focalPointCoordinates.top < stencilCoordinates.top - focalPointHalfHeight ||
+        focalPointCoordinates.left > stencilCoordinates.left - focalPointHalfWidth + stencilCoordinates.width ||
+        focalPointCoordinates.top > stencilCoordinates.top - focalPointHalfHeight + stencilCoordinates.height
+      ) {
+        return;
+      }
+
+      focalPoint.style.left = `${focalPointCoordinates.left}px`;
+      focalPoint.style.top = `${focalPointCoordinates.top}px`;
+    },
+    getStencilCoordinates () {
+      // TODO: use something compatible, not WebKitCSSMatrix (DOMMatrixReadOnly? no because Internet Exp, regular style.transform?, getComputedStyle()?)
+      const stencilElement = document.querySelector('[data-stencil]');
+      const stencilStyle = window.getComputedStyle(stencilElement);
+      const matrix = new window.WebKitCSSMatrix(stencilStyle.transform);
+
+      return {
+        left: matrix.m41,
+        top: matrix.m42,
+        width: stencilElement.clientWidth,
+        height: stencilElement.clientHeight
+      };
     }
   }
 };

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -61,12 +61,9 @@ export default {
       height: null
     },
     isUpdatingCropperCoordinates: false,
-    // TODO: rename these variables
     dragAndDrop: {
-      pos1: 0,
-      pos2: 0,
-      pos3: 0,
-      pos4: 0
+      clientX: 0,
+      clientY: 0
     }
   }),
   watch: {
@@ -143,8 +140,8 @@ export default {
 
       const { focalPoint } = this.$refs;
 
-      this.dragAndDrop.pos3 = event.clientX;
-      this.dragAndDrop.pos4 = event.clientY;
+      this.dragAndDrop.clientX = event.clientX;
+      this.dragAndDrop.clientY = event.clientY;
 
       focalPoint.style.cursor = 'grabbing';
       focalPoint.style.transitionDuration = '0s';
@@ -157,13 +154,11 @@ export default {
 
       const { focalPoint } = this.$refs;
 
-      this.dragAndDrop.pos1 = this.dragAndDrop.pos3 - event.clientX;
-      this.dragAndDrop.pos2 = this.dragAndDrop.pos4 - event.clientY;
-      this.dragAndDrop.pos3 = event.clientX;
-      this.dragAndDrop.pos4 = event.clientY;
+      const left = focalPoint.offsetLeft - this.dragAndDrop.clientX + event.clientX;
+      const top = focalPoint.offsetTop - this.dragAndDrop.clientY + event.clientY;
 
-      const left = focalPoint.offsetLeft - this.dragAndDrop.pos1;
-      const top = focalPoint.offsetTop - this.dragAndDrop.pos2;
+      this.dragAndDrop.clientX = event.clientX;
+      this.dragAndDrop.clientY = event.clientY;
 
       focalPoint.style.left = `${left}px`;
       focalPoint.style.top = `${top}px`;

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -49,14 +49,14 @@ export default {
   emits: [ 'change' ],
   data: () => ({
     debounceTimeout: 200,
+    isUpdatingCropperCoordinates: false,
     stencilCoordinates: {
       left: null,
       top: null,
       width: null,
       height: null
     },
-    isUpdatingCropperCoordinates: false,
-    dragAndDrop: {
+    focalPointDragCoordinates: {
       clientX: 0,
       clientY: 0
     }
@@ -135,8 +135,8 @@ export default {
 
       const { focalPoint } = this.$refs;
 
-      this.dragAndDrop.clientX = event.clientX;
-      this.dragAndDrop.clientY = event.clientY;
+      this.focalPointDragCoordinates.clientX = event.clientX;
+      this.focalPointDragCoordinates.clientY = event.clientY;
 
       focalPoint.style.cursor = 'grabbing';
       focalPoint.style.transitionDuration = '0s';
@@ -149,11 +149,11 @@ export default {
 
       const { focalPoint } = this.$refs;
 
-      const left = focalPoint.offsetLeft - this.dragAndDrop.clientX + event.clientX;
-      const top = focalPoint.offsetTop - this.dragAndDrop.clientY + event.clientY;
+      const left = focalPoint.offsetLeft - this.focalPointDragCoordinates.clientX + event.clientX;
+      const top = focalPoint.offsetTop - this.focalPointDragCoordinates.clientY + event.clientY;
 
-      this.dragAndDrop.clientX = event.clientX;
-      this.dragAndDrop.clientY = event.clientY;
+      this.focalPointDragCoordinates.clientX = event.clientX;
+      this.focalPointDragCoordinates.clientY = event.clientY;
 
       focalPoint.style.left = `${left}px`;
       focalPoint.style.top = `${top}px`;

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -249,9 +249,6 @@ export default {
     storeStencilCoordinates () {
       const stencilElement = document.querySelector('[data-stencil]');
       const stencilStyle = window.getComputedStyle(stencilElement);
-
-      // TODO: DOMMatrixReadOnly is not IE compatible. Should we use something compatible with IE?
-      // In that case, use regular elem.style.transform and extract values with a regex
       const matrix = new window.DOMMatrixReadOnly(stencilStyle.transform);
 
       this.stencilCoordinates = {

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -337,8 +337,12 @@ export default {
 
       const focalPointSize = this.getFocalPointSize();
 
-      const left = Math.round(x / 100 * this.stencilCoordinates.width + this.stencilCoordinates.left - focalPointSize.halfWidth);
-      const top = Math.round(y / 100 * this.stencilCoordinates.height + this.stencilCoordinates.top - focalPointSize.halfHeight);
+      const left = Math.round(
+        x / 100 * this.stencilCoordinates.width + this.stencilCoordinates.left - focalPointSize.halfWidth
+      );
+      const top = Math.round(
+        y / 100 * this.stencilCoordinates.height + this.stencilCoordinates.top - focalPointSize.halfHeight
+      );
 
       focalPoint.style.left = `${left}px`;
       focalPoint.style.top = `${top}px`;

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -27,7 +27,6 @@ import 'vue-advanced-cropper/dist/style.css';
 
 // TODO: focal point tooltip
 // TODO: clicking sets focal point
-// TODO: fix cropper and focal point on load
 // TODO: clean, jsdoc...
 
 export default {
@@ -215,7 +214,8 @@ export default {
      */
     placeFocalPoint () {
       const { focalPoint } = this.$refs;
-      const { x = 50, y = 50 } = this.docFields.data;
+      const x = this.docFields.data.x || 50;
+      const y = this.docFields.data.y || 50;
 
       const focalPointSize = this.getFocalPointSize();
 
@@ -250,6 +250,7 @@ export default {
         y
       });
 
+      console.log(coordinates);
       this.$emit('change', coordinates, false);
     }
   }

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -29,6 +29,8 @@ import { debounce } from 'Modules/@apostrophecms/ui/utils';
 import { Cropper } from 'vue-advanced-cropper';
 import 'vue-advanced-cropper/dist/style.css';
 
+const DEBOUNCE_TIMEOUT = 500;
+
 export default {
   components: {
     Cropper
@@ -45,7 +47,6 @@ export default {
   },
   emits: [ 'change' ],
   data: () => ({
-    debounceTimeout: 500,
     isCropperChanging: false,
     isUpdatingCropperCoordinates: false,
     stencilCoordinates: {

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -106,6 +106,8 @@ export default {
   },
   methods: {
     onCropperReady () {
+      // TODO: force center focal point on first load, if no focal point value
+      // TODO: set focal point value on load with current data
       this.centerFocalPoint();
       window.addEventListener('resize', this.centerFocalPointDebounced);
     },
@@ -188,7 +190,6 @@ export default {
     /**
      * Place the focal point at the center of the stencil.
      * TODO: center focal point only when outside stencil
-     * TODO: force center focal point on first load
      */
     centerFocalPoint () {
       const { focalPoint } = this.$refs;

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -29,8 +29,6 @@ import { debounce } from 'Modules/@apostrophecms/ui/utils';
 import { Cropper } from 'vue-advanced-cropper';
 import 'vue-advanced-cropper/dist/style.css';
 
-const DEBOUNCE_TIMEOUT = 500;
-
 export default {
   components: {
     Cropper
@@ -84,6 +82,13 @@ export default {
     }
   },
   created () {
+    const DEBOUNCE_TIMEOUT = 500;
+
+    this.onScreenResizeDebounced = debounce(this.onScreenResize, DEBOUNCE_TIMEOUT);
+    this.handleCropperChangeDebounced = debounce(this.handleCropperChange, DEBOUNCE_TIMEOUT);
+    this.setCropperCoordinatesDebounced = debounce(this.setCropperCoordinates, DEBOUNCE_TIMEOUT);
+    this.updateFocalPointCoordinatesDebounced = debounce(this.updateFocalPointCoordinates, DEBOUNCE_TIMEOUT);
+
     this.defaultSize = {
       width: this.docFields.data.width,
       height: this.docFields.data.height
@@ -92,10 +97,6 @@ export default {
       top: this.docFields.data.top,
       left: this.docFields.data.left
     };
-    this.onScreenResizeDebounced = debounce(this.onScreenResize, DEBOUNCE_TIMEOUT);
-    this.handleCropperChangeDebounced = debounce(this.handleCropperChange, DEBOUNCE_TIMEOUT);
-    this.setCropperCoordinatesDebounced = debounce(this.setCropperCoordinates, DEBOUNCE_TIMEOUT);
-    this.updateFocalPointCoordinatesDebounced = debounce(this.updateFocalPointCoordinates, DEBOUNCE_TIMEOUT);
   },
   beforeDestroy() {
     this.$refs.focalPoint.removeEventListener('mousedown', this.onFocalPointMouseDown);

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     class="apos-image-cropper"
-    @click="onImageClick"
   >
     <span
       class="apos-image-focal-point"
@@ -206,15 +205,13 @@ export default {
         .entries(coordinates)
         .some(([ name, value ]) => dataFields[name] !== value);
     },
-    /**
-     * Store coordinates in order to use them
-     * to keep focal point inside the stencil when moving it.
-     */
     storeStencilCoordinates () {
-      // TODO: use something compatible, not WebKitCSSMatrix (DOMMatrixReadOnly? no because Internet Exp, regular style.transform?, getComputedStyle()?)
       const stencilElement = document.querySelector('[data-stencil]');
       const stencilStyle = window.getComputedStyle(stencilElement);
-      const matrix = new window.WebKitCSSMatrix(stencilStyle.transform);
+
+      // TODO: DOMMatrixReadOnly is not IE compatible. Should we use something compatible with IE?
+      // In that case, use regular elem.style.transform and extract values with a regex
+      const matrix = new window.DOMMatrixReadOnly(stencilStyle.transform);
 
       this.stencilCoordinates = {
         left: matrix.m41,

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -29,6 +29,7 @@ import { Cropper } from 'vue-advanced-cropper';
 import 'vue-advanced-cropper/dist/style.css';
 
 // TODO: focal point tooltip
+// TODO: handle click
 // TODO: clean, jsdoc...
 
 export default {
@@ -174,7 +175,6 @@ export default {
       document.removeEventListener('mouseup', this.onMouseUp);
     },
     onImageClick (event) {
-      // TODO: wip
       console.log(event);
 
       const { focalPoint } = this.$refs;
@@ -297,8 +297,7 @@ export default {
     border-radius: 50%;
     border: 1px solid var(--a-white);
     background-color: var(--a-primary);
-    /* TODO: use box-shadow variable? */
-    box-shadow: 0 0 4px 0 rgb(0 0 0 / 50%);
+    box-shadow: 0 0 4px var(--a-black);
     transition: left 0.1s ease, top 0.1s ease;
     cursor: grab;
   }

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -212,8 +212,16 @@ export default {
 
       const focalPointSize = this.getFocalPointSize();
 
-      const left = event.clientX - event.currentTarget.offsetLeft - event.currentTarget.offsetParent.offsetLeft - focalPointSize.halfWidth;
-      const top = event.clientY - event.currentTarget.offsetTop - event.currentTarget.offsetParent.offsetTop - focalPointSize.halfHeight;
+      const left =
+        event.clientX -
+        event.currentTarget.offsetLeft -
+        event.currentTarget.offsetParent.offsetLeft -
+        focalPointSize.halfWidth;
+      const top =
+        event.clientY -
+        event.currentTarget.offsetTop -
+        event.currentTarget.offsetParent.offsetTop -
+        focalPointSize.halfHeight;
 
       focalPoint.style.left = `${left}px`;
       focalPoint.style.top = `${top}px`;
@@ -264,16 +272,27 @@ export default {
 
       const focalPointSize = this.getFocalPointSize();
 
-      const x = (focalPoint.offsetLeft + focalPointSize.halfWidth - this.stencilCoordinates.left) / this.stencilCoordinates.width;
-      const y = (focalPoint.offsetTop + focalPointSize.halfHeight - this.stencilCoordinates.top) / this.stencilCoordinates.height;
+      const x = (
+        focalPoint.offsetLeft +
+        focalPointSize.halfWidth -
+        this.stencilCoordinates.left
+      ) / this.stencilCoordinates.width;
+      const y = (
+        focalPoint.offsetTop +
+        focalPointSize.halfHeight -
+        this.stencilCoordinates.top
+      ) / this.stencilCoordinates.height;
 
-      const sanitizeCoordinates = ({ x, y }) => (x >= 0 && x <= 1 && y >= 0 && y <= 1) ? {
-        x: Math.abs(Math.round(x * 100)),
-        y: Math.abs(Math.round(y * 100))
-      } : {
-        x: null,
-        y: null
-      };
+      const sanitizeCoordinates = ({ x, y }) =>
+        (x >= 0 && x <= 1 && y >= 0 && y <= 1)
+          ? {
+            x: Math.abs(Math.round(x * 100)),
+            y: Math.abs(Math.round(y * 100))
+          }
+          : {
+            x: null,
+            y: null
+          };
 
       const coordinates = sanitizeCoordinates({
         x,
@@ -338,10 +357,14 @@ export default {
       const focalPointSize = this.getFocalPointSize();
 
       const left = Math.round(
-        x / 100 * this.stencilCoordinates.width + this.stencilCoordinates.left - focalPointSize.halfWidth
+        x / 100 * this.stencilCoordinates.width +
+        this.stencilCoordinates.left -
+        focalPointSize.halfWidth
       );
       const top = Math.round(
-        y / 100 * this.stencilCoordinates.height + this.stencilCoordinates.top - focalPointSize.halfHeight
+        y / 100 * this.stencilCoordinates.height +
+        this.stencilCoordinates.top -
+        focalPointSize.halfHeight
       );
 
       focalPoint.style.left = `${left}px`;

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -6,6 +6,7 @@
     <span
       class="apos-image-focal-point"
       ref="focalPoint"
+      v-apos-tooltip="'apostrophe:focalPoint'"
       @mousedown="onFocalPointMouseDown"
     />
     <cropper
@@ -28,7 +29,6 @@ import { debounce } from 'Modules/@apostrophecms/ui/utils';
 import { Cropper } from 'vue-advanced-cropper';
 import 'vue-advanced-cropper/dist/style.css';
 
-// TODO: focal point tooltip
 // TODO: clean, jsdoc...
 
 export default {

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -152,11 +152,30 @@ export default {
 
       const { focalPoint } = this.$refs;
 
+      const focalPointSize = this.getFocalPointSize();
+
       const left = focalPoint.offsetLeft - this.focalPointDragCoordinates.clientX + event.clientX;
       const top = focalPoint.offsetTop - this.focalPointDragCoordinates.clientY + event.clientY;
 
       this.focalPointDragCoordinates.clientX = event.clientX;
       this.focalPointDragCoordinates.clientY = event.clientY;
+
+      // For some reason, positioning the focal point at the very top of the image
+      // results in having a negative `top` value.
+      // Let's apply a margin of error for every edge to prevent having `null`
+      // focal point values when placing it at the image borders.
+      const MARGIN_OF_ERROR = 1;
+
+      const limits = {
+        left: -focalPointSize.halfWidth + MARGIN_OF_ERROR,
+        top: -focalPointSize.halfHeight + MARGIN_OF_ERROR,
+        right: focalPoint.offsetParent.clientWidth - focalPointSize.halfWidth - MARGIN_OF_ERROR,
+        bottom: focalPoint.offsetParent.clientHeight - focalPointSize.halfHeight - MARGIN_OF_ERROR
+      };
+
+      if (left < limits.left || top < limits.top || left > limits.right || top > limits.bottom) {
+        return;
+      };
 
       focalPoint.style.left = `${left}px`;
       focalPoint.style.top = `${top}px`;

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -130,6 +130,7 @@ export default {
       this.dragAndDrop.pos4 = event.clientY;
 
       this.$refs.focalPoint.style.cursor = 'grabbing';
+      this.$refs.focalPoint.style.transitionDuration = '0s';
 
       document.addEventListener('mousemove', this.onMouseMove);
       document.addEventListener('mouseup', this.onMouseUp);
@@ -146,6 +147,7 @@ export default {
     },
     onMouseUp() {
       this.$refs.focalPoint.style.cursor = 'grab';
+      this.$refs.focalPoint.style.transitionDuration = '0.1s';
 
       document.removeEventListener('mousemove', this.onMouseMove);
       document.removeEventListener('mouseup', this.onMouseUp);

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -283,8 +283,15 @@ export default {
         this.stencilCoordinates.top
       ) / this.stencilCoordinates.height;
 
-      const sanitizeCoordinates = ({ x, y }) =>
-        (x >= 0 && x <= 1 && y >= 0 && y <= 1)
+      const coordinates = sanitizeCoordinates({
+        x,
+        y
+      });
+
+      this.$emit('change', coordinates, false);
+
+      function sanitizeCoordinates ({ x, y }) {
+        return (x >= 0 && x <= 1 && y >= 0 && y <= 1)
           ? {
             x: Math.abs(Math.round(x * 100)),
             y: Math.abs(Math.round(y * 100))
@@ -293,16 +300,10 @@ export default {
             x: null,
             y: null
           };
-
-      const coordinates = sanitizeCoordinates({
-        x,
-        y
-      });
-
-      this.$emit('change', coordinates, false);
+      }
     },
     /**
-     * Returns wether the cropper coordinates have changed or not.
+     * Returns whether the cropper coordinates have changed or not.
      */
     checkCropperCoordinatesDiff (coordinates, dataFields) {
       return Object

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -104,7 +104,7 @@ export default {
   },
   methods: {
     /**
-     * Place the focal point inside the stencil to its current position.
+     * Places the focal point inside the stencil to its current position.
      */
     onCropperReady () {
       this.storeStencilCoordinates();
@@ -113,8 +113,8 @@ export default {
       window.addEventListener('resize', this.onScreenResizeDebounced);
     },
     /**
-     * Instantly give the information that cropper is changing
-     * and handle its new coordinates.
+     * Instantly gives the information that cropper is changing
+     * and handles its new coordinates.
      * Please note that debounce is handled manually here,
      * not via the cropper `debounce` prop so that we directly have
      * the information it is changing, not after its debounce time.
@@ -125,8 +125,8 @@ export default {
       this.handleCropperChangeDebounced(coordinates);
     },
     /**
-     * Register events and coordinates to handle drag & drop.
-     * Update CSS values during manipulation to have a smooth and clean
+     * Registers events and coordinates to handle drag & drop.
+     * Updates CSS values during manipulation to have a smooth and clean
      * drag & drop experience (pause transition when moving the focal point).
      */
     onFocalPointMouseDown (event) {
@@ -144,8 +144,8 @@ export default {
       document.addEventListener('mouseup', this.onFocalPointMouseUp);
     },
     /**
-     * Move focal point to follow the mouse pointer
-     * and update its new coordinates.
+     * Moves focal point to follow the mouse pointer
+     * and updates its new coordinates.
      */
     onFocalPointMouseMove(event) {
       event.preventDefault();
@@ -183,8 +183,8 @@ export default {
       this.updateFocalPointCoordinatesDebounced();
     },
     /**
-     * Remove events when releasing click on the focal point element.
-     * Revert CSS values after manipulation.
+     * Removes events when releasing click on the focal point element.
+     * Reverts CSS values after manipulation.
      */
     onFocalPointMouseUp() {
       const { focalPoint } = this.$refs;
@@ -196,11 +196,11 @@ export default {
       document.removeEventListener('mouseup', this.onFocalPointMouseUp);
     },
     /**
-     * Place focal point at the position where the image has been clicked
-     * and update its new coordinates.
-     * Position it in relation of the current target offset
+     * Places focal point at the position where the image has been clicked
+     * and updates its new coordinates.
+     * Positions it in relation of the current target offset
      * in order to set the `left` and `top` properties accordingly.
-     * Do not place focal point when cropper is changing (move or resize)
+     * Does not place focal point when cropper is changing (move or resize)
      * to keep a friendly user experience.
      */
     onImageClick (event) {
@@ -229,7 +229,7 @@ export default {
       this.updateFocalPointCoordinatesDebounced();
     },
     /**
-     * Place the focal point back to its position (inside the stencil),
+     * Places the focal point back to its position (inside the stencil),
      * when resizing the screen so that the percentages
      * relative to the stencil remain the same.
      */
@@ -238,8 +238,8 @@ export default {
       this.placeFocalPointInStencil();
     },
     /**
-     * Update stencil and focal point coordinates
-     * after cropper has changed and emit its new coordinates.
+     * Updates stencil and focal point coordinates
+     * after cropper has changed and emits its new coordinates.
      */
     handleCropperChange (coordinates) {
       this.isChangingCropper = false;
@@ -257,14 +257,14 @@ export default {
       this.isUpdatingCropperCoordinates = false;
     },
     /**
-     * Set cropper coordinates via its API.
+     * Sets cropper coordinates via its API.
      */
     setCropperCoordinates (coordinates) {
       this.$refs.cropper.setCoordinates(coordinates);
     },
     /**
-     * Get focal point relative position inside the stencil
-     * and emit it to update `x` and `y` as percentages,
+     * Gets focal point relative position inside the stencil
+     * and emits it to update `x` and `y` as percentages,
      * or as `null` if outside it.
      */
     updateFocalPointCoordinates () {
@@ -302,7 +302,7 @@ export default {
       this.$emit('change', coordinates, false);
     },
     /**
-     * Return wether the cropper coordinates have changed or not.
+     * Returns wether the cropper coordinates have changed or not.
      */
     checkCropperCoordinatesDiff (coordinates, dataFields) {
       return Object
@@ -310,7 +310,7 @@ export default {
         .some(([ name, value ]) => dataFields[name] !== value);
     },
     /**
-     * Store the stencil actual coordinates relative to the viewport,
+     * Stores the stencil actual coordinates relative to the viewport,
      * which are used for focal point DOM manipulation and its
      * relative position calculation.
      */
@@ -327,7 +327,7 @@ export default {
       };
     },
     /**
-     * Return the size and half size of the focal point element,
+     * Returns the size and half size of the focal point element,
      * used for its DOM manipulation and relative position calculation.
      */
     getFocalPointSize () {
@@ -345,7 +345,7 @@ export default {
       };
     },
     /**
-     * Place the focal point at its current coordinates
+     * Places the focal point at its current coordinates
      * inside the stencil or at the center of it by default.
      */
     placeFocalPointInStencil () {

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="apos-image-cropper">
-    <span class="apos-image-focal-point" ref="focalPoint" />
+    <span
+      class="apos-image-focal-point"
+      ref="focalPoint"
+      @mousedown="dragMouseDown"
+    />
     <cropper
       ref="cropper"
       :src="attachment._urls.uncropped
@@ -88,9 +92,10 @@ export default {
       left: this.docFields.data.left
     };
   },
-  mounted () {
-    // TODO: attach mousedown event to elem (@mousedown)
-    this.$refs.focalPoint.addEventListener('mousedown', this.dragMouseDown);
+  destroyed() {
+    const { focalPoint } = this.$refs;
+
+    focalPoint.removeEventListener('mousedown', this.dragMouseDown);
   },
   methods: {
     onChange ({ coordinates }) {
@@ -116,7 +121,6 @@ export default {
       this.dragAndDrop.pos4 = event.clientY;
 
       focalPoint.style.cursor = 'grabbing';
-      // TODO: attach mousemove to focalPoint element
       document.addEventListener('mousemove', this.elementDrag);
       document.addEventListener('mouseup', this.closeDragElement);
     },

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -45,7 +45,7 @@ export default {
   },
   emits: [ 'change' ],
   data: () => ({
-    debounceTimeout: 200,
+    debounceTimeout: 500,
     isCropperChanging: false,
     isUpdatingCropperCoordinates: false,
     stencilCoordinates: {

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageCropper.vue
@@ -52,12 +52,6 @@ export default {
       height: null
     },
     isUpdatingCropperCoordinates: false,
-    // TODO: emit focal point values via event
-    // focal point values in %
-    focalPoint: {
-      x: 0,
-      y: 0
-    },
     // TODO: rename these variables
     dragAndDrop: {
       pos1: 0,
@@ -209,10 +203,12 @@ export default {
       focalPoint.style.left = `${left}px`;
       focalPoint.style.top = `${top}px`;
 
-      this.focalPoint = {
+      const focalPointPercentages = {
         x: 50,
         y: 50
       };
+
+      this.$emit('change', focalPointPercentages, false);
     },
     placeFocalPointOnMove () {
       const { focalPoint } = this.$refs;
@@ -232,10 +228,12 @@ export default {
         focalPoint.style.left = `${left}px`;
         focalPoint.style.top = `${top}px`;
 
-        this.focalPoint = {
+        const focalPointPercentages = {
           x: Math.round((left + focalPointSize.halfWidth - this.stencilCoordinates.left) / this.stencilCoordinates.width * 100),
           y: Math.round((top + focalPointSize.halfHeight - this.stencilCoordinates.top) / this.stencilCoordinates.height * 100)
         };
+
+        this.$emit('change', focalPointPercentages, false);
       }
     }
   }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

[PRO-1973](https://linear.app/apostrophecms/issue/PRO-1973/as-a-user-i-can-specify-a-focal-point-on-an-image-in-an-image-field)

## Summary

Handle focal point by moving it via drag&drop and clicking on the image.

Focal point coordinates are relative to the stencil (cropper rectangle), and are set as percentages.
For instance, clicking at the very center of the stencil, focal point coordinates will be `{ x: 50, y: 50 }`.

When clicking or moving it outside the stencil, coordinates will be sent as `{ x: null, y: null }`.

**Important note:** we cannot rely on the cropper coordinates that come from its API, because they do not reflect reality.
In other words, the cropper coordinates are updated when zooming on the image, but the focal position remains the same.
So taking the cropper coordinates provided by the API into account would give us wrong focal point relative (to the stencil rectangle) position.

## What are the specific steps to test this change?

- add an image and edit the relationship

👉  focal point should be at the very center of the stencil (default behaviour):

![image](https://user-images.githubusercontent.com/8301962/165100443-75586d58-9f7e-4d0e-bcf8-ae36a9adc859.png)

- click and/or drag the focal point to a part of the image you want (eg. this little plant):

![image](https://user-images.githubusercontent.com/8301962/165100950-d0729dc1-d4b3-40c1-bd1d-df8c0f55a5e2.png)

- update image relationship and save image widget editor
- go into preview mode and inspect image
- check that `object-position` values are coherent (eg. `object-position: 88% 88%;` in our example):

![image](https://user-images.githubusercontent.com/8301962/165101345-5a75ab7f-eb47-46e7-b251-b3af49b7f441.png)

- now add a `object-fit: cover` rule to the image element, and change its `width` and `height` in order to have a part of the image visible

👉  the part where the focal point has been set should be visible:

![image](https://user-images.githubusercontent.com/8301962/165102089-012daf9c-e571-4317-b796-ced75e37e1f5.png)

- edit the image relationship again

👉  the focal point should be placed at its last coordinates (not at the center anymore)

- place the focal point outside the stencil:

![image](https://user-images.githubusercontent.com/8301962/165102705-4b9dc186-4a4d-49ca-96bd-ed796a3438c0.png)

- add a `object-fit: cover` rule to the image element, and change its `width` and `height` in order to have a part of the image visible

👉  the image should not have a `object-position` property anymore:

![image](https://user-images.githubusercontent.com/8301962/165103212-65a48944-33cc-417f-a8fe-70dd4f3d688f.png)

- edit the image relationship again
- verify that moving the stencil updates the focal point `x` and `y` percentages (i.e. you do not have to click or move the focal point to take it into account)
- verify that resizing the screen places the focal point back at its position, relative to the stencil (i.e. the position percentages remain the same)
- check that moving and resizing the cropper stencil does not place the focal point at the clicked position (at least for 500ms, which is the debounce time) -- without that, UX is crap.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
