### PR TITLE
display default area-specific widget content

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -438,6 +438,7 @@ export default {
           widget: {
             type: name,
             ...this.contextualWidgetDefaultData(name),
+            ...this.widgetAreaDefaultData(name),
             aposPlaceholder: this.widgetHasPlaceholder(name)
           },
           index
@@ -446,6 +447,7 @@ export default {
         return this.insert({
           widget: {
             type: name,
+            ...this.widgetAreaDefaultData(name),
             aposPlaceholder: this.widgetHasPlaceholder(name)
           },
           index
@@ -454,7 +456,7 @@ export default {
         const componentName = this.widgetEditorComponent(name);
         apos.area.activeEditor = this;
         const widget = await apos.modal.execute(componentName, {
-          value: null,
+          value: this.widgetAreaDefaultData(name),
           options: this.widgetOptionsByType(name),
           type: name,
           docId: this.docId
@@ -482,6 +484,13 @@ export default {
     },
     contextualWidgetDefaultData(type) {
       return this.moduleOptions.contextualWidgetDefaultData[type];
+    },
+    widgetAreaDefaultData(type) {
+      const { _def } = this.options.widgets[type];
+
+      return _def && Object.keys(_def).length
+        ? _def
+        : null;
     },
     async insert({ index, widget }) {
       if (!widget._id) {

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -522,7 +522,7 @@ export default {
       return this.moduleOptions.widgetIsContextual[type];
     },
     widgetHasPlaceholder(type) {
-      return this.moduleOptions.widgetHasPlaceholder[type];
+      return this.moduleOptions.widgetHasPlaceholder[type] && !this.widgetAreaDefaultData(type);
     },
     widgetHasInitialModal(type) {
       return this.moduleOptions.widgetHasInitialModal[type];


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Add the possibility to override a widget default values in a  specific area

## What are the specific steps to test this change?

- on testbed, checkout https://github.com/apostrophecms/testbed/pull/112
- create a `Area Defaults` page type
- add the following widgets to the page area and check that their default value contain "area override" (or "nested area override" when inserted in the two-column widget) when added.
![image](https://user-images.githubusercontent.com/8301962/199764239-4b7683fd-9969-48b2-9cd2-d942b5fca98b.png)

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
