### PR TITLE
fast parking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## UNRELEASED
+
+### Adds
+
+* Relationships load more quickly.
+* Parked page checks at startup are faster.
+
 ## 3.33.0 (2022-11-28)
 
 ### Adds

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -347,6 +347,15 @@ module.exports = {
           submitted: 1,
           aposLocale: 1
         });
+        await self.db.createIndex({
+          type: 1,
+          aposDocId: 1,
+          aposLocale: 1
+        });
+        await self.db.createIndex({
+          aposDocId: 1,
+          aposLocale: 1
+        });
         await self.createPathLevelIndex();
       },
       async createTextIndex() {

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -1867,7 +1867,12 @@ database.`);
           } else {
             parentSlug = item.parent;
           }
-          return self.findOneForEditing(req, { slug: parentSlug });
+          return self.findOneForEditing(req, {
+            slug: parentSlug
+          }, {
+            areas: false,
+            relationships: false
+          });
         }
         async function findExisting() {
           return self.findOneForEditing(req, { parkedId: item.parkedId });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

See changelog. I couldn't wait for UT to start up one more time. Also important for good performance of relationships at all times.

## What are the specific steps to test this change?

Start up a site with a lot of related documents or images on the home page. Parked pages don't take forever and slow down your progress. (I did this already with UT.)

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [X] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
