### PR TITLE
Remove stylelint from webpack

### DIFF
--- a/modules/@apostrophecms/asset/lib/webpack/apos/webpack.scss.js
+++ b/modules/@apostrophecms/asset/lib/webpack/apos/webpack.scss.js
@@ -1,5 +1,3 @@
-const StyleLintPlugin = require('stylelint-webpack-plugin');
-
 module.exports = (options, apos) => {
   return {
     module: {
@@ -58,11 +56,6 @@ module.exports = (options, apos) => {
           ]
         }
       ]
-    },
-    plugins: [
-      new StyleLintPlugin({
-        files: [ './node_modules/apostrophe/modules/**/*.{scss,vue}' ]
-      })
-    ]
+    }
   };
 };

--- a/package.json
+++ b/package.json
@@ -133,8 +133,7 @@
     "eslint-plugin-promise": "^5.1.0",
     "stylelint": "^14.6.1",
     "stylelint-declaration-strict-value": "^1.8.0",
-    "stylelint-order": "^5.0.0",
-    "stylelint-webpack-plugin": "^3.2.0"
+    "stylelint-order": "^5.0.0"
   },
   "browserslist": [
     "ie >= 10"


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Remove stylelint plugin from webpack, this was causing breakage for our staging site after the move of stylelint to devDependencies. We don't need this in webpack because we have it in the lint subtask of our npm tests. Automatically linting project specific apos custom admin styles was nice but not worth the install weight in production. Project level developers should set their own style linting rules.

## What are the specific steps to test this change?

staging should autodeploy successfully after this merges

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
