### PR TITLE
Fix max login attempts msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## unreleased
+## UNRELEASED
 
-### Fixes for
+### Fixes
 
 * Fixes login maximum attempts error message that wasn't showing the plural when lockoutMinutes is more than 1.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Fixes for
+
+* Fixes login maximum attempts error message that wasn't showing the plural when lockoutMinutes is more than 1.
+
 ## 3.21.0 (2022-05-25)
 
 ### Adds

--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -202,11 +202,7 @@ module.exports = {
             .checkLoginAttempts(user.username, loginNamespace);
 
           if (reached) {
-            const maxAttemptsKey = self.options.throttle.lockoutMinutes > 1
-              ? 'apostrophe:loginMaxAttemptsReached_plural'
-              : 'apostrophe:loginMaxAttemptsReached';
-
-            throw self.apos.error('invalid', req.t(maxAttemptsKey, {
+            throw self.apos.error('invalid', req.t('apostrophe:loginMaxAttemptsReached', {
               count: self.options.throttle.lockoutMinutes
             }));
           }
@@ -604,11 +600,7 @@ module.exports = {
         const { cachedAttempts, reached } = await self.checkLoginAttempts(username);
 
         if (reached) {
-          const maxAttemptsKey = self.options.throttle.lockoutMinutes > 1
-            ? 'apostrophe:loginMaxAttemptsReached_plural'
-            : 'apostrophe:loginMaxAttemptsReached';
-
-          throw self.apos.error('invalid', req.t(maxAttemptsKey, {
+          throw self.apos.error('invalid', req.t('apostrophe:loginMaxAttemptsReached', {
             count: self.options.throttle.lockoutMinutes
           }));
         }

--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -202,7 +202,13 @@ module.exports = {
             .checkLoginAttempts(user.username, loginNamespace);
 
           if (reached) {
-            throw self.apos.error('invalid', req.t('apostrophe:loginMaxAttemptsReached'));
+            const maxAttemptsKey = self.options.throttle.lockoutMinutes > 1
+              ? 'apostrophe:loginMaxAttemptsReached_plural'
+              : 'apostrophe:loginMaxAttemptsReached';
+
+            throw self.apos.error('invalid', req.t(maxAttemptsKey, {
+              count: self.options.throttle.lockoutMinutes
+            }));
           }
 
           try {
@@ -598,7 +604,11 @@ module.exports = {
         const { cachedAttempts, reached } = await self.checkLoginAttempts(username);
 
         if (reached) {
-          throw self.apos.error('invalid', req.t('apostrophe:loginMaxAttemptsReached', {
+          const maxAttemptsKey = self.options.throttle.lockoutMinutes > 1
+            ? 'apostrophe:loginMaxAttemptsReached_plural'
+            : 'apostrophe:loginMaxAttemptsReached';
+
+          throw self.apos.error('invalid', req.t(maxAttemptsKey, {
             count: self.options.throttle.lockoutMinutes
           }));
         }


### PR DESCRIPTION
[1142](https://gitlab-dcadcx.michelin.net/pa/apostrophe-enhancements/-/issues/1142)

## Summary
Fixes missing plural label for login max attempts error message.
For normal login and requirement verification

## What are the specific steps to test this change?

* Link branch to A3 project
* Setup `lockoutMinutes` in login module config
```javascript
    '@apostrophecms/login': {
      options: {
        throttle: {
          lockoutMinutes: 2
        }
      }
    },
```
* Try to exceed max login attempt in initial login, the message should take into account the lockoutMinutes value
* Try to exceed max login attempt in totp login, the message should take into account the lockoutMinutes value

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
