### PR TITLE
Change area menu layout to a grid - to better space out widget items at higher quantities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fix disabled context menu for relationship fields editing ([#3820](https://github.com/apostrophecms/apostrophe/issues/3820))
 * In getReq method form the task module, extract the right `role` property from the options object.
 * Fix `def:` option in `array` fields, in order to be able to see the default items in the array editor modal
+* Change area menu layout to a grid - to better space out widget items at higher quantities
 
 ## 3.23.0 (2022-06-22)
 

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
@@ -11,10 +11,9 @@
     >
       <ul class="apos-area-menu__wrapper">
         <li
-          class="apos-area-menu__item"
+          :class="[item.type ? 'apos-area-menu__item--separated' : 'apos-area-menu__item', item.items ? 'apos-has-group' : '']"
           v-for="(item, itemIndex) in myMenu"
           :key="item.type ? `${item.type}_${item.label}` : item.label"
-          :class="{'apos-has-group': item.items}"
           :ref="`item-${itemIndex}`"
         >
           <dl v-if="item.items" class="apos-area-menu__group">
@@ -296,6 +295,9 @@ export default {
 
 .apos-area-menu__wrapper {
   min-width: 250px;
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-rows: repeat(6, minmax(0, 1fr));
 }
 
 .apos-area-menu__button {
@@ -368,6 +370,11 @@ export default {
 .apos-area-menu__item:last-child.apos-has-group .apos-area-menu__group {
   border-bottom: none;
   margin-bottom: 0;
+}
+
+.apos-area-menu__item--separated {
+  grid-row: 1 / -1;
+  border-right: 1px solid var(--a-base-9);
 }
 
 .apos-area-menu__items--accordion {

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaMenuItem.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaMenuItem.vue
@@ -1,7 +1,6 @@
 <template>
   <button
     @click="click" class="apos-area-menu__button"
-    :class="{ 'apos-area-menu__button--separated': item.type }"
     :data-action="item.name"
     :tabindex="String(tabindex)"
     @keydown.prevent.arrow-down="$emit('down')"
@@ -57,12 +56,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .apos-area-menu__button--separated {
-    margin-bottom: 10px;
-    padding-bottom: 10px;
-    border-bottom: 1px solid var(--a-base-9);
-  }
-
   .apos-area-menu__item-icon {
     @include apos-align-icon();
     margin-right: 10px;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Just a little UI update to the Area widget menu/list using CSS grid layout. I found out that after having more than 8-10 widgets, the list becomes vertically a bit too long. Additional scrolling is necessary to have it properly in the view.*

| From:  | To: |
| ------------- | ------------- |
| <img width="273" alt="Screenshot 2022-04-12 at 12 40 56" src="https://user-images.githubusercontent.com/47005900/162954555-68863af7-09f9-4b93-866c-784102c3558d.png">  | <img width="530" alt="Screenshot 2022-04-12 at 12 28 09" src="https://user-images.githubusercontent.com/47005900/162954798-4c870a6f-f3b6-4816-a874-e65716b9beb2.png">  |

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated