### PR TITLE
dynamic choices syntax accepts module and parenthesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ current selection. Currently this works best with newly inserted documents.
 * Localized strings in the admin UI can now use `$t(key)` to localize a string inside
 an interpolated variable. This was accomplished by setting `skipOnVariables` to false
 for i18next, solely on the front end for admin UI purposes.
+* The syntax of the method defined for dynamic `choices` now accepts a module prefix to get the method from, and the `()` suffix.  
+This had been done for consistency with the external conditions syntax shipped in the previous release. See the documentation for more information.
 
 ## 3.41.1 (2023-03-07)
 
@@ -34,7 +36,7 @@ No changes. Publishing to make sure 3.x is tagged `latest` in npm, rather than 2
 ### Adds
 
 * Handle external conditions to display fields according to the result of a module method, or multiple methods from different modules.  
-This can be useful for displaying fields according to the result of an external API or any business logic run on the server.
+This can be useful for displaying fields according to the result of an external API or any business logic run on the server. See the documentation for more information.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ current selection. Currently this works best with newly inserted documents.
 an interpolated variable. This was accomplished by setting `skipOnVariables` to false
 for i18next, solely on the front end for admin UI purposes.
 * The syntax of the method defined for dynamic `choices` now accepts a module prefix to get the method from, and the `()` suffix.  
-This had been done for consistency with the external conditions syntax shipped in the previous release. See the documentation for more information.
+This has been done for consistency with the external conditions syntax shipped in the previous release. See the documentation for more information.
 
 ## 3.41.1 (2023-03-07)
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

- adapt dynamic choices to accept a module name at the beginning and parenthesis at the end
- adapt and use method shared with external conditions
- adapt and add tests for `/choices` api

## What are the specific steps to test this change?

In the example below, we're defining methods to get choices dynamically, from the same module, from another module, with parenthesis.

Test that it still works without parenthesis,  and that an unknown module or method name will result in clean 400 errors (in backend, and clean message given to the frontend and displayed in the modal).
Defining a method with parenthesis with an argument should send a warning on server-side.

```js
  // in "article" piece
  fields: {
    add: {
      select: {
        label: 'Dynamic select',
        type: 'select',
        choices: 'getChoices()'
      },
      checkboxes: {
        label: 'Dynamic checkboxes',
        type: 'checkboxes',
        choices: 'topics:getChoices()'
      },
    }
  },
  methods(self) {
    return {
      async getChoices(req, { docId }) {
        return new Promise(resolve => {
          setTimeout(() => {
            const res = [
              {
                label: 'One',
                value: 'one'
              },
              {
                label: 'Two',
                value: 'two'
              },
              {
                label: 'Three',
                value: 'three'
              }
            ];
            console.log('🚀 ~ file: index.js:126 ~ b ~ docId:', docId);
            resolve(res);
          }, 2000);
        });
      }
    };
  }
```

```js
  // in "topic" piece
 methods(self) {
    return {
      async getChoices(req, { docId }) {
        return new Promise(resolve => {
          setTimeout(() => {
            const res = [
              {
                label: 'Un',
                value: 'un'
              },
              {
                label: 'Deux',
                value: 'deux'
              },
              {
                label: 'Trois',
                value: 'trois'
              }
            ];
            console.log('🚀 ~ file: index.js:126 ~ b ~ docId:', docId);
            resolve(res);
          }, 2000);
        });
      }
    };
```

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
