### PR TITLE
Make __t() globally available per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * Fix missing title translation in the "Array Editor" component.
+* Bring back support for i18n inside macros (`__t()` can be used inside macros again).
 
 ## 3.23.0 (2022-06-22)
 

--- a/modules/@apostrophecms/template/index.js
+++ b/modules/@apostrophecms/template/index.js
@@ -346,6 +346,8 @@ module.exports = {
           // no guarantee newEnv will be called for every req
           self.envs[name] = self.newEnv(req, name, self.getViewFolders(module));
         }
+        // i18n is available per request
+        self.envs[name].addGlobal('__t', req.t);
         return self.envs[name];
       },
 

--- a/modules/@apostrophecms/template/index.js
+++ b/modules/@apostrophecms/template/index.js
@@ -256,6 +256,10 @@ module.exports = {
         const args = self.getRenderArgs(req, data, module);
 
         const env = self.getEnv(req, module);
+        // i18n is globally available per request.
+        // We consider this a "render entry point", all context based
+        // code gets access to the arguments bellow as global context.
+        env.addGlobal('__t', args.__t);
 
         if (type === 'file') {
           let finalName = s;
@@ -346,8 +350,7 @@ module.exports = {
           // no guarantee newEnv will be called for every req
           self.envs[name] = self.newEnv(req, name, self.getViewFolders(module));
         }
-        // i18n is available per request
-        self.envs[name].addGlobal('__t', req.t);
+
         return self.envs[name];
       },
 

--- a/test/modules/fragment-all/views/i18n.html
+++ b/test/modules/fragment-all/views/i18n.html
@@ -1,0 +1,8 @@
+{% extends data.outerLayout %}
+{% import "macro.html" as m %}
+
+{% block main %}
+--i18n_macro--
+{{ m.i18nTest() }}
+--endi18n_macro--
+{% endblock %}

--- a/test/modules/fragment-all/views/macro.html
+++ b/test/modules/fragment-all/views/macro.html
@@ -1,3 +1,7 @@
 {% macro print(text) %}
   {{ text }}
 {% endmacro %}
+
+{% macro i18nTest() %}
+  {{ __t('apostrophe:modifyOrDelete') }}
+{% endmacro %}

--- a/test/templates.js
+++ b/test/templates.js
@@ -303,4 +303,14 @@ describe('Templates', function() {
     assert(result.includes('Modify / Delete'));
   });
 
+  it('should has global __t() available in macros', async function() {
+    const req = apos.task.getReq();
+    const result = await apos.modules['fragment-all'].renderPage(req, 'i18n');
+
+    const data = parseOutput(result, 'i18n_macro');
+    assert.deepStrictEqual(data, [
+      'Modify / Delete'
+    ]);
+  });
+
 });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

This patch adds the `__t()` as global helper so that it is available for macros too. This is possible because `getEnv()` handler receives a real request object when called by our parsers on request. This should be 100% backward compatible change - the fragments are using custom context which takes precedence over the global context. 

## What are the specific steps to test this change?

Use `{{ __t('Some phrase') }}` inside a macro. It should render properly (with no parse errors).

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

