### PR TITLE
Array editor's slats use titleField's select label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ### Fixes
 
 * Fixes login maximum attempts error message that wasn't showing the plural when lockoutMinutes is more than 1.
+* Fixes the text color of the current array item's slat label in the array editor modal 
+* Fixes the maximum width of an array item's slat label so as to not obscure the Remove button in narrow viewports
+
+### Changes
+
+* If an array field's titleField option is set to a select field, use the select's label as the slat label, rather than the select's value.
 
 ## 3.21.1 (2022-06-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Changes
 
-* If an array field's titleField option is set to a select field, use the select's label as the slat label, rather than the select's value.
+* If an array field's titleField option is set to a select field, use the selected option's label as the slat label rather it's value.
 
 ## 3.21.1 (2022-06-04)
 

--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -121,6 +121,7 @@
   "errorCount": "{{ count }} error remaining",
   "errorCount_plural": "{{ count }} errors remaining",
   "errorCreatingNewContent": "Error while creating new, empty content.",
+  "errorFetchingTitleFieldChoicesByMethod": "An error occurred while fetching the choices for the titleField {{ name }}",
   "errorWhileRestoring": "An error occurred while restoring the previously published version.",
   "errorWhileUnpublishing": "An error occurred while unpublishing the document.",
   "errorWhileArchiving": "An error occurred while moving the document to the archive.",

--- a/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
@@ -122,7 +122,6 @@ export default {
         showModal: false
       },
       titleFieldChoices: null,
-      // methodTitleFieldChoices: null,
       // If we don't clone, then we're making
       // permanent modifications whether the user
       // clicks save or not

--- a/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
@@ -212,7 +212,7 @@ export default {
       aposSchema.scrollFieldIntoView(name);
     }
     this.methodTitleFieldChoices = await this.getTitleFieldChoicesFromMethod();
-    
+
   },
   methods: {
     async select(_id) {
@@ -367,10 +367,10 @@ export default {
         if (candidate && titleField.type === 'select') {
 
           // Choices are a normal, hardcoded array
-          if (Array.isArray(titleField.choices)) {  
+          if (Array.isArray(titleField.choices)) {
             choice = titleField.choices?.find(choice => choice.value === candidate);
             if (choice && choice.label) {
-              candidate = choice.label;  
+              candidate = choice.label;
             }
 
           // Choices are provided by a method
@@ -408,7 +408,7 @@ export default {
       let choices = null;
       const action = `${this.moduleOptions.action}/choices`;
       const titleField = this.schema.find(field => field.name === this.field.titleField);
-      
+
       if (titleField?.choices && typeof titleField.choices === 'string') {
         try {
           const result = await apos.http.get(
@@ -420,7 +420,7 @@ export default {
             }
           );
           if (result && result.choices) {
-            choices = result.choices
+            choices = result.choices;
           }
         } catch (e) {
           console.error(this.$t('apostrophe:errorFetchingTitleFieldChoicesByMethod', { name: titleField.name }));

--- a/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
@@ -357,14 +357,15 @@ export default {
     },
     label(item) {
       let candidate;
-      // let choice;
       if (this.field.titleField) {
 
         // Initial field value
         candidate = get(item, this.field.titleField);
 
+        // If the titleField references a select input, use the
+        // select label as the slat label, rather than the value.
         if (this.titleFieldChoices) {
-          const choice = this.titleFieldChoices?.find(choice => choice.value === candidate);
+          const choice = this.titleFieldChoices.find(choice => choice.value === candidate);
           if (choice && choice.label) {
             candidate = choice.label;
           }
@@ -392,29 +393,10 @@ export default {
     },
     async getTitleFieldChoices() {
       // If the titleField references a select input, get it's choices
+      // to use as labels for the slat UI
 
       let choices = null;
-      
       const titleField = this.schema.find(field => field.name === this.field.titleField);
-
-      // // If field is a select, use the choice label as the slat title
-      //   if (candidate && titleField.type === 'select') {
-
-      //     // Choices are a normal, hardcoded array
-      //     if (Array.isArray(titleField.choices)) {
-      //       choice = titleField.choices?.find(choice => choice.value === candidate);
-      //       if (choice && choice.label) {
-      //         candidate = choice.label;
-      //       }
-
-      //     // Choices are provided by a method
-      //     } else if (typeof titleField.choices === 'string') {
-      //       choice = this.methodTitleFieldChoices?.find(choice => choice.value === candidate);
-      //       if (choice && choice.label) {
-      //         candidate = choice.label;
-      //       }
-      //     }
-      //   }
 
       // The titleField is a select
       if (titleField?.choices) {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
@@ -262,6 +262,9 @@ export default {
     &:hover {
       background-color: var(--a-primary-dark-10);
     }
+    .apos-slat__label {
+      color: var(--a-white);
+    }
   }
 
   .apos-slat-list__item--disabled {
@@ -274,6 +277,7 @@ export default {
   .apos-slat__main {
     display: flex;
     align-items: center;
+    max-width: 75%;
     & ::v-deep .trigger {
       /* This gets inline positioned and has doesn't provide an extra class to beef up, sorry */
       /* stylelint-disable-next-line declaration-no-important */
@@ -285,7 +289,6 @@ export default {
     @include type-small;
     overflow: hidden;
     margin-left: 5px;
-    max-width: 220px;
     white-space: nowrap;
     text-overflow: ellipsis;
   }

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "@babel/eslint-parser": "^7.17.0",
     "eslint": "^7.25.0",
     "eslint-config-apostrophe": "^3.4.0",
+    "eslint-plugin-n": "^15.2.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-vue": "^7.9.0",
     "mocha": "^9.1.2",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,6 @@
     "@babel/eslint-parser": "^7.17.0",
     "eslint": "^7.25.0",
     "eslint-config-apostrophe": "^3.4.0",
-    "eslint-plugin-n": "^15.2.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-vue": "^7.9.0",
     "mocha": "^9.1.2",


### PR DESCRIPTION
## Summary

- If an array field's `titleField` option is set to a select field, use the select's label as a slat label rather than it's value
- Fixes the current array slat's label color
- Prevents an array slat's label from obscuring the Remove button in narrow viewports

## What are the specific steps to test this change?

*For example:*
1. In the a3-demo repo you can checkout  & link [test-select-label-as-slat-label](https://github.com/apostrophecms/a3-demo/tree/test-select-label-as-slat-label)
2. `npm run dev`
3. In the Topics piece admin, the Fancy Fields > Array Field uses a select field as its titleField. Confirm the select's `label` is being used as the slat label

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
