### PR TITLE
add share draft option to context menu

### DIFF
--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -91,6 +91,7 @@ module.exports = {
     self.composeSchema();
     self.apos.doc.setManager(self.name, self);
     self.enableBrowserData();
+    self.addContextMenu();
   },
   handlers(self) {
     return {
@@ -281,6 +282,16 @@ module.exports = {
 
   methods(self) {
     return {
+      addContextMenu() {
+        self.apos.doc.addContextOperation(self.__meta.name, {
+          action: 'shareDraft',
+          context: 'update',
+          label: 'apostrophe:shareDraft',
+          modal: 'AposModalShareDraft',
+          manuallyPublished: true,
+          hasUrl: true
+        });
+      },
       getRelatedDocsIds(req, doc) {
         const relatedDocsIds = [];
         const handlers = {

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -91,7 +91,6 @@ module.exports = {
     self.composeSchema();
     self.apos.doc.setManager(self.name, self);
     self.enableBrowserData();
-    self.addContextMenu();
   },
   handlers(self) {
     return {
@@ -282,16 +281,6 @@ module.exports = {
 
   methods(self) {
     return {
-      addContextMenu() {
-        self.apos.doc.addContextOperation(self.__meta.name, {
-          action: 'shareDraft',
-          context: 'update',
-          label: 'apostrophe:shareDraft',
-          modal: 'AposModalShareDraft',
-          manuallyPublished: true,
-          hasUrl: true
-        });
-      },
       getRelatedDocsIds(req, doc) {
         const relatedDocsIds = [];
         const handlers = {

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
@@ -199,7 +199,7 @@ export default {
           return false;
         }
 
-        return op.context === 'update' && this.isUpdateOperation
+        return op.context === 'update' && this.isUpdateOperation;
       });
     },
     moduleName() {

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
@@ -125,7 +125,7 @@ export default {
             action: 'edit'
           }
         ] : []),
-        ...((this.showPreview && this.context._url) ? [
+        ...((this.showPreview && this.hasUrl) ? [
           {
             label: 'apostrophe:preview',
             action: 'preview'
@@ -192,13 +192,14 @@ export default {
     },
     customOperationsByContext() {
       return this.customOperations.filter(op => {
-        if (op.context === 'update' && this.isUpdateOperation) {
-          if (typeof op.manuallyPublished === 'boolean') {
-            return op.manuallyPublished === this.manuallyPublished;
-          }
-          return true;
+        if (typeof op.manuallyPublished === 'boolean' && op.manuallyPublished !== this.manuallyPublished) {
+          return false;
         }
-        return false;
+        if (typeof op.hasUrl === 'boolean' && op.hasUrl !== this.hasUrl) {
+          return false;
+        }
+
+        return op.context === 'update' && this.isUpdateOperation
       });
     },
     moduleName() {
@@ -213,6 +214,9 @@ export default {
     },
     isUpdateOperation() {
       return !!this.context._id;
+    },
+    hasUrl() {
+      return !!this.context._url;
     },
     canPublish() {
       if (this.context._id) {

--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -354,6 +354,7 @@
   "selectManyLabel": "Select {{ typeLabel }}",
   "selectLocales": "Select Locales",
   "sentenceJoiner": " ",
+  "shareDraft": "Share draft",
   "visibilityHelp": "Select whether this content is public or private",
   "slug": "Slug",
   "slugInUse": "Slug already in use",

--- a/modules/@apostrophecms/i18n/i18n/es.json
+++ b/modules/@apostrophecms/i18n/i18n/es.json
@@ -324,6 +324,7 @@
   "selectManyLabel": "Seleccionar {{ typeLabel }}",
   "selectLocales": "Seleccionar Configuración Regional",
   "sentenceJoiner": " ",
+  "shareDraft": "Compartir borrador",
   "visibilityHelp": "Seleccione si este contenido es público o privado",
   "slug": "Slug",
   "slugInUse": "Este slug ya está en uso",

--- a/modules/@apostrophecms/i18n/i18n/fr.json
+++ b/modules/@apostrophecms/i18n/i18n/fr.json
@@ -339,6 +339,7 @@
   "selectManyLabel": "Sélectionner {{ typeLabel }}",
   "selectLocales": "Sélectionner les langues",
   "sentenceJoiner": " ",
+  "shareDraft": "Partager le brouillon",
   "visibilityHelp": "Choisissez si ce contenu est public ou privé",
   "slug": "Slug",
   "slugInUse": "Slug déjà utilisé",

--- a/modules/@apostrophecms/i18n/i18n/pt-BR.json
+++ b/modules/@apostrophecms/i18n/i18n/pt-BR.json
@@ -321,6 +321,7 @@
   "selectManyLabel": "Selecionar {{ typeLabel }}",
   "selectLocales": "Selecionar Localidades",
   "sentenceJoiner": " ",
+  "shareDraft": "Compartilhar rascunho",
   "visibilityHelp": "Selecione se este conteúdo é público ou privado",
   "slug": "Slug",
   "slugInUse": "Este slug já está em uso",

--- a/modules/@apostrophecms/i18n/i18n/sk.json
+++ b/modules/@apostrophecms/i18n/i18n/sk.json
@@ -344,6 +344,7 @@
   "selectManyLabel": "Vybrať {{ typeLabel }}",
   "selectLocales": "Vybrať jazykové mutácie",
   "sentenceJoiner": " ",
+  "shareDraft": "Zdieľať koncept",
   "visibilityHelp": "Vyberte, či je tento obsah verejný alebo súkromný",
   "slug": "Pochopiteľný text URL",
   "slugInUse": "Pochopiteľný text URL sa už používa",

--- a/test/docs.js
+++ b/test/docs.js
@@ -166,16 +166,16 @@ describe('Docs', function() {
       label: 'Menu Label',
       modal: 'SomeModalComponent'
     };
-    assert.strictEqual(apos.doc.contextOperations.length, 0);
+    const initialLength = apos.doc.contextOperations.length;
 
     apos.doc.addContextOperation('test-people', operation);
-    assert.strictEqual(apos.doc.contextOperations.length, 1);
-    assert.deepStrictEqual(apos.doc.contextOperations[0], {
+
+    assert.strictEqual(apos.doc.contextOperations.length, initialLength + 1);
+    assert.deepStrictEqual(apos.doc.contextOperations.find(op => op.action === 'test'), {
       ...operation,
       moduleName: 'test-people'
     });
   });
-
   it('should support custom context menu (with optional)', async function() {
     apos.doc.contextOperations = [];
     const operation = {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Add the "Share draft" option to the context menu of pages and pieces (only pieces that have an index page of their type).

## What are the specific steps to test this change?

- run testbed
- add an article
- the "Share draft" option should not be displayed in the context menu:

![image](https://user-images.githubusercontent.com/8301962/172195316-2946db9a-92f8-4809-9e0e-85b02f25fa76.png)

- open pages manager
- create a page 
- the "Share draft" option should be displayed for this page:

![image](https://user-images.githubusercontent.com/8301962/172195527-a9e4d099-9316-4649-bb41-4a6fecbbf700.png)

- now create a page of the type `Article Index`
- go back to the articles manager
- articles should now display the "Share draft" option:

![Screenshot 2022-06-06 at 17 43 28](https://user-images.githubusercontent.com/8301962/172195898-4c3b91a8-3c02-4cc9-a9f7-84ad0384e6e8.png)

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
