### PR TITLE
display default area-specific widget content

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -423,7 +423,8 @@ export default {
         return this.insert({
           widget: {
             type: name,
-            ...this.contextualWidgetDefaultData(name)
+            ...this.contextualWidgetDefaultData(name),
+            ...this.widgetAreaDefaultData(name)
           },
           index
         });
@@ -431,7 +432,8 @@ export default {
         return this.insert({
           widget: {
             type: name,
-            aposPlaceholder: true
+            aposPlaceholder: true,
+            ...this.widgetAreaDefaultData(name)
           },
           index
         });
@@ -455,6 +457,9 @@ export default {
     },
     contextualWidgetDefaultData(type) {
       return this.moduleOptions.contextualWidgetDefaultData[type];
+    },
+    widgetAreaDefaultData(type) {
+      return this.options.widgets[type]._def || {};
     },
     async insert({ index, widget }) {
       if (!widget._id) {

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -441,7 +441,7 @@ export default {
         const componentName = this.widgetEditorComponent(name);
         apos.area.activeEditor = this;
         const widget = await apos.modal.execute(componentName, {
-          value: null,
+          value: this.widgetAreaDefaultData(name),
           options: this.options.widgets[name],
           type: name,
           docId: this.docId
@@ -459,7 +459,7 @@ export default {
       return this.moduleOptions.contextualWidgetDefaultData[type];
     },
     widgetAreaDefaultData(type) {
-      return this.options.widgets[type]._def || {};
+      return this.options.widgets[type]._def || null;
     },
     async insert({ index, widget }) {
       if (!widget._id) {


### PR DESCRIPTION
Depends on #3882

## Summary

Display default values defined in widgets options of a specific area.

## What are the specific steps to test this change?

On testbed,

In  _topic-widget/index.js_:

- add the `initialModal: false` option to the module
- add `def: 'default title'` to the title field

In _lib/area.js_:

- configure the topic and rich text widget as follow:

```js
topic: {
    _def: {
      title: 'Default title everywhere'
    }
  },
'@apostrophecms/rich-text': {
    _def: {
      content: '<i>Default content everywhere</i>'
    },
    // ...
```

In _modules/articles/article-page/index.js_:

```js
          widgets: {
            topic: {
              _def: {
                title: 'Default title in article pages'
              }
            },
            '@apostrophecms/rich-text': {
              _def: {
                content: '<i>Default content in article pages</i>'
              },
              // ...
```

---

Add a rich text and a topic widget to the home page, they should have should the default data set in the area.

![image](https://user-images.githubusercontent.com/8301962/192338612-5cb6798c-26dc-42ca-8e1d-8d12bd7d3c47.png)

Now add them to an Article page:

![image](https://user-images.githubusercontent.com/8301962/192338637-a5e2b677-62ff-43d7-8203-fb05e3598d64.png)

This should work inside a nested widget:

![image](https://user-images.githubusercontent.com/8301962/192338735-3a3d5575-d515-4ea7-8ae8-840c73d9687e.png)

And in the page settings modal:

![image](https://user-images.githubusercontent.com/8301962/192339044-72a2b4ff-4e60-4705-89db-056b4d28d9ca.png)

Finally, this should also work for non-contextual widgets and those that _do have_ an `initialModal`:

![image](https://user-images.githubusercontent.com/8301962/192784815-5502ad54-7d35-4bf4-9dde-ffb007469cac.png)

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
