### PR TITLE
PRO-3071 cannot find #apos-modals sometimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+Always waits for the DOM to be ready before initializing the Apostrophe Admin UI. `setTimeout` alone might not guarantee that every time.
+
 ## 3.26.0
 
 ### Adds

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -460,9 +460,14 @@ module.exports = {
               ${(tiptap && tiptap.registerCode) || ''}
               ` +
               (app ? stripIndent`
-                setTimeout(() => {
-                  ${app.invokeCode}
-                }, 0);
+              if (document.readyState !== 'loading') {
+                setTimeout(invoke, 0);
+              } else {
+                window.addEventListener('DOMContentLoaded', invoke);
+              }
+              function invoke() {
+                ${app.invokeCode}
+              }
               ` : '') +
               // No delay on these, they expect to run early like ui/public code
               // and the first ones invoked set up expected stuff like apos.http


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Closes #2630 

Don't just rely on setTimeout to do the job of DOMContentLoaded. This can break if the download of the page itself takes a while, resulting in no admin UI.

## What are the specific steps to test this change?

`npm run dev` and the admin UI works normally. TOUGH to prove a negative, but it should still work (eventually) when Chrome's network speed simulator is set to "fast 3G" (checking this is optional).

This could also explain occasional failures in CI, cc Miro.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
