### PR TITLE
PRO-2739 fix nestedModuleSubdirs bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * The `self.email` method of modules now correctly accepts a default `from` address configured for a specific module via the `from` subproperty of the `email` option to that module. Thanks to `chmdebeer` for pointing out the issue and the fix.
 * Fixes `_urls` not added on attachment fields when pieces API index is requested (#3643)
 * Fixes float field UI bug that transforms the value to integer when there is no field error and the first number after the decimal is `0`.
+* The `nestedModuleSubdirs` feature no longer throws an error and interrupts startup if a project contains both `@apostrophecms/asset` and `asset`, which should be considered separate module names.
 
 ## 3.17.0 (2022-03-31)
 

--- a/lib/moog-require.js
+++ b/lib/moog-require.js
@@ -5,6 +5,7 @@ const path = require('path');
 const glob = require('glob');
 const importFresh = require('import-fresh');
 const resolveFrom = require('resolve-from');
+const regExpQuote = require('regexp-quote');
 
 module.exports = function(options) {
   const self = require('./moog')(options);
@@ -62,7 +63,12 @@ module.exports = function(options) {
         self._indexes = glob.sync(self.options.localModules + '/**/index.js');
       }
       const matches = self._indexes.filter(function(index) {
-        return index.endsWith('/' + type + '/index.js');
+        // Double-check that we're not confusing "@apostrophecms/asset" with "asset" by
+        // making sure "type" is not preceded by an npm namespace folder. If type is itself namespaced
+        // this never comes up (because npm namespaces don't nest). The risk is that a legitimate
+        // project level module that happens to end with the same name as a namespaced module
+        // will be rejected as a duplicate when nestedModuleSubdirs is present
+        return index.endsWith('/' + type + '/index.js') && !index.match(new RegExp(`/@[^/]+/${regExpQuote(type)}/index\\.js$`));
       });
       if (matches.length > 1) {
         throw new Error('The module ' + type + ' appears in multiple locations:\n' + matches.join('\n'));


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

The `nestedModuleSubdirs` feature no longer throws an error and interrupts startup if a project contains both `@apostrophecms/asset` and `asset`, which should be considered separate module names.

## What are the specific steps to test this change?

* Check out `apostrophecms/utah-a3`, switch branches to `nestedModules`, npm install, npm link with this branch of apostrophe. Launching "node app" reaches "listening on port 3000" without issue.
* Switch back to the "main" branch of apostrophe and restart. Throws an error complaining that there are two folders for the asset module, which is wrong (the namespaced module `@apostrophecms/asset` should be considered completely unrelated to the module `asset`).

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
