### PR TITLE
Protect against any possibility of dcad-1191 manifesting in A3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Prior to this release, widget templates that contained areas pulled in from related documents would break the ability to add another widget beneath.
 * Validation of object fields now works properly on the browser side, in addition to server-side validation, resolving UX issues.
+* Provisions were added to prevent any possibility of a discrepancy in relationship loading results under high load. It is not clear whether this A2 bug was actually possible in A3.
 
 ## 3.32.0 (2022-11-09)
 

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -661,9 +661,12 @@ module.exports = {
         let relationships = [];
 
         function findRelationships(schema, arrays) {
+          // Shallow clone of each relationship to allow
+          // for independent _dotPath and _arrays properties
+          // for different requests
           const _relationships = _.filter(schema, function (field) {
             return !!self.fieldTypes[field.type].relate;
-          });
+          }).map(relationship => ({ ...relationship }));
           _.each(_relationships, function (relationship) {
             if (!arrays.length) {
               relationship._dotPath = relationship.name;

--- a/test/concurrent-array-relationships.js
+++ b/test/concurrent-array-relationships.js
@@ -1,0 +1,101 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert');
+const { klona } = require('klona');
+
+describe('Concurrent Array Joins', function() {
+
+  after(async function() {
+    return t.destroy(apos);
+  });
+
+  this.timeout(t.timeout);
+
+  let apos;
+
+  // EXISTENCE
+
+  it('should be a property of the apos object', async function() {
+    apos = await t.create({
+      root: module,
+      modules: {
+        'test-person': {
+          extend: '@apostrophecms/piece-type',
+          options: {
+            alias: 'person'
+          },
+          fields: {
+            add: {
+              hobbies: {
+                type: 'array',
+                fields: {
+                  add: {
+                    name: {
+                      type: 'string'
+                    },
+                    _friends: {
+                      type: 'relationship',
+                      withType: 'test-person'
+                      // builders: {
+                      //   project: {
+                      //     title: 1
+                      //   }
+                      // }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+  });
+
+  it('should be able to retrieve hobbies in parallel with all relationships', async function() {
+    const req = apos.task.getReq();
+    const hobbyists = [];
+    for (let i = 0; (i < 10); i++) {
+      hobbyists.push(await apos.person.insert(req, {
+        title: `Hobbyist ${i}`,
+        visibility: 'public'
+      }));
+    }
+    for (let i = 0; (i < 10); i++) {
+      await apos.person.update(req, {
+        ...hobbyists[i],
+        hobbies: [
+          {
+            name: `Hobby ${i}`,
+            _friends: [
+              // Deep clone to avoid infinite recursion during the save operation
+              // as 4 points to 5 and vice versa
+              klona(hobbyists[9 - i])
+            ]
+          }
+        ]
+      });
+    }
+    const promises = [];
+    for (let i = 0; (i < 100); i++) {
+      const req = apos.task.getReq();
+      promises.push(apos.person.find(req).toArray());
+    }
+    const results = await Promise.all(promises);
+    assert.strictEqual(results.length, 100);
+    for (const result of results) {
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare
+      result.sort((a, b) => a.title.localeCompare(b.title));
+      assert.strictEqual(result.length, 10);
+      for (let i = 0; (i < 10); i++) {
+        const person = result[i];
+        assert.strictEqual(person.title, `Hobbyist ${i}`);
+        console.log(person);
+        assert.strictEqual(person.hobbies.length, 1);
+        assert.strictEqual(person.hobbies[0].name, `Hobby ${i}`);
+        assert(person.hobbies[0]._friends);
+        assert(person.hobbies[0]._friends[0]);
+        assert.strictEqual(person.hobbies[0]._friends[0].title, `Hobbyist ${9 - i}`);
+      }
+    }
+  });
+});


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

See the A2 ticket. In A3 it's not clear if this bug is really possible because the `_arrays` and `_dotPaths` properties are never deleted at present, but it is advisable not to share these properties between requests.

## What are the specific steps to test this change?

New tests pass (but they also pass without the patch 🤷‍♂️)

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [X] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
