### PR TITLE
Add manager shortcut option for every doc type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@
 
 ### Adds
 
-* `shortcut` option for modules that are extending `@apostrophecms/doc-type`,   allowing easy re-mapping of the manager command shortcut per module.
+* `shortcut` option for piece modules, allowing easy re-mapping of the manager command shortcut per module. 
+
+### Fixes 
+
+* Ensure there are no conflicting command shortcuts for the core modules.
 
 ## 3.35.0 (2022-12-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+## 3.36.0 (2022-12-22)
+
+### Adds
+
+* `shortcut` option for modules that are extending `@apostrophecms/doc-type`,   allowing easy re-mapping of the manager command shortcut per module.
+
 ## 3.35.0 (2022-12-21)
 
 ### Adds

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -98,7 +98,7 @@ module.exports = {
             action: 'edit',
             type: self.__meta.name
           },
-          shortcut: `G,${self.apos.task.getReq().t(self.options.label).slice(0, 1)}`
+          shortcut: self.options.shortcut ?? `G,${self.apos.task.getReq().t(self.options.label).slice(0, 1)}`
         },
         [`${self.__meta.name}:create-new`]: {
           type: 'item',

--- a/modules/@apostrophecms/file-tag/index.js
+++ b/modules/@apostrophecms/file-tag/index.js
@@ -6,7 +6,8 @@ module.exports = {
     quickCreate: false,
     autopublish: true,
     editRole: 'editor',
-    publishRole: 'editor'
+    publishRole: 'editor',
+    shortcut: 'G,g'
   },
   fields: {
     remove: [ 'visibility' ]

--- a/modules/@apostrophecms/image-tag/index.js
+++ b/modules/@apostrophecms/image-tag/index.js
@@ -6,7 +6,8 @@ module.exports = {
     quickCreate: false,
     autopublish: true,
     editRole: 'editor',
-    publishRole: 'editor'
+    publishRole: 'editor',
+    shortcut: 'G,o'
   },
   fields: {
     remove: [ 'visibility' ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "3.35.0",
+  "version": "3.36.0",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Every module extending `doc-type` has now `options.shortcut`, allowing it to re-map its manager command shortcut.

## What are the specific steps to test this change?

Login in any Apostrophe application and open Image tags manager via `g,o` shortcut and File tags manager via `g,g` shortcut. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
