### PR TITLE
display placeholder for rich-text-widget

### DIFF
--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -263,6 +263,7 @@
   "richTextItalic": "Italic",
   "richTextLink": "Link",
   "richTextParagraph": "Paragraph (P)",
+  "richTextPlaceholder": "Start Typing Here...",
   "richTextH2": "Heading 2 (H2)",
   "richTextH3": "Heading 3 (H3)",
   "richTextH4": "Heading 4 (H4)",

--- a/modules/@apostrophecms/i18n/i18n/es.json
+++ b/modules/@apostrophecms/i18n/i18n/es.json
@@ -242,6 +242,7 @@
   "richTextItalic": "Cursiva",
   "richTextLink": "Liga",
   "richTextParagraph": "Párrafo (P)",
+  "richTextPlaceholder": "Comience a escribir aquí...",
   "richTextH2": "Título 2 (H2)",
   "richTextH3": "Título 3 (H3)",
   "richTextH4": "Título 4 (H4)",

--- a/modules/@apostrophecms/i18n/i18n/fr.json
+++ b/modules/@apostrophecms/i18n/i18n/fr.json
@@ -249,7 +249,7 @@
   "richTextItalic": "Italique",
   "richTextLink": "Lien",
   "richTextParagraph": "Paragraphe (P)",
-  "richTextPlaceholder": "Commencez à taper ici...",
+  "richTextPlaceholder": "Commencez à écrire ici...",
   "richTextH2": "Titre de niveau 2 (H2)",
   "richTextH3": "Titre de niveau 3 (H3)",
   "richTextH4": "Titre de niveau 4 (H4)",

--- a/modules/@apostrophecms/i18n/i18n/fr.json
+++ b/modules/@apostrophecms/i18n/i18n/fr.json
@@ -249,6 +249,7 @@
   "richTextItalic": "Italique",
   "richTextLink": "Lien",
   "richTextParagraph": "Paragraphe (P)",
+  "richTextPlaceholder": "Commencez à taper ici...",
   "richTextH2": "Titre de niveau 2 (H2)",
   "richTextH3": "Titre de niveau 3 (H3)",
   "richTextH4": "Titre de niveau 4 (H4)",

--- a/modules/@apostrophecms/i18n/i18n/pt-BR.json
+++ b/modules/@apostrophecms/i18n/i18n/pt-BR.json
@@ -240,6 +240,7 @@
   "richTextItalic": "Itálico",
   "richTextLink": "Link",
   "richTextParagraph": "Parágrafo (P)",
+  "richTextPlaceholder": "Comece a digitar aqui...",
   "richTextH2": "Título 2 (H2)",
   "richTextH3": "Título 3 (H3)",
   "richTextH4": "Título 4 (H4)",

--- a/modules/@apostrophecms/i18n/i18n/sk.json
+++ b/modules/@apostrophecms/i18n/i18n/sk.json
@@ -252,6 +252,7 @@
   "richTextItalic": "Kurzíva",
   "richTextLink": "Link",
   "richTextParagraph": "Odstavec (P)",
+  "richTextPlaceholder": "Začnite písať tu...",
   "richTextH2": "Nadpis 2 (H2)",
   "richTextH3": "Nadpis 3 (H3)",
   "richTextH4": "Nadpis 4 (H4)",

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -9,6 +9,7 @@ module.exports = {
     icon: 'format-text-icon',
     label: 'apostrophe:richText',
     contextual: true,
+    placeholderText: 'apostrophe:richTextPlaceholder',
     defaultData: { content: '' },
     className: false,
     minimumDefaultOptions: {
@@ -417,7 +418,8 @@ module.exports = {
           tools: self.options.editorTools,
           defaultOptions: self.options.defaultOptions,
           tiptapTextCommands: self.options.tiptapTextCommands,
-          tiptapTypes: self.options.tiptapTypes
+          tiptapTypes: self.options.tiptapTypes,
+          placeholderText: self.options.placeholderText
         };
         return finalData;
       }

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -360,7 +360,6 @@ export default {
     pointer-events: none;
     height: 0;
     color: var(--a-base-4);
-    margin-left: 5px;
   }
 
   .apos-rich-text-editor__editor {

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -357,9 +357,9 @@ export default {
   .apos-rich-text-editor__editor ::v-deep .ProseMirror p.is-empty:first-child::before {
     content: attr(data-placeholder);
     float: left;
-    color: #adb5bd;
     pointer-events: none;
     height: 0;
+    color: var(--a-base-4);
     margin-left: 5px;
   }
 

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -196,7 +196,7 @@ export default {
       Underline,
 
       // For this contextual widget, no need to check `widget.aposPlaceholder` value
-      // since `placeholderText` option is enough to decide whether to display it ot not.
+      // since `placeholderText` option is enough to decide whether to display it or not.
       this.placeholderText && Placeholder.configure({
         placeholder: () => {
           // Avoid brief display of the placeholder when loading the page.
@@ -227,7 +227,7 @@ export default {
       //  - after it, once the page is loaded and we interact with the editors
       // To solve this issue, use another `this.showPlaceholder` variable
       // and toggle it after the placeholder configuration function is called,
-      // thanks to textTick.
+      // thanks to nextTick.
       // The proper thing would be to call nextTick inside the placeholder
       // function so that it can rely on the focus state set by these event
       // listeners, but the placeholder function is called synchronously...

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@opentelemetry/semantic-conventions": "^1.0.1",
     "@tiptap/extension-highlight": "^2.0.0-beta.33",
     "@tiptap/extension-link": "^2.0.0-beta.38",
+    "@tiptap/extension-placeholder": "^2.0.0-beta.196",
     "@tiptap/extension-text-align": "^2.0.0-beta.29",
     "@tiptap/extension-text-style": "^2.0.0-beta.23",
     "@tiptap/extension-underline": "^2.0.0-beta.23",
@@ -124,16 +125,16 @@
     "eslint-config-apostrophe": "^3.4.0",
     "eslint-plugin-n": "^15.2.1",
     "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-vue": "^7.9.0",
     "mocha": "^9.1.2",
     "nyc": "^15.1.0",
     "replace-in-file": "^6.1.0",
-    "vue-eslint-parser": "^7.1.1",
-    "webpack-bundle-analyzer": "^3.9.0",
-    "eslint-plugin-promise": "^5.1.0",
     "stylelint": "^14.6.1",
     "stylelint-declaration-strict-value": "^1.8.0",
-    "stylelint-order": "^5.0.0"
+    "stylelint-order": "^5.0.0",
+    "vue-eslint-parser": "^7.1.1",
+    "webpack-bundle-analyzer": "^3.9.0"
   },
   "browserslist": [
     "ie >= 10"


### PR DESCRIPTION
<!-- Please don't delete this template -->

Depends on #3882
Closes [PRO-3146](https://linear.app/apostrophecms/issue/PRO-3146/implement-per-area-and-global-fallback-placeholder-options-for-rich)

## Summary

Set a default placeholder value for rich text widget:

![image](https://user-images.githubusercontent.com/8301962/191982898-7d821339-e2cf-4495-b59a-efc12a5973b8.png)

The placeholder disappears as soon as we start typing in.
It's overridable on project side, so if it's overridden with a falsy value, it will display the normal/previous behaviour.

## What are the specific steps to test this change?

On testbed:

```js
// in a project's modules/@apostrophecms/rich-text-widget/index.js
options: {
    placeholderText: 'Start typing here!!!'
  },
```

👇 

![image](https://user-images.githubusercontent.com/8301962/191981893-4bc54297-e375-4515-9cd8-0651b8d7072a.png)

---

```js
// in a project's modules/@apostrophecms/rich-text-widget/index.js
options: {
    placeholderText: false // or any falsy value
  },
```

👇 

![image](https://user-images.githubusercontent.com/8301962/191981790-41f14421-e0a9-4393-8f49-28cd94ff340e.png)


## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
