### PR TITLE
add placeholder widget option

### DIFF
--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -554,6 +554,7 @@ module.exports = {
         const widgetEditors = {};
         const widgetManagers = {};
         const widgetIsContextual = {};
+        const widgetHasPlaceholder = {};
         const widgetHasInitialModal = {};
         const contextualWidgetDefaultData = {};
 
@@ -564,7 +565,8 @@ module.exports = {
           widgetEditors[name] = (browserData && browserData.components && browserData.components.widgetEditor) || 'AposWidgetEditor';
           widgetManagers[name] = manager.__meta.name;
           widgetIsContextual[name] = manager.options.contextual;
-          widgetHasInitialModal[name] = manager.options.initialModal !== false;
+          widgetHasPlaceholder[name] = manager.options.placeholder;
+          widgetHasInitialModal[name] = !widgetHasPlaceholder[name] && manager.options.initialModal !== false;
           contextualWidgetDefaultData[name] = manager.options.defaultData;
         });
 
@@ -575,6 +577,7 @@ module.exports = {
             widgetEditors
           },
           widgetIsContextual,
+          widgetHasPlaceholder,
           widgetHasInitialModal,
           contextualWidgetDefaultData,
           widgetManagers,

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -430,14 +430,12 @@ export default {
         });
       } else if (!this.widgetHasInitialModal(name)) {
         const widgetAreaDefaultData = this.widgetAreaDefaultData(name);
-
-        // If a widget has area-specific default values,
-        // then we set aposPlaceholder to false:
+        const aposPlaceholder = this.widgetHasPlaceholder(name) && !widgetAreaDefaultData;
         return this.insert({
           widget: {
             type: name,
-            aposPlaceholder: !widgetAreaDefaultData,
-            ...widgetAreaDefaultData
+            ...widgetAreaDefaultData,
+            aposPlaceholder
           },
           index
         });
@@ -497,6 +495,9 @@ export default {
     },
     widgetIsContextual(type) {
       return this.moduleOptions.widgetIsContextual[type];
+    },
+    widgetHasPlaceholder(type) {
+      return this.moduleOptions.widgetHasPlaceholder[type];
     },
     widgetHasInitialModal(type) {
       return this.moduleOptions.widgetHasInitialModal[type];

--- a/modules/@apostrophecms/image-widget/index.js
+++ b/modules/@apostrophecms/image-widget/index.js
@@ -6,6 +6,7 @@ module.exports = {
     icon: 'image-icon',
     dimensionAttrs: false,
     initialModal: false,
+    placeholder: true,
     placeholderClass: false,
     placeholderUrl: '/modules/@apostrophecms/image-widget/placeholder.jpg'
   },

--- a/modules/@apostrophecms/image-widget/index.js
+++ b/modules/@apostrophecms/image-widget/index.js
@@ -5,7 +5,6 @@ module.exports = {
     className: false,
     icon: 'image-icon',
     dimensionAttrs: false,
-    initialModal: false,
     placeholder: true,
     placeholderClass: false,
     placeholderUrl: '/modules/@apostrophecms/image-widget/placeholder.jpg'

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -9,6 +9,7 @@ module.exports = {
     icon: 'format-text-icon',
     label: 'apostrophe:richText',
     contextual: true,
+    placeholder: true,
     placeholderText: 'apostrophe:richTextPlaceholder',
     defaultData: { content: '' },
     className: false,
@@ -419,7 +420,7 @@ module.exports = {
           defaultOptions: self.options.defaultOptions,
           tiptapTextCommands: self.options.tiptapTextCommands,
           tiptapTypes: self.options.tiptapTypes,
-          placeholderText: self.options.placeholderText
+          placeholderText: self.options.placeholder && self.options.placeholderText
         };
         return finalData;
       }

--- a/modules/@apostrophecms/video-widget/index.js
+++ b/modules/@apostrophecms/video-widget/index.js
@@ -16,6 +16,7 @@ module.exports = {
     className: false,
     icon: 'play-box-icon',
     initialModal: false,
+    placeholder: true,
     placeholderClass: false,
     placeholderUrl: 'https://youtu.be/Q5UX9yexEyM'
   },

--- a/modules/@apostrophecms/video-widget/index.js
+++ b/modules/@apostrophecms/video-widget/index.js
@@ -15,7 +15,6 @@ module.exports = {
     label: 'apostrophe:video',
     className: false,
     icon: 'play-box-icon',
-    initialModal: false,
     placeholder: true,
     placeholderClass: false,
     placeholderUrl: 'https://youtu.be/Q5UX9yexEyM'

--- a/modules/@apostrophecms/widget-type/index.js
+++ b/modules/@apostrophecms/widget-type/index.js
@@ -97,7 +97,10 @@ const _ = require('lodash');
 module.exports = {
   cascades: [ 'fields' ],
   options: {
-    neverLoadSelf: true
+    neverLoadSelf: true,
+    initialModal: true,
+    placeholder: false,
+    placeholderClass: 'apos-placeholder'
   },
   init(self) {
 

--- a/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
+++ b/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
@@ -66,14 +66,12 @@ export default {
     getClasses() {
       const { placeholderClass } = this.moduleOptions;
 
-      if (placeholderClass === false) {
+      if (!placeholderClass) {
         return {};
       }
 
-      const className = placeholderClass || 'apos-placeholder';
-
       return {
-        [className]: this.value.aposPlaceholder === true
+        [placeholderClass]: this.value.aposPlaceholder === true
       };
     }
   }

--- a/test/modules/placeholder-widget/index.js
+++ b/test/modules/placeholder-widget/index.js
@@ -2,7 +2,7 @@ module.exports = {
   extend: '@apostrophecms/widget-type',
   options: {
     label: 'Placeholder Test Widget',
-    initialModal: false
+    placeholder: true
   },
   fields: {
     add: {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Add `placeholder` option to widget modules.
If truthy, it will automatically disable the initial modal (by setting `initialModal` to false) and render widgets that do not have data yet with their placeholder(s).

Placeholder for image, video and rich text widgets are enabled by default in core.

## What are the specific steps to test this change?

In testbed, add `placeholder: true` to a widget of your choice.

- the initial modal should not appear
- the widget should have been inserted with the placeholder defined in the widget field(s).
- image, video and RT widgets should be inserted directly with their placeholder by default.
- placeholders should be overridable (`placeholderUrl` for image and video widgets, `placeholderText` for rich text widget, and `placeholderClass` for any other widget)
- placeholders can be disabled by setting it to a falsy value in a project's widget modules
- `initialModal` can be set to `false`, even with `placeholder: false` --> the widget is inserted without having the initial modal displayed, and without placeholder(s)

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
