### PR TITLE
add readOnlyFields option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Adds
+
+* Add `readOnlyFields` option. Exactly like `showFields`, a boolean/select/checkboxes field in the document can control whether other fields are read-only or not (as opposed to visible or not).
+
 ## 2.226.0
 
 ### Security

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -607,7 +607,7 @@ module.exports = {
           }
         });
       });
-      return !readOnly[name];
+      return readOnly[name];
 
       function setReadOnly(name) {
         readOnly[name] = true;

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -545,19 +545,21 @@ module.exports = {
     // based on showFields options of all fields
 
     self.isVisible = function(schema, object, name) {
+      const transform = value => !value;
       const buildWarningMessage = name => `⚠️ showFields misconfigured, attempts to show/hide ${name} which does not exist`;
-      return self.doesMatchConditionalChoices(schema, object, name, 'showFields', true, buildWarningMessage);
+      return self.doesMatchConditionalChoices(schema, object, name, 'showFields', transform, buildWarningMessage);
     };
 
     // Determine whether the given field is read-only
     // based on readOnlyFields options of all fields
 
     self.isReadOnly = function(schema, object, name) {
+      const transform = value => value;
       const buildWarningMessage = name => `⚠️ readOnlyFields misconfigured, attempts to set ${name} which does not exist as read only`;
-      return self.doesMatchConditionalChoices(schema, object, name, 'readOnlyFields', false, buildWarningMessage);
+      return self.doesMatchConditionalChoices(schema, object, name, 'readOnlyFields', transform, buildWarningMessage);
     };
 
-    self.doesMatchConditionalChoices = function(schema, object, name, actionName, reverse, buildWarningMessage) {
+    self.doesMatchConditionalChoices = function(schema, object, name, actionName, transform, buildWarningMessage) {
       var memo = {};
 
       _.each(schema, function(field) {
@@ -573,28 +575,20 @@ module.exports = {
           }
 
           if (field.type === 'checkboxes') {
-            const condition = reverse
-              ? !object[field.name].includes(choice.value)
-              : object[field.name].includes(choice.value);
-
-            if (object[field.name] && condition) {
+            if (object[field.name] && transform(object[field.name].includes(choice.value))) {
               _.each(choice[actionName], action);
             }
 
             return;
           }
 
-          const condition = reverse
-            ? object[field.name] !== choice.value
-            : object[field.name] === choice.value;
-
-          if (condition) {
+          if (transform(object[field.name] === choice.value)) {
             _.each(choice[actionName], action);
           }
         });
       });
 
-      return reverse ? !memo[name] : memo[name];
+      return transform(memo[name]);
 
       function action(name) {
         memo[name] = true;

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -598,7 +598,7 @@ module.exports = {
         _.each(field.choices, function(choice) {
           if (choice.readOnlyFields) {
             if (field.type === 'checkboxes') {
-              if (object[field.name].includes(choice.value)) {
+              if (object[field.name] && object[field.name].includes(choice.value)) {
                 _.each(choice.readOnlyFields, setReadOnly);
               }
             } else if (object[field.name] === choice.value) {

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -485,7 +485,7 @@ module.exports = {
       }
       var errors = {};
       return async.eachSeries(schema, function(field, callback) {
-        if (field.readOnly) {
+        if (field.readOnly || self.isReadOnly(schema, object, field.name)) {
           return setImmediate(callback);
         }
         // Fields that are contextual are edited in the context of a
@@ -579,6 +579,49 @@ module.exports = {
         _.each(field.choices || [], function(choice) {
           _.each(choice.showFields || [], function(name) {
             hide(name);
+          });
+        });
+      }
+    };
+
+    // Determine whether the given field is read-only
+    // based on readOnlyFields options of all fields
+
+    self.isReadOnly = function(schema, object, name) {
+      var readOnly = {};
+      _.each(schema, function(field) {
+        if (!_.find(field.choices || [], function(choice) {
+          return choice.readOnlyFields;
+        })) {
+          return;
+        }
+        _.each(field.choices, function(choice) {
+          if (choice.readOnlyFields) {
+            if (field.type === 'checkboxes') {
+              if (!object[field.name].includes(choice.value)) {
+                _.each(choice.readOnlyFields, setReadOnly);
+              }
+            } else if (object[field.name] !== choice.value) {
+              _.each(choice.readOnlyFields, setReadOnly);
+            }
+          }
+        });
+      });
+      return !readOnly[name];
+
+      function setReadOnly(name) {
+        readOnly[name] = true;
+        // Cope with nested readOnlyFields
+        var field = _.find(schema, { name });
+        if (!field) {
+          // Do not crash. The linter at startup also catches this,
+          // but is a nonfatal warning for bc, so we should also catch it
+          self.apos.utils.warnDev('⚠️ setReadOnly misconfigured, attempts to set ' + name + ' as read only which does not exist');
+          return;
+        }
+        _.each(field.choices || [], function(choice) {
+          _.each(choice.readOnlyFields || [], function(name) {
+            setReadOnly(name);
           });
         });
       }

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -547,6 +547,7 @@ module.exports = {
     self.isVisible = function(schema, object, name) {
       const transform = value => !value;
       const buildWarningMessage = name => `⚠️ showFields misconfigured, attempts to show/hide ${name} which does not exist`;
+
       return self.doesMatchConditionalChoices(schema, object, name, 'showFields', transform, buildWarningMessage);
     };
 
@@ -556,20 +557,19 @@ module.exports = {
     self.isReadOnly = function(schema, object, name) {
       const transform = value => value;
       const buildWarningMessage = name => `⚠️ readOnlyFields misconfigured, attempts to set ${name} which does not exist as read only`;
+
       return self.doesMatchConditionalChoices(schema, object, name, 'readOnlyFields', transform, buildWarningMessage);
     };
 
     self.doesMatchConditionalChoices = function(schema, object, name, actionName, transform, buildWarningMessage) {
       var memo = {};
 
-      _.each(schema, function(field) {
-        if (!_.find(field.choices || [], function(choice) {
-          return choice[actionName];
-        })) {
+      _.each(schema, field => {
+        if (!_.find(field.choices || [], choice => choice[actionName])) {
           return;
         }
 
-        _.each(field.choices, function(choice) {
+        _.each(field.choices, choice => {
           if (!choice[actionName]) {
             return;
           }
@@ -593,19 +593,18 @@ module.exports = {
       function action(name) {
         memo[name] = true;
 
-        // Cope with nested showFields/readOnlyFields
         var field = _.find(schema, { name });
         if (!field) {
           // Do not crash. The linter at startup also catches this,
           // but is a nonfatal warning for bc, so we should also catch it
           self.apos.utils.warnDev(buildWarningMessage(name));
+
           return;
         }
 
-        _.each(field.choices || [], function(choice) {
-          _.each(choice[actionName] || [], function(name) {
-            action(name);
-          });
+        _.each(field.choices || [], choice => {
+          // Cope with nested showFields/readOnlyFields
+          _.each(choice[actionName] || [], action);
         });
       }
     };

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -598,10 +598,10 @@ module.exports = {
         _.each(field.choices, function(choice) {
           if (choice.readOnlyFields) {
             if (field.type === 'checkboxes') {
-              if (!object[field.name].includes(choice.value)) {
+              if (object[field.name].includes(choice.value)) {
                 _.each(choice.readOnlyFields, setReadOnly);
               }
-            } else if (object[field.name] !== choice.value) {
+            } else if (object[field.name] === choice.value) {
               _.each(choice.readOnlyFields, setReadOnly);
             }
           }
@@ -616,7 +616,7 @@ module.exports = {
         if (!field) {
           // Do not crash. The linter at startup also catches this,
           // but is a nonfatal warning for bc, so we should also catch it
-          self.apos.utils.warnDev('⚠️ setReadOnly misconfigured, attempts to set ' + name + ' as read only which does not exist');
+          self.apos.utils.warnDev('⚠️ readOnlyFields misconfigured, attempts to set ' + name + ' as read only which does not exist');
           return;
         }
         _.each(field.choices || [], function(choice) {

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -545,83 +545,72 @@ module.exports = {
     // based on showFields options of all fields
 
     self.isVisible = function(schema, object, name) {
-      var hidden = {};
-      _.each(schema, function(field) {
-        if (!_.find(field.choices || [], function(choice) {
-          return choice.showFields;
-        })) {
-          return;
-        }
-        _.each(field.choices, function(choice) {
-          if (choice.showFields) {
-            if (field.type === 'checkboxes') {
-              if (!object[field.name].includes(choice.value)) {
-                _.each(choice.showFields, hide);
-              }
-            } else if (object[field.name] !== choice.value) {
-              _.each(choice.showFields, hide);
-            }
-          }
-        });
-      });
-      return !hidden[name];
-
-      function hide(name) {
-        hidden[name] = true;
-        // Cope with nested showFields
-        var field = _.find(schema, { name: name });
-        if (!field) {
-          // Do not crash. The linter at startup also catches this,
-          // but is a nonfatal warning for bc, so we should also catch it
-          self.apos.utils.warnDev('⚠️ showFields misconfigured, attempts to show/hide ' + name + ' which does not exist');
-          return;
-        }
-        _.each(field.choices || [], function(choice) {
-          _.each(choice.showFields || [], function(name) {
-            hide(name);
-          });
-        });
-      }
+      const buildWarningMessage = name => `⚠️ showFields misconfigured, attempts to show/hide ${name} which does not exist`;
+      return self.doesMatchConditionalChoices(schema, object, name, 'showFields', true, buildWarningMessage);
     };
 
     // Determine whether the given field is read-only
     // based on readOnlyFields options of all fields
 
     self.isReadOnly = function(schema, object, name) {
-      var readOnly = {};
+      const buildWarningMessage = name => `⚠️ readOnlyFields misconfigured, attempts to set ${name} which does not exist as read only`;
+      return self.doesMatchConditionalChoices(schema, object, name, 'readOnlyFields', false, buildWarningMessage);
+    };
+
+    self.doesMatchConditionalChoices = function(schema, object, name, actionName, reverse, buildWarningMessage) {
+      var memo = {};
+
       _.each(schema, function(field) {
         if (!_.find(field.choices || [], function(choice) {
-          return choice.readOnlyFields;
+          return choice[actionName];
         })) {
           return;
         }
+
         _.each(field.choices, function(choice) {
-          if (choice.readOnlyFields) {
-            if (field.type === 'checkboxes') {
-              if (object[field.name] && object[field.name].includes(choice.value)) {
-                _.each(choice.readOnlyFields, setReadOnly);
-              }
-            } else if (object[field.name] === choice.value) {
-              _.each(choice.readOnlyFields, setReadOnly);
+          if (!choice[actionName]) {
+            return;
+          }
+
+          if (field.type === 'checkboxes') {
+            const condition = reverse
+              ? !object[field.name].includes(choice.value)
+              : object[field.name].includes(choice.value);
+
+            if (object[field.name] && condition) {
+              _.each(choice[actionName], action);
             }
+
+            return;
+          }
+
+          const condition = reverse
+            ? object[field.name] !== choice.value
+            : object[field.name] === choice.value;
+
+          if (condition) {
+            _.each(choice[actionName], action);
           }
         });
       });
-      return readOnly[name];
 
-      function setReadOnly(name) {
-        readOnly[name] = true;
-        // Cope with nested readOnlyFields
+      return reverse ? !memo[name] : memo[name];
+
+      function action(name) {
+        memo[name] = true;
+
+        // Cope with nested showFields/readOnlyFields
         var field = _.find(schema, { name });
         if (!field) {
           // Do not crash. The linter at startup also catches this,
           // but is a nonfatal warning for bc, so we should also catch it
-          self.apos.utils.warnDev('⚠️ readOnlyFields misconfigured, attempts to set ' + name + ' as read only which does not exist');
+          self.apos.utils.warnDev(buildWarningMessage(name));
           return;
         }
+
         _.each(field.choices || [], function(choice) {
-          _.each(choice.readOnlyFields || [], function(name) {
-            setReadOnly(name);
+          _.each(choice[actionName] || [], function(name) {
+            action(name);
           });
         });
       }

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -839,8 +839,18 @@ apos.define('apostrophe-schemas', {
             }
             var $fieldset = self.findFieldset($el, fieldName);
 
-            $fieldset.find('input').attr('disabled', readOnlyMemo[fieldName]);
-            $fieldset.find('select').attr('disabled', readOnlyMemo[fieldName]);
+            $fieldset
+              .find('input')
+              .attr('disabled', readOnlyMemo[fieldName]);
+            $fieldset
+              .find('select')
+              .attr('disabled', readOnlyMemo[fieldName]);
+
+            // For custom fields such as "color" that don't have regular html input elements:
+            $fieldset
+              .find('.apos-field-readonly-overlay')
+              .toggleClass('apos-field-readonly-overlay--active', readOnlyMemo[fieldName]);
+
             $fieldset.trigger('aposReadOnlyFields');
           });
         });

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -761,6 +761,92 @@ apos.define('apostrophe-schemas', {
       }
     };
 
+    self.enableReadOnlyFields = function(data, name, $field, $el, field) {
+      var $fieldset = self.findFieldset($el, name);
+
+      // afterChange toggle readonly attribute on other fieldsets based on
+      // the current value of this field.
+      // We do this in three situations: at startup, when the
+      // user changes the value, and when the readonly attribute of this
+      // field has been affected by another field with the
+      // readOnlyFields option. This allows nested readOnlyFields to
+      // work properly.
+
+      afterChange();
+
+      $field.on('change', afterChange);
+      $fieldset.on('aposReadOnlyFields', afterChange);
+
+      function afterChange() {
+        // Implement readOnlyFields
+
+        if (!_.find(field.choices || [], function(choice) {
+          return choice.readOnlyFields;
+        })) {
+          // readOnlyFields is not in use for this select
+          return;
+        }
+
+        var val;
+        if (field.checkbox) {
+          val = $field.is(':checked');
+        } else {
+          val = $field.val();
+        }
+
+        // Recall if another choice currently active already chose to set field as read only.
+        // That way, if two choices set the same field as read only, the fact that the second one
+        // is not currently selected does not unset the field as read only the first one just set
+        var readOnlyMemo = {};
+
+        _.each(field.choices || [], function(choice) {
+          // Show the fields for this value if it is the current value
+          // *and* the select field itself is currently visible
+
+          var readOnly;
+
+          if ($fieldset[0].hasAttribute('readonly')) {
+            readOnly = true;
+          } else if (field.type === 'boolean') {
+            // Comparing boolean values is hard because
+            // the string '0' must be considered falsy in
+            // order to permit use of select elements. -Tom
+            if (val === choice.value) {
+              readOnly = true;
+            } else if (!choice.value && (!val || val === '0')) {
+              readOnly = true;
+            } else if (val && (val !== '0')) {
+              readOnly = true;
+            }
+          } else if (field.type === 'checkboxes') {
+            _.each($field || [], function(checkbox) {
+              if (checkbox.checked && checkbox.value === choice.value && choice.readOnlyFields) {
+                readOnly = true;
+              }
+            });
+          } else {
+            // type select
+            if (val === choice.value.toString()) {
+              readOnly = true;
+            }
+          }
+
+          _.each(choice.readOnlyFields || [], function(fieldName) {
+            if (readOnly || readOnlyMemo[fieldName]) {
+              readOnlyMemo[fieldName] = true;
+            } else {
+              readOnlyMemo[fieldName] = false;
+            }
+            var $fieldset = self.findFieldset($el, fieldName);
+
+            $fieldset.find('input').attr('disabled', readOnlyMemo[fieldName]);
+            $fieldset.find('select').attr('disabled', readOnlyMemo[fieldName]);
+            $fieldset.trigger('aposReadOnlyFields');
+          });
+        });
+      }
+    };
+
     self.addFieldType({
       name: 'area',
       populate: function(data, name, $field, $el, field, callback) {
@@ -1277,6 +1363,7 @@ apos.define('apostrophe-schemas', {
           $field.val('0');
         }
         self.enableShowFields(data, name, $field, $el, field);
+        self.enableReadOnlyFields(data, name, $field, $el, field);
         return setImmediate(callback);
       },
       convert: function(data, name, $field, $el, field, callback) {
@@ -1340,6 +1427,7 @@ apos.define('apostrophe-schemas', {
             self.findSafe($fieldset, 'input[name="' + name + '"][value="' + data[name][c] + '"]', '.apos-field').prop('checked', true);
           }
           self.enableShowFields(data, name, $field, $el, field);
+          self.enableReadOnlyFields(data, name, $field, $el, field);
           return setImmediate(callback);
         }
       },
@@ -1448,6 +1536,7 @@ apos.define('apostrophe-schemas', {
           }
           $field.val(value);
           self.enableShowFields(data, name, $field, $el, field);
+          self.enableReadOnlyFields(data, name, $field, $el, field);
           return setImmediate(callback);
         }
       },

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -813,10 +813,14 @@ apos.define('apostrophe-schemas', {
             // order to permit use of select elements. -Tom
             if (val === choice.value) {
               readOnly = true;
-            } else if (!choice.value && (!val || val === '0')) {
-              readOnly = true;
-            } else if (val && (val !== '0')) {
-              readOnly = true;
+            } else if (!choice.value) {
+              if ((!val) || (val === '0')) {
+                readOnly = true;
+              }
+            } else {
+              if (val && (val !== '0')) {
+                readOnly = true;
+              }
             }
           } else if (field.type === 'checkboxes') {
             _.each($field || [], function(checkbox) {

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -839,14 +839,19 @@ apos.define('apostrophe-schemas', {
             }
             var $fieldset = self.findFieldset($el, fieldName);
 
+            // Disable inputs, and color picker via the spectrum API
             $fieldset
               .find('input')
-              .attr('disabled', readOnlyMemo[fieldName]);
+              .attr('disabled', readOnlyMemo[fieldName])
+              .filter('[data-apos-color]')
+              .spectrum(readOnlyMemo[fieldName] ? 'disable' : 'enable');
+
+            // Disable select element
             $fieldset
               .find('select')
               .attr('disabled', readOnlyMemo[fieldName]);
 
-            // For custom fields such as "color" that don't have regular html input elements:
+            // Add a visual overlay to show that the field is read-only
             $fieldset
               .find('.apos-field-readonly-overlay')
               .toggleClass('apos-field-readonly-overlay--active', readOnlyMemo[fieldName]);

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -670,197 +670,107 @@ apos.define('apostrophe-schemas', {
     };
 
     self.enableShowFields = function(data, name, $field, $el, field) {
-
-      var $fieldset = self.findFieldset($el, name);
-
-      // afterChange shows and hides other fieldsets based on
-      // the current value of this field and its visibility.
-      // We do this in three situations: at startup, when the
-      // user changes the value, and when the visibility of this
-      // field has been affected by another field with the
-      // showFields option. This allows nested showFields to
-      // work properly. -Tom
-
-      afterChange();
-
-      $field.on('change', afterChange);
-      $fieldset.on('aposShowFields', afterChange);
-      function afterChange() {
-        // Implement showFields
-
-        if (!_.find(field.choices || [], function(choice) {
-          return choice.showFields;
-        })) {
-          // showFields is not in use for this select
-          return;
-        }
-
-        var val;
-        if (field.checkbox) {
-          val = $field.is(':checked');
-        } else {
-          val = $field.val();
-        }
-
-        // Recall if another choice currently active already chose to show each field.
-        // That way, if two choices show the same field, the fact that the second one
-        // is not currently selected does not hide the field the first one just showed
-        var shown = {};
-
-        _.each(field.choices || [], function(choice) {
-
-          // Show the fields for this value if it is the current value
-          // *and* the select field itself is currently visible
-
-          var show;
-
-          if ($fieldset.hasClass('apos-hidden')) {
-            show = false;
-          } else if (field.type === 'boolean') {
-            // Comparing boolean values is hard because
-            // the string '0' must be considered falsy in
-            // order to permit use of select elements. -Tom
-            if (val === choice.value) {
-              show = true;
-            } else if (!choice.value) {
-              if ((!val) || (val === '0')) {
-                show = true;
-              }
-            } else {
-              if (val && (val !== '0')) {
-                show = true;
-              }
-            }
-          } else if (field.type === 'checkboxes') {
-            _.each($field || [], function(checkbox) {
-              if (checkbox.checked && checkbox.value === choice.value && choice.showFields) {
-                show = true;
-              }
-            });
-          } else {
-            // type select
-            if (val === choice.value.toString()) {
-              show = true;
-            }
-          }
-
-          _.each(choice.showFields || [], function(fieldName) {
-            if (show || shown[fieldName]) {
-              shown[fieldName] = true;
-            } else {
-              shown[fieldName] = false;
-            }
-            var $fieldset = self.findFieldset($el, fieldName);
-
-            $fieldset.toggleClass('apos-hidden', !shown[fieldName]);
-            $fieldset.trigger('aposShowFields');
-          });
-
-        });
-
-      }
+      self.enableConditionalFields(data, name, $field, $el, field, 'showFields', function ($fieldset, match) {
+        $fieldset.toggleClass('apos-hidden', !match);
+      });
     };
 
     self.enableReadOnlyFields = function(data, name, $field, $el, field) {
+      self.enableConditionalFields(data, name, $field, $el, field, 'readOnlyFields', function ($fieldset, match) {
+        // Disable inputs, and color picker via the spectrum API
+        $fieldset
+          .find('input')
+          .attr('disabled', match)
+          .filter('[data-apos-color]')
+          .spectrum(match ? 'disable' : 'enable');
+
+        // Disable select element
+        $fieldset
+          .find('select')
+          .attr('disabled', match);
+
+        // Add a visual overlay to show that the field is read-only
+        $fieldset
+          .find('.apos-field-readonly-overlay')
+          .toggleClass('apos-field-readonly-overlay--active', match);
+      });
+    };
+
+    self.enableConditionalFields = function(data, name, $field, $el, field, actionName, callback) {
+      var eventName = 'apos' + apos.utils.capitalizeFirst(actionName);
       var $fieldset = self.findFieldset($el, name);
 
-      // afterChange toggle readonly attribute on other fieldsets based on
-      // the current value of this field.
+      // afterChange shows and hides or disables other fieldsets based on
+      // the current value of this field..
       // We do this in three situations: at startup, when the
-      // user changes the value, and when the readonly attribute of this
+      // user changes the value, and when the visibility/disability of this
       // field has been affected by another field with the
-      // readOnlyFields option. This allows nested readOnlyFields to
-      // work properly.
+      // showFields/readOnlyFields option.
+      // This allows nested showFields/readOnlyFields to work properly. -Tom
 
       afterChange();
 
       $field.on('change', afterChange);
-      $fieldset.on('aposReadOnlyFields', afterChange);
+      $fieldset.on(eventName, afterChange);
 
       function afterChange() {
-        // Implement readOnlyFields
-
         if (!_.find(field.choices || [], function(choice) {
-          return choice.readOnlyFields;
+          return choice[actionName];
         })) {
-          // readOnlyFields is not in use for this select
           return;
         }
 
-        var val;
-        if (field.checkbox) {
-          val = $field.is(':checked');
-        } else {
-          val = $field.val();
-        }
+        var val = field.checkbox
+          ? $field.is(':checked')
+          : $field.val();
 
-        // Recall if another choice currently active already chose to set field as read only.
-        // That way, if two choices set the same field as read only, the fact that the second one
-        // is not currently selected does not unset the field as read only the first one just set
-        var readOnlyMemo = {};
+        // Recall if another choice currently active already chose to show/disable each field.
+        // That way, if two choices show/disable the same field, the fact that the second one
+        // is not currently selected does not hide/enable the field the first one just showed/disabled
+        var memo = {};
 
         _.each(field.choices || [], function(choice) {
-          // Show the fields for this value if it is the current value
+          var match;
+
+          // Show/disable the fields for this value if it is the current value
           // *and* the select field itself is currently visible
-
-          var readOnly;
-
-          if ($fieldset[0].hasAttribute('readonly')) {
-            readOnly = true;
+          if ($fieldset.hasClass('apos-hidden')) {
+            match = false;
           } else if (field.type === 'boolean') {
             // Comparing boolean values is hard because
             // the string '0' must be considered falsy in
             // order to permit use of select elements. -Tom
             if (val === choice.value) {
-              readOnly = true;
+              match = true;
             } else if (!choice.value) {
               if ((!val) || (val === '0')) {
-                readOnly = true;
+                match = true;
               }
             } else {
               if (val && (val !== '0')) {
-                readOnly = true;
+                match = true;
               }
             }
           } else if (field.type === 'checkboxes') {
             _.each($field || [], function(checkbox) {
-              if (checkbox.checked && checkbox.value === choice.value && choice.readOnlyFields) {
-                readOnly = true;
+              if (checkbox.checked && checkbox.value === choice.value && choice[actionName]) {
+                match = true;
               }
             });
           } else {
             // type select
             if (val === choice.value.toString()) {
-              readOnly = true;
+              match = true;
             }
           }
 
-          _.each(choice.readOnlyFields || [], function(fieldName) {
-            if (readOnly || readOnlyMemo[fieldName]) {
-              readOnlyMemo[fieldName] = true;
-            } else {
-              readOnlyMemo[fieldName] = false;
-            }
+          _.each(choice[actionName] || [], function(fieldName) {
+            memo[fieldName] = match || !!memo[fieldName];
+
             var $fieldset = self.findFieldset($el, fieldName);
 
-            // Disable inputs, and color picker via the spectrum API
-            $fieldset
-              .find('input')
-              .attr('disabled', readOnlyMemo[fieldName])
-              .filter('[data-apos-color]')
-              .spectrum(readOnlyMemo[fieldName] ? 'disable' : 'enable');
-
-            // Disable select element
-            $fieldset
-              .find('select')
-              .attr('disabled', readOnlyMemo[fieldName]);
-
-            // Add a visual overlay to show that the field is read-only
-            $fieldset
-              .find('.apos-field-readonly-overlay')
-              .toggleClass('apos-field-readonly-overlay--active', readOnlyMemo[fieldName]);
-
-            $fieldset.trigger('aposReadOnlyFields');
+            callback($fieldset, memo[fieldName]);
+            $fieldset.trigger(eventName);
           });
         });
       }

--- a/lib/modules/apostrophe-schemas/views/macros.html
+++ b/lib/modules/apostrophe-schemas/views/macros.html
@@ -137,6 +137,7 @@
 {%- endmacro -%}
 
 {%- macro checkboxesBody(field) -%}
+  <div class="apos-field-readonly-overlay"></div>
   {%- for choice in field.choices -%}
     <div class="apos-form-checkbox">
       <label class="apos-form-checkbox-label apos-text-small">

--- a/lib/modules/apostrophe-ui/public/css/components/fields.less
+++ b/lib/modules/apostrophe-ui/public/css/components/fields.less
@@ -6,6 +6,7 @@
 
 .apos-field
 {
+  position: relative;
   margin-bottom: @apos-margin-4;
   width: 100%;
   max-width: 540px;

--- a/lib/modules/apostrophe-ui/public/css/components/fields.less
+++ b/lib/modules/apostrophe-ui/public/css/components/fields.less
@@ -300,6 +300,22 @@
   display: inline-block;
 }
 
+// Field readonly overlay  ===================================
+.apos-field-readonly-overlay {
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 3;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(255, 255, 255, 0.75);
+}
+
+.apos-field-readonly-overlay--active {
+  display: block;
+}
+
 // Browse and autocomplete combo
 .apos-browse-and-autocomplete {
   display: flex;

--- a/lib/modules/apostrophe-ui/public/css/components/fields.less
+++ b/lib/modules/apostrophe-ui/public/css/components/fields.less
@@ -304,9 +304,7 @@
 .apos-field-readonly-overlay {
   display: none;
   position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 3;
+  z-index: @apos-z-index-2;
   width: 100%;
   height: 100%;
   background-color: rgba(255, 255, 255, 0.75);

--- a/lib/modules/apostrophe-ui/views/components/fields.html
+++ b/lib/modules/apostrophe-ui/views/components/fields.html
@@ -30,6 +30,7 @@
 
 {% macro color(name, placeholder, value, readOnly, options) -%}
   <label>
+    <div class="apos-field-readonly-overlay"></div>
     <div class="apos-field-input-color-preview" data-apos-color-preview></div>
     <input id="{{ options.id }}" name="{{ name }}" data-apos-color-empty-label="{{ __ns('apostrophe', "None selected") }}" class="apos-field-input apos-field-input-color{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}" data-apos-color type="text" value="{{__ns('apostrophe', value | d(''))}}"{% if readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
     <span class="apos-field-input-colorpicker-value" data-apos-color-value></span>

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -2129,4 +2129,110 @@ describe('Schemas', function() {
     });
   });
 
+  it('should disregard read-only fields set by a boolean field', function(done) {
+    var req = apos.tasks.getReq();
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          name: 'age',
+          type: 'integer'
+        },
+        {
+          name: 'canEditAge',
+          type: 'boolean',
+          choices: [
+            {
+              value: true
+            },
+            {
+              value: false,
+              readOnlyFields: [ 'age' ]
+            }
+          ]
+        }
+      ]
+    });
+    var object = {
+      age: 20,
+      canEditAge: false
+    };
+    apos.schemas.convert(req, schema, 'form', { age: '30' }, object, function(err) {
+      assert(!err);
+      assert(object.age === 20);
+      done();
+    });
+  });
+
+  it('should disregard read-only fields set by a select field', function(done) {
+    var req = apos.tasks.getReq();
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          name: 'age',
+          type: 'integer'
+        },
+        {
+          name: 'edit',
+          type: 'select',
+          choices: [
+            {
+              label: 'Can edit anything',
+              value: 'canEditAnything'
+            },
+            {
+              label: 'Cannot edit age',
+              value: 'cannotEditAge',
+              readOnlyFields: [ 'age' ]
+            }
+          ]
+        }
+      ]
+    });
+    var object = {
+      age: 20,
+      edit: 'cannotEditAge'
+    };
+    apos.schemas.convert(req, schema, 'form', { age: '30' }, object, function(err) {
+      assert(!err);
+      assert(object.age === 20);
+      done();
+    });
+  });
+
+  it('should disregard read-only fields set by a checkboxes field', function(done) {
+    var req = apos.tasks.getReq();
+    var schema = apos.schemas.compose({
+      addFields: [
+        {
+          name: 'age',
+          type: 'integer'
+        },
+        {
+          name: 'edit',
+          type: 'checkboxes',
+          choices: [
+            {
+              label: 'Can edit anything',
+              value: 'canEditAnything'
+            },
+            {
+              label: 'Cannot edit age',
+              value: 'cannotEditAge',
+              readOnlyFields: [ 'age' ]
+            }
+          ]
+        }
+      ]
+    });
+    var object = {
+      age: 20,
+      edit: 'cannotEditAge'
+    };
+    apos.schemas.convert(req, schema, 'form', { age: '30' }, object, function(err) {
+      assert(!err);
+      assert(object.age === 20);
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Add `readOnlyFields` option, following the `showFields` logic.

## What are the specific steps to test this change?

Add `readOnlyFields` to a boolean field `choices` option such as:

```js
    {
      type: 'boolean',
      name: 'boolean',
      label: 'Boolean',
      choices: [
        {
          value: true,
          readOnlyFields: [ 'foo', 'bar' ]
        },
        {
          value: false,
          readOnlyFields: [ 'baz' ]
        }
      ]
    },
```

When saving the document with the boolean field set to `true`, the `foo` and `bar` field should now be read-only (setting it to `false` will set `baz` read-only and set `foo` and `bar` editable again.

Same logic for `select` and `checkboxes` fields:

```js
    {
      type: 'select', // or checkboxes
      name: 'select',
      label: 'Select',
      choices: [
        {
          label: 'First choice'
          value: 'one',
          readOnlyFields: [ 'foo', 'bar' ]
        },
        {
          label: 'Second choice'
          value: 'two',
          readOnlyFields: [ 'baz' ]
        }
      ]
    },
```

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
