### PR TITLE
Pro 2814 invoke share api

### DIFF
--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -359,6 +359,7 @@
   "shareDraftDescription": "Enabling draft sharing will allow anyone with this link to view the current draft",
   "shareDraftEnable": "Enable draft sharing",
   "shareDraftHeader": "Share this page",
+  "shareDraftError": "This document cannot be shared at this time",
   "visibilityHelp": "Select whether this content is public or private",
   "slug": "Slug",
   "slugInUse": "Slug already in use",

--- a/modules/@apostrophecms/i18n/i18n/es.json
+++ b/modules/@apostrophecms/i18n/i18n/es.json
@@ -329,6 +329,7 @@
   "shareDraftDescription": "Habilitar el uso compartido de borradores permitirá que cualquier persona con este enlace vea el borrador actual",
   "shareDraftEnable": "Habilitar borrador compartido",
   "shareDraftHeader": "Comparte esta página",
+  "shareDraftError": "Este documento no se puede compartir en este momento",
   "visibilityHelp": "Seleccione si este contenido es público o privado",
   "slug": "Slug",
   "slugInUse": "Este slug ya está en uso",

--- a/modules/@apostrophecms/i18n/i18n/fr.json
+++ b/modules/@apostrophecms/i18n/i18n/fr.json
@@ -344,6 +344,7 @@
   "shareDraftDescription": "L'activation du partage de brouillon permettra à toute personne disposant de ce lien d'accéder au brouillon actuel",
   "shareDraftEnable": "Activer le partage de brouillon",
   "shareDraftHeader": "Partager cette page",
+  "shareDraftError": "Ce document ne peut pas être partagé actuellement",
   "visibilityHelp": "Choisissez si ce contenu est public ou privé",
   "slug": "Slug",
   "slugInUse": "Slug déjà utilisé",

--- a/modules/@apostrophecms/i18n/i18n/pt-BR.json
+++ b/modules/@apostrophecms/i18n/i18n/pt-BR.json
@@ -326,6 +326,7 @@
   "shareDraftDescription": "Ativar o compartilhamento de rascunho permitirá que qualquer pessoa com este link visualize o rascunho atual",
   "shareDraftEnable": "Ativar compartilhamento de rascunho",
   "shareDraftHeader": "Compartilhe esta página",
+  "shareDraftError": "Este documento não pode ser compartilhado no momento",
   "visibilityHelp": "Selecione se este conteúdo é público ou privado",
   "slug": "Slug",
   "slugInUse": "Este slug já está em uso",

--- a/modules/@apostrophecms/i18n/i18n/sk.json
+++ b/modules/@apostrophecms/i18n/i18n/sk.json
@@ -349,6 +349,7 @@
   "shareDraftDescription": "Povolenie zdieľania konceptu umožní komukoľvek s týmto odkazom zobraziť aktuálny koncept",
   "shareDraftEnable": "Povoliť zdieľanie konceptov",
   "shareDraftHeader": "Zdieľajte túto stránku",
+  "shareDraftError": "Tento dokument momentálne nie je možné zdieľať",
   "visibilityHelp": "Vyberte, či je tento obsah verejný alebo súkromný",
   "slug": "Pochopiteľný text URL",
   "slugInUse": "Pochopiteľný text URL sa už používa",

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
@@ -96,7 +96,6 @@ export default {
   },
   methods: {
     async copy() {
-      console.log('copy');
       await navigator.clipboard.writeText(this.shareUrl);
     },
     async toggle() {
@@ -128,10 +127,10 @@ export default {
         this.shareUrl = this.generateShareUrl(aposShareKey);
 
       } catch (err) {
-        if (!this.disabled) {
-          this.errorNotif();
-        } else {
+        if (this.disabled) {
           this.shareUrl = '';
+        } else {
+          this.errorNotif();
         }
       }
     },

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
@@ -164,7 +164,7 @@ export default {
           this.shareUrl = this.generateShareUrl(aposShareKey);
         }
       } catch {
-       await this.errorNotif();
+        await this.errorNotif();
       }
     },
     async errorNotif() {

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
@@ -123,7 +123,7 @@ export default {
           return this.errorNotif();
         }
 
-        this.shareUrl = aposShareKey;
+        this.shareUrl = this.generateShareUrl();
 
       } catch (err) {
         if (routeToCall === 'share') {
@@ -154,6 +154,13 @@ export default {
       setTimeout(() => {
         this.close();
       }, 500);
+    },
+    generateShareUrl(aposShareKey) {
+      return apos.http.addQueryToUrl(this.doc._url, {
+        ...apos.http.parseQuery(this.doc._url),
+        aposShareKey,
+        aposShareId: this.doc._id
+      });
     }
   }
 };

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
@@ -36,8 +36,8 @@
               {{ $t('apostrophe:shareDraftDescription') }}
             </p>
             <input
+              v-model="shareUrl"
               type="text"
-              :value="shareUrl"
               disabled
               class="apos-share-draft__url"
             >

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
@@ -175,13 +175,10 @@ export default {
       });
     },
     generateShareUrl(aposShareKey) {
-      const qs = Object.fromEntries(
-        Object.entries(apos.http.parseQuery(this.doc._url))
-          .filter(([ _, val ]) => val)
-      );
+      const url = new URL(`${location.origin}${this.doc._url}`);
 
       const slug = apos.http.addQueryToUrl(this.doc._url, {
-        ...qs,
+        ...apos.http.parseQuery(url.search),
         aposShareKey,
         aposShareId: this.doc._id
       });
@@ -283,7 +280,8 @@ export default {
   height: 63px;
   transition: height 200ms linear;
 
-  &.collapse-enter, &.collapse-leave-to {
+  &.collapse-enter,
+  &.collapse-leave-to {
     height: 0;
   }
 }

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
@@ -157,8 +157,13 @@ export default {
       }, 500);
     },
     generateShareUrl(aposShareKey) {
-      // ...apos.http.parseQuery(this.doc._url),
+      const qs = Object.fromEntries(
+        Object.entries(apos.http.parseQuery(this.doc._url))
+          .filter(([ _, val ]) => val)
+      );
+
       const slug = apos.http.addQueryToUrl(this.doc._url, {
+        ...qs,
         aposShareKey,
         aposShareId: this.doc._id
       });

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
@@ -277,9 +277,9 @@ export default {
 }
 
 .apos-share-draft__url-block {
+  overflow: hidden;
   height: 63px;
   transition: height 200ms linear;
-  overflow: hidden;
 
   &.collapse-enter, &.collapse-leave-to {
     height: 0;

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
@@ -42,6 +42,7 @@
               class="apos-share-draft__url"
             >
             <a
+              v-if="shareUrl"
               href=""
               class="apos-share-draft__link-copy"
               @click.prevent="copy"

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
@@ -141,7 +141,7 @@ export default {
         await this.errorNotif();
       } else if (this.doc.aposShareKey) {
         this.disabled = false;
-        this.shareUrl = this.doc.aposShareKey;
+        this.shareUrl = this.generateShareUrl(this.doc.aposShareKey);
       }
     },
     async errorNotif() {
@@ -156,11 +156,13 @@ export default {
       }, 500);
     },
     generateShareUrl(aposShareKey) {
-      return apos.http.addQueryToUrl(this.doc._url, {
+      const slug = apos.http.addQueryToUrl(this.doc._url, {
         ...apos.http.parseQuery(this.doc._url),
         aposShareKey,
         aposShareId: this.doc._id
       });
+
+      return location.origin + slug;
     }
   }
 };

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
@@ -170,9 +170,7 @@ export default {
         dismiss: true
       });
 
-      setTimeout(() => {
-        this.close();
-      }, 500);
+      setTimeout(this.close, 500);
     },
     generateShareUrl(aposShareKey) {
       const qs = Object.fromEntries(
@@ -186,7 +184,7 @@ export default {
         aposShareId: this.doc._id
       });
 
-      return location.origin + slug;
+      return `${location.origin}${slug}`;
     }
   }
 };

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
@@ -104,12 +104,13 @@ export default {
       await this.setShareUrl();
     },
     async setShareUrl() {
-      const routeToCall = this.disabled ? 'unshare' : 'share';
-
       try {
         const { aposShareKey } = await apos.http.post(
-          `${apos.modules[this.doc.type].action}/${this.doc._id}/${routeToCall}`, {
+          `${apos.modules[this.doc.type].action}/${this.doc._id}/share`, {
             busy: true,
+            body: {
+              share: !this.disabled
+            },
             draft: true
           }
         );
@@ -123,10 +124,10 @@ export default {
           return this.errorNotif();
         }
 
-        this.shareUrl = this.generateShareUrl();
+        this.shareUrl = this.generateShareUrl(aposShareKey);
 
       } catch (err) {
-        if (routeToCall === 'share') {
+        if (!this.disabled) {
           this.errorNotif();
         } else {
           this.shareUrl = '';
@@ -156,8 +157,8 @@ export default {
       }, 500);
     },
     generateShareUrl(aposShareKey) {
+      // ...apos.http.parseQuery(this.doc._url),
       const slug = apos.http.addQueryToUrl(this.doc._url, {
-        ...apos.http.parseQuery(this.doc._url),
         aposShareKey,
         aposShareId: this.doc._id
       });

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
@@ -102,7 +102,7 @@ export default {
   async mounted() {
     this.modal.active = true;
     await this.checkUrlprop();
-    this.getAposShareKey();
+    await this.getAposShareKey();
   },
   methods: {
     async copy() {
@@ -135,14 +135,14 @@ export default {
         if (!aposShareKey) {
           return this.errorNotif();
         }
-        this.shareUrl = this.generateShareUrl(aposShareKey);
 
-      } catch (err) {
+        this.shareUrl = this.generateShareUrl(aposShareKey);
+      } catch {
         if (this.disabled) {
           this.shareUrl = '';
-        } else {
-          this.errorNotif();
+          return;
         }
+        await this.errorNotif();
       }
     },
     close() {
@@ -154,13 +154,17 @@ export default {
       }
     },
     async getAposShareKey() {
-      const { aposShareKey } = await apos.http.get(
-        `${apos.modules[this.doc.type].action}/${this.doc._id}`, {}
-      );
+      try {
+        const { aposShareKey } = await apos.http.get(
+          `${apos.modules[this.doc.type].action}/${this.doc._id}`, {}
+        );
 
-      if (aposShareKey) {
-        this.disabled = false;
-        this.shareUrl = this.generateShareUrl(aposShareKey);
+        if (aposShareKey) {
+          this.disabled = false;
+          this.shareUrl = this.generateShareUrl(aposShareKey);
+        }
+      } catch {
+       await this.errorNotif();
       }
     },
     async errorNotif() {
@@ -169,8 +173,6 @@ export default {
         icon: 'alert-circle-icon',
         dismiss: true
       });
-
-      setTimeout(this.close, 500);
     },
     generateShareUrl(aposShareKey) {
       const qs = Object.fromEntries(

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -475,10 +475,18 @@ module.exports = {
           return self.revertPublishedToPrevious(req, published);
         },
         ':_id/share': async (req) => {
+          const draft = await self.getDraftToShare(req);
 
+          const shared = await self.share(req, draft);
+
+          return shared;
         },
         ':_id/unshare': async (req) => {
+          const draft = await self.getDraftToShare(req);
 
+          const unshared = await self.unshare(req, draft);
+
+          return unshared;
         }
       },
       get: {
@@ -2275,6 +2283,27 @@ database.`);
             }
           }
         });
+      },
+      async getDraftToShare(req) {
+        const { _id } = req.params;
+
+        if (!_id) {
+          throw self.apos.error('invalid');
+        }
+
+        const piece = await self.findOneForEditing(req, {
+          _id
+        });
+
+        if (!piece) {
+          throw self.apos.error('notfound');
+        }
+
+        if (piece.aposMode !== 'draft') {
+          throw self.apos.error('invalid');
+        }
+
+        return piece;
       }
     };
   },

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -473,6 +473,12 @@ module.exports = {
             throw self.apos.error('invalid');
           }
           return self.revertPublishedToPrevious(req, published);
+        },
+        ':_id/share': async (req) => {
+
+        },
+        ':_id/unshare': async (req) => {
+
         }
       },
       get: {

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -476,7 +476,7 @@ module.exports = {
         },
         ':_id/share': async (req) => {
           const { _id } = req.params;
-          const share = self.apos.launder(req.body.share);
+          const share = self.apos.launder.boolean(req.body.share);
 
           if (!_id) {
             throw self.apos.error('invalid');

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -441,7 +441,7 @@ module.exports = {
         },
         ':_id/share': async (req) => {
           const { _id } = req.params;
-          const share = self.apos.boolean(req.body.share);
+          const share = self.apos.launder.boolean(req.body.share);
 
           if (!_id) {
             throw self.apos.error('invalid');

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -438,6 +438,12 @@ module.exports = {
             throw self.apos.error('invalid');
           }
           return self.revertPublishedToPrevious(req, published);
+        },
+        ':_id/share': async (req) => {
+
+        },
+        ':_id/unshare': async (req) => {
+
         }
       }
     };

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -441,7 +441,7 @@ module.exports = {
         },
         ':_id/share': async (req) => {
           const { _id } = req.params;
-          const share = self.apos.launder(req.body.share);
+          const share = self.apos.boolean(req.body.share);
 
           if (!_id) {
             throw self.apos.error('invalid');

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -440,10 +440,19 @@ module.exports = {
           return self.revertPublishedToPrevious(req, published);
         },
         ':_id/share': async (req) => {
+          const draft = await self.getDraftToShare(req);
+
+          const shared = await self.share(req, draft);
+
+          return shared;
 
         },
         ':_id/unshare': async (req) => {
+          const draft = await self.getDraftToShare(req);
 
+          const unshared = await self.unshare(req, draft);
+
+          return unshared;
         }
       }
     };
@@ -944,6 +953,28 @@ module.exports = {
             throw self.apos.error('invalid', 'Document has neither slug nor title, giving up');
           }
         }
+      },
+
+      async getDraftToShare(req) {
+        const { _id } = req.params;
+
+        if (!_id) {
+          throw self.apos.error('invalid');
+        }
+
+        const piece = await self.findOneForEditing(req, {
+          _id
+        });
+
+        if (!piece) {
+          throw self.apos.error('notfound');
+        }
+
+        if (piece.aposMode !== 'draft') {
+          throw self.apos.error('invalid');
+        }
+
+        return piece;
       }
     };
   },


### PR DESCRIPTION
[PRO-2814](https://linear.app/apostrophecms/issue/PRO-2814/as-a-frontend-developer-i-can-invoke-a-draft-sharing-rest-api)

## Summary

Checks infos from the current document to see if it's sharable, otherwise close the modal and notify the user.
When toggling button, call the right API route to share or unshare a document, update url depending on the response.
Adds translation to manage error in notification

## What are the specific steps to test this change?
* Link branch in testbed (or another project)
* In a piece context menu click on `share draft`
* It should open the share draft modal disabled
* Try to enable it, it should create and url and allow to copy it through a link
* Close to modal, if you come back the share draft should be enabled when opening the modal
* When disabling enabling, the  `aposShareKey` should be new
* Do the same test for pages

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
