### PR TITLE
Release 3.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.21.1 (2022-06-04)
+
+### Fixes
+
+* Work around backwards compatibility break in `sass` module by pinning to `sass` `1.50.x` while we investigate. If you saw the error `RangeError: Invalid value: Not in inclusive range 0..145: -1` you can now fix that by upgrading with `npm update`. If it does not immediately clear up the issue in development, try `node app @apostrophecms/asset:clear-cache`.
+ 
 ## 3.21.0 (2022-05-25)
 
 ### Adds

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "3.21.0",
+  "version": "3.21.1",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {
@@ -103,7 +103,7 @@
     "resolve": "^1.19.0",
     "resolve-from": "^5.0.0",
     "sanitize-html": "^2.0.0",
-    "sass": "^1.50.1",
+    "sass": "~1.50.1",
     "sass-loader": "^10.1.1",
     "server-destroy": "^1.0.1",
     "sluggo": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "resolve": "^1.19.0",
     "resolve-from": "^5.0.0",
     "sanitize-html": "^2.0.0",
-    "sass": "~1.50.1",
+    "sass": "1.52.1",
     "sass-loader": "^10.1.1",
     "server-destroy": "^1.0.1",
     "sluggo": "^0.3.0",


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

dart sass got pickier (or buggier?) in 1.52.2, printing:

SassError: RangeError: Invalid value: Not in inclusive range 0..145: -1

1.52.1 does not do that, so pinning for now. Absolutely not doing anything more ambitious in a hotfix. I'll open tickets for deeper solutions.

## What are the specific steps to test this change?

* Blow away `package-lock` and `node_modules` in your checkout of apostrophe itself. Now `npm install` there. Make sure you are npm linked to that checkout in a3-boilerplate. Now try to run `APOS_DEV=1 npm run dev`. You can't, you get the SASS error.
* Now Check out this branch and run `npm install` in your apostrophe folder.
`APOS_DEV=1 npm run dev` should work now.

## What kind of change does this PR introduce?

Pinned sass version temporarily.

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
