### PR TITLE
Flexible rich text default options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * You can now set `inline: true` on schema fields of type `array`. This displays a simple editing interface in the context of the main dialog box for the document in question, avoiding the need to open an additional dialog box. Usually best for cases with just one field or just a few. If your array field has a large number of subfields the default behavior (`inline: false`) is more suitable for your needs.
 * Batch feature for publishing pieces.
+* Add extensibility for `rich-text-widget` `defaultOptions`. Every key will now be used in the `AposRichTextWidgetEditor`.
 
 ### Fixes
 

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -114,12 +114,12 @@ export default {
       );
 
       // Allow default options to pass through if `false`
-      for (const option in this.defaultOptions) {
+      Object.keys(this.defaultOptions).forEach((option) => {
         if (option !== 'styles') {
-          activeOptions[option] =(activeOptions[option] !== undefined)
+          activeOptions[option] = (activeOptions[option] !== undefined)
             ? activeOptions[option] : this.defaultOptions[option];
         }
-      }
+      })
 
       activeOptions.className = (activeOptions.className !== undefined)
         ? activeOptions.className : this.moduleOptions.className;

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -107,15 +107,19 @@ export default {
     editorOptions() {
       const activeOptions = Object.assign({}, this.options);
 
-      // Allow toolbar option to pass through if `false`
-      activeOptions.toolbar = (activeOptions.toolbar !== undefined)
-        ? activeOptions.toolbar : this.defaultOptions.toolbar;
-
       activeOptions.styles = this.enhanceStyles(
         activeOptions.styles?.length
           ? activeOptions.styles
           : this.defaultOptions.styles
       );
+
+      // Allow default options to pass through if `false`
+      for (const option in this.defaultOptions) {
+        if (option !== 'styles') {
+          activeOptions[option] =(activeOptions[option] !== undefined)
+            ? activeOptions[option] : this.defaultOptions[option];
+        }
+      }
 
       activeOptions.className = (activeOptions.className !== undefined)
         ? activeOptions.className : this.moduleOptions.className;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

For easier extension of the rich-text, checking and adding all `defaultOptions` to the `activeOptions`.

## What are the specific steps to test this change?

*For example:*
> 1. Extend your rich-text-widget with new `defaultOptions` (maybe you want to use them in a new and fancy component you've written)
> 2. Check the `activeOptions` for the new `defaultOptions`

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [x] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
  - as far as I have seen there is nothing to update
- [ ] Related tests have been updated 
  - as far as I have seen there is nothing to update

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
