### PR TITLE
run stylelint in ci and fix errors

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,6 +1,7 @@
 {
   plugins: [
-    'stylelint-order', 'stylelint-declaration-strict-value'
+    'stylelint-order',
+    'stylelint-declaration-strict-value'
   ],
   rules: {
     'color-hex-length': 'short',

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarLocale.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarLocale.vue
@@ -309,8 +309,8 @@ export default {
 
 .apos-available-locale {
   display: inline-block;
-  font-size: 10px;
   color: var(--a-primary);
+  font-size: var(--a-type-small);
 }
 
 .apos-available-locale:not(:last-of-type) {

--- a/modules/@apostrophecms/image/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposImageCropper.vue
@@ -428,15 +428,15 @@ export default {
   // flex-grow: 0;
 
   .apos-image-focal-point {
+    z-index: $z-index-default;
     position: absolute;
-    z-index: 1;
     width: 10px;
     height: 10px;
     border-radius: 50%;
     border: 1px solid var(--a-white);
     background-color: var(--a-primary);
     box-shadow: 0 0 4px var(--a-black);
-    transition: left 0.1s ease, top 0.1s ease;
+    transition: left 0.15s ease, top 0.15s ease;
     cursor: grab;
   }
 }

--- a/modules/@apostrophecms/image/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposImageCropper.vue
@@ -429,8 +429,8 @@ export default {
 
   .apos-image-focal-point {
     z-index: $z-index-default;
-    width: 10px;
     position: absolute;
+    width: 10px;
     height: 10px;
     border-radius: 50%;
     border: 1px solid var(--a-white);

--- a/modules/@apostrophecms/image/ui/apos/components/AposImageCropper.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposImageCropper.vue
@@ -429,8 +429,8 @@ export default {
 
   .apos-image-focal-point {
     z-index: $z-index-default;
-    position: absolute;
     width: 10px;
+    position: absolute;
     height: 10px;
     border-radius: 50%;
     border: 1px solid var(--a-white);

--- a/modules/@apostrophecms/image/ui/apos/components/AposImageRelationshipEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposImageRelationshipEditor.vue
@@ -427,7 +427,7 @@ export default {
 .apos-schema {
   margin: 30px 15px 0;
 
- .apos-field {
+  .apos-field {
     margin-bottom: 20px;
 
     &__label {
@@ -448,9 +448,9 @@ export default {
   flex-direction: row;
 
   .apos-field {
+    position: relative;
     display: flex;
     align-items: center;
-    position: relative;
     flex-grow: 1;
 
     &:first-child {
@@ -472,7 +472,7 @@ export default {
   }
 }
 
-.apos-input[type="number"] {
+.apos-input[type='number'] {
   padding-right: 5px;
 }
 
@@ -495,16 +495,16 @@ export default {
 }
 
 .apos-field__label--aligned {
-  margin: 0
+  margin: 0;
 }
 
 .apos-image-cropper__container {
   display: flex;
   justify-content: center;
   align-items: center;
-  margin: 30px 10%;
   // We remove the modal's paddings - header height - container margin
   height: calc(100vh - 40px - 75px - 60px);
+  margin: 30px 10%;
   box-sizing: border-box;
 }
 </style>

--- a/modules/@apostrophecms/login/ui/apos/components/TheAposLoginHeader.vue
+++ b/modules/@apostrophecms/login/ui/apos/components/TheAposLoginHeader.vue
@@ -89,15 +89,16 @@ export default {
 
   &__header--tiny {
     flex-direction: row;
+    // stylelint-disable-next-line scale-unlimited/declaration-strict-value
     color: #F8F9FA;
 
     .apos-login__project {
-      opacity: 0.7
+      opacity: 0.7;
     }
 
     .apos-login__project-name {
+      // stylelint-disable-next-line scale-unlimited/declaration-strict-value
       font-size: 21px;
-
     }
 
     .apos-login__project-env {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSpinner.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSpinner.vue
@@ -110,23 +110,19 @@ module.exports = {
 
 @keyframes clockwise {
   from {
-    // stylelint-disable-next-line property-no-vendor-prefix
-    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
   }
   to {
-    // stylelint-disable-next-line property-no-vendor-prefix
-    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
   }
 }
 
 @keyframes counterClockwise {
   from {
-    // stylelint-disable-next-line property-no-vendor-prefix
-    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
   }
   to {
-    // stylelint-disable-next-line property-no-vendor-prefix
-    -webkit-transform: rotate(-359deg);
+    transform: rotate(-359deg);
   }
 }
 </style>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSpinner.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSpinner.vue
@@ -75,7 +75,7 @@ module.exports = {
       return 'color: var(--a-primary);';
     },
     className() {
-      return `apos-spinner--${this.weight}`
+      return `apos-spinner--${this.weight}`;
     }
   },
 };
@@ -110,18 +110,22 @@ module.exports = {
 
 @keyframes clockwise {
   from {
+    // stylelint-disable-next-line property-no-vendor-prefix
     -webkit-transform: rotate(0deg);
   }
-    to {
+  to {
+    // stylelint-disable-next-line property-no-vendor-prefix
     -webkit-transform: rotate(359deg);
   }
 }
 
 @keyframes counterClockwise {
   from {
+    // stylelint-disable-next-line property-no-vendor-prefix
     -webkit-transform: rotate(0deg);
   }
-    to {
+  to {
+    // stylelint-disable-next-line property-no-vendor-prefix
     -webkit-transform: rotate(-359deg);
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "pretest": "npm run lint",
     "test": "nyc --reporter=html mocha -t 10000",
-    "lint": "eslint . && node scripts/lint-i18n"
+    "lint": "eslint . && node scripts/lint-i18n && stylelint modules/**/*.{scss,vue}"
   },
   "repository": {
     "type": "git",
@@ -105,7 +105,6 @@
     "server-destroy": "^1.0.1",
     "sluggo": "^0.3.0",
     "stylelint": "^14.6.1",
-    "stylelint-config-standard": "^25.0.0",
     "stylelint-declaration-strict-value": "^1.8.0",
     "stylelint-order": "^5.0.0",
     "stylelint-webpack-plugin": "^3.2.0",


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

[PRO-2735](https://linear.app/apostrophecms/issue/PRO-2735/fix-stylelint-issues)

## Summary

- add `stylelint` command to `lint` script, to run it in CI
- fix style lint errors
- remove unused `stylelint-config-standard` dependency

**before**

```sh
modules/@apostrophecms/image/ui/apos/components/AposImageCropper.vue
 432:5   ✖  Expected "z-index" to come before "position"                 order/properties-order                  
 432:5   ✖  Expected variable, function or keyword for "1" of "z-index"  scale-unlimited/declaration-strict-value
 439:22  ✖  Expected a minimum of 150 milliseconds                       time-min-milliseconds                   
 439:22  ✖  Expected a minimum of 150 milliseconds                       time-min-milliseconds                   

modules/@apostrophecms/image/ui/apos/components/AposImageRelationshipEditor.vue
 430:2   ✖  Expected indentation of 2 spaces              indentation                         
 453:5   ✖  Expected "position" to come before "display"  order/properties-order              
 475:18  ✖  Expected single quotes                        string-quotes                       
 498:11  ✖  Expected a trailing semicolon                 declaration-block-trailing-semicolon
 507:3   ✖  Expected "height" to come before "margin"     order/properties-order              

modules/@apostrophecms/login/ui/apos/components/TheAposLoginHeader.vue
  92:5   ✖  Expected variable, function or keyword for "#F8F9FA" of "color"   scale-unlimited/declaration-strict-value
  95:18  ✖  Expected a trailing semicolon                                     declaration-block-trailing-semicolon    
  99:7   ✖  Expected variable, function or keyword for "21px" of "font-size"  scale-unlimited/declaration-strict-value
 101:5   ✖  Unexpected empty line before closing brace                        block-closing-brace-empty-line-before   

modules/@apostrophecms/ui/ui/apos/components/AposSpinner.vue
 113:5  ✖  Unexpected vendor-prefix "-webkit-transform"  property-no-vendor-prefix
 115:5  ✖  Expected indentation of 2 spaces              indentation              
 116:5  ✖  Unexpected vendor-prefix "-webkit-transform"  property-no-vendor-prefix
 122:5  ✖  Unexpected vendor-prefix "-webkit-transform"  property-no-vendor-prefix
 124:5  ✖  Expected indentation of 2 spaces              indentation              
 125:5  ✖  Unexpected vendor-prefix "-webkit-transform"  property-no-vendor-prefix
✖  apostrophe git:(2735-stylelint)
```

**after**

_no style lint error_

## What are the specific steps to test this change?

- run `npm run lint`, there should be **no error**
- in a vue file, create a style error (you can place a `position` property above `width` or `height` for instance)
- run `npm run lint`, the command **should fail**:

```sh
➜  apostrophe git:(2735-stylelint) run lint                              

> apostrophe@3.17.0 lint /Users/etienne/Sites/apostrophe/apostrophe
> eslint . && node scripts/lint-i18n && stylelint modules/**/*.{scss,vue}


modules/@apostrophecms/image/ui/apos/components/AposImageCropper.vue
 433:5  ✖  Expected "position" to come before "width"  order/properties-order

npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! apostrophe@3.17.0 lint: `eslint . && node scripts/lint-i18n && stylelint modules/**/*.{scss,vue}`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the apostrophe@3.17.0 lint script.
```

ℹ️ CI fails correctly:

<img width="1220" alt="image" src="https://user-images.githubusercontent.com/8301962/166456805-d5a11796-c4de-4e6b-bc65-b6e8a447efd8.png">

*https://github.com/apostrophecms/apostrophe/runs/6273424789?check_suite_focus=true*

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [x] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
