### PR TITLE
[A3] upgrades passport version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.41.0
+
+### Fixes
+
+* Upgrades passport to the latest version in order to fix security vulnerability. For passport methods that are internally used by Apostrophe everything is still working. For projects that are accessing the passport instance directly through `self.apos.login.passport`, some verifications may be necessary to avoid any comptibility issue. The internally used methods are `authenticate`, `use`, `serializeUser`, `deserializeUser`, `initialize`, `session`.
+
 ## 3.40.1 (2023-02-18)
 
 * No code change. Patch level bump for package update.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 3.41.0
 
-### Fixes
+### Security
 
-* Upgrades passport to the latest version in order to fix security vulnerability. For passport methods that are internally used by Apostrophe everything is still working. For projects that are accessing the passport instance directly through `self.apos.login.passport`, some verifications may be necessary to avoid any comptibility issue. The internally used methods are `authenticate`, `use`, `serializeUser`, `deserializeUser`, `initialize`, `session`.
+* Upgrades passport to the latest version in order to ensure session regeneration when logging in or out. This adds additional security to logins by mitigating any risks due to XSS attacks. Apostrophe is already robust against XSS attacks. For passport methods that are internally used by Apostrophe everything is still working. For projects that are accessing the passport instance directly through `self.apos.login.passport`, some verifications may be necessary to avoid any compatibility issue. The internally used methods are `authenticate`, `use`, `serializeUser`, `deserializeUser`, `initialize`, `session`.
 
 ## 3.40.1 (2023-02-18)
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "nodemailer": "^6.6.1",
     "nunjucks": "^3.2.1",
     "oembetter": "^1.0.1",
-    "passport": "^0.3.2",
+    "passport": "^0.6.0",
     "passport-local": "^1.0.0",
     "path-to-regexp": "^1.8.0",
     "performance-now": "^2.1.0",


### PR DESCRIPTION
[PRO-3812](https://linear.app/apostrophecms/issue/PRO-3812/[a3]-passport-package-vulnerability)

## Summary

Upgrades passport version to 0.6 due to security vulnerabilities.
A3 uses passport the exact same way as [A2 does](https://github.com/apostrophecms/apostrophe/pull/4059).

## What are the specific steps to test this change?

I tested, the login system that uses passport methods, and checked signatures of internally used methods:
* initialize
* session
* use
* authenticate
* serializeUser
* deserializeUser

Is still working on version 0.6. The Local strategy and the TOTP one have been successfully tested.
`passport-bridge` is the equivalent of `apostrophe-passport` and uses the same methods as the core like for A2.

A warning has been added in the changelog since I didn't test every passport method. Some projects may interact with the passport instance by accessing `self.apos.login.passport`. In this case they should check themselves if everything is still working. That why I bumped the minor version and not the patch one.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
