### PR TITLE
PRO-2784: Add build watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Adds
 
 * Wepback cache for build performance in development and production mode.
+* Add a watcher in development mode to rebuild the assets on changes in the same process.
 
 ### Fixes
 

--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -36,6 +36,7 @@
   "assetWebpackConfigWarning": "⚠️ In the module {{ module }}, your webpack config is incorrect. It must be an object and should contain only two properties extensions and bundles.",
   "assetWebpackBundlesWarning": "⚠️ In the module {{ module }} your webpack config is incorrect. Each bundle can only have one property 'templates' that must be an array of strings.",
   "assetWebpackCacheCleared": "Build cache cleared.",
+  "assetBuildWatchStarted": "Watching for UI changes...",
   "back": "Back",
   "backToHome": "Back to Home",
   "basics": "Basics",

--- a/test/assets.js
+++ b/test/assets.js
@@ -646,17 +646,19 @@ describe('Assets', function() {
 
   it('should not watch if explicitly disabled by option or env in development', async function() {
     await t.destroy(apos);
-    process.env.APOS_ASSETWATCH_DISABLE = '1';
+    process.env.APOS_ASSET_WATCH = '0';
 
     apos = await t.create({
-      root: module
+      root: module,
+      autoBuild: true
     });
     assert(!apos.asset.buildWatcher);
-    delete process.env.APOS_ASSETWATCH_DISABLE;
+    delete process.env.APOS_ASSET_WATCH;
     await t.destroy(apos);
 
     apos = await t.create({
       root: module,
+      autoBuild: true,
       modules: {
         '@apostrophecms/asset': {
           options: {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Keep the same Apostrophe process alive between front-end builds in a development environment.

Awaits #3752 and consequent merge from `build-optimization` branch in order to avoid double code review.

> The node modules paths are adapted so that they don't blow up the developer's machine when deep circular matches are found (think of linked apostrophe, having linked test having linked apostrophe) due to linked modules in development having other linked modules. @boutell  

Closes PRO-2784

## What are the specific steps to test this change?

- In a3-boilerplate and testbed, changes to ui/src or ui/apos or ui/public do not trigger a nodemon restart, yet the build process is successfully repeated, by the existing process.
- A page refresh is triggered in this situation.
- The newly built assets load properly in this situation. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

