### PR TITLE
emit JSON.parse value on change event for AposSelect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,13 @@
 
 ## Unreleased
 
-### Fixes
-
-* `AposSelect` now emits values on `change` event as they were originally given. Their values "just work" so you do not have to think about JSON anymore when you receive it.
-
 ### Adds
 
 * Radio and Checkboxes schema inputs now support a server side `choices` function for supplying their choices array dynamically, like select supports. Future fields can opt into this functionality with the field flag `dynamicChoices`.
 
 ### Fixes
 
+* `AposSelect` now emits values on `change` event as they were originally given. Their values "just work" so you do not have to think about JSON anymore when you receive it.
 * Unpinned tiptap as the tiptap team has made releases that resolve the packaging errors that caused us to pin it in 3.22.1.<F2>
 * Pinned `vue-loader` to the `15.9.x` minor release series for now. The `15.10.0` release breaks support for using `npm link` to develop the `apostrophe` module itself.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## Unreleased
+
+### Fixes
+
+* `AposSelect` now emits values on `change` event as they were originally given. Their values "just work" so you do not have to think about JSON anymore when you receive it.
+
+### Adds
+
 * Radio and Checkboxes schema inputs now support a server side `choices` function for supplying their choices array dynamically, like select supports. Future fields can opt into this functionality with the field flag `dynamicChoices`.
 
 ## 3.24.0 (2022-07-06)`

--- a/modules/@apostrophecms/image/ui/apos/components/AposImageRelationshipEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposImageRelationshipEditor.vue
@@ -396,7 +396,7 @@ export default {
         };
     },
     updateAspectRatio(value) {
-      this.aspectRatio = parseFloat(value);
+      this.aspectRatio = value;
       this.computeMaxSizes();
       this.computeMinSizes();
     },

--- a/modules/@apostrophecms/permission/ui/apos/components/AposInputRole.vue
+++ b/modules/@apostrophecms/permission/ui/apos/components/AposInputRole.vue
@@ -7,26 +7,15 @@
     :display-options="displayOptions"
   >
     <template #body>
-      <div class="apos-input-wrapper apos-input__role">
-        <select
-          class="apos-input apos-input--select apos-input--role" :id="uid"
-          @change="change($event.target.value)"
-          :disabled="field.readOnly"
-        >
-          <option
-            v-for="choice in choices" :key="JSON.stringify(choice.value)"
-            :value="JSON.stringify(choice.value)"
-            :selected="choice.value === value.data"
-          >
-            {{ $t(choice.label) }}
-          </option>
-        </select>
-        <AposIndicator
-          icon="menu-down-icon"
-          class="apos-input-icon"
-          :icon-size="20"
-        />
-      </div>
+      <AposSelect
+        :choices="choices"
+        :disabled="field.readOnly"
+        :selected="value.data"
+        :id="uid"
+        :classes="[ 'apos-input__role' ]"
+        :wrapper-classes="[ 'apos-input__role' ]"
+        @change="change"
+      />
       <div class="apos-input__role__permission-grid">
         <div
           v-for="permissionSet in permissionSets"
@@ -152,7 +141,7 @@ export default {
     },
     change(value) {
       // Allows expression of non-string values
-      this.next = this.choices.find(choice => choice.value === JSON.parse(value)).value;
+      this.next = this.choices.find(choice => choice.value === value).value;
     },
     async getPermissionSets(role) {
       return (await apos.http.get(`${apos.permission.action}/grid`, {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSelect.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSelect.vue
@@ -69,7 +69,7 @@ export default {
     },
     change(value) {
       // Allows expression of non-string values
-      this.next = this.choices.find(choice => choice.value === JSON.parse(value)).value;
+      this.next = this.choices.find(choice => choice.value === value).value;
     }
   }
 };

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSelect.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSelect.vue
@@ -48,7 +48,7 @@ export default {
   emits: [ 'change' ],
   methods: {
     change(value) {
-      this.$emit('change', value);
+      this.$emit('change', JSON.parse(value));
     }
   }
 };

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSelect.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSelect.vue
@@ -1,7 +1,9 @@
 <template>
-  <div class="apos-input-wrapper">
+  <div class="apos-input-wrapper" :class="wrapperClasses">
     <select
       class="apos-input apos-input--select"
+      :class="classes"
+      :uid="uid"
       :disabled="disabled"
       @change="change($event.target.value)"
     >
@@ -29,6 +31,22 @@ export default {
     icon: {
       type: String,
       default: 'menu-down-icon'
+    },
+    uid: {
+      type: Number,
+      default: null
+    },
+    classes: {
+      type: Array,
+      default() {
+        return [];
+      }
+    },
+    wrapperClasses: {
+      type: Array,
+      default() {
+        return [];
+      }
     },
     choices: {
       type: Array,


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

`AposSelect` to emits `JSON.parse` value on change event

## What are the specific steps to test this change?

1. Login to the backoffice
2. Find a piece with an `AposSelect` element and change the value (e.g. `Event`, requires `@apostrophecms/event` to be installed)
3. Save the piece and reload the edit modal to see if the new value is still there
4. Insert an image into a page and change the crop ratio. The selected value must be reflected in the crop area
5. Edit a user and change the `Role`. If you save it and reload, you must see the previously selected value

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
