### PR TITLE
extract permission grid

### DIFF
--- a/modules/@apostrophecms/permission/ui/apos/components/AposInputRole.vue
+++ b/modules/@apostrophecms/permission/ui/apos/components/AposInputRole.vue
@@ -16,48 +16,7 @@
         :wrapper-classes="[ 'apos-input__role' ]"
         @change="change"
       />
-      <div class="apos-input__role__permission-grid">
-        <div
-          v-for="permissionSet in permissionSets"
-          :key="permissionSet.name"
-          class="apos-input__role__permission-grid__set"
-        >
-          <h4 class="apos-input__role__permission-grid__set-name">
-            {{ $t(permissionSet.label) }}
-            <AposIndicator
-              v-if="permissionSet.includes"
-              icon="help-circle-icon"
-              class="apos-input__role__permission-grid__help"
-              :tooltip="getTooltip(permissionSet.includes)"
-              :icon-size="11"
-              icon-color="var(--a-base-4)"
-            />
-          </h4>
-          <dl class="apos-input__role__permission-grid__list">
-            <div
-              v-for="permission in permissionSet.permissions"
-              :key="permission.name"
-              class="apos-input__role__permission-grid__row"
-            >
-              <dd class="apos-input__role__permission-grid__value">
-                <AposIndicator
-                  :icon="permission.value ? 'check-bold-icon' : 'close-icon'"
-                  :icon-color="permission.value ? 'var(--a-success)' : 'var(--a-base-5)'"
-                />
-                <span v-if="permission.value" class="apos-sr-only">
-                  {{ $t('apostrophe:enabled') }}
-                </span>
-                <span v-else class="apos-sr-only">
-                  {{ $t('apostrophe:disabled') }}
-                </span>
-              </dd>
-              <dt class="apos-input__role__permission-grid__label">
-                {{ $t(permission.label) }}
-              </dt>
-            </div>
-          </dl>
-        </div>
-      </div>
+      <AposPermissionGrid :api-params="{ role: next }" />
     </template>
   </AposInputWrapper>
 </template>
@@ -68,23 +27,11 @@ import AposInputMixin from 'Modules/@apostrophecms/schema/mixins/AposInputMixin'
 export default {
   name: 'AposInputRole',
   mixins: [ AposInputMixin ],
-  props: {
-    icon: {
-      type: String,
-      default: 'menu-down-icon'
-    }
-  },
   data() {
     return {
       next: (this.value.data == null) ? null : this.value.data,
-      choices: [],
-      permissionSets: []
+      choices: []
     };
-  },
-  watch: {
-    async next() {
-      this.permissionSets = await this.getPermissionSets(this.next);
-    }
   },
   async mounted() {
     // Add an null option if there isn't one already
@@ -104,32 +51,8 @@ export default {
         this.next = this.field.choices[0].value;
       }
     });
-    if (this.next) {
-      this.permissionSets = await this.getPermissionSets(this.next);
-    }
   },
   methods: {
-    getTooltip(includes) {
-      const html = document.createElement('div');
-      html.setAttribute('class', 'apos-info');
-      const list = document.createElement('ul');
-      const intro = document.createElement('p');
-      const followUp = document.createElement('p');
-      intro.appendChild(document.createTextNode(this.$t('apostrophe:piecePermissionsIntro')));
-      followUp.appendChild(document.createTextNode(this.$t('apostrophe:piecePermissionsPieceTypeList')));
-      html.appendChild(intro);
-      html.appendChild(followUp);
-      includes.forEach(item => {
-        const li = document.createElement('li');
-        li.appendChild(document.createTextNode(this.$t(item)));
-        list.appendChild(li);
-      });
-      html.appendChild(list);
-      return {
-        content: html,
-        localize: false
-      };
-    },
     validate(value) {
       if (this.field.required && !value.length) {
         return 'required';
@@ -142,60 +65,7 @@ export default {
     change(value) {
       // Allows expression of non-string values
       this.next = this.choices.find(choice => choice.value === value).value;
-    },
-    async getPermissionSets(role) {
-      const { permissionSets } = await apos.http.post(`${apos.permission.action}/grid`, {
-        body: {
-          role
-        },
-        busy: true
-      });
-
-      return permissionSets;
     }
   }
 };
 </script>
-
-<style lang="scss" scoped>
-  .apos-input-icon {
-    @include apos-transition();
-  }
-
-  .apos-input__role__permission-grid {
-    @include type-base;
-    display: grid;
-    margin-top: $spacing-triple;
-    grid-template-columns: repeat(auto-fit, minmax(50%, 1fr));
-  }
-
-  .apos-input__role__permission-grid__row {
-    display: flex;
-    align-items: center;
-    padding-bottom: $spacing-three-quarters;
-    margin-bottom: $spacing-three-quarters;
-    border-bottom: 1px solid var(--a-base-9);
-  }
-  .apos-input__role__permission-grid__list {
-    margin-top: 0;
-  }
-  .apos-input__role__permission-grid__set {
-    padding: 0 $spacing-base;
-    margin-bottom: $spacing-double;
-  }
-
-  .apos-input__role__permission-grid__set-name {
-    @include type-title;
-    display: inline-flex;
-    margin: 0 0 $spacing-double;
-  }
-
-  .apos-input__role__permission-grid__value {
-    display: inline-flex;
-    margin: 0 $spacing-half 0 0;
-  }
-
-  .apos-input__role__permission-grid__help {
-    margin-left: $spacing-half;
-  }
-</style>

--- a/modules/@apostrophecms/permission/ui/apos/components/AposPermissionGrid.vue
+++ b/modules/@apostrophecms/permission/ui/apos/components/AposPermissionGrid.vue
@@ -57,16 +57,21 @@ export default {
 
         const ROLE = 'role';
         const ROLES_BY_TYPE = 'rolesByType';
+        const GROUPS = '_groups';
+
         const keys = Object.keys(value);
         const [ key ] = keys;
 
-        if (keys.length > 1 || (key !== ROLE && key !== ROLES_BY_TYPE)) {
+        if (keys.length > 1 || ![ ROLE, ROLES_BY_TYPE, GROUPS ].includes(key)) {
           return false;
         }
         if (value[ROLE] && typeof value[ROLE] !== 'string') {
           return false;
         }
         if (value[ROLES_BY_TYPE] && !Array.isArray(value[ROLES_BY_TYPE])) {
+          return false;
+        }
+        if (value[GROUPS] && !Array.isArray(value[GROUPS])) {
           return false;
         }
         return true;

--- a/modules/@apostrophecms/permission/ui/apos/components/AposPermissionGrid.vue
+++ b/modules/@apostrophecms/permission/ui/apos/components/AposPermissionGrid.vue
@@ -1,0 +1,169 @@
+<template>
+  <div class="apos-input__role__permission-grid">
+    <div
+      v-for="permissionSet in permissionSets"
+      :key="permissionSet.name"
+      class="apos-input__role__permission-grid__set"
+    >
+      <h4 class="apos-input__role__permission-grid__set-name">
+        {{ $t(permissionSet.label) }}
+        <AposIndicator
+          v-if="permissionSet.includes"
+          icon="help-circle-icon"
+          class="apos-input__role__permission-grid__help"
+          :tooltip="getTooltip(permissionSet.includes)"
+          :icon-size="11"
+          icon-color="var(--a-base-4)"
+        />
+      </h4>
+      <dl class="apos-input__role__permission-grid__list">
+        <div
+          v-for="permission in permissionSet.permissions"
+          :key="permission.name"
+          class="apos-input__role__permission-grid__row"
+        >
+          <dd class="apos-input__role__permission-grid__value">
+            <AposIndicator
+              :icon="permission.value ? 'check-bold-icon' : 'close-icon'"
+              :icon-color="permission.value ? 'var(--a-success)' : 'var(--a-base-5)'"
+            />
+            <span v-if="permission.value" class="apos-sr-only">
+              {{ $t('apostrophe:enabled') }}
+            </span>
+            <span v-else class="apos-sr-only">
+              {{ $t('apostrophe:disabled') }}
+            </span>
+          </dd>
+          <dt class="apos-input__role__permission-grid__label">
+            {{ $t(permission.label) }}
+          </dt>
+        </div>
+      </dl>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'AposPermissionGrid',
+  props: {
+    apiParams: {
+      type: Object,
+      required: true,
+      validator(value) {
+        if (typeof value !== 'object') {
+          return false;
+        }
+
+        const ROLE = 'role';
+        const ROLES_BY_TYPE = 'rolesByType';
+        const keys = Object.keys(value);
+        const [ key ] = keys;
+
+        if (keys.length > 1 || (key !== ROLE && key !== ROLES_BY_TYPE)) {
+          return false;
+        }
+        if (value[ROLE] && typeof value[ROLE] !== 'string') {
+          return false;
+        }
+        if (value[ROLES_BY_TYPE] && !Array.isArray(value[ROLES_BY_TYPE])) {
+          return false;
+        }
+        return true;
+      }
+    }
+  },
+  data() {
+    return {
+      permissionSets: []
+    };
+  },
+  watch: {
+    apiParams: {
+      async handler() {
+        this.permissionSets = await this.getPermissionSets();
+        console.log('WATCHED - this.permissionSets', this.permissionSets);
+      },
+      deep: true
+    }
+  },
+  async mounted() {
+    if (this.next) {
+      this.permissionSets = await this.getPermissionSets();
+      console.log('MOUNTED - this.permissionSets', this.permissionSets);
+    }
+  },
+  methods: {
+    getTooltip(includes) {
+      const html = document.createElement('div');
+      html.setAttribute('class', 'apos-info');
+      const list = document.createElement('ul');
+      const intro = document.createElement('p');
+      const followUp = document.createElement('p');
+      intro.appendChild(document.createTextNode(this.$t('apostrophe:piecePermissionsIntro')));
+      followUp.appendChild(document.createTextNode(this.$t('apostrophe:piecePermissionsPieceTypeList')));
+      html.appendChild(intro);
+      html.appendChild(followUp);
+      includes.forEach(item => {
+        const li = document.createElement('li');
+        li.appendChild(document.createTextNode(this.$t(item)));
+        list.appendChild(li);
+      });
+      html.appendChild(list);
+
+      return {
+        content: html,
+        localize: false
+      };
+    },
+    async getPermissionSets() {
+      console.log('this.apiParams', this.apiParams);
+      const { permissionSets } = await apos.http.post(`${apos.permission.action}/grid`, {
+        body: this.apiParams,
+        busy: true
+      });
+
+      return permissionSets;
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+  .apos-input__role__permission-grid {
+    @include type-base;
+    display: grid;
+    margin-top: $spacing-triple;
+    grid-template-columns: repeat(auto-fit, minmax(50%, 1fr));
+  }
+
+  .apos-input__role__permission-grid__row {
+    display: flex;
+    align-items: center;
+    padding-bottom: $spacing-three-quarters;
+    margin-bottom: $spacing-three-quarters;
+    border-bottom: 1px solid var(--a-base-9);
+  }
+  .apos-input__role__permission-grid__list {
+    margin-top: 0;
+  }
+  .apos-input__role__permission-grid__set {
+    padding: 0 $spacing-base;
+    margin-bottom: $spacing-double;
+  }
+
+  .apos-input__role__permission-grid__set-name {
+    @include type-title;
+    display: inline-flex;
+    margin: 0 0 $spacing-double;
+  }
+
+  .apos-input__role__permission-grid__value {
+    display: inline-flex;
+    margin: 0 $spacing-half 0 0;
+  }
+
+  .apos-input__role__permission-grid__help {
+    margin-left: $spacing-half;
+  }
+</style>

--- a/modules/@apostrophecms/permission/ui/apos/components/AposPermissionGrid.vue
+++ b/modules/@apostrophecms/permission/ui/apos/components/AposPermissionGrid.vue
@@ -92,9 +92,7 @@ export default {
     }
   },
   async mounted() {
-    if (this.next) {
-      this.permissionSets = await this.getPermissionSets();
-    }
+    this.permissionSets = await this.getPermissionSets();
   },
   methods: {
     getTooltip(includes) {

--- a/modules/@apostrophecms/permission/ui/apos/components/AposPermissionGrid.vue
+++ b/modules/@apostrophecms/permission/ui/apos/components/AposPermissionGrid.vue
@@ -87,7 +87,6 @@ export default {
     apiParams: {
       async handler() {
         this.permissionSets = await this.getPermissionSets();
-        console.log('WATCHED - this.permissionSets', this.permissionSets);
       },
       deep: true
     }
@@ -95,7 +94,6 @@ export default {
   async mounted() {
     if (this.next) {
       this.permissionSets = await this.getPermissionSets();
-      console.log('MOUNTED - this.permissionSets', this.permissionSets);
     }
   },
   methods: {
@@ -122,7 +120,6 @@ export default {
       };
     },
     async getPermissionSets() {
-      console.log('this.apiParams', this.apiParams);
       const { permissionSets } = await apos.http.post(`${apos.permission.action}/grid`, {
         body: this.apiParams,
         busy: true


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

  - [PRO-2876 - Displaying the permissions grid as part of the rolesByType field](https://linear.app/apostrophecms/issue/PRO-2876/displaying-the-permissions-grid-as-part-of-the-rolesbytype-field)
  - [PRO-2883 - rolesByGroup custom schema field type](https://linear.app/apostrophecms/issue/PRO-2883/rolesbygroup-custom-schema-field-type)

Related PR: https://github.com/apostrophecms/advanced-permission/pull/9

Extract the permission grid in order to be able to instantiate it from different contexts, passing it a `role` (default parameter in core), `rolesByTypes` or `_groups` params (used in advanced permission module, see https://github.com/apostrophecms/advanced-permission/pull/9).

The API params are used to call the permission module's `/grid` POST route API.

```vue
<AposPermissionGrid :api-params="{ role: '...' }" />
```
```vue
<AposPermissionGrid :api-params="{ rolesByType: [ ... ] }" />
```
```vue
<AposPermissionGrid :api-params="{ _groups: [ ... ] }" />
```

## What are the specific steps to test this change?

Run a project
Check that the grid which is displayed when editing a user still works as expected.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
