### PR TITLE
Pro 3205 express cli help error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-* Fixes help message for 'express' module `list-routes` CLI task
+* Fixes help message for `express` module `list-routes` CLI task
 
 ## 3.29.0 (2022-09-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Add "showQuery" in piece-page-type in order to override the query for the "show" page as "indexQuery" does it for the index page
 
+### Fixes
+
 * Fixes help message for 'express' module `list-routes` CLI task
 
 ## 3.29.0 (2022-09-29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Add "showQuery" in piece-page-type in order to override the query for the "show" page as "indexQuery" does it for the index page
 
+* Fixes help message for 'express' module `list-routes` CLI task
+
 ## 3.29.0 (2022-09-29)
 
 ### Adds

--- a/modules/@apostrophecms/express/index.js
+++ b/modules/@apostrophecms/express/index.js
@@ -171,7 +171,7 @@ module.exports = {
   tasks(self) {
     return {
       'list-routes': {
-        help: 'List all Express routes registered via routes(), apiRoutes(), etc. (not directly via apos.app)',
+        usage: 'Usage: node app @apostrophecms/express:list-routes \n\n List all Express routes registered via routes(), apiRoutes(), etc. (not directly via apos.app)',
         async task(argv) {
           for (const info of self.finalModuleMiddlewareAndRoutes) {
             if (info.route) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*

The `express` CLI task `list-routes` help message was malformed and using a `help` rather than `usage` property. This PR corrects this. Closes PRO-3205.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly
1. In an apostrophe project run the command: `node app help @apostrophecms:list-routes`
2. Observe the returned usage message

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
