### PR TITLE
Pro 3223 type without manager polymorphic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* Remove module `@apostrophecms/polymorphic-type` name alias `@apostrophecms/polymorphic`. It was causing warnings
+    e.g. `A permission.can() call was made with a type that has no manager: @apostrophecms/polymorphic-type`.
 
 ## 3.36.0 (2022-12-22)
 

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -1096,8 +1096,9 @@ module.exports = {
       normalizeType(type) {
         if (type === '@apostrophecms/page') {
           // Backwards compatible
-          type = '@apostrophecms/any-page-type';
+          return '@apostrophecms/any-page-type';
         }
+
         return type;
       },
       // Given a doc, an _id, or an aposDocId, this method

--- a/modules/@apostrophecms/polymorphic-type/index.js
+++ b/modules/@apostrophecms/polymorphic-type/index.js
@@ -6,6 +6,24 @@ module.exports = {
     name: '@apostrophecms/polymorphic-type',
     showPermissions: false
   },
+  init(self) {
+    self.removePolymorphicTypeAliasMigration();
+  },
+  methods(self) {
+    return {
+      removePolymorphicTypeAliasMigration() {
+        self.apos.migration.add('remove-polymorphic-type-alias', () => {
+          return self.apos.doc.db.updateMany({
+            type: '@apostrophecms/polymorphic'
+          }, {
+            $set: {
+              type: '@apostrophecms/polymorphic-type'
+            }
+          });
+        });
+      }
+    };
+  },
   routes(self) {
     return {
       post: {

--- a/modules/@apostrophecms/polymorphic-type/index.js
+++ b/modules/@apostrophecms/polymorphic-type/index.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 module.exports = {
   extend: '@apostrophecms/doc-type',
   options: {
-    name: '@apostrophecms/polymorphic',
+    name: '@apostrophecms/polymorphic-type',
     showPermissions: false
   },
   routes(self) {

--- a/modules/@apostrophecms/polymorphic-type/index.js
+++ b/modules/@apostrophecms/polymorphic-type/index.js
@@ -8,7 +8,12 @@ module.exports = {
     showPermissions: false
   },
   init(self) {
-    migrations(self).addMigrations();
+    self.addMigrations();
+  },
+  methods(self) {
+    return {
+      ...migrations(self)
+    };
   },
   routes(self) {
     return {

--- a/modules/@apostrophecms/polymorphic-type/index.js
+++ b/modules/@apostrophecms/polymorphic-type/index.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const migrations = require('./lib/migrations.js');
 
 module.exports = {
   extend: '@apostrophecms/doc-type',
@@ -7,22 +8,7 @@ module.exports = {
     showPermissions: false
   },
   init(self) {
-    self.removePolymorphicTypeAliasMigration();
-  },
-  methods(self) {
-    return {
-      removePolymorphicTypeAliasMigration() {
-        self.apos.migration.add('remove-polymorphic-type-alias', () => {
-          return self.apos.doc.db.updateMany({
-            type: '@apostrophecms/polymorphic'
-          }, {
-            $set: {
-              type: '@apostrophecms/polymorphic-type'
-            }
-          });
-        });
-      }
-    };
+    migrations(self).addMigrations();
   },
   routes(self) {
     return {

--- a/modules/@apostrophecms/polymorphic-type/lib/migrations.js
+++ b/modules/@apostrophecms/polymorphic-type/lib/migrations.js
@@ -1,0 +1,18 @@
+module.exports = (self) => {
+  return {
+    addMigrations() {
+      self.removePolymorphicTypeAliasMigration();
+    },
+    removePolymorphicTypeAliasMigration() {
+      self.apos.migration.add('remove-polymorphic-type-alias', () => {
+        return self.apos.doc.db.updateMany({
+          type: '@apostrophecms/polymorphic'
+        }, {
+          $set: {
+            type: '@apostrophecms/polymorphic-type'
+          }
+        });
+      });
+    }
+  };
+};


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Remove noisy polymorphic-type has no manager warning when running testbed

## What are the specific steps to test this change?

1. Setup testbed to use `github:apostrophecms/apostrophe#pro-3223-type-without-manager-polymorphic`
2. Run cypress tests. You don't need to wait for the full tests to complete. Each scenario was previously returning the warning.

You can compare the output from https://github.com/apostrophecms/testbed/actions/runs/3819327850 (without the fix) vs https://github.com/apostrophecms/testbed/actions/runs/3828244225 (with the fix included).

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
