### PR TITLE
Pro 3495 i18next locale format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Emit a `beforeInsert` event from the `@apostrophecms:attachment` module, with `req` and the `doc` as arguments, in order to give the possibility to override the attachment.
 * Emit a `beforeSaveSafe` event from the `@apostrophecms:user` module, with `req`, `safeUser` and `user` as arguments, in order to give the possibility to override properties of the 'safe' object which contains password hashes and other information too sensitive to be stored in the aposDocs collection.
+* Enforce i18next locale format as xx-XX
 
 ### Fixes
 
@@ -26,14 +27,14 @@
     e.g. `A permission.can() call was made with a type that has no manager: @apostrophecms/polymorphic-type`.
 * The module `webpack.extensions` configuration is not applied to the core Admin UI build anymore. This is the correct and intended behavior as explained in the [relevant documentation](https://v3.docs.apostrophecms.org/guide/webpack.html#extending-webpack-configuration).
 * The `previewImage` option now works properly for widget modules loaded from npm and those that subclass them. Specifically, the preview image may be provided in the `public/` subdirectory of the original module, the project-level configuration of it, or a subclass.
- 
+
 ## 3.36.0 (2022-12-22)
 
 ### Adds
 
-* `shortcut` option for piece modules, allowing easy re-mapping of the manager command shortcut per module. 
+* `shortcut` option for piece modules, allowing easy re-mapping of the manager command shortcut per module.
 
-### Fixes 
+### Fixes
 
 * Ensure there are no conflicting command shortcuts for the core modules.
 

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -409,7 +409,11 @@ module.exports = {
                 continue;
               }
               const data = JSON.parse(fs.readFileSync(path.join(localizationsDir, localizationFile)));
-              const locale = localizationFile.replace('.json', '');
+
+              // enforce i18next locale format as xx-XX
+              const [ language, country ] = localizationFile.replace('.json', '').split('-');
+              const locale = country ? `${language.toLocaleLowerCase()}-${country.toUpperCase()}` : language;
+
               self.i18next.addResourceBundle(locale, ns, data, true, true);
             }
           }
@@ -566,7 +570,11 @@ module.exports = {
         return i18n;
       },
       getLocales() {
-        const locales = self.options.locales || {
+        const locales = Object.fromEntries(Object.entries(self.options.locales).map(([ name, options ]) => {
+          // enforce i18next locale format as xx-XX
+          const [ language, country ] = name.split('-');
+          return country ? [ `${language.toLocaleLowerCase()}-${country.toUpperCase()}`, options ] : [ language, options ];
+        })) || {
           en: {
             label: 'English'
           }


### PR DESCRIPTION
## Summary

Enforce i18next locale format as xx-XX.

**Issue**: declaring a language in lowercase is ok for i18next (for example `en`). But having a locale (language-country) is only correct if the country code is in uppercase - e.g: `en-US` (i18next should still be able to read a locale `en-us` but actually no - it is not A3's fault, as it read the JSON correctly, but when adding resources to i18next, they are just ignored by i18next)

**Solution**: check if the locale contains a country code. If it is the case, format it to `xx-XX` while adding the resources to i18next, and do the same to `locales` configuration in A3 so everything works smoothly.

## What are the specific steps to test this change?

1. `npm link apostrophe` with this branch on testbed
2. In `modules/@apostrophecms/i18n/index.js`, add this to `options.locales`
```js
     'de-de': {
        label: 'German',
        prefix: '/de-de'
      }
```
3. Copy `node_modules/apostrophe/modules/@apostrophecms/i18n/i18n/de.json` to `de-de.json`
4. Run testbed, login and switch to `de-de`. The UI should be in German

<img width="882" alt="image" src="https://user-images.githubusercontent.com/11479686/212728255-5bfe8416-6169-4716-b381-782354990955.png">


## What kind of change does this PR introduce?

**Is it a bug fix or a feature?** 
- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
