### PR TITLE
PRO-2699: Let AposDocEditor pickup changes from other modals

### DIFF
--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -815,6 +815,11 @@ export default {
       window.localStorage.setItem(this.savePreferenceName, pref);
     },
     onContentChanged(e) {
+      if (e.doc.type !== this.docType) {
+        this.docType = e.doc.type;
+      }
+      this.docFields.data = e.doc;
+
       if ((e.action === 'archive') || (e.action === 'delete') || (e.action === 'revert-draft-to-published')) {
         this.modal.showModal = false;
       }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

`AposDocEditor` updates its doc contents on `content-changed` (bus emit).

## What are the specific steps to test this change?

Fire from the dev console:
```js
apos.bus.$emit('content-changed', {
  doc: newDoc,
  action: 'someAction'
});
```
where `newDoc` is a patched version of the current edited document.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

