### PR TITLE
Issue shortcut conflict dev warning only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* Fix buggy development warnings about conflicting keyboard shortcuts.
+
 ## 3.39.2 (2023-02-03)
 
 ### Fixes

--- a/modules/@apostrophecms/command-menu/index.js
+++ b/modules/@apostrophecms/command-menu/index.js
@@ -392,10 +392,12 @@ module.exports = {
             )
           );
 
-        self.apos.util.warnDev(
-          req.t('apostrophe:shortcutConflictNotification'),
-          shortcuts.conflict
-        );
+        if (Object.keys(shortcuts.conflict).length > 0) {
+          self.apos.util.warnDev(
+            req.t('apostrophe:shortcutConflictNotification'),
+            shortcuts.conflict
+          );
+        }
       },
       detectShortcutConflict({
         shortcuts, shortcut, modal, moduleName


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Fix false positive dev warnings for conflicting keyboard shortcuts.

## What are the specific steps to test this change?

Should not see `Shortcut conflicts detected: {}` in the CLI console.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [x] Related documentation has been updated
- [ ] Related tests have been updated

