### PR TITLE
fix 503 error on invalid locales in the locale switcher route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ### Fixes
 
 * Modifies the `aposMode` property of a document, to set it to `previous`, when this one switch from `published` to `previous` state.
+* Invalid locales passed to the i18n locale switching middleware are politely mapped to 400 errors.
+* Any other exceptions thrown in the i18n locale switching middleware can no longer crash the process.
 
 ## 3.37.0 (2023-01-06)
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

* These routes are native express routes so we have to explicitly catch any errors to avoid a process restart.
* Also, explicitly handle an invalid locale name here.

## What are the specific steps to test this change?

* Switch locales in the a3-demo project using the *public* locale switch (the one seen in the demo, not the admin UI one)
* In network panel note uRLs like: `http://localhost:3000/api/v1/@apostrophecms/page/clbxwvf2c0004ncvg0324g2mm:fr:published/locale/en`
* Try one of those with a valid ID but a bogus locale
* Should produce a terse but accurate error message and not crash the process

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
