### PR TITLE
checkboxes and radios support choice fns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Radio and Checkboxes schema inputs now support a server side `choices` function for supplying their choices array, like selects currently support.
 
 ### Adds
 

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1466,7 +1466,6 @@ module.exports = {
           let choices = [];
           if (
             !field ||
-            field.type !== 'select' ||
             !(field.choices && typeof field.choices === 'string')
           ) {
             throw self.apos.error('invalid');

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputCheckboxes.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputCheckboxes.vue
@@ -8,7 +8,7 @@
     <template #body>
       <AposCheckbox
         :for="getChoiceId(uid, choice.value)"
-        v-for="choice in field.choices"
+        v-for="choice in choices"
         :key="choice.value"
         :id="getChoiceId(uid, choice.value)"
         :choice="choice"
@@ -21,10 +21,11 @@
 
 <script>
 import AposInputMixin from 'Modules/@apostrophecms/schema/mixins/AposInputMixin';
+import AposInputChoicesMixin from 'Modules/@apostrophecms/schema/mixins/AposInputChoicesMixin';
 
 export default {
   name: 'AposInputCheckboxes',
-  mixins: [ AposInputMixin ],
+  mixins: [ AposInputMixin, AposInputChoicesMixin ],
   beforeMount: function () {
     this.value.data = Array.isArray(this.value.data) ? this.value.data : [];
   },
@@ -38,7 +39,7 @@ export default {
     },
     validate(values) {
       // The choices and values should always be arrays.
-      if (!Array.isArray(this.field.choices) || !Array.isArray(values)) {
+      if (!Array.isArray(this.choices) || !Array.isArray(values)) {
         return 'malformed';
       }
 
@@ -48,7 +49,7 @@ export default {
 
       if (Array.isArray(values)) {
         values.forEach(chosen => {
-          if (!this.field.choices.map(choice => {
+          if (!this.choices.map(choice => {
             return choice.value;
           }).includes(chosen)) {
             return 'invalid';

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRadio.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRadio.vue
@@ -8,7 +8,7 @@
     <template #body>
       <label
         class="apos-choice-label" :for="getChoiceId(uid, choice.value)"
-        v-for="choice in field.choices" :key="choice.value"
+        v-for="choice in choices" :key="choice.value"
         :class="{'apos-choice-label--disabled': field.readOnly}"
       >
         <input
@@ -43,12 +43,13 @@
 
 <script>
 import AposInputMixin from 'Modules/@apostrophecms/schema/mixins/AposInputMixin';
+import AposInputChoicesMixin from 'Modules/@apostrophecms/schema/mixins/AposInputChoicesMixin';
 import InformationIcon from 'vue-material-design-icons/Information.vue';
 
 export default {
   name: 'AposInputRadio',
   components: { InformationIcon },
-  mixins: [ AposInputMixin ],
+  mixins: [ AposInputMixin, AposInputChoicesMixin ],
   methods: {
     getChoiceId(uid, value) {
       return (uid + JSON.stringify(value)).replace(/\s+/g, '');
@@ -58,7 +59,7 @@ export default {
         return 'required';
       }
 
-      if (value && !this.field.choices.find(choice => choice.value === value)) {
+      if (value && !this.choices.find(choice => choice.value === value)) {
         return 'invalid';
       }
 
@@ -66,7 +67,7 @@ export default {
     },
     change(value) {
       // Allows expression of non-string values
-      this.next = this.field.choices.find(choice => choice.value === JSON.parse(value)).value;
+      this.next = this.choices.find(choice => choice.value === JSON.parse(value)).value;
     }
   }
 };

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSelect.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSelect.vue
@@ -20,10 +20,11 @@
 
 <script>
 import AposInputMixin from 'Modules/@apostrophecms/schema/mixins/AposInputMixin';
+import AposInputChoicesMixin from 'Modules/@apostrophecms/schema/mixins/AposInputChoicesMixin';
 
 export default {
   name: 'AposInputSelect',
-  mixins: [ AposInputMixin ],
+  mixins: [ AposInputMixin, AposInputChoicesMixin ],
   props: {
     icon: {
       type: String,
@@ -37,34 +38,16 @@ export default {
     };
   },
   async mounted() {
-    let choices;
-    if (typeof this.field.choices === 'string') {
-      const action = this.options.action;
-      const response = await apos.http.get(
-        `${action}/choices`,
-        {
-          qs: {
-            fieldId: this.field._id
-          },
-          busy: true
-        }
-      );
-      if (response.choices) {
-        choices = response.choices;
-      }
-    } else {
-      choices = this.field.choices;
-    }
     // Add an null option if there isn't one already
-    if (!this.field.required && !choices.find(choice => {
+    if (!this.field.required && !this.choices.find(choice => {
       return choice.value === null;
     })) {
-      this.choices.push({
+      this.choices.unshift({
         label: '',
         value: null
       });
     }
-    this.choices = this.choices.concat(choices);
+    // this.choices = this.choices.concat(choices);
     this.$nextTick(() => {
       // this has to happen on nextTick to avoid emitting before schemaReady is
       // set in AposSchema

--- a/modules/@apostrophecms/schema/ui/apos/mixins/AposInputChoicesMixin.js
+++ b/modules/@apostrophecms/schema/ui/apos/mixins/AposInputChoicesMixin.js
@@ -1,7 +1,7 @@
 /*
- * Provides prep work for fetching choices from the server or defaulting
- * to the choices provided with the field.
- */
+* Provides prep work for fetching choices from the server
+* or defaulting to the choices provided with the field.
+*/
 
 export default {
   data() {

--- a/modules/@apostrophecms/schema/ui/apos/mixins/AposInputChoicesMixin.js
+++ b/modules/@apostrophecms/schema/ui/apos/mixins/AposInputChoicesMixin.js
@@ -1,0 +1,32 @@
+/*
+ * Provides prep work for fetching choices from the server or defaulting
+ * to the choices provided with the field.
+ */
+
+export default {
+  data() {
+    return {
+      choices: []
+    };
+  },
+
+  async mounted() {
+    if (typeof this.field.choices === 'string') {
+      const action = this.options.action;
+      const response = await apos.http.get(
+        `${action}/choices`,
+        {
+          qs: {
+            fieldId: this.field._id
+          },
+          busy: true
+        }
+      );
+      if (response.choices) {
+        this.choices = response.choices;
+      }
+    } else {
+      this.choices = this.field.choices;
+    }
+  }
+};


### PR DESCRIPTION
## Summary

- Adds support for schema fields `checkboxes` and `radio` to supply server side `choices` fns, like selects do

## What are the specific steps to test this change?

1. check out branch
2. checkout [a3-testbed - test/radio-checkbox-server-choices](https://github.com/apostrophecms/testbed/tree/test/radio-checkbox-server-choices) branch and symlink the apostrophe branch into it
3. `npm run dev`
4. at http://localhost:3000 open Content > Articles and see the first three fields make use of the `myChoices` fn

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
