### PR TITLE
hotfix for node 14

### DIFF
--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -51,9 +51,9 @@ module.exports = (self) => {
       return _.isEqual(one[field.name], two[field.name]);
     },
     validate: function (field, options, warn, fail) {
-      let widgets = field.options?.widgets || {};
+      let widgets = (field.options && field.options.widgets) || {};
 
-      if (field.options?.groups) {
+      if (field.options && field.options.groups) {
         for (const group of Object.keys(field.options.groups)) {
           widgets = {
             ...widgets,


### PR DESCRIPTION
Node 14 does not support `?.`, and Node 14 is still a supported Node.js version in general and for A3, as well as being in use on some of our servers.