### PR TITLE
PRO-3196 widget options might not be flattened in AposAreaEditor, find them in groups if needed

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -445,7 +445,7 @@ export default {
         apos.area.activeEditor = this;
         const widget = await apos.modal.execute(componentName, {
           value: null,
-          options: this.options.widgets[name],
+          options: this.widgetOptionsByType(name),
           type: name,
           docId: this.docId
         });
@@ -457,6 +457,18 @@ export default {
           });
         }
       }
+    },
+    widgetOptionsByType(name) {
+      if (this.options.widgets) {
+        return this.options.widgets[name];
+      } else if (this.options.expanded) {
+        for (const info of Object.values(this.options.groups || {})) {
+          if (info?.widgets?.[name]) {
+            return info.widgets[name];
+          }
+        }
+      }
+      return null;
     },
     contextualWidgetDefaultData(type) {
       return this.moduleOptions.contextualWidgetDefaultData[type];


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Time is limited this week, so I didn't dig hard to figure out why `options.widgets` was not populated here, I just provided a utility to rifle through it for the appropriate set of widget options in either format.

## What are the specific steps to test this change?

Verify the expanded widget menu and regular widget menu still work properly both on the page and in the modal.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated (N/A because the bug was never released)
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
