### PR TITLE
widgets must respect the generation prop

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -38,6 +38,7 @@
         :area-id="areaId"
         :key="widget._id"
         :widget="widget"
+        :generation="generation"
         :i="i"
         :options="options"
         :next="next"

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -102,6 +102,7 @@
         :type="widget.type"
         :doc-id="docId"
         :focused="focused"
+        :key="generation"
       />
       <component
         v-else
@@ -115,6 +116,7 @@
         @edit="$emit('edit', i);"
         :doc-id="docId"
         :rendering="rendering"
+        :key="generation"
       />
       <div
         class="apos-area-widget-controls apos-area-widget-controls--add apos-area-widget-controls--add--bottom"
@@ -200,6 +202,13 @@ export default {
     disabled: {
       type: Boolean,
       default: false
+    },
+    generation: {
+      type: Number,
+      required: false,
+      default() {
+        return null;
+      }
     }
   },
   emits: [ 'clone', 'up', 'down', 'remove', 'edit', 'cut', 'copy', 'update', 'add', 'changed' ],


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

The generation prop must work for changes to widgets within areas. Fun fact: `:key` is not just for v-for...

https://vuejs.org/api/built-in-special-attributes.html#key

## What are the specific steps to test this change?

Two consecutive versions in which a rich text widget **already exists but has a different value** should display properly when clicking them in the versions modal.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

Changelog is N/A because the larger feature this completes has not yet shipped.

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
