### PR TITLE
PRO-2808: properly detect package lock file based on npmRootDir, not rootDir, in case they differ (multisite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-# 3.18.0 (2022-05-03)
+## UNRELEASED
+
+### Fixes
+
+* The admin UI now rebuilds properly in a development environment when new npm modules are installed in a multisite project (`apos.rootDir` differs from `apos.npmRootDir`).
+
+## 3.18.0 (2022-05-03)
 
 ### Adds
 

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -632,16 +632,26 @@ module.exports = {
           async function lockFileIsNewer(name) {
             const timestamp = fs.readFileSync(`${bundleDir}/${name}-build-timestamp.txt`, 'utf8');
             let pkgStats;
-
-            if (await fs.pathExists(`${self.apos.rootDir}/package-lock.json`)) {
-              pkgStats = await fs.stat(`${self.apos.rootDir}/package-lock.json`);
-            } else if (await fs.pathExists(`${self.apos.rootDir}/yarn.lock`)) {
-              pkgStats = await fs.stat(`${self.apos.rootDir}/yarn.lock`);
+            const packageLock = await findPackageLock();
+            if (packageLock) {
+              pkgStats = await fs.stat(packageLock);
             }
 
             const pkgTimestamp = pkgStats && pkgStats.mtimeMs;
 
             return pkgTimestamp > parseInt(timestamp);
+          }
+
+          async function findPackageLock() {
+            const packageLockPath = path.join(self.apos.npmRootDir, 'package-lock.json');
+            const yarnPath = path.join(self.apos.npmRootDir, 'yarn.lock');
+            if (await fs.pathExists(packageLockPath)) {
+              return packageLockPath;
+            } else if (await fs.pathExists(yarnPath)) {
+              return yarnPath;
+            } else {
+              return false;
+            }
           }
 
           function getComponentName(component, { enumerateImports } = {}, i) {


### PR DESCRIPTION
…

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Properly detect package lock file based on npmRootDir, not rootDir, in case they differ (multisite)

## What are the specific steps to test this change?

Adding `@apostrophecms-pro/document-versions` to an existing assembly project (not just single site) should correctly rebuild the admin UI the next time `npm run dev` is invoked. This already worked for single-site projects, and of course must continue to work for them.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
