### PR TITLE
massages inline array styles and ux

### DIFF
--- a/modules/@apostrophecms/asset/lib/globalIcons.js
+++ b/modules/@apostrophecms/asset/lib/globalIcons.js
@@ -80,6 +80,7 @@ module.exports = {
   'trash-can-outline-icon': 'TrashCanOutline',
   'tune-icon': 'Tune',
   'undo-icon': 'UndoVariant',
+  'unfold-less-horizontal-icon': 'UnfoldLessHorizontal',
   'unfold-more-horizontal-icon': 'UnfoldMoreHorizontal',
   'video-icon': 'Video',
   'view-column-icon': 'ViewColumn',

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
@@ -333,11 +333,11 @@ function expandItems(items) {
   .apos-input-array-inline-schema-wrapper {
     max-height: 999px;
     overflow: hidden;
-    transition: max-height .5s;
+    transition: max-height 0.5s;
   }
 
   .collapse-enter, .collapse-leave-to {
-    max-height: 0px;
+    max-height: 0;
   }
 
   .collapse-enter-to, .collapse-leave {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
@@ -326,6 +326,7 @@ export default {
   .apos-field {
     .apos-schema ::v-deep & {
       margin-bottom: $spacing-quadruple;
+      &.apos-field--small,
       &.apos-field--micro,
       &.apos-field--margin-micro {
         margin-bottom: $spacing-double;

--- a/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
@@ -512,6 +512,9 @@ export default {
     &[disabled].apos-button--busy {
       border: 1px solid var(--a-danger-button-disabled);
     }
+    &.apos-button--inline {
+      color: var(--a-danger-button-active);
+    }
     .apos-spinner__svg {
       color: var(--a-danger);
     }


### PR DESCRIPTION
## Summary

- Nudges styles to accommodate larger schemas
- Displays `titleField` labels like the full array editor
- Collapse/expand mechanism for editing

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other