### PR TITLE
Pro 2814 share draft routes

### DIFF
--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -475,10 +475,18 @@ module.exports = {
           return self.revertPublishedToPrevious(req, published);
         },
         ':_id/share': async (req) => {
+          const draft = await self.getDraftToShare(req);
 
+          const shared = await self.share(req, draft);
+
+          return shared;
         },
         ':_id/unshare': async (req) => {
+          const draft = await self.getDraftToShare(req);
 
+          const unshared = await self.unshare(req, draft);
+
+          return unshared;
         }
       },
       get: {
@@ -2275,6 +2283,27 @@ database.`);
             }
           }
         });
+      },
+      async getDraftToShare(req) {
+        const { _id } = req.params;
+
+        if (!_id) {
+          throw self.apos.error('invalid');
+        }
+
+        const piece = await self.findOneForEditing(req, {
+          _id
+        });
+
+        if (!piece) {
+          throw self.apos.error('notfound');
+        }
+
+        if (piece.aposMode !== 'draft') {
+          throw self.apos.error('invalid');
+        }
+
+        return piece;
       }
     };
   },

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -473,6 +473,12 @@ module.exports = {
             throw self.apos.error('invalid');
           }
           return self.revertPublishedToPrevious(req, published);
+        },
+        ':_id/share': async (req) => {
+
+        },
+        ':_id/unshare': async (req) => {
+
         }
       },
       get: {

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -438,6 +438,12 @@ module.exports = {
             throw self.apos.error('invalid');
           }
           return self.revertPublishedToPrevious(req, published);
+        },
+        ':_id/share': async (req) => {
+
+        },
+        ':_id/unshare': async (req) => {
+
         }
       }
     };

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -440,10 +440,19 @@ module.exports = {
           return self.revertPublishedToPrevious(req, published);
         },
         ':_id/share': async (req) => {
+          const draft = await self.getDraftToShare(req);
+
+          const shared = await self.share(req, draft);
+
+          return shared;
 
         },
         ':_id/unshare': async (req) => {
+          const draft = await self.getDraftToShare(req);
 
+          const unshared = await self.unshare(req, draft);
+
+          return unshared;
         }
       }
     };
@@ -944,6 +953,28 @@ module.exports = {
             throw self.apos.error('invalid', 'Document has neither slug nor title, giving up');
           }
         }
+      },
+
+      async getDraftToShare(req) {
+        const { _id } = req.params;
+
+        if (!_id) {
+          throw self.apos.error('invalid');
+        }
+
+        const piece = await self.findOneForEditing(req, {
+          _id
+        });
+
+        if (!piece) {
+          throw self.apos.error('notfound');
+        }
+
+        if (piece.aposMode !== 'draft') {
+          throw self.apos.error('invalid');
+        }
+
+        return piece;
       }
     };
   },


### PR DESCRIPTION
[PRO-2814](https://linear.app/apostrophecms/issue/PRO-2814/as-a-frontend-developer-i-can-invoke-a-draft-sharing-rest-api)
## Summary

Adds routes in `@apostrophecms/piece-type` and `@apostrophecms/page` to share and unshare draft pages.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

