### PR TITLE
PRO-2788: Trigger only the relevant build in watch mode

### DIFF
--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -16,7 +16,8 @@ const {
   getWebpackExtensions,
   fillExtraBundles,
   getBundlesNames,
-  writeBundlesImportFiles
+  writeBundlesImportFiles,
+  findNodeModulesSymlinks
 } = require('./lib/webpack/utils');
 
 module.exports = {
@@ -116,7 +117,7 @@ module.exports = {
       build: {
         usage: 'Build Apostrophe frontend CSS and JS bundles',
         afterModuleInit: true,
-        async task(argv) {
+        async task(argv = {}) {
           // The lock could become huge, cache it, see computeCacheMeta()
           let packageLockContentCached;
           const req = self.apos.task.getReq();
@@ -124,6 +125,18 @@ module.exports = {
           const buildDir = `${self.apos.rootDir}/apos-build/${namespace}`;
           const bundleDir = `${self.apos.rootDir}/public/apos-frontend/${namespace}`;
           const modulesToInstantiate = self.apos.modulesToBeInstantiated();
+          // Make it clear if builds should detect changes
+          const detectChanges = Array.isArray(argv.changes);
+          // Remove invalid changes. `argv.changes` is an array of relative
+          // to `apos.rootDir` files or folders
+          const sourceChanges = detectChanges
+            ? filterValidChanges(
+              argv.changes || [],
+              Object.keys(self.apos.modules)
+            )
+            : [];
+          // Keep track of the executed builds
+          const buildsExecuted = [];
 
           // Don't clutter up with previous builds.
           await fs.remove(buildDir);
@@ -136,9 +149,12 @@ module.exports = {
           await moduleOverrides(`${bundleDir}/modules`, 'public');
 
           for (const [ name, options ] of Object.entries(self.builds)) {
-            // If the option is not present always rebuild everything
+            // If the option is not present always rebuild everything...
             let rebuild = argv && !argv['check-apos-build'];
-            if (!rebuild) {
+            // ...but only when not in a watcher mode
+            if (detectChanges) {
+              rebuild = shouldRebuildFor(name, options, sourceChanges);
+            } else if (!rebuild) {
               let checkTimestamp = false;
 
               // Only builds contributing to the apos admin UI (currently just "apos")
@@ -180,7 +196,19 @@ module.exports = {
                 name,
                 options
               });
+              buildsExecuted.push(name);
             }
+          }
+
+          // No need of deploy if in a watcher mode.
+          // Also we return an array of build names that
+          // have been triggered - this is required by the watcher
+          // so that page refresh is issued only when needed.
+          if (detectChanges) {
+            // merge the scenes that have been built
+            const scenes = [ ...new Set(buildsExecuted.map(name => self.builds[name].scenes).flat()) ];
+            merge(scenes);
+            return buildsExecuted;
           }
 
           // Discover the set of unique asset scenes that exist (currently
@@ -755,6 +783,36 @@ module.exports = {
               // Build probably failed, path is missing, ignore
             }
           }
+
+          // Given a set of changes, leave only those that belong to an active
+          // Apostrophe module. This would avoid unnecessary builds for non-active
+          // watched files (e.g. in multi instance mode).
+          // It's an expensive brute force O(n^2), so we do it once for all builds
+          // and we rely on the fact that mass changes happen rarely.
+          function filterValidChanges(all, modules) {
+            return all.filter(c => {
+              for (const module of modules) {
+                if (c.includes(module)) {
+                  return true;
+                }
+              }
+              return false;
+            });
+          }
+
+          // Detect if a build should be executed based on the changed
+          // paths. This function is invoked only when the appropriate `argv.changes`
+          // is passed to the task.
+          function shouldRebuildFor(buildName, buildOptions, changes) {
+            const name = buildOptions.source || buildName;
+            const id = `/ui/${name}/`;
+            for (const change of changes) {
+              if (change.includes(id)) {
+                return true;
+              }
+            }
+            return false;
+          }
         }
       },
 
@@ -872,8 +930,34 @@ module.exports = {
         return process.env.APOS_ASSET_CACHE ||
               path.join(self.apos.rootDir, 'data/temp/webpack-cache');
       },
-      // Run build task automatically when appropriate
-      async autorunUiBuildTask() {
+
+      // Override to set externally a build watcher (a `chokidar` instance).
+      // This method will be invoked only if/when needed.
+      // Example:
+      // ```js
+      // registerBuildWatcher() {
+      //   self.buildWatcher = chokidar.watch(pathsToWatch, {
+      //     cwd: self.apos.rootDir,
+      //     ignoreInitial: true
+      //   });
+      // }
+      // ```
+      registerBuildWatcher() {
+        self.buildWatcher = null;
+      },
+
+      // Run build task automatically when appropriate.
+      // If `changes` is provided (array of modified files/folders, relative
+      // to the application root), this method will return the result of the
+      // build task (array of builds that have been triggered by the changes).
+      // If `changes` is not provided (falsy value), a boolean will be returned,
+      // indicating if the build task has been invoked or not.
+      // IMPORTANT: Be cautious when changing the return type behavior.
+      // The build watcher initialization (event triggered) depends on a Boolean value,
+      // and the rebuild handler (triggered by the build watcher on
+      // detected change) depends on an Array value.
+      async autorunUiBuildTask(changes) {
+        let result = changes ? [] : false;
         if (
         // Do not automatically build the UI if we're starting from a task
           !self.apos.isTask() &&
@@ -882,26 +966,70 @@ module.exports = {
             // Or if we've set an app option to skip the auto build
             self.apos.options.autoBuild !== false
         ) {
-
           checkModulesWebpackConfig(self.apos.modules, self.apos.task.getReq().t);
           // If starting up normally, run the build task, checking if we
           // really need to update the apos build
-          await self.apos.task.invoke('@apostrophecms/asset:build', {
-            'check-apos-build': true
+          const buildsTriggered = await self.apos.task.invoke('@apostrophecms/asset:build', {
+            'check-apos-build': true,
+            changes
           });
-          return true;
+          result = changes ? buildsTriggered : true;
         }
-        return false;
+        return result;
       },
+
+      // The rebuild handler triggered (debounced) by the build watcher.
+      // The `changes` argument is a reference to a central pool of changes.
+      // It contains relative to the application root file paths.
+      // The pool is being exhausted before triggering the build task.
+      // Array manipulations are sync only, so no race condition is possible.
+      // `rebuildCallback` is used for testing and debug purposes. It allows
+      // access to the changes processed by the build task,
+      // the new restartId and the build names that the changes have triggered.
+      // This handler has no watcher dependencies and it's safe to be invoked
+      // by any code base.
+      async rebuild(changes, rebuildCallback) {
+        const pulledChanges = [];
+        let change = changes.pop();
+        while (change) {
+          pulledChanges.push(change);
+          change = changes.pop();
+        }
+        // No changes - should never happen.
+        if (pulledChanges.length === 0) {
+          if (typeof rebuildCallback === 'function') {
+            rebuildCallback({
+              changes: [],
+              restartId: self.restartId,
+              builds: []
+            });
+          };
+          return;
+        }
+        const buildsTriggered = await self.autorunUiBuildTask(pulledChanges);
+        if (buildsTriggered.length > 0) {
+          self.restartId = self.apos.util.generateId();
+        }
+        if (typeof rebuildCallback === 'function') {
+          rebuildCallback({
+            changes: pulledChanges,
+            restartId: self.restartId,
+            builds: buildsTriggered
+          });
+        };
+      },
+
       // Start watching assets from `modules/` and
       // every symlinked package found in `node_modules/`.
       // `rebuildCallback` is invoked with queue length argument
       //  on actual build attempt only.
       // It's there mainly for testing and debugging purposes.
       async watchUiAndRebuild(rebuildCallback) {
-        if (!self.buildWatcherEnable || self.buildWatcher) {
+        if (!self.buildWatcherEnable) {
           return;
         }
+        // Allow custom watcher registration
+        self.registerBuildWatcher();
         const rootDir = self.apos.rootDir;
         // chokidar may invoke ready event multiple times,
         // we want one "watch enabled" message.
@@ -916,53 +1044,54 @@ module.exports = {
         const queue = [];
         let queueLength = 0;
         let queueRunning = false;
+        // The pool of changes - it HAS to be exhausted by the rebuild handler
+        // or we'll end up with a memory leak in development.
+        const changesPool = [];
 
         const debounceRebuild = _.debounce(chain, self.buildWatcherDebounceMs, {
           leading: false,
           trailing: true
         });
+        const addChangeAndDebounceRebuild = (fileOrDir) => {
+          changesPool.push(fileOrDir);
+          return debounceRebuild();
+        };
 
-        const symLinkModules = await findSymlinks();
-        const watchDirs = [
-          './modules/**/ui/apos/**',
-          './modules/**/ui/src/**',
-          './modules/**/ui/public/**',
-          ...symLinkModules.reduce(
-            (prev, m) => [
-              ...prev,
+        if (!self.buildWatcher) {
+          const symLinkModules = await findNodeModulesSymlinks(rootDir);
+          const watchDirs = [
+            './modules/**/ui/apos/**',
+            './modules/**/ui/src/**',
+            './modules/**/ui/public/**',
+            ...symLinkModules.reduce(
+              (prev, m) => [
+                ...prev,
               `./node_modules/${m}/ui/apos/**`,
               `./node_modules/${m}/ui/src/**`,
               `./node_modules/${m}/ui/public/**`,
               `./node_modules/${m}/modules/**/ui/apos/**`,
               `./node_modules/${m}/modules/**/ui/src/**`,
               `./node_modules/${m}/modules/**/ui/public/**`
-            ],
-            []
-          )
-        ];
-        self.buildWatcher = chokidar.watch(watchDirs, {
-          cwd: rootDir,
-          ignoreInitial: true
-        });
+              ],
+              []
+            )
+          ];
+          self.buildWatcher = chokidar.watch(watchDirs, {
+            cwd: rootDir,
+            ignoreInitial: true
+          });
+        }
 
         self.buildWatcher
-          .on('add', debounceRebuild)
-          .on('change', debounceRebuild)
-          .on('unlink', debounceRebuild)
-          .on('addDir', debounceRebuild)
-          .on('unlinkDir', debounceRebuild)
+          .on('add', addChangeAndDebounceRebuild)
+          .on('change', addChangeAndDebounceRebuild)
+          .on('unlink', addChangeAndDebounceRebuild)
+          .on('addDir', addChangeAndDebounceRebuild)
+          .on('unlinkDir', addChangeAndDebounceRebuild)
           .on('error', e => error(`Watcher error: ${e}`))
           .on('ready', () => logOnce(
             self.apos.task.getReq().t('apostrophe:assetBuildWatchStarted')
           ));
-
-        async function rebuild() {
-          await self.autorunUiBuildTask();
-          self.restartId = self.apos.util.generateId();
-          if (typeof rebuildCallback === 'function') {
-            rebuildCallback(queueLength);
-          };
-        };
 
         // Simple, capped, self-exhausting queue implementation.
         function enqueue(fn) {
@@ -978,37 +1107,18 @@ module.exports = {
             return;
           }
           queueRunning = true;
-          await queue.pop()();
+          await queue.pop()(changesPool, rebuildCallback);
           queueLength--;
           await dequeue();
         }
-        async function chain(f) {
-          enqueue(rebuild);
+        async function chain() {
+          enqueue(self.rebuild);
           if (!queueRunning) {
             await dequeue();
           }
         }
-
-        // Find all symlinks in node modules.
-        // This would find both `module-name` and `@company/module-name`
-        // package symlinks
-        async function findSymlinks(sub = '') {
-          let result = [];
-          const handle = await fs.promises.opendir(path.join(rootDir, 'node_modules', sub));
-          let mod = await handle.read();
-          while (mod) {
-            if (mod.isSymbolicLink()) {
-              result.push(sub + mod.name);
-            } else if (!sub && mod.name.startsWith('@')) {
-              const dres = await findSymlinks(`${mod.name}/`);
-              result = [ ...result, ...dres ];
-            }
-            mod = await handle.read();
-          }
-          await handle.close();
-          return result;
-        }
       },
+
       // An implementation method that you should not need to call.
       // Sets a predetermined configuration for the frontend builds.
       // If you are trying to enable IE11 support for ui/src, use the

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -930,6 +930,9 @@ module.exports = {
           ...symLinkModules.reduce(
             (prev, m) => [
               ...prev,
+              `./node_modules/${m}/ui/apos/**`,
+              `./node_modules/${m}/ui/src/**`,
+              `./node_modules/${m}/ui/public/**`,
               `./node_modules/${m}/modules/**/ui/apos/**`,
               `./node_modules/${m}/modules/**/ui/src/**`,
               `./node_modules/${m}/modules/**/ui/public/**`

--- a/modules/@apostrophecms/task/index.js
+++ b/modules/@apostrophecms/task/index.js
@@ -117,6 +117,8 @@ module.exports = {
       // normally be hyphenated, i.e. at the command line you might write
       // `--total=20`.
       //
+      // This method will return the value returned by the task.
+      //
       // **Gotchas**
       //
       // If you can invoke a method directly rather than invoking a task, do
@@ -132,6 +134,7 @@ module.exports = {
       // task developer might assume they can exit the process directly.
 
       async invoke(name, args, options) {
+        let result;
         const telemetry = self.apos.telemetry;
         const spanName = `task:${self.__meta.name}:${name}`;
         await telemetry.startActiveSpan(spanName, async (span) => {
@@ -155,7 +158,7 @@ module.exports = {
             };
             span.setAttribute(telemetry.Attributes.ARGV, telemetry.stringify(argv));
             self.apos.argv = argv;
-            await task.task(argv);
+            result = await task.task(argv);
             self.apos.argv = aposArgv;
             span.setStatus({ code: telemetry.api.SpanStatusCode.OK });
           } catch (err) {
@@ -165,6 +168,7 @@ module.exports = {
             span.end();
           }
         });
+        return result;
       },
 
       // Identifies the task corresponding to the given command line argument.

--- a/test/assets.js
+++ b/test/assets.js
@@ -507,17 +507,34 @@ describe('Assets', function() {
     await removeCache(altCacheLoc);
   });
 
-  it('should watch and rebuild assets and reload page in development', async function() {
+  it('should watch and rebuild assets and reload page in development (bundle src)', async function() {
     await t.destroy(apos);
+    let result = {};
+    const cb = (obj) => {
+      result = obj;
+    };
 
     apos = await t.create({
       root: module,
       autoBuild: true,
-      modules
+      modules: {
+        ...modules,
+        '@apostrophecms/asset': {
+          extendMethods() {
+            return {
+              async watchUiAndRebuild(_super) {
+                return _super(cb);
+              }
+            };
+          }
+        }
+      }
     });
     const restartId = apos.asset.restartId;
     assert(apos.asset.buildWatcher);
     assert(apos.asset.restartId);
+    assert(!result.builds);
+    assert(!result.changes);
 
     // Modify asset and rebuild
     const assetPath = path.join(process.cwd(), 'test/modules/bundle-page/ui/src/extra.js');
@@ -525,12 +542,12 @@ describe('Assets', function() {
     const assetContent = 'export default () => {};\n';
     fs.writeFileSync(
       assetPath,
-      'export default () => { \'bundle-page-watcher-test\'; };\n',
+      'export default () => { \'bundle-page-watcher-test-src\'; };\n',
       'utf8'
     );
 
     await retryAssertTrue(
-      async () => (await fs.readFile(assetPathPublic, 'utf8')).match(/bundle-page-watcher-test/),
+      async () => (await fs.readFile(assetPathPublic, 'utf8')).match(/bundle-page-watcher-test-src/),
       'Unable to verify public asset was rebuilt by the watcher',
       500,
       10000
@@ -543,10 +560,499 @@ describe('Assets', function() {
       10000
     );
 
+    await retryAssertTrue(
+      () => result.builds.length === 1 && result.builds.includes('src'),
+      'Unable to verify build "src" has been triggered',
+      50,
+      1000
+    );
+
+    await retryAssertTrue(
+      () => result.changes.length === 1 && result.changes[0].includes('modules/bundle-page/ui/src/extra.js'),
+      'Unable to verify changes contain the proper file',
+      50,
+      1000
+    );
+
     await t.destroy(apos);
     assert.equal(apos.asset.buildWatcher, null);
     apos = null;
     fs.writeFileSync(assetPath, assetContent, 'utf8');
+  });
+
+  it('should watch and rebuild assets and reload page in development (src, src-es5)', async function() {
+    await t.destroy(apos);
+    let result = {};
+    const setTestResult = (obj) => {
+      result = obj;
+    };
+    const rootPath = process.cwd();
+    const assetPathJs = path.join(rootPath, 'test/modules/default-page/ui/src/index.js');
+    const assetPathScss = path.join(rootPath, 'test/modules/default-page/ui/src/index.scss');
+    const assetPathPublicJs = path.join(rootPath, 'test/public/apos-frontend/default/public-module-bundle.js');
+    const assetPathPublicCss = path.join(rootPath, 'test/public/apos-frontend/default/public-bundle.css');
+    const assetPathAposJs = path.join(rootPath, 'test/public/apos-frontend/default/apos-module-bundle.js');
+    const assetPathAposCss = path.join(rootPath, 'test/public/apos-frontend/default/apos-bundle.css');
+    const assetContentJs = 'export default () => {};\n';
+    const assetContentScss = '.default-page {color:red};\n';
+    // Resurrect the default assets content if test has failed
+    fs.writeFileSync(assetPathJs, assetContentJs, 'utf8');
+    fs.writeFileSync(assetPathScss, assetContentScss, 'utf8');
+
+    apos = await t.create({
+      root: module,
+      autoBuild: true,
+      modules: {
+        'default-page': {},
+        '@apostrophecms/asset': {
+          options: {
+            es5: true
+          },
+          extendMethods() {
+            return {
+              async watchUiAndRebuild(_super) {
+                return _super(setTestResult);
+              }
+            };
+          }
+        }
+      }
+    });
+    // Assert defaults
+    const restartId = apos.asset.restartId;
+    assert(apos.asset.buildWatcher);
+    assert(apos.asset.restartId);
+    assert(!result.builds);
+    assert(!result.changes);
+
+    // * modify assets and rebuild
+    fs.writeFileSync(
+      assetPathJs,
+      'export default () => { \'default-page-watcher-test-src\'; };\n',
+      'utf8'
+    );
+    fs.writeFileSync(
+      assetPathScss,
+      '.default-page-watcher-test-src{color:red};\n',
+      'utf8'
+    );
+
+    // * change is in the public bundle
+    await retryAssertTrue(
+      async () => (await fs.readFile(assetPathPublicJs, 'utf8')).match(/default-page-watcher-test-src/),
+      'Unable to verify public JS asset was rebuilt by the watcher',
+      500,
+      10000
+    );
+    await retryAssertTrue(
+      async () => (await fs.readFile(assetPathPublicCss, 'utf8')).match(/\.default-page-watcher-test-src/),
+      'Unable to verify public CSS asset was rebuilt by the watcher',
+      500,
+      10000
+    );
+
+    // * change is in the apos bundle
+    await retryAssertTrue(
+      async () => (await fs.readFile(assetPathAposJs, 'utf8')).match(/default-page-watcher-test-src/),
+      'Unable to verify apos JS asset was rebuilt by the watcher',
+      500,
+      10000
+    );
+    await retryAssertTrue(
+      async () => (await fs.readFile(assetPathAposCss, 'utf8')).match(/\.default-page-watcher-test-src/),
+      'Unable to verify apos CSS asset was rebuilt by the watcher',
+      500,
+      10000
+    );
+
+    // * page has been restarted
+    await retryAssertTrue(
+      () => apos.asset.restartId !== restartId,
+      'Unable to verify restartId has been changed',
+      500,
+      10000
+    );
+
+    // * only src related builds were triggered
+    await retryAssertTrue(
+      () => result.builds.length === 2 &&
+        result.builds.includes('src') &&
+        result.builds.includes('src-es5'),
+      'Unable to verify builds "src" and "src-es5" have been triggered',
+      50,
+      1000
+    );
+
+    // * changes detected
+    await retryAssertTrue(
+      () =>
+        result.changes.length === 2 &&
+        result.changes
+          .filter(f =>
+            (f.includes('modules/default-page/ui/src/index.js') ||
+            f.includes('modules/default-page/ui/src/index.scss'))
+          )
+          .length === 2,
+      'Unable to verify changes contain the proper source files',
+      50,
+      1000
+    );
+
+    await t.destroy(apos);
+    assert.equal(apos.asset.buildWatcher, null);
+    apos = null;
+    fs.writeFileSync(assetPathJs, assetContentJs, 'utf8');
+    fs.writeFileSync(assetPathScss, assetContentScss, 'utf8');
+  });
+
+  it('should watch and rebuild assets and reload page in development (public)', async function() {
+    await t.destroy(apos);
+    let result = {};
+    const setTestResult = (obj) => {
+      result = obj;
+    };
+    const rootPath = process.cwd();
+    const assetPathJs = path.join(rootPath, 'test/modules/default-page/ui/public/index.js');
+    const assetPathCss = path.join(rootPath, 'test/modules/default-page/ui/public/index.css');
+    const assetPathPublicJs = path.join(rootPath, 'test/public/apos-frontend/default/public-module-bundle.js');
+    const assetPathPublicCss = path.join(rootPath, 'test/public/apos-frontend/default/public-bundle.css');
+    const assetPathAposJs = path.join(rootPath, 'test/public/apos-frontend/default/apos-module-bundle.js');
+    const assetPathAposCss = path.join(rootPath, 'test/public/apos-frontend/default/apos-bundle.css');
+    const assetContentJs = 'export default () => {};\n';
+    const assetContentScss = '.default-page {color:red};\n';
+    // Resurrect the default assets content if test has failed
+    fs.writeFileSync(assetPathJs, assetContentJs, 'utf8');
+    fs.writeFileSync(assetPathCss, assetContentScss, 'utf8');
+
+    apos = await t.create({
+      root: module,
+      autoBuild: true,
+      modules: {
+        'default-page': {},
+        '@apostrophecms/asset': {
+          options: {
+            es5: true
+          },
+          extendMethods() {
+            return {
+              async watchUiAndRebuild(_super) {
+                return _super(setTestResult);
+              }
+            };
+          }
+        }
+      }
+    });
+    // Assert defaults
+    const restartId = apos.asset.restartId;
+    assert(apos.asset.buildWatcher);
+    assert(apos.asset.restartId);
+    assert(!result.builds);
+    assert(!result.changes);
+
+    // * modify assets and rebuild
+    fs.writeFileSync(
+      assetPathJs,
+      'export default () => { \'default-page-watcher-test-public\'; };\n',
+      'utf8'
+    );
+    fs.writeFileSync(
+      assetPathCss,
+      '.default-page-watcher-test-public{color:red};\n',
+      'utf8'
+    );
+
+    // * change is in the public bundle
+    await retryAssertTrue(
+      async () => (await fs.readFile(assetPathPublicJs, 'utf8')).match(/default-page-watcher-test-public/),
+      'Unable to verify public JS asset was rebuilt by the watcher',
+      500,
+      10000
+    );
+    await retryAssertTrue(
+      async () => (await fs.readFile(assetPathPublicCss, 'utf8')).match(/\.default-page-watcher-test-public/),
+      'Unable to verify public CSS asset was rebuilt by the watcher',
+      500,
+      10000
+    );
+
+    // * change is in the apos bundle
+    await retryAssertTrue(
+      async () => (await fs.readFile(assetPathAposJs, 'utf8')).match(/default-page-watcher-test-public/),
+      'Unable to verify apos JS asset was rebuilt by the watcher',
+      500,
+      10000
+    );
+    await retryAssertTrue(
+      async () => (await fs.readFile(assetPathAposCss, 'utf8')).match(/\.default-page-watcher-test-public/),
+      'Unable to verify apos CSS asset was rebuilt by the watcher',
+      500,
+      10000
+    );
+
+    // * page has been restarted
+    await retryAssertTrue(
+      () => apos.asset.restartId !== restartId,
+      'Unable to verify restartId has been changed',
+      500,
+      10000
+    );
+
+    // * only public build was triggered
+    await retryAssertTrue(
+      () => result.builds.length === 1 &&
+        result.builds.includes('public'),
+      'Unable to verify build "public" has been triggered',
+      50,
+      1000
+    );
+
+    // * changes detected
+    await retryAssertTrue(
+      () =>
+        result.changes.length === 2 &&
+        result.changes
+          .filter(f =>
+            (f.includes('modules/default-page/ui/public/index.js') ||
+            f.includes('modules/default-page/ui/public/index.css'))
+          )
+          .length === 2,
+      'Unable to verify changes contain the proper source files',
+      50,
+      1000
+    );
+
+    await t.destroy(apos);
+    assert.equal(apos.asset.buildWatcher, null);
+    apos = null;
+    fs.writeFileSync(assetPathJs, assetContentJs, 'utf8');
+    fs.writeFileSync(assetPathCss, assetContentScss, 'utf8');
+  });
+
+  it('should watch and rebuild assets and reload page in development (apos)', async function() {
+    await t.destroy(apos);
+    let result = {};
+    const setTestResult = (obj) => {
+      result = obj;
+    };
+    const rootPath = process.cwd();
+    const assetPathJs = path.join(rootPath, 'test/modules/default-page/ui/apos/components/FakeComponent.vue');
+    const assetPathAposJs = path.join(rootPath, 'test/public/apos-frontend/default/apos-module-bundle.js');
+    const assetContentJs = '<template><span /></template>\n';
+    fs.writeFileSync(assetPathJs, assetContentJs, 'utf8');
+
+    apos = await t.create({
+      root: module,
+      autoBuild: true,
+      modules: {
+        'default-page': {
+          options: {
+            components: {
+              fake: 'FakeComponent'
+            }
+          }
+        },
+        '@apostrophecms/asset': {
+          options: {
+            es5: true
+          },
+          extendMethods() {
+            return {
+              async watchUiAndRebuild(_super) {
+                return _super(setTestResult);
+              }
+            };
+          }
+        }
+      }
+    });
+    // Assert defaults
+    const restartId = apos.asset.restartId;
+    assert(apos.asset.buildWatcher);
+    assert(apos.asset.restartId);
+    assert(!result.builds);
+    assert(!result.changes);
+
+    // * modify assets and rebuild
+    fs.writeFileSync(
+      assetPathJs,
+      '<template><span>default-page-watcher-test-apos</span></template>\n',
+      'utf8'
+    );
+
+    // * change is in the apos bundle
+    await retryAssertTrue(
+      async () => (await fs.readFile(assetPathAposJs, 'utf8'))
+        .includes('default-page-watcher-test-apos'),
+      'Unable to verify apos JS asset was rebuilt by the watcher',
+      500,
+      20000
+    );
+
+    // * page has been restarted
+    await retryAssertTrue(
+      () => apos.asset.restartId !== restartId,
+      'Unable to verify restartId has been changed',
+      500,
+      10000
+    );
+
+    // * only apos build was triggered
+    await retryAssertTrue(
+      () => result.builds.length === 1 &&
+        result.builds.includes('apos'),
+      'Unable to verify build "apos" has been triggered',
+      50,
+      1000
+    );
+
+    // * changes detected
+    await retryAssertTrue(
+      () =>
+        result.changes.length === 1 &&
+        result.changes[0].includes('modules/default-page/ui/apos/components/FakeComponent.vue'),
+      'Unable to verify changes contain the proper source files',
+      50,
+      1000
+    );
+
+    await t.destroy(apos);
+    assert.equal(apos.asset.buildWatcher, null);
+    apos = null;
+    fs.writeFileSync(assetPathJs, assetContentJs, 'utf8');
+  });
+
+  it('should watch but not rebuild assets and not reload page when changes are not in use', async function() {
+    await t.destroy(apos);
+    let result = {};
+    let rebuilt = false;
+    const setTestResult = (obj) => {
+      result = obj;
+      rebuilt = true;
+    };
+    const rootPath = process.cwd();
+    const assetPathJs = path.join(rootPath, 'test/modules/default-page/ui/src/index.js');
+    const assetPathScss = path.join(rootPath, 'test/modules/default-page/ui/src/index.scss');
+    const assetPathPublicJs = path.join(rootPath, 'test/public/apos-frontend/default/public-module-bundle.js');
+    const assetPathPublicCss = path.join(rootPath, 'test/public/apos-frontend/default/public-bundle.css');
+    const assetPathAposJs = path.join(rootPath, 'test/public/apos-frontend/default/apos-module-bundle.js');
+    const assetPathAposCss = path.join(rootPath, 'test/public/apos-frontend/default/apos-bundle.css');
+    const assetContentJs = 'export default () => {};\n';
+    const assetContentScss = '.default-page {color:red};\n';
+    // Resurrect the default assets content if test has failed
+    fs.writeFileSync(assetPathJs, assetContentJs, 'utf8');
+    fs.writeFileSync(assetPathScss, assetContentScss, 'utf8');
+
+    apos = await t.create({
+      root: module,
+      autoBuild: true,
+      modules: {
+        '@apostrophecms/asset': {
+          options: {
+            es5: true
+          },
+          extendMethods() {
+            return {
+              async watchUiAndRebuild(_super) {
+                return _super(setTestResult);
+              }
+            };
+          }
+        }
+      }
+    });
+    // Assert defaults
+    const restartId = apos.asset.restartId;
+    assert(apos.asset.buildWatcher);
+    assert(apos.asset.restartId);
+    assert(!result.builds);
+    assert(!result.changes);
+    assert.equal(rebuilt, false);
+
+    // * modify assets
+    fs.writeFileSync(
+      assetPathJs,
+      'export default () => { \'default-page-watcher-test-src\'; };\n',
+      'utf8'
+    );
+    fs.writeFileSync(
+      assetPathScss,
+      '.default-page-watcher-test-src{color:red};\n',
+      'utf8'
+    );
+
+    // * rebuild handler has been triggered
+    await retryAssertTrue(
+      () => rebuilt === true,
+      'Unable to verify rebuild has been triggered',
+      500,
+      10000
+    );
+
+    // * change is NOT in the public bundle
+    await retryAssertTrue(
+      async () => !(await fs.readFile(assetPathPublicJs, 'utf8')).match(/default-page-watcher-test-src/),
+      'Unable to verify public JS asset was NOT rebuilt by the watcher',
+      500,
+      1000
+    );
+    await retryAssertTrue(
+      async () => !(await fs.readFile(assetPathPublicCss, 'utf8')).match(/\.default-page-watcher-test-src/),
+      'Unable to verify public CSS asset was NOT rebuilt by the watcher',
+      500,
+      1000
+    );
+
+    // * change is NOT in the apos bundle
+    await retryAssertTrue(
+      async () => !(await fs.readFile(assetPathAposJs, 'utf8')).match(/default-page-watcher-test-src/),
+      'Unable to verify apos JS asset was NOT rebuilt by the watcher',
+      500,
+      1000
+    );
+    await retryAssertTrue(
+      async () => !(await fs.readFile(assetPathAposCss, 'utf8')).match(/\.default-page-watcher-test-src/),
+      'Unable to verify apos CSS asset was NOT rebuilt by the watcher',
+      500,
+      1000
+    );
+
+    // * page has NOT been restarted
+    await retryAssertTrue(
+      () => apos.asset.restartId === restartId,
+      'Unable to verify restartId has NOT been changed',
+      500,
+      1000
+    );
+
+    // * no builds were triggered
+    await retryAssertTrue(
+      () => result.builds.length === 0,
+      'Unable to verify builds "src" and "src-es5" have NOT been triggered',
+      50,
+      1000
+    );
+
+    // * changes detected
+    await retryAssertTrue(
+      () =>
+        result.changes.length === 2 &&
+        result.changes
+          .filter(f =>
+            (f.includes('modules/default-page/ui/src/index.js') ||
+            f.includes('modules/default-page/ui/src/index.scss'))
+          )
+          .length === 2,
+      'Unable to verify changes contain the proper source files',
+      50,
+      1000
+    );
+
+    await t.destroy(apos);
+    assert.equal(apos.asset.buildWatcher, null);
+    apos = null;
+    fs.writeFileSync(assetPathJs, assetContentJs, 'utf8');
+    fs.writeFileSync(assetPathScss, assetContentScss, 'utf8');
   });
 
   it('should watch and rebuild assets in a debounced queue', async function() {
@@ -642,6 +1148,34 @@ describe('Assets', function() {
       }
     });
     assert.equal(apos.asset.buildWatcherDebounceMs, 500);
+  });
+
+  it('should be able to register an external build watcher', async function() {
+    await t.destroy(apos);
+
+    const chokidar = require('chokidar');
+    let instance;
+
+    apos = await t.create({
+      root: module,
+      autoBuild: true,
+      modules: {
+        '@apostrophecms/asset': {
+          methods(self) {
+            return {
+              registerBuildWatcher() {
+                self.buildWatcher = chokidar.watch([ __filename ], {
+                  cwd: self.apos.rootDir,
+                  ignoreInitial: true
+                });
+                instance = self.buildWatcher;
+              }
+            };
+          }
+        }
+      }
+    });
+    assert.equal(apos.asset.buildWatcher, instance);
   });
 
   it('should not watch if explicitly disabled by option or env in development', async function() {

--- a/test/modules/default-page/ui/apos/components/FakeComponent.vue
+++ b/test/modules/default-page/ui/apos/components/FakeComponent.vue
@@ -1,0 +1,1 @@
+<template><span /></template>

--- a/test/modules/default-page/ui/public/index.css
+++ b/test/modules/default-page/ui/public/index.css
@@ -1,0 +1,1 @@
+.default-page {color:red};

--- a/test/modules/default-page/ui/public/index.js
+++ b/test/modules/default-page/ui/public/index.js
@@ -1,0 +1,1 @@
+export default () => {};

--- a/test/modules/default-page/ui/src/index.js
+++ b/test/modules/default-page/ui/src/index.js
@@ -1,0 +1,1 @@
+export default () => {};

--- a/test/modules/default-page/ui/src/index.scss
+++ b/test/modules/default-page/ui/src/index.scss
@@ -1,0 +1,1 @@
+.default-page {color:red};


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Improve the build task to accept a `changes` parameter and based on that to detect what build to execute. Improve the build watcher to send the paths of the detected changes and restart the application only when needed. Allow external chokidar watcher to be registered. The smart building of Apostrophe UI happens on relevant change, no matter if `APOS_DEV` is enabled.

Additionally fix a bug where some Apostrophe modules symlinked in node_modules are not being watched.

Closes  PRO-2788, PRO-2828


## What are the specific steps to test this change?

1. Start Apostrophe application in dev mode: `node app`
- the old build behavior is expected (execute `src` related and `public` builds, complie `apos` based on `package-lock.json`)
- a "watching files" message should be visible in the console
- a change to `ui/src` should re-concatenate all bundles but only recompile the `ui/src` portion
- a change to `ui/public` should re-concatenate everything but no webpack builds should be executed
- a change to `ui/apos` should only rebuild the apos bundle
2. Start Apostrophe application in dev mode: `APOS_DEV=1 node app`
- the old build behavior is expected (rebuild everything)
- same as 1.
3. Start Apostrophe application in dev mode: `APOS_ASSET_WATCH=0 node app`
- a "watching files" message should NOT be visible in the console
- the old build behavior is expected (execute `src` related and `public` builds, complie `apos` based on `package-lock.json`)
- after the initial build, changes should not trigger any build

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

