### PR TITLE
PRO-2568: vue 2 admin UI build coexists with vue 3 project level build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+* Vue 3 may now be used in a separate webpack build at project level without causing problems for the admin UI Vue 2 build.
 * Fixes `cache` module `clear-cache` CLI task message
 * Fixes help message for `express` module `list-routes` CLI task
 

--- a/modules/@apostrophecms/asset/lib/webpack/apos/webpack.config.js
+++ b/modules/@apostrophecms/asset/lib/webpack/apos/webpack.config.js
@@ -24,6 +24,8 @@ module.exports = ({
 
   const config = {
     entry: importFile,
+    // Ensure that the correct version of vue-loader is found
+    context: __dirname,
     mode: process.env.NODE_ENV || 'development',
     optimization: {
       minimize: process.env.NODE_ENV === 'production'

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "vue": "^2.6.14",
     "vue-advanced-cropper": "^1.10.1",
     "vue-click-outside-element": "^1.0.15",
-    "vue-loader": "~15.9.8",
+    "vue-loader": "^15.10.0",
     "vue-material-design-icons": "~4.12.1",
     "vue-style-loader": "^4.1.2",
     "vue-template-compiler": "^2.6.14",


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

* vue 2 admin UI build coexists with vue 3 project level build

## What are the specific steps to test this change?

* Check out the `pro-2568` branch of `testbed` and `npm install` it normally (do not npm link). It has a github dependency on the appropriate branch of the apostrophe module.
* `npm run dev`
* Note that a vue 3 component (self-identified) appears on the page and has a functioning button
* Note that the admin UI also works if logged in
* Make sure everything also works, including tweaking the admin UI code (touch a core admin UI vue component), if you `npm link` apostrophe into the project.

We had originally pinned `vue-loader` to a slightly earlier release because of a release that broke our ability to `npm link` apostrophe and still have a valid admin UI build. However I did not observe this bug today. I think they introduced it and then fixed it.

The big win they introduced however is that `vue-template-compiler` is no longer a separate dependency we have to care about, which solves the original problem. This is why my PoC non-Apostrophe project worked but I couldn't reproduce that result with Apostrophe at first. (It is also important to set `context` in webpack.)

It is still appropriate to cap `vue-loader` at major version 15. I think the later series are for Vue 3 only. Normal npm resolution solves this OK because the project level has a different major version and `context` solves the "requiring from the wrong root" problem.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
