### PR TITLE
Apostrophe 2: add excludeCertainUsers from seeing a piece or a page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Adds
+
+* Allows to exclude certain groups of users from seeing a piece or a page in `Permissions` tab.
+
 ## 2.222.0 (2022-07-20)
 
 ## Adds

--- a/lib/modules/apostrophe-doc-type-manager/index.js
+++ b/lib/modules/apostrophe-doc-type-manager/index.js
@@ -59,6 +59,11 @@ module.exports = {
             value: 'certainUsers',
             label: 'Certain People',
             showFields: [ '_viewGroups', '_viewUsers' ]
+          },
+          {
+            value: 'excludeCertainUsers',
+            label: 'Exclude Certain People',
+            showFields: [ '_excludeViewGroups' ]
           }
         ]
       },
@@ -77,6 +82,15 @@ module.exports = {
         withType: 'apostrophe-group',
         label: 'These Groups can View',
         idsField: 'viewGroupsIds',
+        sortable: false,
+        editDocs: false
+      },
+      {
+        name: '_excludeViewGroups',
+        type: 'joinByArray',
+        withType: 'apostrophe-group',
+        label: 'These Groups cannot View',
+        idsField: 'excludeViewGroupsIds',
         sortable: false,
         editDocs: false
       },

--- a/lib/modules/apostrophe-doc-type-manager/index.js
+++ b/lib/modules/apostrophe-doc-type-manager/index.js
@@ -63,6 +63,7 @@ module.exports = {
           {
             value: 'excludeCertainUsers',
             label: 'Exclude Certain People',
+            help: 'Selected group members will not be allowed to view the document. Please note that it will still require a logged-in user to view it, logged-out users will be excluded.',
             showFields: [ '_excludeViewGroups' ]
           }
         ]

--- a/lib/modules/apostrophe-docs/lib/api.js
+++ b/lib/modules/apostrophe-docs/lib/api.js
@@ -336,6 +336,7 @@ module.exports = function(self, options) {
     var fields = {
       viewGroupsIds: 'view',
       viewUsersIds: 'view',
+      excludeViewGroupsIds: 'exclude-view',
       editGroupsIds: 'edit',
       editUsersIds: 'edit'
     };
@@ -947,7 +948,7 @@ module.exports = function(self, options) {
   // etc.
 
   self.docUnversionedFields = function(req, doc, fields) {
-    fields.push('slug', 'docPermissions', 'viewUserIds', 'viewGroupIds', 'editUserIds', 'editGroupIds', 'loginRequired');
+    fields.push('slug', 'docPermissions', 'viewUserIds', 'viewGroupIds', 'excludeViewGroupIds', 'editUserIds', 'editGroupIds', 'loginRequired');
   };
 
   // Lock the given doc id to a given `contextId`, such

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -227,7 +227,7 @@ module.exports = function(self, options) {
 
     var admin = req.user && req.user._permissions.admin;
 
-    var allowed = [ 'view' ];
+    var allowed = [ 'view', 'exclude-view' ];
     if (admin) {
       allowed.push('edit');
     }
@@ -313,6 +313,7 @@ module.exports = function(self, options) {
         'loginRequired',
         'viewUsersIds',
         'viewGroupsIds',
+        'excludeViewGroupsIds',
         'editUsersIds',
         'editGroupsIds',
         'docPermissions'

--- a/lib/modules/apostrophe-permissions/lib/strategiesApi.js
+++ b/lib/modules/apostrophe-permissions/lib/strategiesApi.js
@@ -58,6 +58,12 @@ module.exports = function(self, options) {
           if (req.user && _.intersection(self.userPermissionNames(req.user, 'edit'), object.docPermissions).length) {
             return true;
           }
+
+          // Case #5: object is restricted to exclude certain people
+          if (req.user && object.published && (object.loginRequired === 'excludeCertainUsers') && _.intersection(self.userPermissionNames(req.user, 'exclude-view'), object.docPermissions).length === 0) {
+            return true;
+          }
+
         } else {
           // Not view permissions
 
@@ -95,7 +101,6 @@ module.exports = function(self, options) {
             }
 
             // Case #3: doc is restricted to certain people
-
             clauses.push({
               published: true,
               loginRequired: 'certainUsers',
@@ -120,6 +125,13 @@ module.exports = function(self, options) {
                   }
                 }
               ]
+            });
+
+            // Case #5: doc is restricted to exclude certain people
+            clauses.push({
+              published: true,
+              loginRequired: 'excludeCertainUsers',
+              docPermissions: { $nin: self.userPermissionNames(req.user, 'exclude-view') }
             });
           }
         } else {

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -2736,7 +2736,7 @@ module.exports = {
     // Return all standard field names currently associated with permissions editing,
     // for consistency in arrangeFields, batch permissions schemas, etc.
     self.getPermissionsFieldNames = function() {
-      return [ 'loginRequired', '_viewUsers', '_viewGroups', '_editUsers', '_editGroups', 'applyToSubpages' ];
+      return [ 'loginRequired', '_viewUsers', '_viewGroups', '_excludeViewGroups', '_editUsers', '_editGroups', 'applyToSubpages' ];
     };
 
   }

--- a/lib/modules/apostrophe-users/index.js
+++ b/lib/modules/apostrophe-users/index.js
@@ -803,6 +803,7 @@ module.exports = {
         var fields = {
           'viewUsersIds': [],
           'viewGroupsIds': [],
+          'excludeViewGroupsIds': [],
           'editUsersIds': [],
           'editGroupsIds': []
         };

--- a/test/permissions.js
+++ b/test/permissions.js
@@ -86,6 +86,15 @@ describe('Permissions', function() {
     it('certainUsers will not let you slide past to an unpublished doc', function() {
       assert(!apos.permissions.can(req({ user: { _id: 1 } }), 'view-doc', { loginRequired: 'certainUsers', docPermissions: [ 'view-1' ] }));
     });
+    it('forbids view-doc for individual with group id', function() {
+      assert(!apos.permissions.can(req({ user: { _id: 1, groupIds: [ 1001, 1002 ] } }), 'view-doc', { published: true, loginRequired: 'excludeCertainUsers', docPermissions: [ 'exclude-view-1002' ] }));
+    });
+    it('permits view-doc for individual with wrong group id', function() {
+      assert(apos.permissions.can(req({ user: { _id: 2, groupIds: [ 1001, 1002 ] } }), 'view-doc', { published: true, loginRequired: 'excludeCertainUsers', docPermissions: [ 'exclude-view-1003' ] }));
+    });
+    it('excludeCertainUsers will not let you slide past to an unpublished doc', function() {
+      assert(!apos.permissions.can(req({ user: { _id: 1 } }), 'exclude-view-doc', { loginRequired: 'excludeCertainUsers', docPermissions: [ 'exclude-view-1' ] }));
+    });
     it('permits view-doc for unpublished doc for individual with group id for editing', function() {
       assert(apos.permissions.can(req({ user: { _id: 1, groupIds: [ 1001, 1002 ] } }), 'view-doc', { docPermissions: [ 'edit-1002' ] }));
     });

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -153,6 +153,7 @@ var realWorldCase = {
         "loginRequired",
         "_viewUsers",
         "_viewGroups",
+        "_excludeViewGroups",
         "_editUsers",
         "_editGroups"
       ],


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

⚠️ this is an **Apostrophe 2** feature request

Allow to exclude certain groups from seeing a piece or a page

## What are the specific steps to test this change?

Pre-requisite:
`apostrophe-users` option `groups` must be false for `Groups` to appear in the admin-bar.

1. Create 2 groups `premium` & `basic` with the `Guest` permission
2. Create 2 users `premium` & `basic` and assign it the group with the same name
3. Create a new page `premium` and select in the `Permissions` tab the following
  a. `Who can view this?` = `Certain people`
  b. `These Groups can View` = `premium`
4. Create a new page `basic` and select in the `Permissions` tab the following
  a. `Who can view this?` = `Exclude Certain people`
  b. `These Groups cannot View` = `premium`
5. Login as `premium` and check that you can only see the `premium` page
6. Login as `basic` and check that you can only see the `basic` page
7. `npx mocha` must be green.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
