### PR TITLE
PRO-3428 fix lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+* The `bulletList` and `orderedList` TipTap toolbar items now work as expected.
 * When using the autocomplete/typeahead feature of relationship fields, typing a space at the start no longer results in an error.
 * Replace [`credential`](https://www.npmjs.com/package/credential) package with [`credentials`](https://www.npmjs.com/package/credentials) to fix the [`mout` Prototype Pollution vulnerability](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7792). There was no actual vulnerability in Apostrophe or credential due to the way the module was actually used, and this was done to address vulnerability scan reports.
 

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -185,7 +185,8 @@ export default {
     const extensions = [
       StarterKit.configure({
         document: false,
-        heading: false
+        heading: false,
+        listItem: false
       }),
       TextAlign.configure({
         types: [ 'heading', 'paragraph' ]

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Default.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Default.js
@@ -1,8 +1,16 @@
 // If a style has been marked `def`, we need to make sure it
-// and it's attributes are prioritized in our editor.
-// It's easier to create a new Node with our specifications and put it
-// at the front of the line than try to infer between editor instantiation
-// and the editor-user setting styles via the toolbar to know when its needed.
+// and its attributes are prioritized in our editor.
+//
+// Specifically, when the "enter" key is pressed, we don't want
+// tiptap/prosemirror to insert "paragraph" nodes in a rich
+// text widget in which they are not even configured as an option.
+//
+// The simplest way to ensure this is to create a new node type that
+// matches the tag and CSS class of the default style (the first
+// configured style, or the one marked with def: `true`).
+//
+// Matching extensions have been provided to the document and listItem types
+// to prefer defaultNode rather than paragraph.
 
 import { Node } from '@tiptap/core';
 import Heading from '@tiptap/extension-heading';

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/ListItem.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/ListItem.js
@@ -1,0 +1,6 @@
+import ListItem from '@tiptap/extension-list-item';
+export default (options) => {
+  return ListItem.extend({
+    content: 'defaultNode block*'
+  });
+};


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

* Fixed bulleted and ordered lists. You can select existing text and create a list from it
* You can then continue the list with the "enter" key and you get the default style of your particular rich text widget as expected inside each item

## What are the specific steps to test this change?

* You can select existing text and create a list from it (if you don't see any bullets make sure your project has styles, or check the inspector; but definitely make sure the markup is there)
* There will be paragraphs (or your other default style's tag) inside each list item, this is mandatory ProseMirror behavior, I did not come to catch that fish today

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
