### PR TITLE
PRO-2640: The "remove attachment" button should be disabled during upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixes
 
 * Fixes login maximum attempts error message that wasn't showing the plural when lockoutMinutes is more than 1.
+* Disable the slat controls of the attachment component while uploading.
+* Fixes bug when re-attaching the same file won't trigger an upload.
+* AposSlat now fully respects the disabled state.
 
 ## 3.21.1 (2022-06-04)
 

--- a/modules/@apostrophecms/ui/ui/apos/components/AposFile.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposFile.vue
@@ -24,6 +24,7 @@
         </template>
       </p>
       <input
+        ref="uploadField"
         type="file"
         class="apos-sr-only"
         :disabled="disabled || fileOrAttachment"
@@ -35,7 +36,7 @@
       <AposSlatList
         :value="[fileOrAttachment]"
         @input="update"
-        :disabled="readOnly"
+        :disabled="attachmentDisabled"
       />
     </div>
   </div>
@@ -77,10 +78,13 @@ export default {
     };
   },
   computed: {
-    fileOrAttachment () {
+    fileOrAttachment() {
       return this.selectedFile || this.attachment;
     },
-    messages () {
+    attachmentDisabled() {
+      return this.uploading || this.readOnly || this.disabled;
+    },
+    messages() {
       const msgs = {
         primary: 'Drop a file here or',
         highlighted: 'click to open the file explorer'
@@ -100,6 +104,7 @@ export default {
     async uploadFile ({ target, dataTransfer }) {
       this.dragging = false;
       const [ file ] = target.files ? target.files : (dataTransfer.files || []);
+      this.resetField();
 
       const extension = file.name.split('.').pop();
       const allowedFile = await this.checkFileGroup(`.${extension}`);
@@ -116,6 +121,9 @@ export default {
       };
 
       this.$emit('upload-file', file);
+    },
+    resetField() {
+      this.$refs.uploadField.value = null;
     },
     dragHandler (event) {
       event.preventDefault();

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
@@ -8,7 +8,8 @@
       :class="{
         'apos-is-engaged': engaged,
         'apos-is-only-child': slatCount === 1,
-        'apos-is-selected': selected
+        'apos-is-selected': selected,
+        'apos-is-disabled': disabled,
       }"
       @keydown.prevent.space="toggleEngage"
       @keydown.prevent.enter="toggleEngage"
@@ -33,6 +34,7 @@
           @item-clicked="$emit('item-clicked', item)"
           menu-placement="bottom-start"
           menu-offset="40, 10"
+          disabled="disabled"
         />
         <AposButton
           class="apos-slat__editor-btn"
@@ -46,6 +48,7 @@
           :icon-only="true"
           :modifiers="['inline']"
           @click="$emit('item-clicked', item)"
+          disabled="disabled"
         />
         <a
           class="apos-slat__control apos-slat__control--view"
@@ -221,6 +224,12 @@ export default {
     background-color: var(--a-base-9);
     color: var(--a-text-primary);
     @include apos-transition();
+
+    &.apos-is-disabled {
+      .apos-slat__control--view {
+        pointer-events: none;
+      }
+    }
 
     &:hover {
       cursor: grab;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

* Disable the slat controls of the attachment component while uploading.
* Fixes bug when re-attaching the same file won't trigger an upload.
* AposSlat now fully respects the disabled state.

## What are the specific steps to test this change?

1. Use attachment field to upload a large file
2. Verify the preview link and the remove attachment button are disabled during the upload
3. Verify the preview link and the remove attachment button are disabled after the upload is finished
4. Remove the attachment
5. Select the SAME file to upload
6. The upload should start

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

