### PR TITLE
docs: fix simple typo, idefntifier -> identifier

### DIFF
--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -1014,7 +1014,7 @@ module.exports = {
       // }
       // All properties are required.
       // The only supported `context` for now is `update`.
-      // `action` is the operation idefntifier and should be globally unique.
+      // `action` is the operation identifier and should be globally unique.
       // Overriding existing custom actions is possible (the last wins).
       // `modal` is the name of the modal component to be opened.
       // `label` is the menu label to be shown when expanding the context menu.


### PR DESCRIPTION
There is a small typo in modules/@apostrophecms/doc/index.js.

Should read `identifier` rather than `idefntifier`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md