### PR TITLE
PRO-2694: add after all modes deleted event

### DIFF
--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -272,7 +272,9 @@ module.exports = {
         // deletes both the published and previous docs.
         async deleteOtherModes(req, doc, options) {
           if (doc.aposLocale && doc.aposLocale.endsWith(':draft')) {
-            return cleanup('published');
+            await cleanup('published');
+            await self.emit('afterAllModesDeleted', req, doc, options);
+            return;
           }
           if (doc.aposLocale && doc.aposLocale.endsWith(':published')) {
             return cleanup('previous');


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Add event `afterAllModesDeleted` fired after all document modes are purged.

## What are the specific steps to test this change?

Modules are now able to register handlers for `@apostrophecms/doc:afterAllModesDeleted`. It provides access to the last purged (draft mode) doc.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [ ] Related tests have been updated

