### PR TITLE
enhancements to utility operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,30 @@
 # Changelog
 
+## UNRELEASED
+
+### Adds
+
+* The `utilityOperations` feature of piece types now supports additional properties:
+`relationship: true` (show the operation only when editing a relationship), `relationship: false` (never show
+the operation when editing a relationship), `button: true`, `icon` and `iconOnly: true`.
+When `button: true` is specified, the operation appears as a standalone button rather than
+being tucked away in the "more" menu.
+* Those extending our admin UI on the front end can now open a modal to create or edit a page or piece by calling
+`await apos.doc.edit({ type: 'article' })` (the type here is an example). To edit an existing document add an
+`_id` property. To copy an existing document (like our "duplicate" feature) add a `copyOf`
+property.
+* This feature is also available by emitting an `edit` event on the Apostrophe bus with
+the same options object as its payload, for instance by configuring `utilityOperations` to do so.
+* Localized strings in the admin UI can now use `$t(key)` to localize a string inside
+an interpolated variable. This was accomplished by setting `skipOnVariables` to false
+for i18next, solely on the front end for admin UI purposes.
+
+### Changes
+
 ## 3.40.1 (2023-02-18)
 
 * No code change. Patch level bump for package update.
+
 ## 3.40.0 (2023-02-17)
 
 ### Adds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ property. When creating new pages, `type` can be sent to `@apostrophecms/page` f
 (note that the `type` property does not override the default or current page type in the editor).
 * The `edit` Apostrophe event is now available and takes an object with the same properties
 as above. This is useful when configuring `utilityOperations`.
+* The `content-changed` Apostrophe event can now be emitted with a `select: true` property. If a
+document manager for the relevant content type is open, it will attempt to add the document to the
+current selection. Currently this works best with newly inserted documents.
 * Localized strings in the admin UI can now use `$t(key)` to localize a string inside
 an interpolated variable. This was accomplished by setting `skipOnVariables` to false
 for i18next, solely on the front end for admin UI purposes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@
 the operation when editing a relationship), `button: true`, `icon` and `iconOnly: true`.
 When `button: true` is specified, the operation appears as a standalone button rather than
 being tucked away in the "more" menu.
+* In addition, `utilityOperations` can now specify `eventOptions` with an `event` subproperty
+instead of `modalOptions`. This is useful with the new `edit` event (see below).
 * Those extending our admin UI on the front end can now open a modal to create or edit a page or piece by calling
 `await apos.doc.edit({ type: 'article' })` (the type here is an example). To edit an existing document add an
 `_id` property. To copy an existing document (like our "duplicate" feature) add a `copyOf`
-property.
-* This feature is also available by emitting an `edit` event on the Apostrophe bus with
-the same options object as its payload, for instance by configuring `utilityOperations` to do so.
+property. When creating new pages, `type` can be sent to `@apostrophecms/page` for convenience
+(note that the `type` property does not override the default or current page type in the editor).
+* The `edit` Apostrophe event is now available and takes an object with the same properties
+as above. This is useful when configuring `utilityOperations`.
 * Localized strings in the admin UI can now use `$t(key)` to localize a string inside
 an interpolated variable. This was accomplished by setting `skipOnVariables` to false
 for i18next, solely on the front end for admin UI purposes.

--- a/modules/@apostrophecms/doc/ui/apos/apps/AposDoc.js
+++ b/modules/@apostrophecms/doc/ui/apos/apps/AposDoc.js
@@ -4,10 +4,13 @@
 // configuration etc.
 
 export default () => {
-  // Create or edit a document. `type` must be the document type.
+  // Create or edit a document. `type` must be the document type, or
+  // `@apostrophecms/page`.
+  //
   // `_id` should be the `_id` of the existing document to edit; leave
-  // blank to create a new document. `copyOf` is an optional, existing document
-  // from which properties should be copied.
+  // blank to create a new document.
+  //
+  // `copyOf` is an optional, existing document from which properties should be copied.
   //
   // On success, returns the new or updated document. If the modal is cancelled,
   // `undefined` is returned. Be sure to `await` the result.
@@ -19,7 +22,10 @@ export default () => {
     if (!type) {
       throw new Error('You must specify the type of document to edit.');
     }
-    const modal = apos.modules[type]?.components?.editorModal || (apos.page.validPageTypes.includes(type) && apos.page.components.editorModal);
+    if (apos.page.validPageTypes.includes(type)) {
+      type = '@apostrophecms/page';
+    }
+    const modal = apos.modules[type]?.components?.editorModal;
     if (!modal) {
       throw new Error(`${type} is not a valid piece or page type, or cannot be edited`);
     }

--- a/modules/@apostrophecms/doc/ui/apos/apps/AposDoc.js
+++ b/modules/@apostrophecms/doc/ui/apos/apps/AposDoc.js
@@ -1,0 +1,36 @@
+// High-level conveniences for working with documents in Apostrophe
+// on the front end, so that developers need only know the document
+// type they want and do not have to look up modal names in module
+// configuration etc.
+
+export default () => {
+  // Create or edit a document. `type` must be the document type.
+  // `_id` should be the `_id` of the existing document to edit; leave
+  // blank to create a new document. `copyOf` is an optional, existing document
+  // from which properties should be copied.
+  //
+  // On success, returns the new or updated document. If the modal is cancelled,
+  // `undefined` is returned. Be sure to `await` the result.
+  apos.doc.edit = async ({
+    type,
+    _id,
+    copyOf
+  }) => {
+    if (!type) {
+      throw new Error('You must specify the type of document to edit.');
+    }
+    const modal = apos.modules[type]?.components?.editorModal || (apos.page.validPageTypes.includes(type) && apos.page.components.editorModal);
+    if (!modal) {
+      throw new Error(`${type} is not a valid piece or page type, or cannot be edited`);
+    }
+    return apos.modal.execute(modal, {
+      moduleName: type,
+      docId: _id,
+      copyOf
+    });
+  };
+  // If you don't care about the returned value, you can emit an
+  // 'edit' apostrophe event with the same object you would pass to
+  // apos.doc.edit().
+  apos.bus.$on('edit', apos.doc.edit);
+};

--- a/modules/@apostrophecms/image/index.js
+++ b/modules/@apostrophecms/image/index.js
@@ -464,7 +464,6 @@ module.exports = {
       getBrowserData(_super, req) {
         const data = _super(req);
         data.components.managerModal = 'AposMediaManager';
-        data.utilityOperationsNewButton = false;
         return data;
       }
     };

--- a/modules/@apostrophecms/image/index.js
+++ b/modules/@apostrophecms/image/index.js
@@ -57,6 +57,9 @@ module.exports = {
     },
     relationshipPostprocessor: 'autocrop'
   },
+  utilityOperations: {
+    remove: [ 'new' ]
+  },
   fields: {
     remove: [ 'visibility' ],
     add: {
@@ -461,6 +464,7 @@ module.exports = {
       getBrowserData(_super, req) {
         const data = _super(req);
         data.components.managerModal = 'AposMediaManager';
+        data.utilityOperationsNewButton = false;
         return data;
       }
     };

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -23,8 +23,13 @@
         @click="confirmAndCancel"
       />
     </template>
-    <template v-if="relationshipField" #primaryControls>
+    <template #primaryControls>
+      <AposUtilityOperations
+        :module-options="moduleOptions"
+        :has-relationship-field="!!relationshipField"
+      />
       <AposButton
+        v-if="relationshipField"
         type="primary"
         :label="saveRelationshipLabel"
         :disabled="!!relationshipErrors"

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -815,6 +815,9 @@ database.`);
         browserOptions.quickCreate = self.options.quickCreate && self.apos.permission.can(req, 'edit', '@apostrophecms/any-page-type', 'draft');
         browserOptions.localized = true;
         browserOptions.autopublish = false;
+        // A list of all valid page types, including parked pages etc. This is
+        // not a menu of choices for creating a page manually
+        browserOptions.validPageTypes = self.apos.instancesOf('@apostrophecms/page-type').map(module => module.__meta.name);
         return browserOptions;
       },
       // Returns a query that finds pages the current user can edit

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -102,7 +102,24 @@ module.exports = {
       }
     }
   },
-  utilityOperations: {},
+  utilityOperations(self) {
+    return {
+      add: {
+        new: {
+          canEdit: true,
+          relationship: true,
+          label: {
+            key: 'apostrophe:newDocType',
+            type: `$t(${self.options.label})`
+          },
+          eventOptions: {
+            event: 'edit',
+            type: self.__meta.name
+          }
+        }
+      }
+    };
+  },
   batchOperations: {
     add: {
       publish: {

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
@@ -18,11 +18,9 @@
       />
     </template>
     <template #primaryControls>
-      <AposContextMenu
-        v-if="utilityOperations.menu.length"
-        :button="utilityOperations.button"
-        :menu="utilityOperations.menu"
-        @item-clicked="utilityOperationsHandler"
+      <AposUtilityOperations
+        :module-options="moduleOptions"
+        :has-relationship-field="!!relationshipField"
       />
       <AposButton
         v-if="relationshipField"
@@ -149,15 +147,6 @@ export default {
       filterValues: {},
       queryExtras: {},
       holdQueries: false,
-      utilityOperations: {
-        button: {
-          label: 'apostrophe:moreOperations',
-          iconOnly: true,
-          icon: 'dots-vertical-icon',
-          type: 'outline'
-        },
-        menu: []
-      },
       filterChoices: {},
       allPiecesSelection: {
         isSelected: false,
@@ -233,7 +222,6 @@ export default {
     this.headers = this.computeHeaders();
     // Get the data. This will be more complex in actuality.
     this.modal.active = true;
-    this.setUtilityOperations();
     await this.getPieces();
     await this.getAllPiecesTotal();
 
@@ -248,14 +236,6 @@ export default {
     apos.bus.$off('command-menu-manager-close', this.confirmAndCancel);
   },
   methods: {
-    utilityOperationsHandler(action) {
-      if (action === 'new') {
-        this.create();
-        return;
-      }
-
-      this.handleUtilityOperation(action);
-    },
     setCheckedDocs(checked) {
       this.checkedDocs = checked;
       this.checked = this.checkedDocs.map(item => {
@@ -264,28 +244,6 @@ export default {
     },
     async create() {
       await this.edit(null);
-    },
-    async handleUtilityOperation(action) {
-      const operation = this.utilityOperations.menu
-        .find((op) => op.action === action);
-
-      if (!operation) {
-        return;
-      }
-
-      const {
-        modal, ...modalOptions
-      } = operation.modalOptions || {};
-
-      if (modal) {
-        await apos.modal.execute(modal, {
-          moduleAction: this.moduleOptions.action,
-          action,
-          labels: this.moduleLabels,
-          messages: operation.messages,
-          ...modalOptions
-        });
-      }
     },
 
     // If pieceOrId is null, a new piece is created
@@ -492,24 +450,6 @@ export default {
           console.error(error);
         }
       }
-    },
-    setUtilityOperations () {
-      const { utilityOperations } = this.moduleOptions;
-
-      const newPiece = {
-        action: 'new',
-        label: {
-          key: 'apostrophe:newDocType',
-          type: this.$t(this.moduleLabels.singular)
-        }
-      };
-
-      this.utilityOperations.menu = [
-        ...this.relationshipField && this.moduleOptions.canEdit
-          ? [ newPiece ] : [],
-        ...this.utilityOperations.menu,
-        ...(!this.relationshipField && Array.isArray(utilityOperations) && utilityOperations) || []
-      ];
     }
   }
 };

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposUtilityOperations.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposUtilityOperations.vue
@@ -62,16 +62,14 @@ export default {
 
   methods: {
     async handleUtilityOperation(action) {
-      console.log('>>', action);
       const operation = [ ...this.utilityOperations.menu, ...this.utilityOperations.buttons ]
         .find((op) => op.action === action);
 
       if (!operation) {
-        console.log('utility operation definition was not found');
+        console.error('utility operation definition was not found');
         return;
       }
 
-      console.log(JSON.stringify(operation));
       const {
         modal, ...modalOptions
       } = operation.modalOptions || {};
@@ -89,7 +87,6 @@ export default {
           ...modalOptions
         });
       } else if (event) {
-        console.log('emitting event', event, payload);
         apos.bus.$emit(event, payload);
       } else {
         // For backwards compatibility, because it did nothing before we should not

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposUtilityOperations.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposUtilityOperations.vue
@@ -1,0 +1,129 @@
+<!-- The utility operations component presents additional non-selection-specific
+  options in docs managers, such as the "new document" option during
+  selection. -->
+<template>
+  <div class="apos-utility-operations">
+    <AposButton
+      v-for="button in utilityOperations.buttons"
+      :key="button.action"
+      type="default"
+      :icon-only="button.iconOnly"
+      :icon="button.icon || false"
+      :label="button.label"
+      @click="handleUtilityOperation(button.action)"
+    />
+    <AposContextMenu
+      v-if="utilityOperations.menu.length"
+      :button="utilityOperations.button"
+      :menu="utilityOperations.menu"
+      @item-clicked="handleUtilityOperation"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    moduleOptions: {
+      type: Object,
+      required: true
+    },
+    hasRelationshipField: {
+      type: Boolean,
+      required: true
+    }
+  },
+  data() {
+    return {
+      utilityOperations: {
+        button: {
+          label: 'apostrophe:moreOperations',
+          iconOnly: true,
+          icon: 'dots-vertical-icon',
+          type: 'outline'
+        },
+        menu: []
+      }
+    };
+  },
+
+  computed: {
+    moduleLabels() {
+      return {
+        singular: this.moduleOptions.label,
+        plural: this.moduleOptions.pluralLabel
+      };
+    }
+  },
+
+  async mounted() {
+    this.setUtilityOperations();
+  },
+
+  methods: {
+    async handleUtilityOperation(action) {
+      console.log('>>', action);
+      const operation = [ ...this.utilityOperations.menu, ...this.utilityOperations.buttons ]
+        .find((op) => op.action === action);
+
+      if (!operation) {
+        console.log('utility operation definition was not found');
+        return;
+      }
+
+      console.log(JSON.stringify(operation));
+      const {
+        modal, ...modalOptions
+      } = operation.modalOptions || {};
+
+      const {
+        event, ...payload
+      } = operation.eventOptions || {};
+
+      if (modal) {
+        await apos.modal.execute(modal, {
+          moduleAction: this.moduleOptions.action,
+          action,
+          labels: this.moduleLabels,
+          messages: operation.messages,
+          ...modalOptions
+        });
+      } else if (event) {
+        console.log('emitting event', event, payload);
+        apos.bus.$emit(event, payload);
+      } else {
+        // For backwards compatibility, because it did nothing before we should not
+        // throw a hard error here
+        console.error('utility operation has no modalOptions.modal or eventOptions.event property');
+      }
+    },
+    setUtilityOperations () {
+      const { utilityOperations, canEdit } = this.moduleOptions;
+
+      const operations = ((Array.isArray(utilityOperations) && utilityOperations) || []).filter(operation => {
+        let ok = true;
+        if (operation.relationship != null) {
+          if (this.hasRelationshipField) {
+            ok = operation.relationship;
+          } else {
+            ok = !operation.relationship;
+          }
+        }
+        if (operation.canEdit) {
+          ok = ok && canEdit;
+        }
+        return ok;
+      });
+
+      this.utilityOperations.menu = operations.filter(operation => !operation.button);
+      this.utilityOperations.buttons = operations.filter(operation => operation.button);
+    }
+  }
+};
+</script>
+<style scoped>
+  .apos-utility-operations {
+    display: flex;
+    column-gap: 16px;
+  }
+</style>

--- a/modules/@apostrophecms/ui/ui/apos/lib/i18next.js
+++ b/modules/@apostrophecms/ui/ui/apos/lib/i18next.js
@@ -24,6 +24,7 @@ export default {
       interpolation: {
         escapeValue: false
       },
+      skipOnVariables: false,
       appendNamespaceToMissingKey: true,
       defaultNS: [ apos.i18n.defaultNamespace ],
       parseMissingKeyHandler (key) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Improvements to the `utilityOperations` cascade and related features. Please see the changelog.

## What are the specific steps to test this change?

* When editing a relationship between piece types (example: in the testbed, edit an Article and click browse to select a Topic), the kebab menu at top right of the manager still appears and the "New Topic" choice within it still works.
* If you temporarily add `button: true` to the definition of that button in `piece-type/index.js`, it shows up as an independent button instead, which also supports `icon` and `iconOnly` properties (icons must be registered in the usual way in the icons property, and icons are not supported at all right now unless `button: true` is used).
* If you temporarily remove `relationship: true` from the definition of that button, a redundant "New" button appears in the kebab menu at the top right of the manager even when not editing a relationship, and the type name is localized properly (try this with "Redirects" since "Topics" are project level and not localized anyway).
* In the dev console, you can call `await apos.doc.edit('@apostrophecms/user')` to open an editor to create a new user. When the modal closes the new user is returned on the console.
* You can also open that modal with `apos.bus.$emit('edit', '@apostrophecms/user')`, although that doesn't return a value (client side events are not async).

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [X] New feature
- [X] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
