### PR TITLE
Bugfix/rescale is missing an await

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* The promise to rescale cropped images is now awaited and working correctly.
+
 ## 3.39.0 (2023-02-01)
 
 ### Adds

--- a/modules/@apostrophecms/attachment/lib/tasks/rescale.js
+++ b/modules/@apostrophecms/attachment/lib/tasks/rescale.js
@@ -67,7 +67,7 @@ module.exports = function(self) {
         const originalFile = '/attachments/' + file._id + '-' + file.name + '.' + crop.left + '.' + crop.top + '.' + crop.width + '.' + crop.height + '.' + file.extension;
         console.log('Cropping ' + tempFile + ' to ' + originalFile);
         try {
-          Promise.promisify(self.uploadfs.copyImageIn)(tempFile, originalFile, {
+          await Promise.promisify(self.uploadfs.copyImageIn)(tempFile, originalFile, {
             crop: crop,
             sizes: self.imageSizes
           });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

The cropped images were not rescaled, because the function was not awaited.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or *c) a clear description of the bug it resolves*
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
