### PR TITLE
emit beforeInsert event in attachment module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Adds
+
+* Emit a `beforeInsert` event from the `@apostrophecms:attachment` module, with `req` and the `doc` as arguments, in order to give the possibility to override the attachment.
+
 ## 3.37.0 (2023-01-06)
 
 ### Adds

--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -443,6 +443,9 @@ module.exports = {
           await Promise.promisify(self.uploadfs.copyIn)(file.path, '/attachments/' + info._id + '-' + info.name + '.' + info.extension);
         }
         info.createdAt = new Date();
+
+        await self.emit('beforeInsert', req, info);
+
         await self.db.insertOne(info);
         return info;
       },


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Emit event before inserting an attachment in order to be able to modify it.
Necessary for the enterprise [@apostrophe-pro/doc-global-sharding](https://github.com/apostrophecms/doc-global-sharding) module.

cf. https://github.com/apostrophecms/doc-global-sharding/pull/4
