### PR TITLE
do not render widgets placeholder on preview mode

### DIFF
--- a/modules/@apostrophecms/widget-type/index.js
+++ b/modules/@apostrophecms/widget-type/index.js
@@ -164,6 +164,11 @@ module.exports = {
         const clonedWidget = { ...widget };
 
         if (widget.aposPlaceholder === true) {
+          // Do not render widget on preview mode:
+          if (req.query.aposEdit !== '1') {
+            return '';
+          }
+
           self.schema.forEach(field => {
             if (!widget[field.name] && field.placeholder !== undefined) {
               clonedWidget[field.name] = field.placeholder;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Render widgets that have a placeholder, only on edit mode.  


| edit mode                                                                                                      | preview mode                                                                                                   |
|----------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
| ![image](https://user-images.githubusercontent.com/8301962/193244758-1ffcfee4-9464-49a8-9344-bd247a03dd5c.png) | ![image](https://user-images.githubusercontent.com/8301962/193244890-0b29f0fe-49db-473e-bf3e-88056c4a7af8.png) |


## What are the specific steps to test this change?

Ensure that placeholders are rendered only on edit mode, for any type of widget, on page and in edit page modal. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
