### PR TITLE
fix the search index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * Nested areas work properly in widgets that have the `initialModal: false` property.
+* Apostrophe's search index now properly incorporates most string field types as in A2.
 
 ### Adds
 

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -78,6 +78,18 @@ module.exports = (self) => {
           }
         }
       }
+    },
+    index: function (value, field, texts) {
+      for (const item of ((value && value.items) || [])) {
+        const manager = self.apos.area.getWidgetManager(item.type);
+        if (!manager) {
+          self.apos.area.warnMissingWidgetType(item.type);
+          return;
+        }
+        if (manager.addSearchTexts) {
+          manager.addSearchTexts(item, texts);
+        }
+      }
     }
   });
 

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -81,7 +81,7 @@ module.exports = (self) => {
     },
     index: function (value, field, texts) {
       for (const item of ((value && value.items) || [])) {
-        const manager = self.apos.area.getWidgetManager(item.type);
+        const manager = item.type && self.apos.area.getWidgetManager(item.type);
         if (!manager) {
           self.apos.area.warnMissingWidgetType(item.type);
           return;
@@ -856,6 +856,11 @@ module.exports = (self) => {
         return true;
       }
       return self.isEqual(req, field.schema, one[field.name], two[field.name]);
+    },
+    index: function (value, field, texts) {
+      if (value) {
+        self.apos.schema.indexFields(field.schema, value, texts);
+      }
     },
     def: {}
   });


### PR DESCRIPTION
Makes sure you can search i18n static pieces by value and not just by key. This was never properly ported from A2 to A3 before.