### PR TITLE
Remove deep-get-set package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * Replace [`credential`](https://www.npmjs.com/package/credential) package with [`credentials`](https://www.npmjs.com/package/credentials) to fix the [`mout` Prototype Pollution vulnerability](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7792). There was no actual vulnerability in Apostrophe or credential due to the way the module was actually used, and this was done to address vulnerability scan reports.
+* Fix vulnerability by removing package `deep-get-set` used in areas
 
 ## 2.223.0 (2022-11-28)
 

--- a/lib/modules/apostrophe-areas/lib/api.js
+++ b/lib/modules/apostrophe-areas/lib/api.js
@@ -1,6 +1,5 @@
 var _ = require('@sailshq/lodash');
 var async = require('async');
-var deep = require('deep-get-set');
 
 module.exports = function(self, options) {
 
@@ -213,13 +212,13 @@ module.exports = function(self, options) {
         // and is not an area.
 
         if (components.length > 1) {
-          var existing = deep(doc, dotPath);
+          var existing = getDeepObject(doc, dotPath);
           if (existing && (existing.type !== 'area')) {
             return callback(new Error('forbidden'));
           }
         }
 
-        var existingArea = deep(doc, dotPath);
+        var existingArea = getDeepObject(doc, dotPath);
         var existingItems = (existingArea && existingArea.items) || [];
         if (_.isEqual(self.apos.utils.clonePermanent(items), self.apos.utils.clonePermanent(existingItems))) {
           // No real change — don't waste a version and clutter the database.
@@ -228,7 +227,7 @@ module.exports = function(self, options) {
           return setImmediate(callback);
         }
 
-        deep(doc, dotPath, {
+        getDeepObject(doc, dotPath, {
           type: 'area',
           items: items
         });
@@ -242,6 +241,21 @@ module.exports = function(self, options) {
     }, function(err) {
       return callback(err);
     });
+
+    function getDeepObject (obj, path) {
+      var keys = Array.isArray(path) ? path : path.split('.');
+      for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        if (!obj ||
+          !Object.prototype.hasOwnProperty.call(obj, key) ||
+          !(key !== '__proto__' && key !== 'prototype' && key !== 'constructor')) {
+          obj = undefined;
+          break;
+        }
+        obj = obj[key];
+      }
+      return obj;
+    }
   };
 
   // Lock, sanitize and save the area described by `areaInfo` on behalf

--- a/lib/modules/apostrophe-areas/lib/api.js
+++ b/lib/modules/apostrophe-areas/lib/api.js
@@ -212,13 +212,13 @@ module.exports = function(self, options) {
         // and is not an area.
 
         if (components.length > 1) {
-          var existing = getDeepObject(doc, dotPath);
+          var existing = _.get(doc, dotPath);
           if (existing && (existing.type !== 'area')) {
             return callback(new Error('forbidden'));
           }
         }
 
-        var existingArea = getDeepObject(doc, dotPath);
+        var existingArea = _.get(doc, dotPath);
         var existingItems = (existingArea && existingArea.items) || [];
         if (_.isEqual(self.apos.utils.clonePermanent(items), self.apos.utils.clonePermanent(existingItems))) {
           // No real change — don't waste a version and clutter the database.
@@ -227,7 +227,7 @@ module.exports = function(self, options) {
           return setImmediate(callback);
         }
 
-        getDeepObject(doc, dotPath, {
+        _.set(doc, dotPath, {
           type: 'area',
           items: items
         });
@@ -241,21 +241,6 @@ module.exports = function(self, options) {
     }, function(err) {
       return callback(err);
     });
-
-    function getDeepObject (obj, path) {
-      var keys = Array.isArray(path) ? path : path.split('.');
-      for (var i = 0; i < keys.length; i++) {
-        var key = keys[i];
-        if (!obj ||
-          !Object.prototype.hasOwnProperty.call(obj, key) ||
-          !(key !== '__proto__' && key !== 'prototype' && key !== 'constructor')) {
-          obj = undefined;
-          break;
-        }
-        obj = obj[key];
-      }
-      return obj;
-    }
   };
 
   // Lock, sanitize and save the area described by `areaInfo` on behalf

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "cookie-parser": "^1.4.5",
     "credentials": "^3.0.2",
     "cuid": "^1.3.8",
-    "deep-get-set": "^1.1.1",
     "diff": "^4.0.1",
     "emulate-mongo-2-driver": "^1.2.3",
     "express": "^4.17.1",


### PR DESCRIPTION
## Summary

All versions of package deep-get-set are vulnerable to Prototype Pollution via the 'deep' function. Note: This vulnerability derives from an incomplete fix of [CVE-2020-7715](https://security.snyk.io/vuln/SNYK-JS-DEEPGETSET-598666)

## What are the specific steps to test this change?

> 1. Run the website and log in as an admin
> 2. Edit an area and check if it saved correctly

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

