### PR TITLE
PRO-2956: fix bug preventing two caches from having a key by the same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+## Fixes
+
+* Previously, cache objects returned by `apos.caches.get` shared an incorrectly configured unique key index that prevented the same key from existing in two caches. This did not lead to any data integrity problems, because it was too strict rather than not strict enough. In this release the offending index is replaced with a correct one, which must be unique only on a combination of `name` (the cache name) and `key`, and unit test coverage is added to prevent a recurrence.
+
 ## 2.221.1 (2022-06-22)
 
 ## Fixes

--- a/lib/modules/apostrophe-caches/index.js
+++ b/lib/modules/apostrophe-caches/index.js
@@ -16,6 +16,7 @@ module.exports = {
 
   afterConstruct: function(self, callback) {
     self.addClearCacheTask();
+    self.removeBadIndexMigration();
     return self.getCollection(function(err) {
       if (err) {
         return callback(err);
@@ -213,7 +214,7 @@ module.exports = {
     self.ensureIndexes = function(callback) {
       return async.series({
         keyIndex: function(callback) {
-          return self.cacheCollection.ensureIndex({ key: 1, cache: 1 }, { unique: true }, callback);
+          return self.cacheCollection.ensureIndex({ key: 1, name: 1 }, { unique: true }, callback);
         },
         expireIndex: function(callback) {
           return self.cacheCollection.ensureIndex({ expires: 1 }, { expireAfterSeconds: 0 }, callback);
@@ -241,6 +242,27 @@ module.exports = {
           return self.clearCacheTask(argv, callback);
         }
       );
+    };
+
+    self.removeBadIndexMigration = function() {
+      // Cache module wakes before migrations module so we have to wait
+      // for apostrophe:modulesReady before registering the migration. Most modules
+      // can register one directly from afterConstruct
+      self.on('apostrophe:modulesReady', 'addRemoveBadIndexMigration', function() {
+        self.apos.migrations.add(self.__meta.name + '.removeBadIndex', async function() {
+          const indexes = await self.cacheCollection.indexes();
+          const culprit = indexes.find(index => index.key &&
+            (Object.keys(index.key).length === 2) &&
+            index.key.key &&
+            index.key.cache &&
+            index.unique
+          );
+          if (culprit) {
+            self.apos.utils.log('Removing incorrect cache index');
+            return self.cacheCollection.dropIndex(culprit.name);
+          }
+        });
+      });
     };
   }
 };

--- a/test/caches.js
+++ b/test/caches.js
@@ -11,6 +11,8 @@ describe('Caches', function() {
 
   var apos;
   var cache;
+  let cache2;
+
   it('should exist on the apos object', function(done) {
     apos = require('../index.js')({
       root: module,
@@ -116,5 +118,32 @@ describe('Caches', function() {
         assert(!monkey);
         return true;
       });
+  });
+  it('should give us a second, independent cache object', function() {
+    cache2 = apos.caches.get('testMonkeys2');
+  });
+  it('cache 1 should allow us to store capuchin', function() {
+    return cache.set('capuchin', { message: 'eek eek' });
+  });
+  it('cache 2 should allow us to store capuchin with another message', function() {
+    return cache2.set('capuchin', { message: 'ook ook' });
+  });
+  it('cache 1 should contain its unique message', async function() {
+    assert.strictEqual((await cache.get('capuchin')).message, 'eek eek');
+  });
+  it('cache 2 should contain its unique message', async function() {
+    assert.strictEqual((await cache2.get('capuchin')).message, 'ook ook');
+  });
+  it('unique index still prevents double insert of key within a namespace', async function() {
+    try {
+      await apos.caches.cacheCollection.insert({
+        key: 'capuchin',
+        name: 'testMonkeys'
+      });
+      // That's bad, unique index should have stopped us
+      assert(false);
+    } catch (e) {
+      // This is what we wanted to happen
+    }
   });
 });


### PR DESCRIPTION
…name

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Fix bug preventing two caches from having a key by the same name

## What are the specific steps to test this change?

* `npx mocha test/caches.js` should pass (in a proper checkout of this branch in which `npm install` has been completed)
* Project-level code in which two differently named caches have a key with the same name should work properly

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [X] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
