### PR TITLE
keep query string in redirections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+## Fixes
+
+* Take into account query string in redirections.
+
 ## 2.221.0 (2022-06-07)
 
 ## Adds

--- a/lib/modules/apostrophe-soft-redirects/index.js
+++ b/lib/modules/apostrophe-soft-redirects/index.js
@@ -48,21 +48,26 @@ module.exports = {
     };
 
     self.pageNotFound = function(req, callback) {
-      return self.apos.docs.find(req, { historicUrls: { $in: [ req.url ] } }).sort({ updatedAt: -1 }).toObject(function(err, doc) {
-        if (err) {
-          return callback(err);
-        }
-        if (!doc) {
+      return self.apos.docs
+        .find(req, { historicUrls: req.path })
+        .sort({ updatedAt: -1 })
+        .toObject(function(err, doc) {
+          if (err) {
+            return callback(err);
+          }
+          if (!doc) {
+            return callback(null);
+          }
+          if (!doc._url) {
+            return callback(null);
+          }
+          if (self.local(doc._url) !== req.path) {
+            const queryParams = self.stringifyQueryParams(req.query);
+
+            return req.res.redirect(statusCode, `${self.local(doc._url)}${queryParams}`);
+          }
           return callback(null);
-        }
-        if (!doc._url) {
-          return callback(null);
-        }
-        if (self.local(doc._url) !== req.url) {
-          return req.res.redirect(statusCode, self.local(doc._url));
-        }
-        return callback(null);
-      });
+        });
     };
 
     self.pageBeforeSend = function(req, callback) {
@@ -92,6 +97,15 @@ module.exports = {
     // Remove any protocol, // and host/port/auth from URL
     self.local = function(url) {
       return url.replace(/^(https?:)?\/\/[^/]+/, '');
+    };
+
+    self.stringifyQueryParams = function(queryParams) {
+      const joinedQueryParams = Object
+        .entries(queryParams)
+        .map(([key, value]) => value ? `${key}=${value}` : key)
+        .join('&');
+
+      return joinedQueryParams ? `?${joinedQueryParams}` : '';
     };
 
   }

--- a/lib/modules/apostrophe-soft-redirects/index.js
+++ b/lib/modules/apostrophe-soft-redirects/index.js
@@ -62,9 +62,9 @@ module.exports = {
             return callback(null);
           }
           if (self.local(doc._url) !== req.path) {
-            const queryParams = self.stringifyQueryParams(req.query);
+            const queryString = self.buildQueryString(req.query);
 
-            return req.res.redirect(statusCode, `${self.local(doc._url)}${queryParams}`);
+            return req.res.redirect(statusCode, `${self.local(doc._url)}${queryString}`);
           }
           return callback(null);
         });
@@ -99,13 +99,13 @@ module.exports = {
       return url.replace(/^(https?:)?\/\/[^/]+/, '');
     };
 
-    self.stringifyQueryParams = function(queryParams) {
-      const joinedQueryParams = Object
-        .entries(queryParams)
+    self.buildQueryString = function(parameters) {
+      const joinedParameters = Object
+        .entries(parameters)
         .map(([key, value]) => value ? `${key}=${value}` : key)
         .join('&');
 
-      return joinedQueryParams ? `?${joinedQueryParams}` : '';
+      return joinedParameters ? `?${joinedParameters}` : '';
     };
 
   }

--- a/lib/modules/apostrophe-soft-redirects/index.js
+++ b/lib/modules/apostrophe-soft-redirects/index.js
@@ -1,5 +1,6 @@
 var _ = require('@sailshq/lodash');
 var async = require('async');
+var qs = require('qs');
 
 // Implements "soft redirects." When a 404 is about to occur, Apostrophe will look
 // for a page or piece that has been associated with that URL in the past, and
@@ -62,9 +63,10 @@ module.exports = {
             return callback(null);
           }
           if (self.local(doc._url) !== req.path) {
-            const queryString = self.buildQueryString(req.query);
-
-            return req.res.redirect(statusCode, `${self.local(doc._url)}${queryString}`);
+            return req.res.redirect(
+              statusCode,
+              `${self.local(doc._url)}${qs.stringify(req.query, { addQueryPrefix: true })}`
+            );
           }
           return callback(null);
         });
@@ -97,15 +99,6 @@ module.exports = {
     // Remove any protocol, // and host/port/auth from URL
     self.local = function(url) {
       return url.replace(/^(https?:)?\/\/[^/]+/, '');
-    };
-
-    self.buildQueryString = function(parameters) {
-      const joinedParameters = Object
-        .entries(parameters)
-        .map(([key, value]) => value ? `${key}=${value}` : key)
-        .join('&');
-
-      return joinedParameters ? `?${joinedParameters}` : '';
     };
 
   }

--- a/test/soft-redirects.js
+++ b/test/soft-redirects.js
@@ -74,14 +74,14 @@ describe('Soft Redirects', function() {
 
   it('should be able to serve the page at its old URL too, via redirect', function(done) {
     return request({
-      url: 'http://localhost:7900/child',
+      url: 'http://localhost:7900/child?a-query-param=foo&another',
       followRedirect: false
     }, function(err, response, body) {
       assert(!err);
       // Is our status code good?
       assert.equal(response.statusCode, 302);
       // Are we going to be redirected to our page?
-      assert.equal(response.headers['location'], '/child-moved');
+      assert.equal(response.headers.location, '/child-moved?a-query-param=foo&another');
       return done();
     });
   });
@@ -151,14 +151,14 @@ describe('Soft Redirects - with `statusCode` option', function() {
 
   it('should be able to serve the page at its old URL too, via redirect', function(done) {
     return request({
-      url: 'http://localhost:7900/child',
+      url: 'http://localhost:7900/child?a-query-param=foo&another',
       followRedirect: false
     }, function(err, response, body) {
       assert(!err);
       // Is our status code good?
       assert.equal(response.statusCode, 301);
       // Are we going to be redirected to our page?
-      assert.equal(response.headers['location'], '/child-moved');
+      assert.equal(response.headers.location, '/child-moved?a-query-param=foo&another');
       return done();
     });
   });

--- a/test/soft-redirects.js
+++ b/test/soft-redirects.js
@@ -74,6 +74,20 @@ describe('Soft Redirects', function() {
 
   it('should be able to serve the page at its old URL too, via redirect', function(done) {
     return request({
+      url: 'http://localhost:7900/child',
+      followRedirect: false
+    }, function(err, response, body) {
+      assert(!err);
+      // Is our status code good?
+      assert.equal(response.statusCode, 302);
+      // Are we going to be redirected to our page?
+      assert.equal(response.headers.location, '/child-moved');
+      return done();
+    });
+  });
+
+  it('should be able to serve the page at its old URL too, via redirect, with query params', function(done) {
+    return request({
       url: 'http://localhost:7900/child?a-query-param=foo&another',
       followRedirect: false
     }, function(err, response, body) {
@@ -150,6 +164,20 @@ describe('Soft Redirects - with `statusCode` option', function() {
   });
 
   it('should be able to serve the page at its old URL too, via redirect', function(done) {
+    return request({
+      url: 'http://localhost:7900/child',
+      followRedirect: false
+    }, function(err, response, body) {
+      assert(!err);
+      // Is our status code good?
+      assert.equal(response.statusCode, 301);
+      // Are we going to be redirected to our page?
+      assert.equal(response.headers.location, '/child-moved');
+      return done();
+    });
+  });
+
+  it('should be able to serve the page at its old URL too, via redirect, with query params', function(done) {
     return request({
       url: 'http://localhost:7900/child?a-query-param=foo&another',
       followRedirect: false

--- a/test/soft-redirects.js
+++ b/test/soft-redirects.js
@@ -88,14 +88,14 @@ describe('Soft Redirects', function() {
 
   it('should be able to serve the page at its old URL too, via redirect, with query params', function(done) {
     return request({
-      url: 'http://localhost:7900/child?a-query-param=foo&another',
+      url: 'http://localhost:7900/child?a-query-param=foo&bar[]=a&bar[]=b&another',
       followRedirect: false
     }, function(err, response, body) {
       assert(!err);
       // Is our status code good?
       assert.equal(response.statusCode, 302);
       // Are we going to be redirected to our page?
-      assert.equal(response.headers.location, '/child-moved?a-query-param=foo&another');
+      assert.equal(response.headers.location, '/child-moved?a-query-param=foo&bar%5B0%5D=a&bar%5B1%5D=b&another=');
       return done();
     });
   });
@@ -176,19 +176,4 @@ describe('Soft Redirects - with `statusCode` option', function() {
       return done();
     });
   });
-
-  it('should be able to serve the page at its old URL too, via redirect, with query params', function(done) {
-    return request({
-      url: 'http://localhost:7900/child?a-query-param=foo&another',
-      followRedirect: false
-    }, function(err, response, body) {
-      assert(!err);
-      // Is our status code good?
-      assert.equal(response.statusCode, 301);
-      // Are we going to be redirected to our page?
-      assert.equal(response.headers.location, '/child-moved?a-query-param=foo&another');
-      return done();
-    });
-  });
-
 });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Take into account query string in redirections.

## What are the specific steps to test this change?

- create a page or a piece
- change its slug
- access the the old slug with one or multiple query params
- you should be redirected to the new slug, with the query param(s)

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
