### PR TITLE
PRO-3140 corrects CLI usage message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Add "showQuery" in piece-page-type in order to override the query for the "show" page as "indexQuery" does it for the index page
 
+### Fixes
+
+* Fix `cache` module `clear-cache` CLI task message
+
 ## 3.29.0 (2022-09-29)
 
 ### Adds

--- a/modules/@apostrophecms/cache/index.js
+++ b/modules/@apostrophecms/cache/index.js
@@ -97,7 +97,7 @@ module.exports = {
   tasks(self) {
     return {
       'clear-cache': {
-        help: 'Usage: node app @apostrophecms/cache:clear namespace1 namespace2...\n\nClears all values stored in a given namespace or namespaces. If you are using apos.cache in your own code you will\nknow the namespace name. Standard caches include "@apostrophecms/oembed". Normally it is not necessary to clear them.',
+        help: 'Usage: node app @apostrophecms/cache:clear-cache namespace1 namespace2...\n\nClears all values stored in a given namespace or namespaces. If you are using apos.cache in your own code you will\nknow the namespace name. Standard caches include "@apostrophecms/oembed". Normally it is not necessary to clear them.',
         task: async (argv) => {
           const namespaces = argv._.slice(1);
           if (!namespaces.length) {

--- a/modules/@apostrophecms/cache/index.js
+++ b/modules/@apostrophecms/cache/index.js
@@ -97,7 +97,7 @@ module.exports = {
   tasks(self) {
     return {
       'clear-cache': {
-        help: 'Usage: node app @apostrophecms/cache:clear-cache namespace1 namespace2...\n\nClears all values stored in a given namespace or namespaces. If you are using apos.cache in your own code you will\nknow the namespace name. Standard caches include "@apostrophecms/oembed". Normally it is not necessary to clear them.',
+        usage: 'Usage: node app @apostrophecms/cache:clear-cache namespace1 namespace2...\n\nClears all values stored in a given namespace or namespaces. If you are using apos.cache in your own code you will\nknow the namespace name. Standard caches include "@apostrophecms/oembed". Normally it is not necessary to clear them.',
         task: async (argv) => {
           const namespaces = argv._.slice(1);
           if (!namespaces.length) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
The current help message for using the `clear-cache` CLI task of the `cache` module is incorrect. It gives the task name as `clear`, rather than `clear-cache`. Additionally, the message has a property of `help`, which is incorrect. It should be `usage`. This PR corrects these errors . Closes PRO-3140.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly
1. From the command line in an apostrophe project run: `node app help @apostrophecms/cache:clear-cache`.
2. Observe help tip.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
