### PR TITLE
Page: uppercase URL is redirected to lowercase URL if not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Adds
 
 * Emit a `beforeInsert` event from the `@apostrophecms:attachment` module, with `req` and the `doc` as arguments, in order to give the possibility to override the attachment.
-* Emit a `beforeSaveSafe` event from the `@apostrophecms:user` module, with `req`, `safeUser` and `user` as arguments, in order to give the possibility to override properties of the 'safe' object which contains password hashes and other information too sensitive to be stored in the aposDocs collection.
+* Emit a `beforeSaveSafe` event from the `@apostrophecms:user` module, with `req`, `safeUser` and `user` as arguments, in order to give the possibility to override properties of the `safeUser` object which contains password hashes and other information too sensitive to be stored in the aposDocs collection.
 * Convert uppercase URLs automatically to their lowercase version - can be disabled with `redirectFailedUpperCaseUrls: false` in `@apostrophecms/page/index.js` options.
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Adds
 
 * Emit a `beforeInsert` event from the `@apostrophecms:attachment` module, with `req` and the `doc` as arguments, in order to give the possibility to override the attachment.
-
+* Convert uppercase URLs automatically to their lowercase version - can be disabled through `forceLowerCaseUrls` option in `@apostrophecms/page/index.js`.
 ## 3.37.0 (2023-01-06)
 
 ### Adds
@@ -21,14 +21,14 @@
     e.g. `A permission.can() call was made with a type that has no manager: @apostrophecms/polymorphic-type`.
 * The module `webpack.extensions` configuration is not applied to the core Admin UI build anymore. This is the correct and intended behavior as explained in the [relevant documentation](https://v3.docs.apostrophecms.org/guide/webpack.html#extending-webpack-configuration).
 * The `previewImage` option now works properly for widget modules loaded from npm and those that subclass them. Specifically, the preview image may be provided in the `public/` subdirectory of the original module, the project-level configuration of it, or a subclass.
- 
+
 ## 3.36.0 (2022-12-22)
 
 ### Adds
 
-* `shortcut` option for piece modules, allowing easy re-mapping of the manager command shortcut per module. 
+* `shortcut` option for piece modules, allowing easy re-mapping of the manager command shortcut per module.
 
-### Fixes 
+### Fixes
 
 * Ensure there are no conflicting command shortcuts for the core modules.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Adds
 
 * Emit a `beforeInsert` event from the `@apostrophecms:attachment` module, with `req` and the `doc` as arguments, in order to give the possibility to override the attachment.
-* Convert uppercase URLs automatically to their lowercase version - can be disabled through `forceLowerCaseUrls` option in `@apostrophecms/page/index.js`.
+* Convert uppercase URLs automatically to their lowercase version - can be disabled with `redirectFailedUpperCaseUrls: false` in `@apostrophecms/page/index.js` options.
 
 ### Fixes
 

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -34,7 +34,7 @@ module.exports = {
         title: 'Archive'
       }
     ],
-    forceLowerCaseUrls: true
+    redirectFailedUpperCaseUrls: true
   },
   batchOperations: {
     add: {
@@ -1617,7 +1617,7 @@ database.`);
         }
 
         // If uppercase letters in URL, try with lowercase
-        if(self.options.forceLowerCaseUrls && /[A-Z]/.test(req.path)) {
+        if (self.options.redirectFailedUpperCaseUrls && /[A-Z]/.test(req.path)) {
           req.redirect = self.apos.url.build(req.path.toLowerCase(), req.query);
         }
 

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -33,7 +33,8 @@ module.exports = {
         orphan: true,
         title: 'Archive'
       }
-    ]
+    ],
+    forceLowerCaseUrls: true
   },
   batchOperations: {
     add: {
@@ -1616,7 +1617,7 @@ database.`);
         }
 
         // If uppercase letters in URL, try with lowercase
-        if(/[A-Z]/.test(req.path)) {
+        if(self.options.forceLowerCaseUrls && /[A-Z]/.test(req.path)) {
           req.redirect = self.apos.url.build(req.path.toLowerCase(), req.query);
         }
 

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -1565,6 +1565,7 @@ database.`);
         if (self.isFound(req)) {
           return;
         }
+
         if (req.user && (req.mode === 'published')) {
           // Try again in draft mode
           try {
@@ -1613,6 +1614,12 @@ database.`);
             // Nonfatal, we were just probing
           }
         }
+
+        // If uppercase letters in URL, try with lowercase
+        if(/[A-Z]/.test(req.path)) {
+          req.redirect = self.apos.url.build(req.path.toLowerCase(), req.query);
+        }
+
         // Give all modules a chance to save the day
         await self.emit('notFound', req);
         // Are we happy now?

--- a/test/modules/test-page/views/page.html
+++ b/test/modules/test-page/views/page.html
@@ -10,4 +10,6 @@
   {% for tab in data.home._children %}
     <a href="{{ tab._url }}">Tab: {{ tab.slug }}</a>
   {% endfor %}
+
+  URL: {{ data.page._url }}
 {% endblock %}

--- a/test/pages.js
+++ b/test/pages.js
@@ -215,6 +215,13 @@ describe('Pages', function() {
     assert(page.path === `${homeId.replace(':en:published', '')}/parent/child`);
   });
 
+  it('should redirect to a lowercase URL when uppercase is detected', async function() {
+    const response = await apos.http.get('/PArent/cHild', {
+      fullResponse: true
+    });
+    assert(response.body.match(/URL: \/parent\/child/));
+  });
+
   it('should be able to include the ancestors of a page', async function() {
     const cursor = apos.page.find(apos.task.getAnonReq(), { slug: '/parent/child' });
 
@@ -1151,8 +1158,6 @@ describe('Pages', function() {
 
       it('should grant public access to a draft after having enabled draft sharing', async function() {
         const publicUrl = generatePublicUrl(shareResponse);
-        console.log('publicUrl', publicUrl);
-
         const response = await apos.http.get(shareResponse._url, { fullResponse: true });
         const publicResponse = await apos.http.get(publicUrl, { fullResponse: true });
 

--- a/test/pages.js
+++ b/test/pages.js
@@ -215,11 +215,22 @@ describe('Pages', function() {
     assert(page.path === `${homeId.replace(':en:published', '')}/parent/child`);
   });
 
-  it('should redirect to a lowercase URL when uppercase is detected', async function() {
+  it('should convert an uppercase URL to its lowercase version', async function() {
     const response = await apos.http.get('/PArent/cHild', {
       fullResponse: true
     });
     assert(response.body.match(/URL: \/parent\/child/));
+  });
+
+  it('should NOT convert an uppercase URL if forceLowerCaseUrls is false', async function() {
+    apos.page.options.forceLowerCaseUrls = false;
+    try {
+      await apos.http.get('/PArent/cHild', {
+        fullResponse: true
+      });
+    } catch (error) {
+      assert(error.status === 404);
+    }
   });
 
   it('should be able to include the ancestors of a page', async function() {

--- a/test/pages.js
+++ b/test/pages.js
@@ -222,8 +222,8 @@ describe('Pages', function() {
     assert(response.body.match(/URL: \/parent\/child/));
   });
 
-  it('should NOT convert an uppercase URL if forceLowerCaseUrls is false', async function() {
-    apos.page.options.forceLowerCaseUrls = false;
+  it('should NOT convert an uppercase URL if redirectFailedUpperCaseUrls is false', async function() {
+    apos.page.options.redirectFailedUpperCaseUrls = false;
     try {
       await apos.http.get('/PArent/cHild', {
         fullResponse: true


### PR DESCRIPTION
## Summary

Convert uppercase URLs automatically to their lowercase version - can be disabled through `forceLowerCaseUrls` option in `@apostrophecms/page/index.js`.

## What are the specific steps to test this change?

Run tests

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated
