### PR TITLE
Make changes argument command line friendly, add missing CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Adds
 
-* Trigger only the relevant build when in a watch mode (development).
+* Trigger only the relevant build when in a watch mode (development). The build paths should not contain comma (`,`).
 * Adds an `unpublish` method, available for any doc-type.  
 An _Unpublish_ option has also been added to the context menu of the modal when editing a piece or a page.
 
@@ -13,6 +13,7 @@ An _Unpublish_ option has also been added to the context menu of the modal when 
 * Vue files not being parsed when running eslint through command line, fixes all lint errors in vue files.
 * Fix a bug where some Apostrophe modules symlinked in `node_modules` are not being watched.
 * Recover after webpack build error in watch mode (development only).
+* Fixes an edge case when failing (throw) task invoked via `task.invoke` will result in `apos.isTask()` to always return true due to `apos.argv` not reverted properly.
 
 ## 3.20.1 (2022-05-17)
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

A patch related to https://github.com/apostrophecms/apostrophe/pull/3769

- Make `argv.changes` command line friendly (comma separated list). Introduces limitation when build paths should not contain comma characters.
- Add missing entry of `task.invoke` fix to the CHANGELOG

## What are the specific steps to test this change?

No change in the behavior introduced in the related PR (see above).

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

