### PR TITLE
Bugfix | Extended menu error after widget deletion

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaExpandedMenu.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaExpandedMenu.vue
@@ -168,7 +168,8 @@ export default {
       }
 
       for (const item of Object.keys(config.widgets)) {
-        group.widgets.push(apos.modules[`${item}-widget`]);
+        const widget = apos.modules[`${item}-widget`];
+        if (widget) group.widgets.push(widget);
       }
 
       return group;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

If I use the extended menu, after deleting a previously used widget, there appears an error upon opening the menu. The menu is not rendered because of it.

I am unsure how deep this issue goes, so I just created a quick fix that simply checks for the existence of the widget before pushing it into group.

## What are the specific steps to test this change?

*For example:*
1. Create a widget
  1.1. maybe use the extended menu
  1.2 maybe use the widget and delete the creation again
2. Delete the widget (removing it from the app.js should be enough)
3. Open the extended menu
4. Error should appear in the console and the menu should be empty.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
