### PR TITLE
Support for APOS_BASE_URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.40.0 (2023-02-11)
+
+* For devops purposes, the `APOS_BASE_URL` environment variable is now respected as an override of the `baseUrl` option.
+
 ## 3.39.2 (2023-02-03)
 
 ### Fixes

--- a/index.js
+++ b/index.js
@@ -449,6 +449,8 @@ async function apostrophe(options, telemetry, rootSpan) {
       throw 'Specify the `shortName` option and set it to the name of your project\'s repository or folder';
     }
     self.title = self.options.title;
+    // Environment variable override
+    self.options.baseUrl = process.env.APOS_BASE_URL || self.options.baseUrl;
     self.baseUrl = self.options.baseUrl;
     self.prefix = self.options.prefix || '';
   }

--- a/test/attachments.js
+++ b/test/attachments.js
@@ -201,7 +201,7 @@ describe('Attachment', function() {
         extension: 'jpg',
         _id: 'test'
       });
-      assert(url === '/uploads/attachments/test-test.full.jpg');
+      assert.strictEqual(url, '/uploads/attachments/test-test.full.jpg');
     });
 
     it('should generate the "one-half" URL when one-half size specified for image', function() {

--- a/test/base-url-env-var.js
+++ b/test/base-url-env-var.js
@@ -1,0 +1,36 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert');
+let apos;
+let savedBaseUrl;
+
+const config = {
+  root: module,
+  // Should get overridden by the above
+  baseUrl: 'http://localhost:3000'
+};
+
+describe('Locales', function() {
+  this.timeout(t.timeout);
+
+  before(async function() {
+    savedBaseUrl = process.env.APOS_BASE_URL;
+    process.env.APOS_BASE_URL = 'https://madethisup.com';
+    apos = await t.create(config);
+  });
+
+  after(function() {
+    if (savedBaseUrl) {
+      process.env.APOS_BASE_URL = savedBaseUrl;
+    } else {
+      delete process.env.APOS_BASE_URL;
+    }
+    return t.destroy(apos);
+  });
+
+  it('APOS_BASE_URL should take effect', async function() {
+    const req = apos.task.getReq();
+    const home = await apos.doc.find(req, { slug: '/' }).toObject();
+    assert(home);
+    assert.strictEqual(home._url, 'https://madethisup.com/');
+  });
+});


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

* For devops purposes, add support for an `APOS_BASE_URL` environment variable.

## What are the specific steps to test this change?

* You can start up with `APOS_BASE_URL` set to `http://imadethisup` in your environment. Links to subpages or articles etc. on the front end (not in the admin UI) should be prefixed with that (and will fail of course unless you add that name to your /etc/hosts, which is not necessary to the test).

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [X] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
