### PR TITLE
PRO-2928: Fix missing Vue binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Fix missing title translation in the "Array Editor" component.
 * Add `follow: true` flag to `glob` functions (with `**` pattern) to allow registering symlink files and folders for nested modules
+* Fix disabled context menu for relationship fields editing ([#3820](https://github.com/apostrophecms/apostrophe/issues/3820))
 
 ## 3.23.0 (2022-06-22)
 

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
@@ -34,7 +34,7 @@
           @item-clicked="$emit('item-clicked', item)"
           menu-placement="bottom-start"
           menu-offset="40, 10"
-          disabled="disabled"
+          :disabled="disabled"
         />
         <AposButton
           class="apos-slat__editor-btn"
@@ -48,7 +48,7 @@
           :icon-only="true"
           :modifiers="['inline']"
           @click="$emit('item-clicked', item)"
-          disabled="disabled"
+          :disabled="disabled"
         />
         <a
           class="apos-slat__control apos-slat__control--view"
@@ -169,7 +169,7 @@ export default {
   },
   computed: {
     itemSize() {
-      const size = this.item.length.size;
+      const size = this.item.length?.size;
       if (size < 1000000) {
         return `${(size / 1000).toFixed(0)}KB`;
       } else {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

This patches disabled context menu for relationship editing as reported in #3820.
Optional chaining added in order to not break the Vue Devtools while debugging.

Closes PRO-2928, Closes #3820

## What are the specific steps to test this change?

Follow the steps to reproduce from the original report #3820. The context menu in question should be enabled.

## What kind of change does this PR introduce?
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [] Related documentation has been updated
- [x] Related tests have been updated

