### PR TITLE
Pro 3534 slugs lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Adds
+
+* Convert uppercase URLs automatically to their lowercase version - can be disabled with `redirectFailedUpperCaseUrls: false` in `apostrophe-pages/index.js` options.
+
 ## 2.223.1 (2022-12-21)
 
 ### Fixes

--- a/lib/modules/apostrophe-pages/index.js
+++ b/lib/modules/apostrophe-pages/index.js
@@ -255,6 +255,8 @@ module.exports = {
 
   alias: 'pages',
 
+  redirectFailedUpperCaseUrls: true,
+
   types: [
     {
       // So that the minimum parked pages don't result in an error when home has no manager. -Tom
@@ -324,12 +326,14 @@ module.exports = {
         name: 'trash',
         label: 'Trash'
       }
-    ].concat(options.apos.docs.trashInSchema ? [
-      {
-        name: 'rescue',
-        label: 'Rescue'
-      }
-    ] : []).concat([
+    ].concat(options.apos.docs.trashInSchema
+      ? [
+        {
+          name: 'rescue',
+          label: 'Rescue'
+        }
+      ]
+      : []).concat([
       {
         name: 'publish',
         label: 'Publish'

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -429,7 +429,13 @@ module.exports = function(self, options) {
           .trash(null)
           .published(null)
           .areas(false)
-          .ancestors(_.assign({ depth: 1, trash: null, published: null, areas: false, permission: false }, options.filters || {}))
+          .ancestors(_.assign({
+            depth: 1,
+            trash: null,
+            published: null,
+            areas: false,
+            permission: false
+          }, options.filters || {}))
           .applyFilters(options.filters || {})
           .toObject(function(err, page) {
             if (err) {
@@ -460,7 +466,13 @@ module.exports = function(self, options) {
           .trash(null)
           .published(null)
           .areas(false)
-          .ancestors(_.assign({ depth: 1, trash: null, published: null, areas: false, permission: false }, options.filters || {}))
+          .ancestors(_.assign({
+            depth: 1,
+            trash: null,
+            published: null,
+            areas: false,
+            permission: false
+          }, options.filters || {}))
           .applyFilters(options.filters || {})
           .toObject(function(err, page) {
             if (err) {
@@ -516,7 +528,11 @@ module.exports = function(self, options) {
       function nudgeNewPeers(callback) {
         // Nudge down the pages that should now follow us
         // Always remember multi: true
-        self.apos.docs.db.update(mergeCriteria({ path: self.matchDescendants(parent), level: parent.level + 1, rank: { $gte: rank } }), { $inc: { rank: 1 } }, { multi: true }, function(err, count) {
+        self.apos.docs.db.update(mergeCriteria({
+          path: self.matchDescendants(parent),
+          level: parent.level + 1,
+          rank: { $gte: rank }
+        }), { $inc: { rank: 1 } }, { multi: true }, function(err, count) {
           return callback(err);
         });
       }
@@ -738,7 +754,12 @@ module.exports = function(self, options) {
       [
         function getPage(cb) {
         // check permissions and load page to trash/untrash
-          return self.find(req, { _id: _id }).permission('edit').trash(null).ancestors({ depth: 1, published: null, trash: null, areas: false }).toObject((err, _page) => {
+          return self.find(req, { _id: _id }).permission('edit').trash(null).ancestors({
+            depth: 1,
+            published: null,
+            trash: null,
+            areas: false
+          }).toObject((err, _page) => {
             page = _page;
             tree.push(page);
             parent = page._ancestors[0];
@@ -876,14 +897,17 @@ module.exports = function(self, options) {
     var parent;
     var changed = [];
 
-    return async.series([findTrash, findPage, movePage], function(err) {
+    return async.series([ findTrash, findPage, movePage ], function(err) {
       return callback(err, parent && parent.slug, changed);
     });
 
     function findTrash(callback) {
       // Always only one trash page at level 1, so we don't have
       // to hardcode the slug
-      return self.find(req, { trash: true, level: 1 })
+      return self.find(req, {
+        trash: true,
+        level: 1
+      })
         .permission(false)
         .published(null)
         .trash(null)
@@ -899,7 +923,12 @@ module.exports = function(self, options) {
 
     function findPage(callback) {
       // Also checks permissions
-      return self.find(req, { _id: _id }).permission('edit').ancestors({ depth: 1, published: null, trash: null, areas: false }).toObject(function(err, _page) {
+      return self.find(req, { _id: _id }).permission('edit').ancestors({
+        depth: 1,
+        published: null,
+        trash: null,
+        areas: false
+      }).toObject(function(err, _page) {
         if (err || (!_page)) {
           return callback('Page not found');
         }
@@ -943,7 +972,12 @@ module.exports = function(self, options) {
 
     function findPage(callback) {
       // Also checks permissions
-      return self.find(req, { _id: _id }).permission('publish').trash(true).ancestors({ depth: 1, published: null, trash: null, areas: false }).toObject(function(err, _page) {
+      return self.find(req, { _id: _id }).permission('publish').trash(true).ancestors({
+        depth: 1,
+        published: null,
+        trash: null,
+        areas: false
+      }).toObject(function(err, _page) {
         if (err || (!_page)) {
           return callback('Page not found');
         }
@@ -1134,6 +1168,12 @@ module.exports = function(self, options) {
       if (self.isFound(req)) {
         return callback(null);
       }
+
+      if (options.redirectFailedUpperCaseUrls && /[A-Z]/.test(req.path)) {
+        req.redirect = self.apos.urls.build(req.path.toLowerCase(), req.query);
+        return callback(null);
+      }
+
       req.data.suggestedSearch = self.apos.utils.slugify(req.url, { separator: ' ' });
       req.notFound = true;
       req.res.statusCode = 404;
@@ -1141,7 +1181,7 @@ module.exports = function(self, options) {
       // Give the browser a chance to do something interesting with a 404.
       // This is often a better idea than doing a heavy fallback search
       // server side, because those are triggered heavily by bots
-      req.browserCall("apos.emit('notfound', ?)", {
+      req.browserCall('apos.emit(\'notfound\', ?)', {
         suggestedSearch: req.data.suggestedSearch,
         url: req.url
       });
@@ -1421,7 +1461,10 @@ module.exports = function(self, options) {
 
   self.ensurePathIndex = function(callback) {
     var params = self.getPathIndexParams();
-    return self.apos.docs.db.ensureIndex(params, { unique: true, sparse: true }, callback);
+    return self.apos.docs.db.ensureIndex(params, {
+      unique: true,
+      sparse: true
+    }, callback);
   };
 
   self.getPathIndexParams = function() {
@@ -1502,8 +1545,14 @@ module.exports = function(self, options) {
     var matchParentPathPrefix = new RegExp('^' + self.apos.utils.regExpQuote(originalPath + '/'));
     var matchParentSlugPrefix = new RegExp('^' + self.apos.utils.regExpQuote(originalSlug + '/'));
     var done = false;
-    var cursor = self.apos.docs.db.findWithProjection(mergeCriteria({ path: matchParentPathPrefix }), { slug: 1, path: 1, level: 1 });
-    return async.whilst(function() { return !done; }, function(callback) {
+    var cursor = self.apos.docs.db.findWithProjection(mergeCriteria({ path: matchParentPathPrefix }), {
+      slug: 1,
+      path: 1,
+      level: 1
+    });
+    return async.whilst(function() {
+      return !done;
+    }, function(callback) {
       return cursor.nextObject(function(err, desc) {
         if (err) {
           return callback(err);
@@ -1996,10 +2045,10 @@ module.exports = function(self, options) {
   self.validateTypeChoices = function() {
     _.each(self.typeChoices, function(choice) {
       if (!choice.name) {
-        throw new Error("One of the page types specified for your 'types' option has no 'name' property.");
+        throw new Error('One of the page types specified for your \'types\' option has no \'name\' property.');
       }
       if (!choice.label) {
-        throw new Error("One of the page types specified for your 'types' option has no 'label' property.");
+        throw new Error('One of the page types specified for your \'types\' option has no \'label\' property.');
       }
     });
   };
@@ -2060,7 +2109,10 @@ module.exports = function(self, options) {
 
   self.removeSlugFromHomepageSchema = function(page, schema) {
     if (page.level === 0) {
-      schema = _.reject(schema, { type: 'slug', name: 'slug' });
+      schema = _.reject(schema, {
+        type: 'slug',
+        name: 'slug'
+      });
     }
     return schema;
   };

--- a/test/pages.js
+++ b/test/pages.js
@@ -433,7 +433,6 @@ describe('Pages', function() {
       assert(body.match(/Home: \//));
       // Does the response prove that data.home._children was available?
       assert(body.match(/Tab: \/another-parent/));
-      // console.log(body);
       return done();
     });
   });
@@ -443,7 +442,10 @@ describe('Pages', function() {
       assert(!err);
       // Is our status code good?
       assert.equal(response.statusCode, 404);
-
+      // Does the response prove that data.home was available?
+      assert(body.match(/Home: \//));
+      // Does the response prove that data.home._children was available?
+      assert(body.match(/Tab: \/another-parent/));
       return done();
     });
   });
@@ -475,6 +477,9 @@ describe('Pages', function() {
     return request('http://localhost:7900/chiLD', function (err, response, body) {
       assert(!err);
       assert.equal(response.statusCode, 200);
+      assert(body.match(/Sing to me, Oh Muse./));
+      assert(body.match(/Home: \//));
+      assert(body.match(/Tab: \/another-parent/));
       return done();
     });
   });

--- a/test/pages.js
+++ b/test/pages.js
@@ -443,11 +443,7 @@ describe('Pages', function() {
       assert(!err);
       // Is our status code good?
       assert.equal(response.statusCode, 404);
-      // Does the response prove that data.home was available?
-      assert(body.match(/Home: \//));
-      // Does the response prove that data.home._children was available?
-      assert(body.match(/Tab: \/another-parent/));
-      // console.log(body);
+
       return done();
     });
   });
@@ -473,6 +469,26 @@ describe('Pages', function() {
         done();
       });
     });
+  });
+
+  it('should redirect to url with path in lower case by default', function(done) {
+    return request('http://localhost:7900/chiLD', function (err, response, body) {
+      assert(!err);
+      assert.equal(response.statusCode, 200);
+      return done();
+    });
+  });
+
+  it('should not redirect to url with path in lower case if the option is disabled', function(done) {
+    apos.pages.options.redirectFailedUpperCaseUrls = false;
+
+    return request('http://localhost:7900/chiLD', function (err, response, body) {
+      assert(!err);
+      assert.equal(response.statusCode, 404);
+      return done();
+    });
+
+    apos.pages.options.redirectFailedUpperCaseUrls = true;
   });
 
   it('should detect that the home page is an ancestor of any page except itself', function() {
@@ -562,7 +578,6 @@ describe('Pages', function() {
       done();
     });
   });
-
 });
 
 describe('Pages with trashInSchema', function() {

--- a/test/pages.js
+++ b/test/pages.js
@@ -485,10 +485,10 @@ describe('Pages', function() {
     return request('http://localhost:7900/chiLD', function (err, response, body) {
       assert(!err);
       assert.equal(response.statusCode, 404);
+      apos.pages.options.redirectFailedUpperCaseUrls = true;
       return done();
     });
 
-    apos.pages.options.redirectFailedUpperCaseUrls = true;
   });
 
   it('should detect that the home page is an ancestor of any page except itself', function() {
@@ -577,6 +577,7 @@ describe('Pages', function() {
       assert.equal(page.path, '/newish-page');
       done();
     });
+
   });
 });
 


### PR DESCRIPTION
[PRO-3534](https://linear.app/apostrophecms/issue/PRO-3534/[a2-version]-as-a-user-when-typing-%E2%80%8B%E2%80%8Ba%E2%80%8B%E2%80%8B-url-slug-with-uppercase)

## Summary

Porting [this PR](https://github.com/apostrophecms/apostrophe/pull/3995) to A2.
I guess we should create an issue to update the documentation also.

## What are the specific steps to test this change?

> 1. Link to an A2 project
> 2. Try to access pages with uppercase letters in the slug, it should redirect to the lowercase version by default 
> 3. Verify that params are not touched (you can add random params to test).
> 4. Disable the option `redirectFailedUpperCaseUrls` by setting it to false in the options of the `apostrophe-pages` module.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [X] Related tests have been updated
