### PR TITLE
fix range field def `0` value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixes
 
 * Do not display shortcut conflicts if none.
+* Range field correctly handles the `def` attribute set to `0` now.  
+The default range field will be used when the field has no value provided; a value going over the max or below the min threshold still returns `null`.
 
 ## 3.39.2 (2023-02-03)
 

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -682,8 +682,8 @@ module.exports = (self) => {
       // `min` here does not imply requirement, it is the minimum value the range UI will represent
       if (
         typeof destination[field.name] !== 'number' ||
-        destination[field.name] < field.min ||
-        destination[field.name] > field.max
+        data[field.name] < field.min ||
+        data[field.name] > field.max
       ) {
         destination[field.name] = null;
       }

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -681,9 +681,9 @@ module.exports = (self) => {
       // Allow for ranges to go unset
       // `min` here does not imply requirement, it is the minimum value the range UI will represent
       if (
-        !data[field.name] ||
-        data[field.name] < field.min ||
-        data[field.name] > field.max
+        typeof destination[field.name] !== 'number' ||
+        destination[field.name] < field.min ||
+        destination[field.name] > field.max
       ) {
         destination[field.name] = null;
       }

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRange.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRange.vue
@@ -90,10 +90,13 @@ export default {
     }
   },
   methods: {
-    // Default to a value outside the range, to be used as a flag.
+    // Default to a value outside the range when no def is defined,
+    // to be used as a flag.
     // The value will be set to null later in validation
     unset() {
-      this.next = this.field.min - 1;
+      this.next = typeof this.field.def === 'number'
+        ? this.field.def
+        : this.field.min - 1;
     },
     validate(value) {
       if (this.field.required) {

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -1127,6 +1127,96 @@ describe('Schemas', function() {
     assert(result.price === 11.4);
   });
 
+  it('should set the default range field value when undefined is given', async function() {
+    const schema = apos.schema.compose({
+      addFields: [
+        {
+          type: 'range',
+          name: 'rating',
+          label: 'Rating',
+          def: 0,
+          min: 0,
+          max: 5
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    const input = {};
+    const req = apos.task.getReq();
+    const result = {};
+    await apos.schema.convert(req, schema, input, result);
+    assert(result.rating === 0);
+  });
+
+  it('should set the default range field value when null is given', async function() {
+    const schema = apos.schema.compose({
+      addFields: [
+        {
+          type: 'range',
+          name: 'rating',
+          label: 'Rating',
+          def: 0,
+          min: 0,
+          max: 5
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    const input = {
+      rating: null
+    };
+    const req = apos.task.getReq();
+    const result = {};
+    await apos.schema.convert(req, schema, input, result);
+    assert(result.rating === 0);
+  });
+
+  it('should set the range field value to null when a value below the min threshold is given', async function() {
+    const schema = apos.schema.compose({
+      addFields: [
+        {
+          type: 'range',
+          name: 'rating',
+          label: 'Rating',
+          def: 0,
+          min: 0,
+          max: 5
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    const input = {
+      rating: -1
+    };
+    const req = apos.task.getReq();
+    const result = {};
+    await apos.schema.convert(req, schema, input, result);
+    assert(result.rating === null);
+  });
+
+  it('should set the range field value to null when a value over the max threshold is given', async function() {
+    const schema = apos.schema.compose({
+      addFields: [
+        {
+          type: 'range',
+          name: 'rating',
+          label: 'Rating',
+          def: 0,
+          min: 0,
+          max: 5
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    const input = {
+      rating: 6
+    };
+    const req = apos.task.getReq();
+    const result = {};
+    await apos.schema.convert(req, schema, input, result);
+    assert(result.rating === null);
+  });
+
   it('should convert simple data correctly', async function() {
     const schema = apos.schema.compose({
       addFields: simpleFields


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Range field correctly handles the def attribute set to 0 now.
The default range field will be used when the field has no value provided; a value going over the max or below the min threshold still returns null.

## What are the specific steps to test this change?

- link apostrophe (on pro-3629-fix-def-range) to testbed
- edit `modules/topic/index.js` as follow:

```diff
       rangeField: {
         type: 'range',
         label: 'Range',
-        help: 'From 18 to 32, with steps of 2',
-        min: 18,
+        help: 'From 18 to 32, with steps of 2, defaults to 0',
+        def: 0,
+        min: 0,
         max: 32,
         step: 2 // optional
```

- create a topic, leave its range field to 0
- create a topic page and visit it
- the topic should have its range showing 0:

<img width="1263" alt="image" src="https://user-images.githubusercontent.com/8301962/216307357-fd9e9d29-103b-459b-bbc8-41a46ce517e8.png">

- checkout `main` on apostrophe
- edit the topic again (leave it's range field to 0)
- the range field default value did not work:

<img width="1297" alt="image" src="https://user-images.githubusercontent.com/8301962/216307187-0714edab-556a-4f66-a4da-319c9a2c0aae.png">

The fix also applies for widgets that have a range field.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
