### PR TITLE
2689 minsize when browing

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
+++ b/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
@@ -5,6 +5,8 @@ export default function() {
 
   let widgetsRendering = 0;
 
+  apos.area.widgetOptions = [];
+
   createWidgetClipboardApp();
 
   createAreaApps();

--- a/modules/@apostrophecms/image/ui/apos/apps/AposImageRelationshipQueryFilter.js
+++ b/modules/@apostrophecms/image/ui/apos/apps/AposImageRelationshipQueryFilter.js
@@ -1,0 +1,15 @@
+export default () => {
+  const queryOptions = [ 'minSize' ];
+
+  apos.bus.$on('piece-relationship-query', (query) => {
+    const [ options = {} ] = apos.area?.widgetOptions || [];
+
+    Object.entries(options).forEach(([ optName, optValue ]) => {
+      if (queryOptions.includes(optName)) {
+        query[optName] = optValue;
+      }
+    });
+
+    return 'looool';
+  });
+};

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -120,7 +120,7 @@ export default {
       required: true
     }
   },
-  emits: [ 'safe-close', 'archive', 'save', 'search' ],
+  emits: [ 'safe-close', 'archive', 'save', 'search', 'piece-relationship-query' ],
   data() {
     return {
       items: [],
@@ -248,6 +248,10 @@ export default {
             qs.choices = filter.name;
           }
         });
+      }
+
+      if (this.relationshipField) {
+        apos.bus.$emit('piece-relationship-query', qs);
       }
 
       // Avoid undefined properties.

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageRelationshipEditor.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageRelationshipEditor.vue
@@ -145,7 +145,11 @@ export default {
   },
   methods: {
     setDataValues () {
-      if (this.item._fields) {
+      if (
+        this.item._fields &&
+        this.item._fields.width &&
+        this.item._fields.height
+      ) {
         return { ...this.item._fields };
       }
 

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposImageRelationshipEditor.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposImageRelationshipEditor.vue
@@ -113,6 +113,10 @@ export default {
     item: {
       type: Object,
       default: () => ({})
+    },
+    field: {
+      type: Object,
+      required: true
     }
   },
   emits: [ 'modal-result', 'safe-close' ],
@@ -133,10 +137,7 @@ export default {
         key: 'apostrophe:editImageRelationshipTitle',
         title: this.title
       },
-      groups: [],
-      tabs: [],
-      currentTab: null,
-      alignedFields: [ 'width', 'height' ]
+      currentTab: null
     };
   },
   async mounted() {
@@ -216,6 +217,7 @@ export default {
     display: flex;
     align-items: center;
     position: relative;
+    flex-grow: 1;
 
     &:first-child {
       margin-right: 10px;

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -157,29 +157,36 @@ export default {
       this.next = items;
     },
     async input () {
-      if (!this.searching) {
-        if (this.searchTerm.length) {
-          this.searching = true;
-          const list = await apos.http.get(
-            `${apos.modules[this.field.withType].action}?autocomplete=${this.searchTerm}`,
-            {
-              busy: false,
-              draft: true
-            });
-          // filter items already selected
-          this.searchList = list.results.filter(item => {
-            return !this.next.map(i => i._id).includes(item._id);
-          }).map(item => {
-            return {
-              ...item,
-              disabled: this.disableUnpublished && !item.lastPublishedAt
-            };
-          });
-          this.searching = false;
-        } else {
-          this.searchList = [];
-        }
+      if (this.searching) {
+        return;
       }
+
+      if (!this.searchTerm.length) {
+        this.searchList = [];
+        return;
+      }
+
+      const qs = {};
+      apos.bus.$emit('piece-relationship-query', qs);
+
+      this.searching = true;
+      const list = await apos.http.get(
+        `${apos.modules[this.field.withType].action}?autocomplete=${this.searchTerm}`,
+        {
+          busy: false,
+          draft: true,
+          qs
+        }
+      );
+      // filter items already selected
+      this.searchList = list.results
+        .filter(item => !this.next.map(i => i._id).includes(item._id))
+        .map(item => ({
+          ...item,
+          disabled: this.disableUnpublished && !item.lastPublishedAt
+        }));
+
+      this.searching = false;
     },
     handleFocusOut() {
       // hide search list when click outside the input
@@ -211,7 +218,8 @@ export default {
         schema: this.field.schema,
         item,
         title: item.title,
-        value: item._fields
+        value: item._fields,
+        field: this.field
       });
       if (result) {
         const index = this.next.findIndex(_item => _item._id === item._id);

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -134,18 +134,18 @@ export default {
       }
     }
   },
+  mounted () {
+    this.validate(this.next);
+  },
   methods: {
     validate(value) {
       if (this.field.required && !value.length) {
+        this.searchTerm = '';
         return { message: 'required' };
       }
-      if (this.limitReached) {
-        this.searchTerm = 'Limit reached!';
-        this.disabled = true;
-      } else {
-        this.searchTerm = '';
-        this.disabled = false;
-      }
+
+      this.searchTerm = this.limitReached ? 'Limit reached!' : '';
+      this.disabled = !!this.limitReached;
 
       if (this.field.min && this.field.min > value.length) {
         return { message: `minimum of ${this.field.min} required` };
@@ -167,7 +167,10 @@ export default {
       }
 
       const qs = {};
-      apos.bus.$emit('piece-relationship-query', qs);
+
+      if (this.field.withType === '@apostrophecms/image') {
+        apos.bus.$emit('piece-relationship-query', qs);
+      }
 
       this.searching = true;
       const list = await apos.http.get(

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -128,7 +128,15 @@ export default {
     }
   },
   async mounted() {
+    apos.area.widgetOptions = [
+      klona(this.options),
+      ...apos.area.widgetOptions
+    ];
     this.modal.active = true;
+  },
+  destroyed() {
+    apos.area.widgetOptions = apos.area.widgetOptions
+      .filter((widget) => widget._id !== this.value._id);
   },
   created() {
     this.original = this.value ? klona(this.value) : this.getDefault();


### PR DESCRIPTION
[PRO-2689](https://linear.app/apostrophecms/issue/PRO-2689/as-an-editor-when-browsing-images-for-a-relationship-i-must-not-be)

## Summary
When minSize are defined for a widget type of an area, we make it available when editing a widget of that type. when browsing relationship images from the media manager, or from the relationship input directly we get only images of the right size.
Also light fixes on the relationship input (the text limit reached was not removed).

## What are the specific steps to test this change?

* Config a minSize in an area : 
```javascript
  '@apostrophecms/image': {
    minSize: [ 800, 600 ]
  },
```
* Create an image widget
* Check that when browsing from relationship input you get only images of the right size
![image](https://user-images.githubusercontent.com/17548370/164471347-8d710c51-a073-4ccb-91ec-6f2edaaa19b5.png)
* Check that when clicking on `Browse Images`, you get the same images from the media manager
![image](https://user-images.githubusercontent.com/17548370/164471447-aac38785-f454-4b11-89dd-128128611de8.png)


## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
