### PR TITLE
give preview access to a shared draft

### DIFF
--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1293,18 +1293,15 @@ module.exports = {
       builders: {
         transformDraftForSharing: {
           after(results) {
-            const { aposShareId, aposShareKey } = query.req.query;
-
-            if (
-              typeof aposShareId !== 'string' || !aposShareId.length ||
-              typeof aposShareKey !== 'string' || !aposShareKey.length
-            ) {
+            if (!self.isShareDraftRequest(query.req)) {
               return;
             }
 
+            const { aposShareId, aposShareKey } = query.req.query;
+
+            // Change drafts values to make it pass for a published document
             results.forEach(transformDraftToPublished);
 
-            // Change drafts values to make it pass for a published document.
             function transformDraftToPublished (result) {
               if (result._id === aposShareId && result.aposShareKey === aposShareKey) {
                 const changeToPublished = string => string.replace(':draft', ':published');
@@ -2145,8 +2142,6 @@ module.exports = {
               queryLocale = `${query.req.locale}:${query.req.mode}`;
             }
             if (queryLocale) {
-              const { aposShareId, aposShareKey } = query.req.query;
-
               const $or = [
                 {
                   aposLocale: queryLocale
@@ -2156,10 +2151,9 @@ module.exports = {
                 }
               ];
 
-              if (
-                typeof aposShareId === 'string' && aposShareId.length &&
-                typeof aposShareKey === 'string' && aposShareKey.length
-              ) {
+              if (self.isShareDraftRequest(query.req)) {
+                const { aposShareId, aposShareKey } = query.req.query;
+
                 $or.push({
                   _id: aposShareId,
                   aposShareKey,

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1222,7 +1222,7 @@ module.exports = {
         }
 
         const { aposShareKey: _aposShareKey, ...draft } = doc;
-        const aposShareKey = _aposShareKey || self.apos.util.generateId();
+        const aposShareKey = doc.aposShareKey || self.apos.util.generateId();
 
         await self.apos.doc.db.updateOne({
           _id: doc._id

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1304,11 +1304,7 @@ module.exports = {
 
             results.forEach(transformDraftToPublished);
 
-            /**
-             * Change drafts values to make it
-             * pass for a published document.
-             * @param {Object[]} result
-             */
+            // Change drafts values to make it pass for a published document.
             function transformDraftToPublished (result) {
               if (result._id === aposShareId && result.aposShareKey === aposShareKey) {
                 const changeToPublished = string => string.replace(':draft', ':published');

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -2160,7 +2160,10 @@ module.exports = {
                 }
               ];
 
-              if (typeof aposShareId === 'string' && typeof aposShareKey === 'string') {
+              if (
+                typeof aposShareId === 'string' && aposShareId.length &&
+                typeof aposShareKey === 'string' && aposShareKey.length
+              ) {
                 $or.push({
                   _id: aposShareId,
                   aposShareKey,

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -2456,7 +2456,6 @@ module.exports = {
           await query.finalize();
           const criteria = query.get('criteria');
           const lateCriteria = query.get('lateCriteria');
-          // console.log(require('util').inspect(criteria, { depth: 5, colors: true }));
           if (lateCriteria) {
             _.assign(criteria, lateCriteria);
           }

--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -809,7 +809,6 @@ module.exports = {
       removeUserForDraftSharing: {
         before: '@apostrophecms/i18n',
         middleware(req, res, next) {
-          console.log(req.query);
           if (req.query.aposShareId || req.query.aposShareKey) {
             delete req.user;
           }

--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -816,6 +816,7 @@ module.exports = {
             typeof aposShareId === 'string' && aposShareId.length &&
             typeof aposShareKey === 'string' && aposShareKey.length
           ) {
+            // TODO: test when connected that UI is removed
             delete req.user;
           }
           return next();

--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -811,6 +811,7 @@ module.exports = {
         middleware(req, res, next) {
           const { aposShareId, aposShareKey } = req.query;
 
+          // Remove user to hide the admin UI, in order to simulate a logged-out page view
           if (
             typeof aposShareId === 'string' && aposShareId.length &&
             typeof aposShareKey === 'string' && aposShareKey.length

--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -811,7 +811,10 @@ module.exports = {
         middleware(req, res, next) {
           const { aposShareId, aposShareKey } = req.query;
 
-          if (typeof aposShareId === 'string' && typeof aposShareKey === 'string') {
+          if (
+            typeof aposShareId === 'string' && aposShareId.length &&
+            typeof aposShareKey === 'string' && aposShareKey.length
+          ) {
             delete req.user;
           }
           return next();

--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -806,6 +806,16 @@ module.exports = {
           return (req, res, next) => req.user ? next() : passportSession(req, res, next);
         })()
       },
+      removeUserForDraftSharing: {
+        before: '@apostrophecms/i18n',
+        middleware(req, res, next) {
+          console.log(req.query);
+          if (req.query.aposShareId || req.query.aposShareKey) {
+            delete req.user;
+          }
+          return next();
+        }
+      },
       honorLoginInvalidBefore: {
         before: '@apostrophecms/i18n',
         middleware(req, res, next) {

--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -809,7 +809,9 @@ module.exports = {
       removeUserForDraftSharing: {
         before: '@apostrophecms/i18n',
         middleware(req, res, next) {
-          if (req.query.aposShareId || req.query.aposShareKey) {
+          const { aposShareId, aposShareKey } = req.query;
+
+          if (typeof aposShareId === 'string' && typeof aposShareKey === 'string') {
             delete req.user;
           }
           return next();

--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -816,7 +816,6 @@ module.exports = {
             typeof aposShareId === 'string' && aposShareId.length &&
             typeof aposShareKey === 'string' && aposShareKey.length
           ) {
-            // TODO: test when connected that UI is removed
             delete req.user;
           }
           return next();

--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -809,13 +809,8 @@ module.exports = {
       removeUserForDraftSharing: {
         before: '@apostrophecms/i18n',
         middleware(req, res, next) {
-          const { aposShareId, aposShareKey } = req.query;
-
           // Remove user to hide the admin UI, in order to simulate a logged-out page view
-          if (
-            typeof aposShareId === 'string' && aposShareId.length &&
-            typeof aposShareKey === 'string' && aposShareKey.length
-          ) {
+          if (self.isShareDraftRequest(req)) {
             delete req.user;
           }
           return next();

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -746,6 +746,17 @@ module.exports = {
         }
       },
 
+      isShareDraftRequest(req) {
+        const { aposShareId, aposShareKey } = req.query;
+
+        return (
+          typeof aposShareId === 'string' &&
+          aposShareId.length &&
+          typeof aposShareKey === 'string' &&
+          aposShareKey.length
+        );
+      },
+
       // Merge in the event emitter / responder capabilities
       ...require('./lib/events.js')(self)
     };

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -140,7 +140,9 @@ module.exports = {
               }
             };
           } else {
-            return {
+            const { aposShareId, aposShareKey } = req.query;
+
+            const query = {
               aposMode: {
                 $in: [ null, 'published' ]
               },
@@ -149,6 +151,24 @@ module.exports = {
                 $nin: restrictedViewTypes
               }
             };
+
+            if (typeof aposShareId === 'string' && typeof aposShareKey === 'string') {
+              const { aposMode, ...rest } = query;
+
+              return {
+                $or: [
+                  { aposMode },
+                  {
+                    aposMode: 'draft',
+                    _id: aposShareId,
+                    aposShareKey: aposShareKey
+                  }
+                ],
+                ...rest
+              };
+            }
+
+            return query;
           }
         } else if (action === 'edit') {
           if (role === 'contributor') {

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -140,8 +140,6 @@ module.exports = {
               }
             };
           } else {
-            const { aposShareId, aposShareKey } = req.query;
-
             const query = {
               aposMode: {
                 $in: [ null, 'published' ]
@@ -152,10 +150,8 @@ module.exports = {
               }
             };
 
-            if (
-              typeof aposShareId === 'string' && aposShareId.length &&
-              typeof aposShareKey === 'string' && aposShareKey.length
-            ) {
+            if (self.isShareDraftRequest(req)) {
+              const { aposShareId, aposShareKey } = req.query;
               const { aposMode, ...rest } = query;
 
               return {
@@ -163,9 +159,9 @@ module.exports = {
                 $or: [
                   { aposMode },
                   {
-                    aposMode: 'draft',
                     _id: aposShareId,
-                    aposShareKey: aposShareKey
+                    aposShareKey,
+                    aposMode: 'draft'
                   }
                 ],
                 // We do not want the published version of the document

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -168,6 +168,9 @@ module.exports = {
                     aposShareKey: aposShareKey
                   }
                 ],
+                // We do not want the published version of the document
+                // in the case where we want to access the draft with a
+                // public URL:
                 $and: [
                   {
                     _id: {

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -152,7 +152,10 @@ module.exports = {
               }
             };
 
-            if (typeof aposShareId === 'string' && typeof aposShareKey === 'string') {
+            if (
+              typeof aposShareId === 'string' && aposShareId.length &&
+              typeof aposShareKey === 'string' && aposShareKey.length
+            ) {
               const { aposMode, ...rest } = query;
 
               return {

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -167,13 +167,9 @@ module.exports = {
                 // We do not want the published version of the document
                 // in the case where we want to access the draft with a
                 // public URL:
-                $and: [
-                  {
-                    _id: {
-                      $ne: aposShareId.replace(':draft', ':published')
-                    }
-                  }
-                ]
+                _id: {
+                  $ne: aposShareId.replace(':draft', ':published')
+                }
               };
             }
 

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -156,6 +156,7 @@ module.exports = {
               const { aposMode, ...rest } = query;
 
               return {
+                ...rest,
                 $or: [
                   { aposMode },
                   {
@@ -164,7 +165,13 @@ module.exports = {
                     aposShareKey: aposShareKey
                   }
                 ],
-                ...rest
+                $and: [
+                  {
+                    _id: {
+                      $ne: aposShareId.replace(':draft', ':published')
+                    }
+                  }
+                ]
               };
             }
 

--- a/modules/@apostrophecms/soft-redirect/index.js
+++ b/modules/@apostrophecms/soft-redirect/index.js
@@ -37,12 +37,12 @@ module.exports = {
     return {
       '@apostrophecms/page:notFound': {
         async notFoundRedirect(req) {
-          const url = new URL(`${req.baseUrl}${req.url}`);
+          const urlPathname = req.url.replace(/\?.*$/, '');
 
           const doc = await self.apos.doc
             .find(req, {
               historicUrls: {
-                $in: [ url.pathname ]
+                $in: [ urlPathname ]
               }
             })
             .sort({ updatedAt: -1 })

--- a/modules/@apostrophecms/soft-redirect/index.js
+++ b/modules/@apostrophecms/soft-redirect/index.js
@@ -38,11 +38,8 @@ module.exports = {
       '@apostrophecms/page:notFound': {
         async notFoundRedirect(req) {
           const url = new URL(`${req.baseUrl}${req.url}`);
+
           const doc = await self.apos.doc.find(req, { historicUrls: { $in: [ url.pathname ] } }).sort({ updatedAt: -1 }).toObject();
-          console.log('-----------------------------');
-          console.log(doc);
-          console.log('-----------------------------');
-          // TODO: handle the fact that doc._url is not defined
           if (!(doc && doc._url)) {
             return;
           }

--- a/modules/@apostrophecms/soft-redirect/index.js
+++ b/modules/@apostrophecms/soft-redirect/index.js
@@ -37,7 +37,12 @@ module.exports = {
     return {
       '@apostrophecms/page:notFound': {
         async notFoundRedirect(req) {
-          const doc = await self.apos.doc.find(req, { historicUrls: { $in: [ req.url ] } }).sort({ updatedAt: -1 }).toObject();
+          const url = new URL(`${req.baseUrl}${req.url}`);
+          const doc = await self.apos.doc.find(req, { historicUrls: { $in: [ url.pathname ] } }).sort({ updatedAt: -1 }).toObject();
+          console.log('-----------------------------');
+          console.log(doc);
+          console.log('-----------------------------');
+          // TODO: handle the fact that doc._url is not defined
           if (!(doc && doc._url)) {
             return;
           }

--- a/modules/@apostrophecms/soft-redirect/index.js
+++ b/modules/@apostrophecms/soft-redirect/index.js
@@ -39,7 +39,14 @@ module.exports = {
         async notFoundRedirect(req) {
           const url = new URL(`${req.baseUrl}${req.url}`);
 
-          const doc = await self.apos.doc.find(req, { historicUrls: { $in: [ url.pathname ] } }).sort({ updatedAt: -1 }).toObject();
+          const doc = await self.apos.doc
+            .find(req, {
+              historicUrls: {
+                $in: [ url.pathname ]
+              }
+            })
+            .sort({ updatedAt: -1 })
+            .toObject();
           if (!(doc && doc._url)) {
             return;
           }

--- a/test/modules/test-page/views/page.html
+++ b/test/modules/test-page/views/page.html
@@ -1,8 +1,13 @@
-<h3>Sing to me, Oh Muse.</h3>
+{% extends data.outerLayout %}
 
+{% block main %}
+  <title>{{ data.page.title }}</title>
 
-<a href="{{ data.home._url }}">Home: {{ data.home.slug }}</a>
+  <h3>Sing to me, Oh Muse.</h3>
 
-{% for tab in data.home._children %}
-  <a href="{{ tab._url }}">Tab: {{ tab.slug }}</a>
-{% endfor %}
+  <a href="{{ data.home._url }}">Home: {{ data.home.slug }}</a>
+
+  {% for tab in data.home._children %}
+    <a href="{{ tab._url }}">Tab: {{ tab.slug }}</a>
+  {% endfor %}
+{% endblock %}

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -1719,6 +1719,10 @@ describe('Pieces', function() {
         apos.task.getReq({ mode: 'draft' }),
         { _id: 'some-product:en:draft' }
       );
+      await apos.modules.product.update(req, {
+        ...previousDraft,
+        title: 'Some Product EDITED'
+      });
     });
 
     this.afterEach(async function() {
@@ -1727,10 +1731,6 @@ describe('Pieces', function() {
 
     describe('share', function() {
       this.beforeEach(async function() {
-        await apos.modules.product.update(req, {
-          ...previousDraft,
-          title: 'Some Product EDITED'
-        });
         shareResponse = await apos.modules.product.share(req, previousDraft);
       });
 
@@ -1791,10 +1791,6 @@ describe('Pieces', function() {
 
     describe('unshare', function() {
       this.beforeEach(async function() {
-        await apos.modules.product.update(req, {
-          ...previousDraft,
-          title: 'Some Product EDITED'
-        });
         shareResponse = await apos.modules.product.share(req, previousDraft);
       });
 

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -1764,6 +1764,18 @@ describe('Pieces', function() {
         assert(publicResponse.body.includes('Some Product EDITED'));
       });
 
+      it('should grant public access to a draft without admin UI, even when logged-in', async function() {
+        const publicUrl = generatePublicUrl(shareResponse);
+        const publicResponse = await apos.http.get(publicUrl, {
+          fullResponse: true,
+          jar
+        });
+
+        assert(publicResponse.status === 200);
+        assert(publicResponse.body.includes('Some Product EDITED'));
+        assert(!publicResponse.body.includes('apos-admin-bar'));
+      });
+
       it('should grant public access to a draft after having re-enabled draft sharing', async function() {
         await apos.modules.product.unshare(req, previousDraft);
 

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -1763,6 +1763,18 @@ describe('Pieces', function() {
         assert(publicResponse.status === 200);
         assert(publicResponse.body.includes('Some Product EDITED'));
       });
+
+      it('should grant public access to a draft after having re-enabled draft sharing', async function() {
+        await apos.modules.product.unshare(req, previousDraft);
+
+        const shareResponse = await apos.modules.product.share(req, previousDraft);
+        const publicUrl = generatePublicUrl(shareResponse);
+
+        const publicResponse = await apos.http.get(publicUrl, { fullResponse: true });
+
+        assert(publicResponse.status === 200);
+        assert(publicResponse.body.includes('Some Product EDITED'));
+      });
     });
 
     describe('unshare', function() {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Grant access to the preview of a shared draft.

To do this, provided that the URL query string contains the right key, we hide the admin UI by removing the user from `req`, we edit mongo criteria to force-fetch the draft, and we transform the draft data to make it pass for a published doc.

## What are the specific steps to test this change?

- edit a piece (article for instance, and check that a Article Piece Index page has been created first)
- enable the draft sharing option
- use the URL
  - while logged-in 👉 you should see your last modification (not yet published), without any admin UI
  - while logged-out 👉 you should see your last modification (not yet published)
- do the same for a page

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
