### PR TITLE
Feature/image loading type and default size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@
 * Support for `div` tags in the rich text toolbar, if you choose to include them in `styles`. This is often necessary for A2 content migration and can potentially be useful in new work when combined with a `class` if there is no suitable semantic block tag.
 * The new `@apostrophecms/attachment:download-all --to=folder` command line task is useful to download all of your attachments from an uploadfs backend other than local storage, especially if you do not have a more powerful "sync" utility for that particular backend.
 * For the widget `image-widget`
-  * `manager.option` properties:  `loadingType` and `size`
-  * If `loadingType` is set in the options the attribute `loading={{ loadingType }}` is added to the `img``
-  * With the `size` property it is possible to have a configurable default `size` for the `apos.attachment.url`-function
+  * Two new options have been added: `loadingType` and `size`
+  * `loadingType` adds the attribute `loading={{ loadingType }}` to the `img`
+  * With the `size` option it is possible to have a configurable default `size` for the `apos.attachment.url`-function
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Basic support for editing tables by adding `table` to the rich text toolbar. Enabling `table` allows you to create tables, including `td` and `th` tags, with the ability to merge and split cells. For now the table editing UI is basic, all of the functionality is there but we plan to add more conveniences for easy table editing soon. See the "Table" dropdown for actions that are permitted based on the current selection.
 * Support for `div` tags in the rich text toolbar, if you choose to include them in `styles`. This is often necessary for A2 content migration and can potentially be useful in new work when combined with a `class` if there is no suitable semantic block tag.
 * The new `@apostrophecms/attachment:download-all --to=folder` command line task is useful to download all of your attachments from an uploadfs backend other than local storage, especially if you do not have a more powerful "sync" utility for that particular backend.
+* For the widget `image-widget`
+  * `manager.option` properties:  `loadingType` and `size`
+  * If `loadingType` is set in the options the attribute `loading={{ loadingType }}` is added to the `img``
+  * With the `size` property it is possible to have a configurable default `size` for the `apos.attachment.url`-function
 
 ### Fixes
 

--- a/modules/@apostrophecms/image-widget/views/widget.html
+++ b/modules/@apostrophecms/image-widget/views/widget.html
@@ -5,24 +5,18 @@
     class="image-widget-placeholder"
   />
 {% else %}
-  {% if data.options.className %}
-    {% set className = data.options.className %}
-  {% elif data.manager.options.className %}
-    {% set className = data.manager.options.className %}
-  {% endif %}
-
-  {% if data.options.dimensionAttrs %}
-    {% set dimensionAttrs = data.options.dimensionAttrs %}
-  {% elif data.manager.options.dimensionAttrs %}
-    {% set dimensionAttrs = data.manager.options.dimensionAttrs  %}
-  {% endif %}
+  {% set className = data.options.className or data.manager.options.className %}
+  {% set dimensionAttrs = data.options.dimensionAttrs or data.manager.options.dimensionAttrs %}
+  {% set loadingType = data.options.loadingType or data.manager.options.loadingType %}
+  {% set size = data.options.size or data.manager.options.size or 'full' %}
 
   {% set attachment = apos.image.first(data.widget._image) %}
 
   {% if attachment %}
     <img {% if className %} class="{{ className }}"{% endif %}
+      {% if loadingType %} loading="{{ loadingType }}"{% endif %}
       srcset="{{ apos.image.srcset(attachment) }}"
-      src="{{ apos.attachment.url(attachment, { size: data.options.size or 'full' }) }}"
+      src="{{ apos.attachment.url(attachment, { size: size }) }}"
       alt="{{ attachment._alt or '' }}"
       {% if dimensionAttrs %}
         {% if attachment.width %} width="{{ apos.attachment.getWidth(attachment) }}" {% endif %}


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

I am working on the loading performance and therefore I added two properties to the `image-widget`.
Via `loadingType` the attribute `loading={{loadingType}}` can be set.
And the `size` can now be set in the `manager.options` to have a default size other than `'full'`.

## What are the specific steps to test this change?

1. Create a file `sites/modules/@apostrophecms/image-widget/index.js` with 
```javascript
module.exports = {
  options: {
    size: 'one-sixth',
    loadingType: 'lazy'
  },
};
```
2. Upload an image and use it on the website
3. Check the HTML of it.
4. The `img`-tag should have `loading="lazy"` and the `src` should have the image with the size of `one-sixth`

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes **a) the existing issue ID being resolved**, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves (at least I hope it is convincing)
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated


Issue (I just opened): #4020 