### PR TITLE
Permission options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 ## Unreleased
 
+## Adds
+
+* Add `showPermissions` options set to false to `polymorphic` module.
+
 ### Fixes
 
 * Fix missing title translation in the "Array Editor" component.
 * Add `follow: true` flag to `glob` functions (with `**` pattern) to allow registering symlink files and folders for nested modules
 * Fix disabled context menu for relationship fields editing ([#3820](https://github.com/apostrophecms/apostrophe/issues/3820))
+* In getReq method form the task module, extract the right `role` property from the options object.
 
 ## 3.23.0 (2022-06-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## Adds
+### Adds
 
 * Add `showPermissions` options set to false to the `polymorphic` module.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Adds
 
-* Add `showPermissions` options set to false to `polymorphic` module.
+* Add `showPermissions` options set to false to the `polymorphic` module.
 
 ### Fixes
 

--- a/modules/@apostrophecms/polymorphic-type/index.js
+++ b/modules/@apostrophecms/polymorphic-type/index.js
@@ -2,7 +2,10 @@ const _ = require('lodash');
 
 module.exports = {
   extend: '@apostrophecms/doc-type',
-  options: { name: '@apostrophecms/polymorphic' },
+  options: {
+    name: '@apostrophecms/polymorphic',
+    showPermissions: false
+  },
   routes(self) {
     return {
       post: {

--- a/modules/@apostrophecms/task/index.js
+++ b/modules/@apostrophecms/task/index.js
@@ -287,9 +287,11 @@ module.exports = {
         };
         addCloneMethod(req);
         req.res.__ = req.__;
-        const { _role, ...properties } = options || {};
+        const { role: _role, ...properties } = options || {};
+
         Object.assign(req, properties);
         self.apos.i18n.setPrefixUrls(req);
+
         return req;
 
         function addCloneMethod(req) {


### PR DESCRIPTION
Useful for this ticket [PRO-2881](https://linear.app/apostrophecms/issue/PRO-2881/getcontenttypesreq-method-of-advanced-permissions)

## Summary

Adds the `showPermissions` options set to false to the `polymorhic` module.
Fixes the getReq method, extract the right `role` property from the options.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

