### PR TITLE
provide original doc to editor component's children

### DIFF
--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -158,7 +158,9 @@ export default {
       },
       triggerValidation: false,
       original: null,
-      originalDoc: {},
+      originalDoc: {
+        ref: null
+      },
       published: null,
       errorCount: 0,
       restoreOnly: false,

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -125,6 +125,11 @@ export default {
     AposAdvisoryLockMixin,
     AposArchiveMixin
   ],
+  provide () {
+    return {
+      originalDoc: this.originalDoc
+    };
+  },
   props: {
     moduleName: {
       type: String,
@@ -153,6 +158,7 @@ export default {
       },
       triggerValidation: false,
       original: null,
+      originalDoc: {},
       published: null,
       errorCount: 0,
       restoreOnly: false,
@@ -363,7 +369,8 @@ export default {
     manuallyPublished() {
       this.saveMenu = this.computeSaveMenu();
     },
-    original() {
+    original(newVal) {
+      this.originalDoc.ref = newVal;
       this.saveMenu = this.computeSaveMenu();
     },
     tabs() {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

[PRO-2746](https://linear.app/apostrophecms/issue/PRO-2746/aposdoceditor-should-inject-originaldoc-into-descendant-components)

## Summary

Provides the original document to `AposDocEditor` children.

## What are the specific steps to test this change?

Inside a child component (`AposModalRail.vue` for instance), inject `originalDoc` and display one of its properties:

```vue
<template>
  <div class="apos-modal__rail" :class="`apos-modal__rail--${type}`">
    <p>{{ originalDoc.ref && originalDoc.ref.lastPublishedAt }}</p> <!-- ACCESS -->
    <slot />
  </div>
</template>
<script>
export default {
  name: 'AposModalRail',
  inject: [ 'originalDoc' ], // INJECTION
  props: {
    type: {
      type: String,
      default: 'left'
    }
  },
  computed: {

  }
};
</script>
```

The property of the doc should be accessible:

<img width="765" alt="image" src="https://user-images.githubusercontent.com/8301962/166655620-576bcd9a-53de-4079-bdec-85ff890ede71.png">

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [x] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
