### PR TITLE
PRO-3170: Better i18n UI state management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Fixes
 
 - Query builders for regular select fields have always accepted null to mean "do not filter on this property." Now this also works for dynamic select fields.
+- The i18n UI state management now doesn't allow actions while it's busy
 
 ## 3.31.0 (2022-10-27)
 

--- a/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
+++ b/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
@@ -500,12 +500,10 @@ export default {
           .map(doc => [ doc.aposLocale.split(':')[0], doc ])
       );
       await this.updateRelatedDocs();
-    } catch (e) {
-      //
+    } finally {
+      this.wizard.step = this.visibleStepNames[0];
+      this.wizard.busy = false;
     }
-
-    this.wizard.step = this.visibleStepNames[0];
-    this.wizard.busy = false;
   },
   methods: {
     close() {
@@ -742,8 +740,6 @@ export default {
         });
         const filtered = docs.filter(doc => result.editable.includes(doc._id));
         return filtered;
-      } catch (e) {
-        //
       } finally {
         this.wizard.busy = status;
       }

--- a/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
+++ b/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
@@ -224,7 +224,7 @@
             v-if="isLastStep()"
             type="primary"
             label="apostrophe:localizeContent"
-            :disabled="!complete()"
+            :disabled="!complete() || wizard.busy"
             @click="submit"
           />
           <AposButton
@@ -233,13 +233,14 @@
             @click="goToNext()"
             icon="arrow-right-icon"
             :modifiers="['icon-right']"
-            :disabled="!complete()"
+            :disabled="!complete() || wizard.busy"
             :icon-size="12"
             label="apostrophe:next"
           />
           <AposButton
             v-if="!isFirstStep()"
             type="default"
+            :disabled="wizard.busy"
             @click="goToPrevious()"
             label="apostrophe:back"
           />
@@ -288,6 +289,7 @@ export default {
       },
       wizard: {
         step: 'selectContent',
+        busy: false,
         sections: {
           selectContent: {
             title: this.$t('apostrophe:selectContent'),
@@ -451,6 +453,10 @@ export default {
     }
   },
   watch: {
+    // Debug busy state - controlling disabled state for actions.
+    // 'wizard.busy'(newVal) {
+    //   console.log('BUSY STATUS', newVal);
+    // },
     'wizard.values.relatedDocSettings.data'() {
       this.updateRelatedDocs();
     },
@@ -473,26 +479,33 @@ export default {
   },
   async mounted() {
     this.modal.active = true;
-    this.fullDoc = await apos.http.get(
+    this.wizard.busy = true;
+    try {
+      this.fullDoc = await apos.http.get(
       `${this.action}/${this.doc._id}`,
       {
         busy: true
       }
-    );
+      );
 
-    const docs = await apos.http.get(
+      const docs = await apos.http.get(
       `${this.action}/${this.fullDoc._id}/locales`,
       {
         busy: true
       }
-    );
-    this.localized = Object.fromEntries(
-      docs.results
-        .filter(doc => doc.aposLocale.endsWith(':draft'))
-        .map(doc => [ doc.aposLocale.split(':')[0], doc ])
-    );
-    await this.updateRelatedDocs();
+      );
+      this.localized = Object.fromEntries(
+        docs.results
+          .filter(doc => doc.aposLocale.endsWith(':draft'))
+          .map(doc => [ doc.aposLocale.split(':')[0], doc ])
+      );
+      await this.updateRelatedDocs();
+    } catch (e) {
+      //
+    }
+
     this.wizard.step = this.visibleStepNames[0];
+    this.wizard.busy = false;
   },
   methods: {
     close() {
@@ -605,6 +618,7 @@ export default {
     async submit() {
       let docs = [];
       const notifications = [];
+      this.wizard.busy = true;
 
       if (this.wizard.values.toLocalize.data !== 'relatedDocsOnly') {
         docs.push(this.fullDoc);
@@ -713,18 +727,26 @@ export default {
     },
     // Get all related documents
     async getRelatedDocs(doc) {
+      const status = this.wizard.busy;
+      this.wizard.busy = true;
       const schema = apos.modules[doc.type].schema;
       const docs = getRelatedBySchema(doc, schema);
       if (!docs.length) {
         return [];
       }
-      const result = await apos.http.post(`${apos.doc.action}/editable?aposMode=draft`, {
-        body: {
-          ids: docs.map(doc => doc._id)
-        }
-      });
-      const filtered = docs.filter(doc => result.editable.includes(doc._id));
-      return filtered;
+      try {
+        const result = await apos.http.post(`${apos.doc.action}/editable?aposMode=draft`, {
+          body: {
+            ids: docs.map(doc => doc._id)
+          }
+        });
+        const filtered = docs.filter(doc => result.editable.includes(doc._id));
+        return filtered;
+      } catch (e) {
+        //
+      } finally {
+        this.wizard.busy = status;
+      }
 
       function getRelatedBySchema(object, schema) {
         let related = [];
@@ -770,6 +792,8 @@ export default {
       if (this.wizard.values.toLocalize.data === 'thisDoc') {
         return;
       }
+      const status = this.wizard.busy;
+      this.wizard.busy = true;
       let relatedDocs = await this.getRelatedDocs(this.fullDoc);
       this.allRelatedDocs = relatedDocs;
       this.allRelatedDocsKnown = true;
@@ -794,6 +818,7 @@ export default {
         relatedDocs = relatedDocs.filter(doc => unlocalizedIds.has(doc._id));
       }
       this.relatedDocs = relatedDocs;
+      this.wizard.busy = status;
     }
   }
 };


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Solves the problem of navigating the modal wizard, while the state is not ready for that. No matter we introduce the global busy state (the blue screen of death) on every request to the back-end, it takes reasonable time before it shims the entire screen. With this patch the action buttons are always disabled when an action should not be performed.

## What are the specific steps to test this change?

See the ticket acceptance criteria.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
