### PR TITLE
release 3.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.31.0 (UNRELEASED)
+## 3.31.0 (2022-10-27)
 
 ### Adds
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Adds
 
-TODO: set documentation link once created:
 * Adds `placeholder: true` and `initialModal: false` features to improve the user experience of adding widgets to the page. Checkout the [Widget Placeholders documentation](https://v3.docs.apostrophecms.org/guide/areas-and-widgets.html#adding-placeholder-content-to-widgets) for more detail. 
 
 ## 3.30.0 (2022-10-12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Adds
 
 TODO: set documentation link once created:
-* Adds the widget placeholders feature. Checkout the [Widget Placeholders documentation](https://v3.docs.apostrophecms.org/) for more detail. 
+* Adds `placeholder: true` and `initialModal: false` features to improve the user experience of adding widgets to the page. Checkout the [Widget Placeholders documentation](https://v3.docs.apostrophecms.org/guide/areas-and-widgets.html#adding-placeholder-content-to-widgets) for more detail. 
 
 ## 3.30.0 (2022-10-12)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "3.30.0",
+  "version": "3.31.0",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Release 3.31.0, with tweaks to changelog including correct final link to the widget placeholder docs.