### PR TITLE
Implement getObjectManager for Object field types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* `getObjectManager` is now implemented for `Object` field types.
+
 ## 3.25.0 (2022-07-20)
 
 ### Adds

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1405,6 +1405,10 @@ module.exports = {
       getArrayManager(name) {
         return self.arrayManagers[name];
       },
+      // This allows the getManagerOf method to operate on objects of type "object".
+      getObjectManager(name) {
+        return self.objectManagers[name];
+      },
       // Regenerate all array item, area and widget ids so they are considered
       // new. Useful when copying an entire doc.
       regenerateIds(req, schema, doc) {

--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -663,7 +663,7 @@ module.exports = {
         } else if (object.metaType === 'arrayItem') {
           return self.apos.schema.getArrayManager(object.scopedArrayName);
         } else if (object.metaType === 'object') {
-          return self.apos.schema.getArrayManager(object.scopedObjectName);
+          return self.apos.schema.getObjectManager(object.scopedObjectName);
         } else {
           throw new Error(`Unsupported metaType in getManagerOf: ${object.metaType}`);
         }


### PR DESCRIPTION
## Summary

This PR implements the `getObjectManager` method for `Object` field types. This closes #3755.

## What are the specific steps to test this change?

Create a field of type `Object` with a sub-field of type `area`. The area should be rendered properly this time with no templating errors being raised.

## What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
