### PR TITLE
handle default array items in array editor modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add `follow: true` flag to `glob` functions (with `**` pattern) to allow registering symlink files and folders for nested modules
 * Fix disabled context menu for relationship fields editing ([#3820](https://github.com/apostrophecms/apostrophe/issues/3820))
 * In getReq method form the task module, extract the right `role` property from the options object.
+* Fix `def:` option in `array` fields, in order to be able to see the default items in the array editor modal
 
 ## 3.23.0 (2022-06-22)
 

--- a/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
@@ -113,6 +113,12 @@ export default {
   },
   emits: [ 'modal-result', 'safe-close' ],
   data() {
+    // Automatically add `_id` to default items
+    const items = this.items.map(item => ({
+      ...item,
+      _id: item._id || cuid()
+    }));
+
     return {
       currentId: null,
       currentDoc: null,
@@ -129,8 +135,8 @@ export default {
       // If we don't clone, then we're making
       // permanent modifications whether the user
       // clicks save or not
-      next: klona(this.items),
-      original: klona(this.items),
+      next: klona(items),
+      original: klona(items),
       triggerValidation: false,
       minError: false,
       maxError: false,


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

The `def` items were not displayed in the UI because they were missing an `_id`.

## What are the specific steps to test this change?

Link `apostrophe` into an A3 project, and add default items to an array field type, as below:

```js
people: {
  type: 'array',
  fields: {
    add: {
      firstName: {
        type: 'string'
      },
      lastName: {
        type: 'string'
      }
    }
  },
  def: [
    {
      firstName: 'Jane',
      lastName: 'Doe'
    },
    {
      firstName: 'Saul',
      lastName: 'Goodman'
    }
  ]
}
```

The 2 items above should be added by default:

![image](https://user-images.githubusercontent.com/8301962/176163267-c830b2ae-4b16-4e71-b21b-e0bd3f9463db.png)

Saving a doc without having edited the array field will still store the default fields:

<img width="326" alt="image" src="https://user-images.githubusercontent.com/8301962/176163583-a139fa75-c1a0-4680-8a1a-f13f100e3673.png">

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
