### PR TITLE
keep default page-type fields at the beginning

### DIFF
--- a/modules/@apostrophecms/page-type/index.js
+++ b/modules/@apostrophecms/page-type/index.js
@@ -38,12 +38,16 @@ module.exports = {
       remove: [ 'archived' ],
       group: {
         utility: {
-          fields: [
+          // Keep `slug`, `type`, `visibility` and `orphan` fields before others,
+          // in case of modules improving `@apostrophecms/doc-type` that would add
+          // custom fields (included in `self.fieldsGroups.utility.fields`).
+          fields: _.uniq([
             'slug',
             'type',
             'visibility',
-            'orphan'
-          ]
+            'orphan',
+            ...self.fieldsGroups.utility.fields
+          ])
         }
       }
     };


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

In the case where modules are improving `@apostrophecms/doc-type` and add some custom fields, these custom fields are placed _before_ the follwing default `page-type` module's fields:

```
            'slug',
            'type',
            'visibility',
            'orphan',
```

To prevent that and keep these fields above ☝️, _above_ the rest, merge the ones added by modules improving `doc-type` into the `page-type` ones.

Example with a module that improves `doc-type` and adds the `Publish this document on` and `Unpublish this document on` fields:

**before**

<img width="1049" alt="image" src="https://user-images.githubusercontent.com/8301962/168632673-f7869ae9-677c-4a25-abff-b2f03e88adc1.png">

**after**

<img width="1047" alt="image" src="https://user-images.githubusercontent.com/8301962/168632502-4c6a73a3-5524-4caa-abff-f912ec6c33f6.png">

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [x] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
