### PR TITLE
PRO-2830: recover after a build error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Vue files not being parsed when running eslint through command line, fixes all lint errors in vue files.
 * Fix a bug where some Apostrophe modules symlinked in `node_modules` are not being watched.
+* Recover after webpack build error in watch mode (development only).
 
 ## 3.19.0
 

--- a/modules/@apostrophecms/task/index.js
+++ b/modules/@apostrophecms/task/index.js
@@ -137,11 +137,11 @@ module.exports = {
         let result;
         const telemetry = self.apos.telemetry;
         const spanName = `task:${self.__meta.name}:${name}`;
+        const aposArgv = self.apos.argv;
         await telemetry.startActiveSpan(spanName, async (span) => {
           span.setAttribute(SemanticAttributes.CODE_FUNCTION, 'invoke');
           span.setAttribute(SemanticAttributes.CODE_NAMESPACE, '@apostrophecms/task');
           try {
-            const aposArgv = self.apos.argv;
             if (Array.isArray(args)) {
               args.splice(0, 0, name);
             } else {
@@ -159,12 +159,12 @@ module.exports = {
             span.setAttribute(telemetry.Attributes.ARGV, telemetry.stringify(argv));
             self.apos.argv = argv;
             result = await task.task(argv);
-            self.apos.argv = aposArgv;
             span.setStatus({ code: telemetry.api.SpanStatusCode.OK });
           } catch (err) {
             telemetry.handleError(span, err);
             throw err;
           } finally {
+            self.apos.argv = aposArgv;
             span.end();
           }
         });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Recover after a build error when in a watch mode. This fix provides solution in two stages:
- Add a rebuild error handling so that errors don't break the process
- Fixes an issue with `task.invoke` when it doesn't reset properly the apos `argv` which is best observable in this particular scenario but it also affects any error handled task invocations (`apos.isTask()` will always return `true`). 

Closes PRO-2830

## What are the specific steps to test this change?

Run application in development mode and:
- Edit a watched asset and create a bad code to reproduce webpack build error
- Console log should show detailed information about the error
- The page should not be reloaded
- Edit the same file and correct the error
- A normal rebuild should occur
- The page should be reloaded 

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

