### PR TITLE
[A2] upgrades passport version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* Upgrades passport to latest version in order to fix security vulnerability. For passport methods that are internally used by Apostrophe everything is still working. For projects that are accessing the passport instance directly through `self.apos.login.passport`, some verifications may be necessary to avoid any comptibility issue. The internally used methods are `authenticate`, `use`, `serializeUser`, `deserializeUser`, `initialize`, `session`.
+* Upgrades passport to the latest version in order to fix security vulnerability. For passport methods that are internally used by Apostrophe everything is still working. For projects that are accessing the passport instance directly through `self.apos.login.passport`, some verifications may be necessary to avoid any comptibility issue. The internally used methods are `authenticate`, `use`, `serializeUser`, `deserializeUser`, `initialize`, `session`.
 
 ## 2.225.0 (2023-02-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 2.226.0
 
-### Fixes
+### Security
 
-* Upgrades passport to the latest version in order to fix security vulnerability. For passport methods that are internally used by Apostrophe everything is still working. For projects that are accessing the passport instance directly through `self.apos.login.passport`, some verifications may be necessary to avoid any comptibility issue. The internally used methods are `authenticate`, `use`, `serializeUser`, `deserializeUser`, `initialize`, `session`.
+* Upgrades passport to the latest version in order to ensure session regeneration when logging in or out. This adds additional security to logins by mitigating any risks due to XSS attacks. Apostrophe is already robust against XSS attacks. For passport methods that are internally used by Apostrophe everything is still working. For projects that are accessing the passport instance directly through `self.apos.login.passport`, some verifications may be necessary to avoid any compatibility issue. The internally used methods are `authenticate`, `use`, `serializeUser`, `deserializeUser`, `initialize`, `session`.
 
 ## 2.225.0 (2023-02-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.226.0
+
+### Fixed
+
+* Upgrades passport version to latest to fix security vulnerability. For passport methods that are internally used by Apostrophe nothing changes. For projects that are accessing passport instance directly through `self.apos.login.passport`, some verifications may be necessary to be sure there are no comptibility issues. The internally used methods are `authenticate`, `use`, `serializeUser`, `deserializeUser`, `initialize`, `session`.
+
 ## 2.225.0 (2023-02-17)
 
 ### Adds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.226.0
 
-### Fixed
+### Fixes
 
 * Upgrades passport to latest version in order to fix security vulnerability. For passport methods that are internally used by Apostrophe everything is still working. For projects that are accessing the passport instance directly through `self.apos.login.passport`, some verifications may be necessary to avoid any comptibility issue. The internally used methods are `authenticate`, `use`, `serializeUser`, `deserializeUser`, `initialize`, `session`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-* Upgrades passport version to latest to fix security vulnerability. For passport methods that are internally used by Apostrophe nothing changes. For projects that are accessing passport instance directly through `self.apos.login.passport`, some verifications may be necessary to be sure there are no comptibility issues. The internally used methods are `authenticate`, `use`, `serializeUser`, `deserializeUser`, `initialize`, `session`.
+* Upgrades passport to latest version in order to fix security vulnerability. For passport methods that are internally used by Apostrophe everything is still working. For projects that are accessing the passport instance directly through `self.apos.login.passport`, some verifications may be necessary to avoid any comptibility issue. The internally used methods are `authenticate`, `use`, `serializeUser`, `deserializeUser`, `initialize`, `session`.
 
 ## 2.225.0 (2023-02-17)
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "moog-require": "^1.1.0",
     "nodemailer": "^6.6.2",
     "oembetter": "^1.0.1",
-    "passport": "^0.3.2",
+    "passport": "^0.6.0",
     "passport-local": "^1.0.0",
     "passport-totp": "0.0.2",
     "path-to-regexp": "^1.7.0",


### PR DESCRIPTION
[PRO-3654](https://linear.app/apostrophecms/issue/PRO-3654/[a2]-passport-package-vulnerability)

## Summary

Upgrades passport to 0.6 due to security vulnerabilities.

## What are the specific steps to test this change?

I tested, the login system that uses passport methods, and checked signatures of internally used methods:
* initialize
* session
* use
* authenticate
* serializeUser
* deserializeUser

Is still working on version 0.6. The Local strategy and TOTP one have been successfully tested.
I noticed that `apostrophe-passport` also interacts with passport instance through `self.apos.login.passport`.
Since it uses the same methods than the core and nothing more (authenticate, use), it should work as well (and we can't test every possible passport module).

A warning has been added in the changelog since I didn't test every passport method. Some projects may interact with the passport instance by accessing `self.apos.login.passport`. In this case they should check themselves if everything is still working. That why I bumped the minor version and not the patch one.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
