### PR TITLE
Fix symlinked node modules not being rebuilt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* Fix a Webpack cache issue leading to modules symlinked in `node_modules` not being rebuilt. 
+
 ## 3.21.0 (2022-05-25)
 
 ### Adds

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -125,6 +125,7 @@ module.exports = {
           const buildDir = `${self.apos.rootDir}/apos-build/${namespace}`;
           const bundleDir = `${self.apos.rootDir}/public/apos-frontend/${namespace}`;
           const modulesToInstantiate = self.apos.modulesToBeInstantiated();
+          const symLinkModules = await findNodeModulesSymlinks(self.apos.npmRootDir);
           // Make it clear if builds should detect changes
           const detectChanges = typeof argv.changes === 'string';
           // Remove invalid changes. `argv.changes` is a comma separated list of relative
@@ -353,9 +354,16 @@ module.exports = {
                 ? webpackMerge(webpackInstanceConfig, ...Object.values(self.webpackExtensions))
                 : webpackInstanceConfig;
 
-              // Inject the cache location at the end - we need the merged
-              const cacheMeta = await computeCacheMeta(name, webpackInstanceConfigMerged);
+              // Inject the cache location at the end - we need the merged config
+              const cacheMeta = await computeCacheMeta(name, webpackInstanceConfigMerged, symLinkModules);
               webpackInstanceConfigMerged.cache.cacheLocation = cacheMeta.location;
+              // Exclude symlinked modules from the cache managedPaths, no other way for now
+              // https://github.com/webpack/webpack/issues/12112
+              if (cacheMeta.managedPathsRegex) {
+                webpackInstanceConfigMerged.snapshot = {
+                  managedPaths: [ cacheMeta.managedPathsRegex ]
+                };
+              }
 
               const result = await webpack(webpackInstanceConfigMerged);
               await writeCacheMeta(name, cacheMeta);
@@ -716,7 +724,7 @@ module.exports = {
           // but it can be overridden by an APOS_ASSET_CACHE environment.
           // In order to compute an accurate hash, this helper needs
           // the final, merged webpack configuration.
-          async function computeCacheMeta(name, webpackConfig) {
+          async function computeCacheMeta(name, webpackConfig, symLinkModules) {
             const cacheBase = self.getCacheBasePath();
 
             if (!packageLockContentCached) {
@@ -759,10 +767,22 @@ module.exports = {
             );
             const location = path.resolve(cacheBase, hash);
 
+            // Retrieve symlinkModules and convert them to managedPaths regex rule
+            let managedPathsRegex;
+            if (symLinkModules.length > 0) {
+              const regex = symLinkModules
+                .map(m => m.replace('/', '\\/'))
+                .join('|');
+              managedPathsRegex = new RegExp(
+                '^(.+?[\\/]node_modules)[\\/]((?!' + regex + ')).*[\\/]*'
+              );
+            }
+
             return {
               base: cacheBase,
               hash,
-              location
+              location,
+              managedPathsRegex
             };
           }
 

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -771,7 +771,7 @@ module.exports = {
             let managedPathsRegex;
             if (symLinkModules.length > 0) {
               const regex = symLinkModules
-                .map(m => m.replace('/', '\\/'))
+                .map(m => self.apos.util.regExpQuote(m))
                 .join('|');
               managedPathsRegex = new RegExp(
                 '^(.+?[\\/]node_modules)[\\/]((?!' + regex + ')).*[\\/]*'

--- a/test/assets.js
+++ b/test/assets.js
@@ -1215,6 +1215,7 @@ describe('Assets', function() {
       );
       await Promise.delay(300);
     }
+
     await retryAssertTrue(
       async () => (await fs.readFile(assetPathPublic, 'utf8')).match(/bundle-page-watcher-test-3/),
       'Unable to verify public asset rebuilding by the watcher',
@@ -1245,8 +1246,8 @@ describe('Assets', function() {
       10000
     );
     await retryAssertTrue(
-      () => timesRebuilt === 2,
-      `Expected to rebuild 2 times, got ${timesRebuilt}`,
+      () => timesRebuilt === 3,
+      `Expected to rebuild 3 times, got ${timesRebuilt}`,
       100,
       5000
     );


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Fix a Webpack cache issue leading to modules symlinked in `node_modules` not being rebuilt. 

## What are the specific steps to test this change?

Copy the asset module index.js from this PR to `node_modules/apostrophe/modules/@apostrophecms/asset/index.js` in the dedicated test repo. Clear the Webpack cache, boot and do changes. The changes should be applied.

Fixes a random failing test due to wrong expectations.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

