### PR TITLE
release 3.39.1: just the rescale task fix for 1N

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## UNRELEASED
+## 3.39.1 (2023-02-02)
 
 ### Fixes
 
-* The promise to rescale cropped images is now awaited and working correctly.
+* Rescaling cropped images with the `@apostrophecms/attachment:rescale` task now works correctly. Thanks to [Waldemar Pankratz](https://github.com/waldemar-p) for this contribution.
 
 ## 3.39.0 (2023-02-01)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "3.39.0",
+  "version": "3.39.1",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Due to client need (and the client's contribution of the fix too!) I'm putting this out as a hotfix. Convenient today because nothing else has landed in main since yesterday's release, otherwise I'd make a fussier PR off the previous release.