### PR TITLE
Add "whenEmpty" prop to "array" field

### DIFF
--- a/modules/@apostrophecms/asset/lib/globalIcons.js
+++ b/modules/@apostrophecms/asset/lib/globalIcons.js
@@ -1,8 +1,6 @@
 // Alphabetical collection of globally available vue-material-design-icons.
 module.exports = {
-  'account-icon': 'Account',
   'account-box-icon': 'AccountBox',
-  'account-group-icon': 'AccountGroup',
   'alert-circle-icon': 'AlertCircle',
   'alpha-x-icon': 'AlphaX',
   'anchor-icon': 'Anchor',

--- a/modules/@apostrophecms/asset/lib/globalIcons.js
+++ b/modules/@apostrophecms/asset/lib/globalIcons.js
@@ -1,6 +1,8 @@
 // Alphabetical collection of globally available vue-material-design-icons.
 module.exports = {
+  'account-icon': 'Account',
   'account-box-icon': 'AccountBox',
+  'account-group-icon': 'AccountGroup',
   'alert-circle-icon': 'AlertCircle',
   'alpha-x-icon': 'AlphaX',
   'anchor-icon': 'Anchor',

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
@@ -321,9 +321,9 @@ function alwaysExpand(field) {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    border: 1px solid var(--a-base-9);
     margin-bottom: $spacing-base;
     padding: $spacing-triple 0;
+    border: 1px solid var(--a-base-9);
     color: var(--a-base-8);
   }
   .apos-input-array-inline-empty-label {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
@@ -8,7 +8,6 @@
       <AposMinMaxCount
         :field="field"
         :value="next"
-        v-if="!field.inline"
       />
     </template>
     <template #body>

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
@@ -4,6 +4,13 @@
     :uid="uid" :items="next"
     :display-options="displayOptions"
   >
+    <template #additional>
+      <AposMinMaxCount
+        :field="field"
+        :value="next"
+        v-if="!field.inline"
+      />
+    </template>
     <template #body>
       <div v-if="field.inline">
         <div

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
@@ -4,14 +4,24 @@
     :uid="uid" :items="next"
     :display-options="displayOptions"
   >
-    <template #additional>
-      <AposMinMaxCount
-        :field="field"
-        :value="next"
-      />
-    </template>
     <template #body>
       <div v-if="field.inline">
+        <div
+          v-if="!items.length && field.whenEmpty"
+          class="apos-input-array-inline-empty"
+        >
+          <component
+            v-if="field.whenEmpty.icon"
+            :is="field.whenEmpty.icon"
+            size="50"
+          />
+          <label
+            v-if="field.whenEmpty.label"
+            class="apos-input-array-inline-empty-label"
+          >
+            {{ $t(field.whenEmpty.label) }}
+          </label>
+        </div>
         <draggable
           v-if="field.inline"
           class="apos-input-array-inline"
@@ -82,7 +92,7 @@
           </div>
         </draggable>
         <AposButton
-          type="button"
+          type="primary"
           label="apostrophe:addItem"
           icon="plus-icon"
           :disabled="disableAdd()"
@@ -298,6 +308,20 @@ function alwaysExpand(field) {
   .apos-is-dragging {
     opacity: 0.5;
     background: var(--a-base-4);
+  }
+  .apos-input-array-inline-empty {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    border: 1px solid var(--a-base-9);
+    margin-bottom: $spacing-base;
+    padding: $spacing-triple 0;
+    color: var(--a-base-8);
+  }
+  .apos-input-array-inline-empty-label {
+    @include type-label;
+    color: var(--a-base-3);
   }
   .apos-input-array-inline-label {
     transition: background-color 0.3s ease;


### PR DESCRIPTION
## Summary

As an admin I can easily understand what is needed when the user or group permission list is empty

The visualization of the initially empty selections (see first image above) will be handled by introducing a new feature of inline array fields, activated by a new whenEmpty option. whenEmpty can have label and icon subproperties. When this option is configured for an inline array field and the array is currently empty, the configured icon and label are displayed per the design above. Icons themselves should be added to the system the same way widget icons already are (see the documentation and the source code for examples).

## Acceptance criteria

When an inline array is empty, a hint appears as described above.

When an inline array is no longer empty, the hint disappears.

Configure these per the design for the user and group permissions fields. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

