### PR TITLE
Add `null` to select fields with a function name as choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
+## Unreleased
+
+Fixes
+
+- Add `null` to select fields with a function name as choices.
+
 ## 3.31.0 (2022-10-27)
 
 ### Adds
 
-* Adds `placeholder: true` and `initialModal: false` features to improve the user experience of adding widgets to the page. Checkout the [Widget Placeholders documentation](https://v3.docs.apostrophecms.org/guide/areas-and-widgets.html#adding-placeholder-content-to-widgets) for more detail. 
+* Adds `placeholder: true` and `initialModal: false` features to improve the user experience of adding widgets to the page. Checkout the [Widget Placeholders documentation](https://v3.docs.apostrophecms.org/guide/areas-and-widgets.html#adding-placeholder-content-to-widgets) for more detail.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Fixes
 
-- Add `null` to select fields with a function name as choices.
+- Query builders for regular select fields have always accepted null to mean "do not filter on this property." Now this also works for dynamic select fields.
 
 ## 3.31.0 (2022-10-27)
 

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -368,7 +368,7 @@ module.exports = (self) => {
             });
           } else {
             value = (typeof field.choices) === 'string'
-              ? self.apos.launder.string(value)
+              ? self.apos.launder.string(value, null)
               : self.apos.launder.select(value, field.choices, null);
             if (value === null) {
               return null;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Add `null` to select fields with a function name as choices.

When there is a select field with a function as choices and a filter for this same field, documents are not displayed in the manager modal by default. One has to select a namespace in the filter to see some pieces. It’s because of `def: null` in the filters.

## What are the specific steps to test this change?

1. Create a module with a schema using a select with a function name for choices:
```js
module.exports = {
  extend: '@apostrophecms/piece-type',
  options: {
    label: 'test',
  },
  fields: {
    add: {
      item: {
        label: 'Item,
        type: 'select',
        choices: 'getItems',
      },
    },
  },
  filters: {
    add: {
      item: {
        label: 'Item',
        def: null,
      },
    },
  },
  methods(self) {
    return {
      getItems(req) {
        return [{ label:'item 1', value: 'item1' }, { label: 'item 2', value: 'item2' }] 
      },
    }
  },
}
```
2. Create pieces and choose different "items".
3. Open the manager modal, all pieces should be displayed by default and when selecting a value in the filter, only matching items should be displayed.

## What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

