### PR TITLE
fix captcha bug when login failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixes
 
-* After a failed login attempt, no more requirements check in order not to prevent the user from submitting the login form again.
+* Resolved a bug in which users making a password error in the presence of pre-login checks such as a CAPTCHA were unable to try again until they refreshed the page.
 
 ## 3.28.1 (2022-09-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 * Add "showQuery" in piece-page-type in order to override the query for the "show" page as "indexQuery" does it for the index page
 
+
+### Fixes
+
+* After a failed login attempt, no more requirements check in order not to prevent the user from submitting the login form again.
+
 ## 3.28.1 (2022-09-15)
 
 ### Fixes

--- a/modules/@apostrophecms/login/ui/apos/components/TheAposLogin.vue
+++ b/modules/@apostrophecms/login/ui/apos/components/TheAposLogin.vue
@@ -232,7 +232,6 @@ export default {
       } catch (e) {
         this.error = e.message || 'An error occurred. Please try again.';
         this.phase = 'beforeSubmit';
-        this.requirements = getRequirements();
       } finally {
         this.busy = false;
       }
@@ -257,7 +256,6 @@ export default {
         this.redirectAfterLogin();
       } catch (e) {
         this.error = e.message || 'An error occurred. Please try again.';
-        this.requirements = getRequirements();
         this.phase = 'beforeSubmit';
       } finally {
         this.busy = false;

--- a/modules/@apostrophecms/login/ui/apos/components/TheAposLogin.vue
+++ b/modules/@apostrophecms/login/ui/apos/components/TheAposLogin.vue
@@ -237,10 +237,12 @@ export default {
       }
     },
     getInitialSubmitRequirementsData() {
-      return Object.fromEntries(this.requirements.filter(r => r.phase !== 'afterPasswordVerified').map(r => ([
-        r.name,
-        r.value
-      ])));
+      return Object.fromEntries(this.requirements
+        .filter(r => r.phase !== 'afterPasswordVerified' || !r.done)
+        .map(r => ([
+          r.name,
+          r.value
+        ])));
     },
     async invokeFinalLoginApi() {
       try {


### PR DESCRIPTION
https://linear.app/apostrophecms/issue/PRO-3101/login-button-remains-disabled-after-invalid-login-attempt-when-using

Remove requirements check after a failed login attempt (because it has been validated before submission)