### PR TITLE
PRO-3284: fix bugs in widget preview image URL handling, introduce placeholderImage option, consolidate the implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@
 ### Adds
 
 * Use `mergeWithCustomize` when merging extended source Webpack configuration. Introduce overideable asset module methods `srcCustomizeArray` and `srcCustomizeObject`, with reasonable default behavior, for fine tuning Webpack config arrays and objects merging. More info - [the Webpack mergeWithCustomize docs](https://github.com/survivejs/webpack-merge#mergewithcustomize-customizearray-customizeobject-configuration--configuration)
+* The image widget now accepts a `placeholderImage` option that works like `previewImage` (just specify a file extension, like `placeholderImage: 'jpg'`, and provide the file `public/placeholder.jpg` in the module). The `placeholderUrl` option is still available for backwards compatibility.
 
 ### Fixes
 
 * Remove module `@apostrophecms/polymorphic-type` name alias `@apostrophecms/polymorphic`. It was causing warnings
     e.g. `A permission.can() call was made with a type that has no manager: @apostrophecms/polymorphic-type`.
 * The module `webpack.extensions` configuration is not applied to the core Admin UI build anymore. This is the correct and intended behavior as explained in the [relevant documentation](https://v3.docs.apostrophecms.org/guide/webpack.html#extending-webpack-configuration).
-
+* The `previewImage` option now works properly for widget modules loaded from npm and those that subclass them. Specifically, the preview image may be provided in the `public/` subdirectory of the original module, the project-level configuration of it, or a subclass.
+ 
 ## 3.36.0 (2022-12-22)
 
 ### Adds

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaExpandedMenu.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaExpandedMenu.vue
@@ -36,8 +36,8 @@
                     class="apos-icon--add"
                   />
                   <img
-                    v-if="item.previewImage"
-                    :src="previewUrl(item)"
+                    v-if="item.previewImageUrl"
+                    :src="item.previewImageUrl"
                     :alt="`${item.name} preview`"
                     class="apos-widget__preview-image"
                   >
@@ -175,9 +175,6 @@ export default {
     },
     hasIcon(widget) {
       return widget.previewIcon || widget.icon;
-    },
-    previewUrl(widget) {
-      return widget.previewImage ? apos.util.assetUrl(`/modules/${widget.name}-widget/preview.${widget.previewImage}`) : '';
     },
     close() {
       this.modal.showModal = false;

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaExpandedMenu.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaExpandedMenu.vue
@@ -36,8 +36,8 @@
                     class="apos-icon--add"
                   />
                   <img
-                    v-if="item.previewImageUrl"
-                    :src="item.previewImageUrl"
+                    v-if="item.previewUrl"
+                    :src="item.previewUrl"
                     :alt="`${item.name} preview`"
                     class="apos-widget__preview-image"
                   >

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -1343,6 +1343,11 @@ module.exports = {
           return 'url(\'' + filter(url) + '\')';
         });
         return css;
+      },
+      // Return the URL of the asset with the given path, taking into account
+      // the release id, uploadfs, etc.
+      url(path) {
+        return `${self.getAssetBaseUrl()}${path}`;
       }
     };
   },
@@ -1360,8 +1365,10 @@ module.exports = {
         }
         return self.apos.template.safe(`<script data-apos-refresh-on-restart="${self.action}/restart-id" src="${self.action}/refresh-on-restart"></script>`);
       },
+      // Return the URL of the release asset with the given path, taking into account
+      // the release id, uploadfs, etc.
       url(path) {
-        return `${self.getAssetBaseUrl()}${path}`;
+        return self.url(path);
       }
     };
   },

--- a/modules/@apostrophecms/image-widget/index.js
+++ b/modules/@apostrophecms/image-widget/index.js
@@ -7,7 +7,7 @@ module.exports = {
     dimensionAttrs: false,
     placeholder: true,
     placeholderClass: false,
-    placeholderUrl: '/modules/@apostrophecms/image-widget/placeholder.jpg'
+    placeholderImage: 'jpg'
   },
   fields: {
     add: {
@@ -19,5 +19,8 @@ module.exports = {
         withType: '@apostrophecms/image'
       }
     }
+  },
+  init(self) {
+    self.determineBestAssetUrl('placeholder');
   }
 };

--- a/modules/@apostrophecms/image-widget/views/widget.html
+++ b/modules/@apostrophecms/image-widget/views/widget.html
@@ -1,6 +1,6 @@
 {% if data.widget.aposPlaceholder and data.manager.options.placeholderUrl %}
   <img
-    src="{{ apos.asset.url(data.manager.options.placeholderUrl) }}"
+    src="{{ data.manager.options.placeholderUrl }}"
     alt="{{ __t('apostrophe:imagePlaceholder') }}"
     class="image-widget-placeholder"
   />

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -795,7 +795,9 @@ module.exports = {
         if (urlOption && urlOption.startsWith('/modules')) {
           urlOption = self.apos.asset.url(urlOption);
         }
-        self.options[`${name}Url`] = urlOption;
+        if (urlOption) {
+          self.options[`${name}Url`] = urlOption;
+        }
       },
 
       // Merge in the event emitter / responder capabilities

--- a/modules/@apostrophecms/widget-type/index.js
+++ b/modules/@apostrophecms/widget-type/index.js
@@ -387,7 +387,7 @@ module.exports = {
           description: self.options.description,
           icon: self.options.icon,
           previewIcon: self.options.previewIcon,
-          previewImageUrl: self.options.previewImageUrl,
+          previewUrl: self.options.previewUrl,
           action: self.action,
           schema: schema,
           contextual: self.options.contextual,

--- a/modules/@apostrophecms/widget-type/index.js
+++ b/modules/@apostrophecms/widget-type/index.js
@@ -106,6 +106,8 @@ module.exports = {
 
     self.enableBrowserData();
 
+    self.determineBestAssetUrl('preview');
+
     self.template = self.options.template || 'widget';
 
     self.name = self.__meta.name.replace(/-widget$/, '');
@@ -362,6 +364,7 @@ module.exports = {
           version. The method in 3.x simply returns an empty array.`);
         return [];
       }
+
     };
   },
   extendMethods(self) {
@@ -384,7 +387,7 @@ module.exports = {
           description: self.options.description,
           icon: self.options.icon,
           previewIcon: self.options.previewIcon,
-          previewImage: self.options.previewImage,
+          previewImageUrl: self.options.previewImageUrl,
           action: self.action,
           schema: schema,
           contextual: self.options.contextual,


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

See changelog.

## What are the specific steps to test this change?

* Note that preview images (in the expanded menu, which can be found *only* in the "widget previews" page type on testbed) work in the corresponding branch of testbed (which I'd like to merge), even if they are added at project level on behalf of a core module (image-widget)
* Note that the image widget placeholder image still works even though I changed the standard config to use the new `placeholderImage` option, which works like `previewImage` and shares an implementation

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [X] New feature
- [X] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
