### PR TITLE
Release 3.39.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.39.2 (2023-02-03)
+
+### Fixes
+
+* Hotfix for a backwards compatibility break in webpack that triggered a tiptap bug. The admin UI build will now succeed as expected.
+
 ## 3.39.1 (2023-02-02)
 
 ### Fixes

--- a/modules/@apostrophecms/asset/lib/webpack/apos/webpack.config.js
+++ b/modules/@apostrophecms/asset/lib/webpack/apos/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const merge = require('webpack-merge').merge;
 const scss = require('./webpack.scss');
 const vue = require('./webpack.vue');
+const mjs = require('./webpack.mjs');
 
 let BundleAnalyzerPlugin;
 
@@ -12,7 +13,7 @@ if (process.env.APOS_BUNDLE_ANALYZER) {
 module.exports = ({
   importFile, modulesDir, outputPath, outputFilename
 }, apos) => {
-  const tasks = [ scss, vue ].map(task =>
+  const tasks = [ scss, vue, mjs ].map(task =>
     task(
       {
         importFile,

--- a/modules/@apostrophecms/asset/lib/webpack/apos/webpack.config.js
+++ b/modules/@apostrophecms/asset/lib/webpack/apos/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const merge = require('webpack-merge').merge;
 const scss = require('./webpack.scss');
 const vue = require('./webpack.vue');
-const mjs = require('./webpack.mjs');
+const js = require('./webpack.js');
 
 let BundleAnalyzerPlugin;
 
@@ -13,7 +13,7 @@ if (process.env.APOS_BUNDLE_ANALYZER) {
 module.exports = ({
   importFile, modulesDir, outputPath, outputFilename
 }, apos) => {
-  const tasks = [ scss, vue, mjs ].map(task =>
+  const tasks = [ scss, vue, js ].map(task =>
     task(
       {
         importFile,

--- a/modules/@apostrophecms/asset/lib/webpack/apos/webpack.js.js
+++ b/modules/@apostrophecms/asset/lib/webpack/apos/webpack.js.js
@@ -3,10 +3,13 @@ module.exports = (options, apos) => {
     module: {
       rules: [
         {
-          test: /\.mjs$/i,
+          test: /\.(m)?js$/i,
           resolve: {
             byDependency: {
               esm: {
+                // Be tolerant of imports like lodash/debounce that
+                // should really be lodash/debounce.js, as dependencies
+                // like tiptap are not fully on board with that rule yet
                 fullySpecified: false
               }
             }

--- a/modules/@apostrophecms/asset/lib/webpack/apos/webpack.mjs.js
+++ b/modules/@apostrophecms/asset/lib/webpack/apos/webpack.mjs.js
@@ -1,0 +1,18 @@
+module.exports = (options, apos) => {
+  return {
+    module: {
+      rules: [
+        {
+          test: /\.mjs$/i,
+          resolve: {
+            byDependency: {
+              esm: {
+                fullySpecified: false
+              }
+            }
+          }
+        }
+      ]
+    }
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "3.39.1",
+  "version": "3.39.2",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Hotfix for webpack's decision not to accept "import foo from 'lodash/foo'" as an equivalent for "import foo from 'lodash/foo.js'" anymore, by opting into the old behavior. We should talk to tiptap about fixing their import syntax and consider reverting this workaround afterwards.

## What are the specific steps to test this change?

"npm run dev" succeeds when this branch is a git dependency. (The bug doesn't seem to occur with symlinks so we can't test that way.) I have already done this test.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
