### PR TITLE
remove deep-get-set dependency to fix vulnerability scan report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* Replace `deep-get-set` dependency with `lodash`'s `get` and `set` functions to fix the [Prototype Pollution in deep-get-set](https://github.com/advisories/GHSA-mjjj-6p43-vhhv) vulnerability. There was no actual vulnerability in Apostrophe due to the way the module was actually used, and this was done to address vulnerability scan reports.
+
 ## 3.40.1 (2023-02-18)
 
 * No code change. Patch level bump for package update.
+
 ## 3.40.0 (2023-02-17)
 
 ### Adds

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -250,7 +250,6 @@ module.exports = {
         function findParent(doc, dotPath) {
           const pathSplit = dotPath.split('.');
           const parentDotPath = pathSplit.slice(0, pathSplit.length - 1).join('.');
-          console.log('_.get(doc, parentDotPath, doc)', _.get(doc, parentDotPath, doc));
           return _.get(doc, parentDotPath, doc);
         }
       },

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -1,5 +1,4 @@
 const _ = require('lodash');
-const deep = require('deep-get-set');
 const { stripIndent } = require('common-tags');
 
 // An area is a series of zero or more widgets, in which users can add
@@ -243,15 +242,16 @@ module.exports = {
 
           const areaRendered = await self.apos.area.renderArea(req, preppedArea, context);
 
-          deep(context, `${path}._rendered`, areaRendered);
-          deep(context, `${path}._fieldId`, undefined);
-          deep(context, `${path}.items`, undefined);
+          _.set(context, [ path, '_rendered' ], areaRendered);
+          _.set(context, [ path, '_fieldId' ], undefined);
+          _.set(context, [ path, 'items' ], undefined);
         }
 
         function findParent(doc, dotPath) {
           const pathSplit = dotPath.split('.');
           const parentDotPath = pathSplit.slice(0, pathSplit.length - 1).join('.');
-          return deep(doc, parentDotPath) || doc;
+          console.log('_.get(doc, parentDotPath, doc)', _.get(doc, parentDotPath, doc));
+          return _.get(doc, parentDotPath, doc);
         }
       },
       // Sanitize an input array of items intended to become
@@ -365,12 +365,12 @@ module.exports = {
           // always okay - unless it already exists
           // and is not an area.
           if (components.length > 1) {
-            const existing = deep(doc, dotPath);
+            const existing = _.get(doc, dotPath);
             if (existing && existing.metaType !== 'area') {
               throw self.apos.error('forbidden');
             }
           }
-          const existingArea = deep(doc, dotPath);
+          const existingArea = _.get(doc, dotPath);
           const existingItems = existingArea && (existingArea.items || []);
           if (_.isEqual(self.apos.util.clonePermanent(items), self.apos.util.clonePermanent(existingItems))) {
             // No real change — don't waste a version and clutter the database.
@@ -378,7 +378,7 @@ module.exports = {
             // nothing has changed. -Tom
             return;
           }
-          deep(doc, dotPath, {
+          _.set(doc, dotPath, {
             metaType: 'area',
             items: items
           });

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "cuid": "^2.1.8",
     "dayjs": "^1.9.8",
     "debounce-async": "0.0.2",
-    "deep-get-set": "^1.1.1",
     "dompurify": "^2.3.1",
     "express": "^4.16.4",
     "express-bearer-token": "^2.4.0",


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Replace `deep-get-set` with lodash's get and set functions.

## What are the specific steps to test this change?

In testbed, create an article with nested areas in it (two-column for instance).
Then use the API to fetch one article or all of them, with the `?render-areas=true` query parameter:

`http://localhost:3000/api/v1/article/clee30s0h00177d1u6lne6gyf:en:draft?render-areas=true`
`http://localhost:3000/api/v1/article?render-areas=true`

The `_rendered` property should be set:

```js
{
  "_id": "clee30s0h00177d1u6lne6gyf:en:draft",
  "title": "test",
  "blurb": {
    "_id": "clee307jt000v3b68xq2c8wzw",
    "metaType": "area",
    "_edit": true,
    "_docId": "clee30s0h00177d1u6lne6gyf:en:draft",
👉  "_rendered": "\n<div class=\"apos-area\">\n  \n\n<div data-rich-text class=\"demo-rte\" >\n  <p>qedfqwef</p>\n</div>\n</div>\n"
  },
  "slug": "test",
 // ....
```

```js
{
  "pages": 1,
  "currentPage": 1,
  "results": [
    {
      "_id": "clee30s0h00177d1u6lne6gyf:en:published",
      "aposDocId": "clee30s0h00177d1u6lne6gyf",
      "aposLocale": "en:published",
      "lastPublishedAt": "2023-02-21T10:43:05.524Z",
      "slug": "test",
      "title": "test",
      "blurb": {
        "_id": "clee307jt000v3b68xq2c8wzw",
        "metaType": "area",
        "_edit": true,
        "_docId": "clee30s0h00177d1u6lne6gyf:en:published",
    👉  "_rendered": "\n<div class=\"apos-area\">\n  \n\n<div data-rich-text class=\"demo-rte\" >\n  <p>qedfqwef</p>\n</div>\n</div>\n"
      },
      "visibility": "public",
      "scheduledPublish": null,
      "scheduledUnpublish": null,
      "main": {
        "_id": "clee307jw000y3b68utsq6sq9",
        "metaType": "area",
        "_edit": true,
        "_docId": "clee30s0h00177d1u6lne6gyf:en:published",
    👉  "_rendered": "\n<div class=\"apos-area\"><div class=\"widget-two-column\">\n  <div class=\"widget-two-column-one\">\n    \n<div class=\"apos-area\"></div>\n\n  </div>\n  <div class=\"widget-two-column-two\">\n    \n<div class=\"apos-area\">\n  \n\n<div data-rich-text class=\"demo-rte\" >\n  <p>ewfewf</p>\n</div>\n<div data-test-widget=\"widget with placeholder\">\n  <h3>widget-with-def-placeholder def</h3>\n\n  <h4>Array:</h4>\n  <ul>\n  \n    <li>\n      array item 1 - string field def\n      <ul>\n      \n        <li>array item 1 - nested string field def</li>\n      \n      </ul>\n    </li>\n  \n    <li>\n      array item 2 - string field def\n      <ul>\n      \n        <li>array item 2 - nested string field def</li>\n      \n      </ul>\n    </li>\n  \n    <li>\n      wefewf\n      <ul>\n      \n      </ul>\n    </li>\n  \n  </ul>\n  \n\n  <h4>Object:</h4>\n  <ul>\n    <li>\n      object - string field def\n      <ul>\n        <li>object - nested string field def</li>\n      </ul>\n    </li>\n  </ul>\n</div></div>\n\n  </div>\n</div>\n</div>\n"
      },
      "openGraphTitle": "",
  // ...
```

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [x] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
