### PR TITLE
PRO-3558 download all attachments from any uploadfs backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Adds
+
+* The new `@apostrophecms/attachment:download-all --to=folder` command line task is useful to download all of your attachments from an uploadfs backend other than local storage, especially if you do not have a more powerful "sync" utility for that particular backend.
+
 ## 3.38.0 (2023-01-18)
 
 ### Adds

--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -112,6 +112,7 @@ module.exports = {
     self.sizeAvailableInArchive = self.options.sizeAvailableInArchive || 'one-sixth';
 
     self.rescaleTask = require('./lib/tasks/rescale.js')(self);
+    self.downloadAllTask = require('./lib/tasks/download-all.js')(self);
     self.addFieldType();
     self.enableBrowserData();
 
@@ -127,6 +128,10 @@ module.exports = {
       rescale: {
         usage: 'Usage: node app @apostrophecms/attachment:rescale\n\nRegenerate all sizes of all image attachments. Useful after a new size\nis added to the configuration. Takes a long time!',
         task: self.rescaleTask
+      },
+      'download-all': {
+        usage: 'Usage: node app @apostrophecms/attachment:download-all --to=public/uploads/attachments [--resume] [--parallel=3]\n\nDownload all attachments to a local folder, usually to sync\nfrom a non-local uploadfs backend. Takes a long time!',
+        task: self.downloadAllTask
       },
       'migrate-to-disabled-file-key': {
         usage: 'Usage: node app @apostrophecms/attachment:migrate-to-disabled-file-key\n\nThis task should be run after adding the disabledFileKey option to uploadfs\nfor the first time. It should only be relevant for storage backends where\nthat option is not mandatory, i.e. only local storage as of this writing.',

--- a/modules/@apostrophecms/attachment/lib/tasks/download-all.js
+++ b/modules/@apostrophecms/attachment/lib/tasks/download-all.js
@@ -1,0 +1,77 @@
+// Direct use of console is appropriate in tasks. -Tom
+/* eslint-disable no-console */
+
+const fs = require('fs');
+const sep = require('path').sep;
+
+// Download everything Apostrophe believes to be in uploadfs.
+// Useful when uploadfs is not using a storage backend we
+// can conveniently sync from in some other way
+
+module.exports = function(self) {
+  return async function(argv) {
+    const copyOut = require('util').promisify(self.uploadfs.copyOut);
+    if (!argv.to) {
+      throw 'You must specify a --to=directory argument';
+    }
+    console.log(`Downloading all attachments to ${argv.to} (this takes time)`);
+    const files = fs.readdirSync(argv.to);
+    if ((files.length > 0) && (!argv.resume)) {
+      throw `The directory ${argv.to} is not empty and --resume not specified, exiting`;
+    }
+    if (!argv.to.endsWith(sep)) {
+      argv.to += sep;
+    }
+    const total = await self.db.count();
+    let n = 0;
+    const parallel = argv.parallel ? parseInt(argv.parallel) : 1;
+    await self.each({}, parallel, async function(file) {
+      const isImage = [ 'jpg', 'png', 'gif', 'webp' ].includes(file.extension);
+      const originalFile = filename(file);
+      n++;
+      console.log(n + ' of ' + total + ': ' + originalFile);
+      const files = [
+        originalFile
+      ];
+      if (isImage) {
+        files.push(...self.imageSizes.map(size => {
+          return filename(file, size);
+        }));
+        for (const crop of (file.crops || [])) {
+          files.push(filename(file, false, crop));
+          files.push(...self.imageSizes.map(size => filename(file, size, crop)));
+        }
+      }
+      for (const file of files) {
+        const to = argv.to + file;
+        const tmp = to + '.tmp';
+        if (fs.existsSync(to)) {
+          console.log(`${to} already exists, skipping`);
+        } else {
+          try {
+            console.log(`about to copy out: ${file}`);
+            await copyOut(`/attachments/${file}`, tmp);
+            fs.renameSync(tmp, argv.to + file);
+          } catch (e) {
+            if (e.code === 'ENOSPC') {
+              throw e;
+            } else {
+              console.log(`${e.code}: ${file} was probably never uploaded to uploadfs, skipping`);
+            }
+          }
+        }
+      }
+      function filename(file, size, crop) {
+        let name = file._id + '-' + file.name;
+        if (crop) {
+          name += '.' + crop.left + '.' + crop.top + '.' + crop.width + '.' + crop.height;
+        }
+        if (size) {
+          name += '.' + size.name;
+        }
+        name += '.' + file.extension;
+        return name;
+      }
+    });
+  };
+};


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

New command line task to download all attachments from any uploadfs backend.

## What are the specific steps to test this change?

```
mkdir /some/test/dir
node app @apostrophecms/attachment:download-all --to=/some/test/dir
```

If your existing site is using local uploadfs storage (the default) then it will finish really fast, but it's still a valid test because uploadfs abstracts away differences between storage backends.

Note that nonexistent files are skipped without a panic because it is super common for some expected files to be missing, inaccessible or of sizes the developer never bothered to rescale existing uploadfs to. We log the error code instead. We do try to throw an error and stop if we see `ENOSPC` (out of disk space).

You can use `--parallel=3` to download more than one attachment at a time, which makes sense only up to a point, 3 seems like a pretty good number so far today with Azure.

## What kind of change does this PR introduce?

*(Check at least one)*

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
