### PR TITLE
follow symlinked directories when expanding ** patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * Fix missing title translation in the "Array Editor" component.
+* Add `follow: true` flag to `glob` functions (with `**` pattern) to allow registering symlink files and folders for nested modules
 
 ## 3.23.0 (2022-06-22)
 

--- a/index.js
+++ b/index.js
@@ -371,7 +371,7 @@ async function apostrophe(options, telemetry, rootSpan) {
     if (!options.nestedModuleSubdirs) {
       return;
     }
-    const configs = glob.sync(self.localModules + '/**/modules.js');
+    const configs = glob.sync(self.localModules + '/**/modules.js', { follow: true });
     _.each(configs, function(config) {
       try {
         _.merge(self.options.modules, require(config));

--- a/lib/moog-require.js
+++ b/lib/moog-require.js
@@ -60,7 +60,7 @@ module.exports = function(options) {
         // Fetching a list of index.js files on the first call and then searching it each time for
         // one that refers to the right type name shaves as much as 60 seconds off the startup
         // time in a large project, compared to using the glob cache feature
-        self._indexes = glob.sync(self.options.localModules + '/**/index.js');
+        self._indexes = glob.sync(self.options.localModules + '/**/index.js', { follow: true });
       }
       const matches = self._indexes.filter(function(index) {
         // Double-check that we're not confusing "@apostrophecms/asset" with "asset" by


### PR DESCRIPTION
## Summary

I am using symlinks in a project. A module inside `modules` folder has other nested modules. Without the `follow: true` flag, `glob` package does not register the nested modules during Apostrophe's module initialisation.

## What are the specific steps to test this change?

*For example:*
> 1. Add a symlink folder inside `modules` folder
> 2. Add nested modules
> 3. Register nested modules inside `modules.js`

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other