### PR TITLE
PRO-2696: Add support for custom context operations 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Handlers listening for `apostrophe:run` event are now able to send exit signal to the Apostrophe bootstrap routine.
 * Adds new event `@apostrophecms/doc:afterAllModesDeleted` fired after all modes of a given document are purged.
 * Support for Node.js 17 and 18. MongoDB connections to `localhost` will now successfully find a typical dev MongoDB server bound only to `127.0.0.1`, Apostrophe can generate valid ipv6 URLs pointing back to itself, and `webpack` and `vue-loader` have been updated to address incompatibilities.
+* Adds support for custom context menus provided by any module (see `apos.doc.addContextOperation()`).
 
 ### Fixes
 

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
@@ -323,7 +323,7 @@ export default {
     menuHandler(action) {
       const operation = this.customOperations.find(op => op.action === action);
       if (operation) {
-        this._customAction(this.context, operation);
+        this.customAction(this.context, operation);
         return;
       }
       this[action](this.context);
@@ -357,7 +357,7 @@ export default {
         }
       });
     },
-    async _customAction(doc, operation) {
+    async customAction(doc, operation) {
       await apos.modal.execute(operation.modal, {
         moduleName: operation.moduleName,
         doc

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
@@ -103,7 +103,9 @@ export default {
   data() {
     return {
       // Updated by both the context prop and any content-changed apos events
-      context: this.doc
+      context: this.doc,
+      // Custom context menu operations
+      customOperations: apos.modules['@apostrophecms/doc'].contextOperations
     };
   },
   computed: {
@@ -147,6 +149,7 @@ export default {
             action: 'localize'
           }
         ] : []),
+        ...this.customMenusByContext,
         ...((this.showDiscardDraft && this.canDiscardDraft) ? [
           {
             label: this.context.lastPublishedAt ? 'apostrophe:discardDraft' : 'apostrophe:deleteDraft',
@@ -170,6 +173,24 @@ export default {
       ];
       return menu;
     },
+    customMenusByContext() {
+      const menus = this.customOperationsByContext
+        .map(op => ({
+          label: op.label,
+          action: op.action,
+          modifiers: op.modifiers || []
+        }));
+      menus.sort((a, b) => a.modifiers.length - b.modifiers.length);
+      return menus;
+    },
+    customOperationsByContext() {
+      return this.customOperations.filter(op => {
+        if (op.context === 'update' && this.isUpdateOperation) {
+          return true;
+        }
+        return false;
+      });
+    },
     moduleName() {
       if (apos.modules[this.context.type].action === apos.modules['@apostrophecms/page'].action) {
         return '@apostrophecms/page';
@@ -179,6 +200,9 @@ export default {
     },
     moduleOptions() {
       return apos.modules[this.moduleName];
+    },
+    isUpdateOperation() {
+      return !!this.context._id;
     },
     canPublish() {
       if (this.context._id) {
@@ -297,6 +321,11 @@ export default {
       }
     },
     menuHandler(action) {
+      const operation = this.customOperations.find(op => op.action === action);
+      if (operation) {
+        this._customAction(this.context, operation);
+        return;
+      }
       this[action](this.context);
     },
     async edit(doc) {
@@ -326,6 +355,12 @@ export default {
             _id: doc._id
           }
         }
+      });
+    },
+    async _customAction(doc, operation) {
+      await apos.modal.execute(operation.modal, {
+        moduleName: operation.moduleName,
+        doc
       });
     },
     async localize(doc) {

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -998,18 +998,21 @@ module.exports = {
       // }
       // All properties are required.
       // The only supported `context` for now is `update`.
-      // `action` is the operation idefntifier and should be unique per a module -
-      // the actual action registered is `moduleName:action`.
+      // `action` is the operation idefntifier and should be globally unique.
+      // Overriding existing custom actions is possible (the last wins).
       // `modal` is the name of the modal component to be opened.
       // `label` is the menu label to be shown when expanding the context menu.
       // Additional optional `modifiers` property is supported - button modifiers
       // as supported by `AposContextMenu` (e.g. modifiers: [ 'danger' ]).
       addContextOperation(moduleName, operation) {
-        self.contextOperations.push({
-          ...operation,
-          action: `${moduleName}:${operation.action}`,
-          moduleName
-        });
+        self.contextOperations = [
+          ...self.contextOperations
+            .filter(op => op.action !== operation.action),
+          {
+            ...operation,
+            moduleName
+          }
+        ];
       },
       getBrowserData(req) {
         return {

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -30,6 +30,7 @@ module.exports = {
   },
   async init(self) {
     self.managers = {};
+    self.contextOperations = [];
     self.enableBrowserData();
     await self.enableCollection();
     self.apos.isNew = await self.detectNew();
@@ -987,9 +988,33 @@ module.exports = {
           'slug'
         ];
       },
+      // Add context menu operation to be used in AposDocContextMenu.
+      // Expected operation format is:
+      // {
+      //   context: 'update',
+      //   action: 'someAction',
+      //   modal: 'ModalComponent',
+      //   label: 'Context Menu Label'
+      // }
+      // All properties are required.
+      // The only supported `context` for now is `update`.
+      // `action` is the operation idefntifier and should be unique per a module -
+      // the actual action registered is `moduleName:action`.
+      // `modal` is the name of the modal component to be opened.
+      // `label` is the menu label to be shown when expanding the context menu.
+      // Additional optional `modifiers` property is supported - button modifiers
+      // as supported by `AposContextMenu` (e.g. modifiers: [ 'danger' ]).
+      addContextOperation(moduleName, operation) {
+        self.contextOperations.push({
+          ...operation,
+          action: `${moduleName}:${operation.action}`,
+          moduleName
+        });
+      },
       getBrowserData(req) {
         return {
-          action: self.action
+          action: self.action,
+          contextOperations: self.contextOperations
         };
       },
       migrateRelationshipIds(doc) {

--- a/test/docs.js
+++ b/test/docs.js
@@ -159,6 +159,67 @@ describe('Docs', function() {
     assert(person._friends[0].slug === 'larry');
   });
 
+  it('should support custom context menu (required only)', async function() {
+    const operation = {
+      context: 'update',
+      action: 'test',
+      label: 'Menu Label',
+      modal: 'SomeModalComponent'
+    };
+    assert.strictEqual(apos.doc.contextOperations.length, 0);
+
+    apos.doc.addContextOperation('test-people', operation);
+    assert.strictEqual(apos.doc.contextOperations.length, 1);
+    assert.deepStrictEqual(apos.doc.contextOperations[0], {
+      ...operation,
+      moduleName: 'test-people'
+    });
+  });
+
+  it('should support custom context menu (with optional)', async function() {
+    apos.doc.contextOperations = [];
+    const operation = {
+      context: 'update',
+      action: 'test',
+      label: 'Menu Label',
+      modal: 'SomeModalComponent',
+      modifiers: [ 'danger' ]
+    };
+    assert.strictEqual(apos.doc.contextOperations.length, 0);
+
+    apos.doc.addContextOperation('test-people', operation);
+    assert.strictEqual(apos.doc.contextOperations.length, 1);
+    assert.deepStrictEqual(apos.doc.contextOperations[0], {
+      ...operation,
+      moduleName: 'test-people'
+    });
+  });
+
+  it('should override custom context menu', async function() {
+    apos.doc.contextOperations = [];
+    const operation1 = {
+      context: 'update',
+      action: 'test',
+      label: 'Op1',
+      modal: 'SomeModalComponent'
+    };
+    const operation2 = {
+      context: 'update',
+      action: 'test',
+      label: 'Op2',
+      modal: 'SomeModalComponent'
+    };
+    assert.strictEqual(apos.doc.contextOperations.length, 0);
+
+    apos.doc.addContextOperation('test-people', operation1);
+    apos.doc.addContextOperation('test-people', operation2);
+    assert.strictEqual(apos.doc.contextOperations.length, 1);
+    assert.deepStrictEqual(apos.doc.contextOperations[0], {
+      ...operation2,
+      moduleName: 'test-people'
+    });
+  });
+
   /// ///
   // UNIQUENESS
   /// ///


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Allow every module to add custom context operations to `AposDocContextMenu`.

## What are the specific steps to test this change?

Use `apos.doc.addContextOperation()` to add context operation from within any module. Enter edit mode and find the corresponding context menu (Editor modal and In-context editor menu). Click it to open the provided modal component.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [x] Related tests have been updated

**Other information:**

Corresponding UI tests are to be found in the testbed.