### PR TITLE
Fix and enhance the public build Webpack configuration merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-* The module `webpack.extensions` configuration is not applied to the core Admin UI build anymore.
+* The module `webpack.extensions` configuration is not applied to the core Admin UI build anymore. This is the correct and intended behavior as explained in the [relevant documentation](https://v3.docs.apostrophecms.org/guide/webpack.html#extending-webpack-configuration).
 
 ## 3.36.0 (2022-12-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Adds
+
+* Use `mergeWithCustomize` when merging extended source Webpack configuration. Introduce overideable asset module methods `srcCustomizeArray` and `srcCustomizeObject`, with reasonable default behavior, for fine tuning Webpack config arrays and objects merging. More info - [the Webpack mergeWithCustomize docs](https://github.com/survivejs/webpack-merge#mergewithcustomize-customizearray-customizeobject-configuration--configuration)
+
+### Fixes
+
+* The module `webpack.extensions` configuration is not applied to the core Admin UI build anymore.
 
 ## 3.36.0 (2022-12-22)
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

- Do not merge module `webpack.extensions` configuration with the core `apos` build
- Allow applications and modules to control array and object Webpack configuration merging 

**A (Real World) Scenario**

A module `public-forms` is providing public forms via a Vue 3 UI. It extends webpack configuration in order to achieve that. Here is the relevant implementation, that is only possible with the changes made in this PR (explanations "How" can be found below).

```js
// possible npm module  'public-forms' - index.js
module.exports = {
  webpack: {
    extensions: {
      vue3: {
        resolve: {
          extensions: [ '*', '.js', '.ts', '.vue', '.json' ],
          alias: {
           // The application should introduce vue3 dependency, 
           // ensure to build without vue runtime duplicates.
            vue$: path.resolve(
              process.cwd(),
              './node_modules/vue/dist/vue.runtime.esm-bundler.js'
            )
          }
        },
        // Control the loaders resolution - this module, the app, finally apostrophe - in this order.
       // We will introduce `extensionOptions.vue3()` options in order to control this behavior outside.
        resolveLoader: {
          extensions: [ '*', '.js', '.ts', '.vue', '.json' ],
          modules: [
            path.join(__dirname, 'node_modules'),
            'node_modules',
            'node_modules/apostrophe/node_modules'
          ]
        },
        module: {
          rules: [
            // handle SFC
            {
              test: /\.vue$/,
              loader: 'vue-loader',
              options: {
                sourceMap: true
              }
            },
            // yup, Typescript too
            {
              test: /\.ts$/,
              loader: 'ts-loader',
              options: { appendTsSuffixTo: [ /\.vue$/ ] }
            },
            // for the <style  lang="css"> blocks, postcss can be added too
            {
              test: /\.css$/,
              use: [
                'vue-style-loader',
                {
                  loader: 'css-loader',
                  options: {
                    esModule: false,
                    sourceMap: true
                  }
                }
              ]
            }
          ]
        },
        plugins: [
          new VueLoaderPlugin(),
          // ... even more plugins
        ]
      }
    }
  },
  init(self) {
    self.enableBrowserData('public');
  },
  // ...components and other stuff
  methods(self) {
    return {
      getBrowserData(req) {
       // some useful Vue app configuration
        return {
          key: 'value'
        };
      }
    };
  }
};
```
The relevant portion of the core webpack configuration
```js
// apostrophe/modules/@apostrophecms/asset/lib/webpack/src/webpack.config.js
{
  // ...
  resolveLoader: {
    extensions: [ '*', '.js' ],
    modules: [ 'node_modules', 'node_modules/apostrophe/node_modules' ]
  },
  resolve: {
    extensions: [ '*', '.js' ],
    alias: {
      Modules: path.resolve(modulesDir)
    },
    modules: [
      'node_modules',
      `${apos.npmRootDir}/node_modules`,
      `${apos.npmRootDir}/node_modules/apostrophe/node_modules`
    ],
    symlinks: false
  },
  // ...
}
```

**The Benefits**
1. Unique configuration arrays for key parts of the webpack config
2. Before the change the resulting merged config will be:
```js
{
        resolve: {
          extensions: [ '*', '.js', '*',  '.js', '.ts', '.vue', '.json' ],
          // ...
        },
        resolveLoader: {
          extensions: [ '*', '.js', '*', '.js', '.ts', '.vue', '.json' ],
          modules: [
            'node_modules',
            'node_modules/apostrophe/node_modules'
            'node_modules/public/form/node_modules',
            'node_modules',
            'node_modules/apostrophe/node_modules'
          ]
        },
}
```
After the change and after the module has added a `srcCustomizeArray` handler it is:
```js
{
        resolve: {
          extensions: [ '*',  '.js', '.ts', '.vue', '.json' ],
          // ...
        },
        resolveLoader: {
          extensions: [ '*', '.js', '.ts', '.vue', '.json' ],
          modules: [
            'node_modules/public/form/node_modules',
            'node_modules',
            'node_modules/apostrophe/node_modules'
          ]
        },
}
```
The developer can fine tune very important parts - loaders resolving now defaults to the module that provides the relevant loaders (options could be provided to control that from outside), the application comes second, and the fallback is finally the Apostrophe owned modules.

This scenario is tested in a real life module and everything works as expected. 

## What are the specific steps to test this change?

- The `apos` build configuration should not contain anything from any `webpack.extensions` configuration
- `extensions` and `modules` Webpack configuration keys should not contain duplicates by default when  `webpack.extensions` provide such
- Extending or overriding the asset owned `srcCustomizeArray` and `srcCustomizeObject` methods should reflect in modified Webpack merge algorithm 

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
