### PR TITLE
handle private locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Adds
 
 * Add `showPermissions` options set to false to the `polymorphic` module.
-* Handle `private: true` locale option in i18n module, preventing logged out users from accessing the content in a private locale.
+* Handle `private: true` locale option in i18n module, preventing logged out users from accessing the content of a private locale.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Adds
 
 * Add `showPermissions` options set to false to the `polymorphic` module.
+* Handle `private: true` locale option in i18n module, preventing logged out users from accessing the content in a private locale.
 
 ### Fixes
 

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -638,9 +638,9 @@ module.exports = {
         return req.user
           ? locales
           : Object.fromEntries(
-            Object.entries(locales)
+            Object
+              .entries(locales)
               .filter(([ name, options ]) => options.private !== true)
-              .map(([ name, options ]) => [ name, options ])
           );
       }
     };

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -637,12 +637,11 @@ module.exports = {
       filterPrivateLocales(req, locales) {
         return req.user
           ? locales
-          : Object.entries(locales)
-            .filter(([ name, options ]) => options.private !== true)
-            .reduce((memo, [ name, options ]) => ({
-              ...memo,
-              [name]: options
-            }), {});
+          : Object.fromEntries(
+            Object.entries(locales)
+              .filter(([ name, options ]) => options.private !== true)
+              .map(([ name, options ]) => [ name, options ])
+          );
       }
     };
   }

--- a/test/pages.js
+++ b/test/pages.js
@@ -1229,10 +1229,11 @@ describe('Pages', function() {
         try {
           const publicUrl = generatePublicUrl(shareResponse);
           await apos.http.get(publicUrl, { fullResponse: true });
-          throw new Error('should have thrown 404 error');
         } catch (error) {
           assert(error.status === 404);
+          return;
         }
+        throw new Error('should have thrown 404 error');
       });
     });
   });

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -1818,10 +1818,11 @@ describe('Pieces', function() {
         try {
           const publicUrl = generatePublicUrl(shareResponse);
           await apos.http.get(publicUrl, { fullResponse: true });
-          throw new Error('should have thrown 404 error');
         } catch (error) {
           assert(error.status === 404);
+          return;
         }
+        throw new Error('should have thrown 404 error');
       });
     });
   });

--- a/test/static-i18n.js
+++ b/test/static-i18n.js
@@ -92,7 +92,7 @@ describe('static i18n', function() {
     assert.strictEqual(browserData.i18n.en.custom.customTestOne, 'Custom Test One From Subtype');
   });
 
-  it('should return a 404 HTTP error code when a logged out user tries to access to a private locale', async function() {
+  it('should return a 404 HTTP error code when a logged out user tries to access to a content in a private locale', async function() {
     try {
       await apos.http.get('/es');
     } catch (error) {

--- a/test/static-i18n.js
+++ b/test/static-i18n.js
@@ -21,6 +21,10 @@ describe('static i18n', function() {
               en: {},
               fr: {
                 prefix: '/fr'
+              },
+              es: {
+                prefix: '/es',
+                private: true
               }
             }
           }
@@ -86,6 +90,16 @@ describe('static i18n', function() {
   it('should honor the browser: true flag in the i18n section of an index.js file', function() {
     const browserData = apos.i18n.getBrowserData(apos.task.getReq());
     assert.strictEqual(browserData.i18n.en.custom.customTestOne, 'Custom Test One From Subtype');
+  });
+
+  it('should return a 404 HTTP error code when a logged out user tries to access to a private locale', async function() {
+    try {
+      await apos.http.get('/es');
+    } catch (error) {
+      assert(error.status === 404);
+      return;
+    }
+    throw new Error('should have thrown 404 error');
   });
 
 });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

If a locale has a `private: true` option, accessing to the content in that locale while logged out will result in a 404.

## What are the specific steps to test this change?

Link `apostrophe` into a project.
In the project, configure `@apostrophecms/i18n` module with one or several locales with the `private: true` option:

![image](https://user-images.githubusercontent.com/8301962/175975897-99539447-fc21-444c-8643-b1414db05f48.png)

While logged in, you should be able to access to the private locales, but not logged out.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
