### PR TITLE
pro-733 No cropping for svg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# unreleased
+
+### Adds
+
+* Uses the isCroppable method to know if an image attachment is croppable or not. Passes this info to the frontend when requesting documents attachments. Uses this info to show the context menu or not.
+
 # 3.17.0 (2022-03-31)
 
 ### Adds

--- a/modules/@apostrophecms/asset/lib/globalIcons.js
+++ b/modules/@apostrophecms/asset/lib/globalIcons.js
@@ -53,6 +53,7 @@ module.exports = {
   'help-circle-icon': 'HelpCircle',
   'information-outline-icon': 'InformationOutline',
   'information-icon': 'Information',
+  'image-edit-outline': 'ImageEditOutline',
   'image-icon': 'Image',
   'image-size-select-actual-icon': 'ImageSizeSelectActual',
   'play-box-icon': 'PlayBox',

--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -685,6 +685,14 @@ module.exports = {
             if (o.alt) {
               value._alt = o.alt;
             }
+
+            value._isCroppable = self.isCroppable(value);
+
+            console.log('value firsté ===> ', require('util').inspect(value, {
+              colors: true,
+              depth: 0
+            }));
+
             o[key] = value;
 
             // If one of our ancestors has a relationship to the piece that
@@ -733,6 +741,11 @@ module.exports = {
                 value._url = self.url(value);
               }
             }
+
+            console.log('value ===> ', require('util').inspect(value, {
+              colors: true,
+              depth: 0
+            }));
             winners.push(value);
           }
         });
@@ -830,7 +843,16 @@ module.exports = {
       // Returns true if this type of attachment is croppable.
       // Available as a template helper.
       isCroppable(attachment) {
-        return attachment && self.croppable[self.resolveExtension(attachment.extension)];
+        const res = attachment
+          ? self.croppable[self.resolveExtension(attachment.extension)]
+          : false;
+
+        console.log('res ===> ', require('util').inspect(res, {
+          colors: true,
+          depth: 2
+        }));
+
+        return res;
       },
       // Returns true if this type of attachment is sized,
       // i.e. uploadfs produces versions of it for each configured

--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -688,11 +688,6 @@ module.exports = {
 
             value._isCroppable = self.isCroppable(value);
 
-            console.log('value firsté ===> ', require('util').inspect(value, {
-              colors: true,
-              depth: 0
-            }));
-
             o[key] = value;
 
             // If one of our ancestors has a relationship to the piece that
@@ -742,10 +737,6 @@ module.exports = {
               }
             }
 
-            console.log('value ===> ', require('util').inspect(value, {
-              colors: true,
-              depth: 0
-            }));
             winners.push(value);
           }
         });
@@ -843,16 +834,9 @@ module.exports = {
       // Returns true if this type of attachment is croppable.
       // Available as a template helper.
       isCroppable(attachment) {
-        const res = attachment
-          ? self.croppable[self.resolveExtension(attachment.extension)]
-          : false;
-
-        console.log('res ===> ', require('util').inspect(res, {
-          colors: true,
-          depth: 2
-        }));
-
-        return res;
+        return (attachment &&
+          self.croppable[self.resolveExtension(attachment.extension)]) ||
+          false;
       },
       // Returns true if this type of attachment is sized,
       // i.e. uploadfs produces versions of it for each configured

--- a/modules/@apostrophecms/image/index.js
+++ b/modules/@apostrophecms/image/index.js
@@ -30,6 +30,8 @@ module.exports = {
     // another document that references them
     relatedDocument: true,
     relationshipEditor: 'AposImageRelationshipEditor',
+    relationshipEditorLabel: 'apostrophe:editImageAdjustments',
+    relationshipEditorIcon: 'image-edit-outline',
     relationshipFields: {
       add: {
         top: {

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1027,6 +1027,9 @@ module.exports = {
           lintType(field.withType);
           const withTypeManager = self.apos.doc.getManager(field.withType);
           field.editor = field.editor || withTypeManager.options.relationshipEditor;
+          field.editorLabel = field.editorLabel || withTypeManager.options.relationshipEditorLabel;
+          field.editorIcon = field.editorIcon || withTypeManager.options.relationshipEditorIcon;
+
           if (!field.schema && !Array.isArray(field.withType)) {
             const fieldsOption = withTypeManager.options.relationshipFields;
             const fields = fieldsOption && fieldsOption.add;

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -213,6 +213,7 @@ export default {
         title: item.title,
         value: item._fields
       });
+
       if (result) {
         const index = this.next.findIndex(_item => _item._id === item._id);
         this.$set(this.next, index, {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -43,7 +43,7 @@
           :value="next"
           :disabled="field.readOnly"
           :has-relationship-schema="!!field.schema"
-          :label-key="getSlatLabelKey()"
+          :edit-relationship-label="getEditRelationshipLabel()"
         />
         <AposSearchList
           :list="searchList"
@@ -222,7 +222,7 @@ export default {
         });
       }
     },
-    getSlatLabelKey () {
+    getEditRelationshipLabel () {
       if (this.field.editor === 'AposImageRelationshipEditor') {
         return 'apostrophe:editImageAdjustments';
       }

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -43,7 +43,8 @@
           :value="next"
           :disabled="field.readOnly"
           :has-relationship-schema="!!field.schema"
-          :edit-relationship-label="getEditRelationshipLabel()"
+          :editor-label="field.editorLabel"
+          :editor-icon="field.editorIcon"
         />
         <AposSearchList
           :list="searchList"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
@@ -27,12 +27,23 @@
           :size="13"
         />
         <AposContextMenu
-          v-if="hasContextMenu"
+          v-if="hasContextMenu && more.menu.length"
           :button="more.button"
           :menu="more.menu"
           @item-clicked="$emit('item-clicked', item)"
           menu-placement="bottom-start"
           menu-offset="40, 10"
+        />
+        <AposButton
+          v-if="editorIcon"
+          :tooltip="{
+            content: editorLabel,
+            placement: 'bottom'
+          }"
+          :icon="editorIcon"
+          :icon-only="true"
+          :modifiers="['no-motion', 'inline']"
+          @click="$emit('item-clicked', item)"
         />
         <a
           class="apos-slat__control apos-slat__control--view"
@@ -40,6 +51,7 @@
           :href="item._url || item._urls.original"
           target="_blank"
         >
+          <span>toto</span>
           <eye-icon :size="14" class="apos-slat__control--view-icon" />
         </a>
         <div
@@ -122,7 +134,11 @@ export default {
       type: Boolean,
       default: false
     },
-    editRelationshipLabel: {
+    editorLabel: {
+      type: String,
+      default: null
+    },
+    editorIcon: {
       type: String,
       default: null
     }
@@ -139,10 +155,10 @@ export default {
           type: 'inline'
         },
         menu: [
-          {
-            label: this.editRelationshipLabel || 'apostrophe:editRelationship',
+          ...!this.editorIcon ? [ {
+            label: 'apostrophe:editRelationship',
             action: 'edit-relationship'
-          }
+          } ] : []
         ]
       }
     };

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
@@ -27,7 +27,7 @@
           :size="13"
         />
         <AposContextMenu
-          v-if="hasContextMenu && more.menu.length"
+          v-if="hasRelationshipSchema && more.menu.length"
           :button="more.button"
           :menu="more.menu"
           @item-clicked="$emit('item-clicked', item)"
@@ -35,14 +35,16 @@
           menu-offset="40, 10"
         />
         <AposButton
-          v-if="editorIcon"
+          class="apos-slat__editor-btn"
+          v-if="editorIcon && hasRelationshipSchema"
+          role="button"
           :tooltip="{
             content: editorLabel,
             placement: 'bottom'
           }"
           :icon="editorIcon"
           :icon-only="true"
-          :modifiers="['no-motion', 'inline']"
+          :modifiers="['inline']"
           @click="$emit('item-clicked', item)"
         />
         <a
@@ -51,7 +53,6 @@
           :href="item._url || item._urls.original"
           target="_blank"
         >
-          <span>toto</span>
           <eye-icon :size="14" class="apos-slat__control--view-icon" />
         </a>
         <div
@@ -171,13 +172,6 @@ export default {
       } else {
         return `${(size / 1000000).toFixed(1)}MB`;
       }
-    },
-    hasContextMenu() {
-      if (this.item.attachment && this.item.attachment.group === 'images') {
-        return this.hasRelationshipSchema && this.item.attachment._isCroppable;
-      }
-
-      return this.hasRelationshipSchema;
     }
   },
   methods: {
@@ -288,6 +282,10 @@ export default {
     max-width: 220px;
     white-space: nowrap;
     text-overflow: ellipsis;
+  }
+
+  .apos-slat__editor-btn {
+    margin-right: 5px;
   }
 
   .apos-slat__control {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
@@ -27,7 +27,7 @@
           :size="13"
         />
         <AposContextMenu
-          v-if="hasRelationshipSchema"
+          v-if="hasContextMenu"
           :button="more.button"
           :menu="more.menu"
           @item-clicked="$emit('item-clicked', item)"
@@ -122,7 +122,7 @@ export default {
       type: Boolean,
       default: false
     },
-    labelKey: {
+    editRelationshipLabel: {
       type: String,
       default: null
     }
@@ -140,9 +140,7 @@ export default {
         },
         menu: [
           {
-            label: this.labelKey
-              ? 'apostrophe:editImageAdjustments'
-              : 'apostrophe:editRelationship',
+            label: this.editRelationshipLabel || 'apostrophe:editRelationship',
             action: 'edit-relationship'
           }
         ]
@@ -157,6 +155,13 @@ export default {
       } else {
         return `${(size / 1000000).toFixed(1)}MB`;
       }
+    },
+    hasContextMenu() {
+      if (this.item.attachment && this.item.attachment.group === 'images') {
+        return this.hasRelationshipSchema && this.item.attachment._isCroppable;
+      }
+
+      return this.hasRelationshipSchema;
     }
   },
   methods: {
@@ -175,11 +180,8 @@ export default {
     },
     move(dir) {
       if (this.engaged) {
-        if (dir > 0) {
-          this.$emit('move', this.item._id, 1);
-        } else {
-          this.$emit('move', this.item._id, -1);
-        }
+        const direction = dir > 0 ? 1 : -1;
+        this.$emit('move', this.item._id, direction);
       }
     },
     remove(focusNext) {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlatList.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlatList.vue
@@ -32,7 +32,8 @@
           :slat-count="next.length"
           :removable="removable"
           :has-relationship-schema="hasRelationshipSchema"
-          :edit-relationship-label="editRelationshipLabel"
+          :editor-label="editorLabel"
+          :editor-icon="editorIcon"
         />
       </transition-group>
     </draggable>
@@ -68,7 +69,11 @@ export default {
       type: Boolean,
       default: false
     },
-    editRelationshipLabel: {
+    editorLabel: {
+      type: String,
+      default: null
+    },
+    editorIcon: {
       type: String,
       default: null
     }

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlatList.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlatList.vue
@@ -32,7 +32,7 @@
           :slat-count="next.length"
           :removable="removable"
           :has-relationship-schema="hasRelationshipSchema"
-          :label-key="labelKey"
+          :edit-relationship-label="editRelationshipLabel"
         />
       </transition-group>
     </draggable>
@@ -68,7 +68,7 @@ export default {
       type: Boolean,
       default: false
     },
-    labelKey: {
+    editRelationshipLabel: {
       type: String,
       default: null
     }


### PR DESCRIPTION
[PRO-733](https://linear.app/apostrophecms/issue/PRO-733/as-a-user-i-should-not-be-able-to-crop-an-svg-ie-it-should-not-try-and)

## Summary
Reuse logic from A2 to check if an image attachment is croppable or not.
Passes the info to frontend when requesting documents attachments.
Renames `labelKey` in `editRelationLabel` to make it understandable. Uses this one instead of the classic one when passed.

## What are the specific steps to test this change?

* Link the branch in an A3 project (testbed)
* Add image widget on a page
* Add normal images and see you can still open the cropping modal
* Add svg image in the widget and see the context menu disapear.

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated