### PR TITLE
Change _crop assignment to allow `getHeight()` and `getWidth()` to work correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* Fix attachment `getHeight()` and `getWidth()` template helpers by changing the assignment of the `attachment._crop` property.
+* Change assignment of `attachment._focalPoint` for consistency.
+
 ## 3.28.0 (2022-08-31)
 
 ### Fixes

--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -708,8 +708,8 @@ module.exports = {
               if (ancestorFields) {
                 value = _.clone(value);
                 o.attachment = value;
-                value._crop = _.pick(ancestorFields, 'width', 'height', 'top', 'left');
-                value._focalPoint = _.pick(ancestorFields, 'x', 'y');
+                value._crop = ancestorFields.width ? _.pick(ancestorFields, 'width', 'height', 'top', 'left') : undefined;
+                value._focalPoint = ancestorFields.x ? _.pick(ancestorFields, 'x', 'y') : undefined;
                 break;
               }
             }

--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -709,7 +709,7 @@ module.exports = {
                 value = _.clone(value);
                 o.attachment = value;
                 value._crop = ancestorFields.width ? _.pick(ancestorFields, 'width', 'height', 'top', 'left') : undefined;
-                value._focalPoint = ancestorFields.x ? _.pick(ancestorFields, 'x', 'y') : undefined;
+                value._focalPoint = (typeof ancestorFields.x === 'number') ? _.pick(ancestorFields, 'x', 'y') : undefined;
                 break;
               }
             }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*

The `attachment` module currently assigns an empty object to the `attachment._crop` property. Both the `getHeight()` and `getWidth()` template helpers of this module interrogate this property to return either the original dimension or the cropped dimension by simply testing truthiness. Since an empty object is true, the methods are returning `undefined` for the dimension of uncropped images. This PR changes the assignment of the value of `attachment._crop` to `undefined`, which is falsy if no crop has occurred. This PR also changes the assignment of `attachment._focal` for consistency. Closes PRO-3112.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

1. Add a page that utilizes the `getHeight()`,`getWidtth()` and/or `getFocalPoint()`.
2. Build the website.
3. Add a cropped image attachment, an uncropped attachment, and a non-image attachment to the page and observe the expected values are returned. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
