### PR TITLE
emit beforeSaveSafe event providing the safe user and the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Adds
 
 * Emit a `beforeInsert` event from the `@apostrophecms:attachment` module, with `req` and the `doc` as arguments, in order to give the possibility to override the attachment.
-* Emit a `beforeSaveSafe` event from the `@apostrophecms:user` module, with `req`, `safeUser` and `user` as arguments, in order to give the possibility to override the safe user.
+* Emit a `beforeSaveSafe` event from the `@apostrophecms:user` module, with `req`, `safeUser` and `user` as arguments, in order to give the possibility to override properties of the 'safe' object which contains password hashes and other information too sensitive to be stored in the aposDocs collection.
 
 ## 3.37.0 (2023-01-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Adds
 
 * Emit a `beforeInsert` event from the `@apostrophecms:attachment` module, with `req` and the `doc` as arguments, in order to give the possibility to override the attachment.
+* Emit a `beforeSaveSafe` event from the `@apostrophecms:user` module, with `req`, `safeUser` and `user` as arguments, in order to give the possibility to override the safe user.
 
 ## 3.37.0 (2023-01-06)
 

--- a/modules/@apostrophecms/user/index.js
+++ b/modules/@apostrophecms/user/index.js
@@ -292,6 +292,9 @@ module.exports = {
 
         await self.hashPassword(doc, safeUser);
         await self.hashSecrets(doc, safeUser);
+
+        await self.emit('beforeSaveSafe', req, safeUser, doc);
+
         if (action === 'insert') {
           await self.safe.insertOne(safeUser);
         } else {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Emit event before inserting a safe user in order to be able to modify it.
Necessary for the enterprise [@apostrophe-pro/doc-global-sharding](https://github.com/apostrophecms/doc-global-sharding) module.

cf. https://github.com/apostrophecms/doc-global-sharding/pull/3
