### PR TITLE
Autocropping versus svg

### DIFF
--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -467,7 +467,9 @@ module.exports = {
         }
 
         if (!self.croppable[info.extension]) {
-          throw new Error(info.extension + ' files cannot be cropped, do not present cropping UI for this type');
+          throw self.apos.error('invalid', req.t('apostrophe:fileTypeCannotBeCropped', {
+            extension: info.extension
+          }));
         }
         const crops = info.crops || [];
         const existing = _.find(crops, crop);

--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -144,6 +144,7 @@
   "fileTypeNotAccepted": "File type was not accepted. Allowed extensions: {{ extensions }}",
   "fileInvalid": "File was not accepted. It may be corrupted or its content may not match its file extension.",
   "files": "Files",
+  "fileTypeCannotBeCropped": "{{ extension}} files cannot be cropped, do not present the cropping UI for this type",
   "filter": "Filter",
   "filterByTag": "Filter by Tag",
   "filterResultsByType": "Filter Results By Type",

--- a/modules/@apostrophecms/image/index.js
+++ b/modules/@apostrophecms/image/index.js
@@ -146,7 +146,7 @@ module.exports = {
         }
         const relationship = await sanitizeRelationship(req.body.relationship);
         for (const image of relationship) {
-          if (!closeEnough(image)) {
+          if (!closeEnough(image) && self.apos.attachment.isCroppable(image.attachment)) {
             await autocrop(image, widgetOptions);
           }
         }

--- a/modules/@apostrophecms/image/ui/apos/components/AposImageRelationshipEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposImageRelationshipEditor.vue
@@ -269,7 +269,8 @@ export default {
           body: {
             _id: this.item.attachment._id,
             crop: this.docFields.data
-          }
+          },
+          busy: true
         });
       }
       this.$emit('modal-result', this.docFields.data);


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

The manual cropping interface does not appear for SVGs, whether the placement involves a fixed aspectRatio or not.

The autocrop feature should behave analogously by just not trying to autocrop SVGs.

(Not allowing them to be selected in the presence of aspectRatio is an interesting idea but not in scope and not required for A2 parity.)

## What are the specific steps to test this change?

* Fire up the `feature-image-cropping` branch of `testbed` with the `autocropping-versus-svg` branch of apostrophe
* Verify you can pick an svg for an image widget nested in a two-column widget (has 3x2 aspect ratio constraint). The svg will not be constrained, that's OK
* Verify that if you pick a jpg it does get constrained when you save the widget, even if you never manually crop it (this is autocrop)

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
