### PR TITLE
PRO-2768 workaround for not deep watching value of AposSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Adds new event `@apostrophecms/doc:afterAllModesDeleted` fired after all modes of a given document are purged.
 * Support for Node.js 17 and 18. MongoDB connections to `localhost` will now successfully find a typical dev MongoDB server bound only to `127.0.0.1`, Apostrophe can generate valid ipv6 URLs pointing back to itself, and `webpack` and `vue-loader` have been updated to address incompatibilities.
 * Adds support for custom context menus provided by any module (see `apos.doc.addContextOperation()`).
+* The `AposSchema` component now supports an optional `generation` prop which may be used to force a refresh when the value of the object changes externally. This is a compromise to avoid the performance hit of checking numerous subfields for possible changes every time the `value` prop changes in response to an `input` event.
 
 ### Fixes
 

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -115,23 +115,23 @@ export default {
       default() {
         return {};
       }
+    },
+    generation: {
+      type: Number,
+      required: false,
+      default() {
+        return null;
+      }
     }
   },
   emits: [ 'changed' ],
   data() {
-    const validItems = this.items.filter(item => {
-      if (!window.apos.modules[`${item.type}-widget`]) {
-        console.warn(`The widget type ${item.type} exists in the content but is not configured.`);
-      }
-      return window.apos.modules[`${item.type}-widget`];
-    });
-
     return {
       addWidgetEditor: null,
       addWidgetOptions: null,
       addWidgetType: null,
       areaId: cuid(),
-      next: validItems,
+      next: this.getValidItems(),
       hoveredWidget: null,
       focusedWidget: null,
       contextMenuOptions: {
@@ -189,6 +189,9 @@ export default {
         _id: this.id,
         items: this.next
       });
+    },
+    generation() {
+      this.next = this.getValidItems();
     }
   },
   mounted() {
@@ -506,6 +509,14 @@ export default {
       } else {
         return this.renderings[widget._id];
       }
+    },
+    getValidItems() {
+      return this.items.filter(item => {
+        if (!window.apos.modules[`${item.type}-widget`]) {
+          console.warn(`The widget type ${item.type} exists in the content but is not configured.`);
+        }
+        return window.apos.modules[`${item.type}-widget`];
+      });
     }
   }
 };

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -71,6 +71,7 @@
               @validate="triggerValidate"
               :server-errors="serverErrors"
               :ref="tab.name"
+              :generation="generation"
             />
           </div>
         </template>
@@ -95,6 +96,7 @@
             :modifiers="['small', 'inverted']"
             ref="utilitySchema"
             :server-errors="serverErrors"
+            :generation="generation"
           />
         </div>
       </AposModalRail>
@@ -154,7 +156,8 @@ export default {
       published: null,
       errorCount: 0,
       restoreOnly: false,
-      saveMenu: null
+      saveMenu: null,
+      generation: 0
     };
   },
   computed: {
@@ -819,6 +822,7 @@ export default {
         this.docType = e.doc.type;
       }
       this.docFields.data = e.doc;
+      this.generation++;
 
       if ((e.action === 'archive') || (e.action === 'delete') || (e.action === 'revert-draft-to-published')) {
         this.modal.showModal = false;

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArea.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArea.vue
@@ -22,6 +22,7 @@
           :id="next._id"
           :field-id="field._id"
           :field="field"
+          :generation="generation"
           @changed="changed"
         />
       </div>
@@ -37,6 +38,15 @@ import cuid from 'cuid';
 export default {
   name: 'AposInputArea',
   mixins: [ AposInputMixin ],
+  props: {
+    generation: {
+      type: Number,
+      required: false,
+      default() {
+        return null;
+      }
+    }
+  },
   data () {
     return {
       next: this.value.data || this.getEmptyValue(),

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputObject.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputObject.vue
@@ -14,6 +14,7 @@
             :schema="field.schema"
             :trigger-validation="triggerValidation"
             :utility-rail="false"
+            :generation="generation"
             v-model="schemaInput"
             ref="schema"
           />
@@ -25,13 +26,21 @@
 
 <script>
 import AposInputMixin from 'Modules/@apostrophecms/schema/mixins/AposInputMixin.js';
-import { klona } from 'klona';
 
 export default {
   name: 'AposInputObject',
   mixins: [ AposInputMixin ],
+  props: {
+    generation: {
+      type: Number,
+      required: false,
+      default() {
+        return null;
+      }
+    }
+  },
   data () {
-    const next = this.value ? this.value.data : (this.field.def || {});
+    const next = this.getNext();
     return {
       schemaInput: {
         data: next
@@ -42,6 +51,12 @@ export default {
   watch: {
     schemaInput() {
       this.next = this.schemaInput.data;
+    },
+    generation() {
+      this.next = this.getNext();
+      this.schemaInput = {
+        data: this.next
+      };
     }
   },
   methods: {
@@ -49,6 +64,10 @@ export default {
       if (this.schemaInput.hasErrors) {
         return 'invalid';
       }
+    },
+    // Return next at mount or when generation changes
+    getNext() {
+      return this.value ? this.value.data : (this.field.def || {});
     }
   }
 };

--- a/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
@@ -1,5 +1,25 @@
 <!--
-  AposSchema takes an array of fields with their values, renders their inputs, and emits their `input` events
+  AposSchema takes an array of fields (`schema`), renders their inputs,
+  and emits a new object with a `value` subproperty and a `hasErrors`
+  subproperty via the input event whenever the value of a field
+  or subfield changes.
+
+  At mount time the fields are initialized from the subproperties of the
+  `value.data` prop.
+
+  For performance reasons, this component is not strictly v-model compliant.
+  While all changes will emit an outgoing `input` event, the
+  incoming `value` prop only updates the fields in three situations:
+
+  1. At mount time, to set the initial values of the fields.
+
+  2. When `value.data._id` changes (an entirely different document is in play).
+
+  3. When the optional prop `generation` changes to a new number.
+
+  If you need to force an update from the calling component, increment the
+  `generation` prop. This should be done only if the value has changed for
+  an external reason.
 -->
 <template>
   <div class="apos-schema">
@@ -34,6 +54,13 @@ export default {
     value: {
       type: Object,
       required: true
+    },
+    generation: {
+      type: Number,
+      required: false,
+      default() {
+        return null;
+      }
     },
     schema: {
       type: Array,
@@ -135,21 +162,22 @@ export default {
     schema() {
       this.populateDocData();
     },
-    value: {
-      deep: true,
-      handler(newVal, oldVal) {
-        // The doc might be swapped out completely in cases such as the media
-        // library editor. Repopulate the fields if that happens.
-        if (
-          // If the fieldState had been cleared and there's new populated data
-          (!this.fieldState._id && newVal.data._id) ||
-          // or if there *is* active fieldState, but the new data is a new doc
-          (this.fieldState._id && newVal.data._id !== this.fieldState._id.data)
-        ) {
-          // repopulate the schema.
-          this.populateDocData();
-        }
+    'value.data._id'(_id) {
+      // The doc might be swapped out completely in cases such as the media
+      // library editor. Repopulate the fields if that happens.
+      if (
+        // If the fieldState had been cleared and there's new populated data
+        (!this.fieldState._id && _id) ||
+        // or if there *is* active fieldState, but the new data is a new doc
+        (this.fieldState._id && _id !== this.fieldState._id.data)
+      ) {
+        // repopulate the schema.
+        this.populateDocData();
       }
+    },
+    generation() {
+      // repopulate the schema.
+      this.populateDocData();
     },
     conditionalFields(newVal, oldVal) {
       for (const field in oldVal) {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
@@ -15,7 +15,8 @@
 
   2. When `value.data._id` changes (an entirely different document is in play).
 
-  3. When the optional prop `generation` changes to a new number.
+  3. When the optional prop `generation` changes to a new number. This
+  prop is also passed on to the individual input field components.
 
   If you need to force an update from the calling component, increment the
   `generation` prop. This should be done only if the value has changed for
@@ -40,6 +41,7 @@
         :server-error="fields[field.name].serverError"
         :doc-id="docId"
         :ref="field.name"
+        :generation="generation"
       />
     </div>
   </div>


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

We don't really deep-watch the value prop of AposSchema for performance reasons, schemas can be deeply nested and the potential for this to cause severe performance problems if we check it every time `value` changes due to our own `input` event is too great. `value` is primarily consulted only at mount time so this is usually OK, however occasionally a truly external change to the data does occur and there must be a way to force a refresh of all fields. Implement and internally document that mechanism so our internal developers know we're not strictly respecting `v-model` in this component.

## What are the specific steps to test this change?

When npm linked to both this branch of apostrophe and the corresponding branch of Document Versions, open Document Versions for the home page, then try this in the browser console:

```
apos.bus.$emit('content-changed', {
  doc: { ...apos.adminBar.context, title: 'New Title' },
  action: 'someAction'
});
```

The title change will be respected in the displayed dialog.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [X] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [X] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
