### PR TITLE
QA errata for placeholders

### DIFF
--- a/test/modules/bundle-page/ui/src/extra.js
+++ b/test/modules/bundle-page/ui/src/extra.js
@@ -1,1 +1,1 @@
-export default () => {};
+export default () => { 'bundle-page-watcher-test-30'; };

--- a/test/modules/bundle-page/ui/src/extra.js
+++ b/test/modules/bundle-page/ui/src/extra.js
@@ -1,1 +1,1 @@
-export default () => { 'bundle-page-watcher-test-30'; };
+export default () => {};

--- a/test/widgets.js
+++ b/test/widgets.js
@@ -212,11 +212,6 @@ describe('Widgets', function() {
           {
             _id: 'widget4',
             ...widgetData
-          },
-          {
-            _id: 'widget5',
-            ...widgetData,
-            aposPlaceholder: true
           }
         ];
 
@@ -261,14 +256,6 @@ describe('Widgets', function() {
         assert(result.includes('<li>widget4 - float: 2.2</li>'));
         assert(result.includes('<li>widget4 - date: 2022-09-21</li>'));
         assert(result.includes('<li>widget4 - time: 15:39:12</li>'));
-      });
-
-      it('should not render the placeholders when widget\'s fields are defined', function() {
-        assert(result.includes('<li>widget5 - string: Some string</li>'));
-        assert(result.includes('<li>widget5 - integer: 2</li>'));
-        assert(result.includes('<li>widget5 - float: 2.2</li>'));
-        assert(result.includes('<li>widget5 - date: 2022-09-21</li>'));
-        assert(result.includes('<li>widget5 - time: 15:39:12</li>'));
       });
 
       it('should not render the placeholders on preview mode', async function() {


### PR DESCRIPTION
* do not try to "convert" while aposPlaceholder is still in effect (it breaks required fields)
* do not clone unnecessarily (performance)
* always respect placeholders regardless of field values until aposPlaceholder is cleared

See the `link-widget` branch of `testbed` which introduces a simple link widget that exercises the features that required the "no convert when aposPlaceholder is true" fix. The other changes were not critical for that particular QA test but are still improvements.