### PR TITLE
PRO-2779: allow manuallyPublished chck for the custom context menus

### DIFF
--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
@@ -186,6 +186,9 @@ export default {
     customOperationsByContext() {
       return this.customOperations.filter(op => {
         if (op.context === 'update' && this.isUpdateOperation) {
+          if (typeof op.manuallyPublished === 'boolean') {
+            return op.manuallyPublished === this.manuallyPublished;
+          }
           return true;
         }
         return false;

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -1004,6 +1004,9 @@ module.exports = {
       // `label` is the menu label to be shown when expanding the context menu.
       // Additional optional `modifiers` property is supported - button modifiers
       // as supported by `AposContextMenu` (e.g. modifiers: [ 'danger' ]).
+      // An optional `manuallyPublished` boolean property is supported - if true
+      // the menu will be shown only for docs which have `autopublish: false` and
+      // `localized: true` options.
       addContextOperation(moduleName, operation) {
         self.contextOperations = [
           ...self.contextOperations

--- a/test/docs.js
+++ b/test/docs.js
@@ -183,6 +183,7 @@ describe('Docs', function() {
       action: 'test',
       label: 'Menu Label',
       modal: 'SomeModalComponent',
+      manuallyPublished: true,
       modifiers: [ 'danger' ]
     };
     assert.strictEqual(apos.doc.contextOperations.length, 0);


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Custom menus can define `manuallyPublished` property. Based on that value they will be shown only in the desired context. For example `manuallyPublished :true` will show the menu only when the corresponding doc module options are `autopublish: false` and `localized: true`.  

## What are the specific steps to test this change?

Set `manuallyPublished: true` to a custom menu. E.g. Users piece should not have that context menu available.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
