### PR TITLE
Pro 3800 checkboxes field combo

### DIFF
--- a/modules/@apostrophecms/i18n/i18n/de.json
+++ b/modules/@apostrophecms/i18n/i18n/de.json
@@ -4,6 +4,7 @@
   "addWidgetType": "{{ label }} hinzufügen",
   "admin": "Administrator",
   "affirmativeLabel": "Ja, fortsetzen.",
+  "allSelected": "Alle ausgewählt",
   "altText": "Alternativtext",
   "altTextHelp": "Bildbeschreibung oder alternativer Text, der für Bildschirmleser verwendet wird.",
   "any": "Irgendwas",

--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -8,7 +8,6 @@
   "addWidgetType": "Add {{ label }}",
   "admin": "Admin",
   "affirmativeLabel": "Yes, continue.",
-  "allItems": "All {{ items }}",
   "allSelected": "All Selected",
   "altText": "Alt Text",
   "altTextHelp": "Image description used for accessibility",

--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -8,6 +8,8 @@
   "addWidgetType": "Add {{ label }}",
   "admin": "Admin",
   "affirmativeLabel": "Yes, continue.",
+  "allItems": "All {{ items }}",
+  "allSelected": "All Selected",
   "altText": "Alt Text",
   "altTextHelp": "Image description used for accessibility",
   "anchorId": "Anchor ID",

--- a/modules/@apostrophecms/i18n/i18n/es.json
+++ b/modules/@apostrophecms/i18n/i18n/es.json
@@ -3,6 +3,7 @@
   "addItem": "Añadir Elemento",
   "addWidgetType": "Añadir {{ label }}",
   "admin": "Administrador",
+  "allSelected": "Todo seleccionado",
   "altText": "Texto Alternativo",
   "altTextHelp": "Descripción de imagen utilizada para accesibilidad",
   "any": "Cualquiera",

--- a/modules/@apostrophecms/i18n/i18n/fr.json
+++ b/modules/@apostrophecms/i18n/i18n/fr.json
@@ -3,6 +3,7 @@
   "addItem": "Ajouter un élément",
   "addWidgetType": "Ajouter {{ label }}",
   "affirmativeLabel": "Oui, continuer.",
+  "allSelected": "Tout Selectionné",
   "altText": "Texte alternatif",
   "altTextHelp": "Description d'image utilisée pour l'accessibilité",
   "any": "Quelconque",

--- a/modules/@apostrophecms/i18n/i18n/pt-BR.json
+++ b/modules/@apostrophecms/i18n/i18n/pt-BR.json
@@ -3,6 +3,7 @@
   "addItem": "Adicionar Item",
   "addWidgetType": "Adicionar {{ label }}",
   "admin": "Admin",
+  "allSelected": "Tudo Selecionado",
   "altText": "Texto Alternativo",
   "altTextHelp": "Descrição da imagem usada para acessibilidade",
   "any": "Qualquer",

--- a/modules/@apostrophecms/i18n/i18n/sk.json
+++ b/modules/@apostrophecms/i18n/i18n/sk.json
@@ -4,6 +4,7 @@
   "addWidgetType": "Pridať {{ label }}",
   "admin": "Admin",
   "affirmativeLabel": "Áno, pokračovať.",
+  "allSelected": "Všetky Vybrané",
   "altText": "Alternatívny text",
   "altTextHelp": "Alternatívny popis obrázkov pre zlepšenú prístupnosť",
   "any": "ľubovoľný",

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputCheckboxes.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputCheckboxes.vue
@@ -6,7 +6,14 @@
     :display-options="displayOptions"
   >
     <template #body>
+      <AposCombo
+        v-if="field?.style === 'combo'"
+        :choices="choices"
+        :field="field"
+        :value="value"
+      />
       <AposCheckbox
+        v-else
         :for="getChoiceId(uid, choice.value)"
         v-for="choice in choices"
         :key="choice.value"
@@ -26,7 +33,7 @@ import AposInputChoicesMixin from 'Modules/@apostrophecms/schema/mixins/AposInpu
 export default {
   name: 'AposInputCheckboxes',
   mixins: [ AposInputMixin, AposInputChoicesMixin ],
-  beforeMount: function () {
+  beforeMount () {
     this.value.data = Array.isArray(this.value.data) ? this.value.data : [];
   },
   methods: {
@@ -69,6 +76,11 @@ export default {
       }
 
       return false;
+    },
+    getComponentName() {
+      return this.field?.style === 'combo'
+        ? 'AposCombo'
+        : 'AposCheckbox';
     }
   }
 };

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputCheckboxes.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputCheckboxes.vue
@@ -80,7 +80,7 @@ export default {
       return false;
     },
     selectItems(choice) {
-      if (choice.value === 'all') {
+      if (choice.value === '__all') {
         this.value.data = this.choices.length === this.value.data.length
           ? []
           : this.choices.map(({ value }) => value);

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputCheckboxes.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputCheckboxes.vue
@@ -7,7 +7,7 @@
   >
     <template #body>
       <AposCombo
-        v-if="field?.style === 'combo' && choices.length"
+        v-if="field.style === 'combo' && choices.length"
         :choices="choices"
         :field="field"
         :value="value"
@@ -58,12 +58,12 @@ export default {
 
       if (this.field.min) {
         if ((values != null) && (values.length < this.field.min)) {
-          return `min ${this.field.min}`;
+          return this.$t('apostrophe:minUi', { number: this.field.min });
         }
       }
       if (this.field.max) {
         if ((values != null) && (values.length > this.field.max)) {
-          return `max ${this.field.max}`;
+          return this.$t('apostrophe:maxUi', { number: this.field.max });
         }
       }
 

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputCheckboxes.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputCheckboxes.vue
@@ -7,11 +7,13 @@
   >
     <template #body>
       <AposCombo
-        v-if="field?.style === 'combo'"
+        v-if="field?.style === 'combo' && choices.length"
         :choices="choices"
         :field="field"
         :value="value"
+        @select-item="selectItem"
       />
+
       <AposCheckbox
         v-else
         :for="getChoiceId(uid, choice.value)"
@@ -76,6 +78,21 @@ export default {
       }
 
       return false;
+    },
+    selectItem(choice) {
+      if (choice.value === 'all') {
+        this.value.data = this.choices.length === this.value.data.length
+          ? []
+          : this.choices.map(({ value }) => value);
+
+        return;
+      }
+
+      if (this.value.data.includes(choice.value)) {
+        this.value.data = this.value.data.filter((val) => val !== choice.value);
+      } else {
+        this.value.data.push(choice.value);
+      }
     },
     getComponentName() {
       return this.field?.style === 'combo'

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputCheckboxes.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputCheckboxes.vue
@@ -11,7 +11,7 @@
         :choices="choices"
         :field="field"
         :value="value"
-        @select-item="selectItem"
+        @select-items="selectItems"
       />
 
       <AposCheckbox
@@ -79,7 +79,7 @@ export default {
 
       return false;
     },
-    selectItem(choice) {
+    selectItems(choice) {
       if (choice.value === 'all') {
         this.value.data = this.choices.length === this.value.data.length
           ? []

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputCheckboxes.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputCheckboxes.vue
@@ -93,11 +93,6 @@ export default {
       } else {
         this.value.data.push(choice.value);
       }
-    },
-    getComponentName() {
-      return this.field?.style === 'combo'
-        ? 'AposCombo'
-        : 'AposCheckbox';
     }
   }
 };

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputCheckboxes.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputCheckboxes.vue
@@ -58,12 +58,12 @@ export default {
 
       if (this.field.min) {
         if ((values != null) && (values.length < this.field.min)) {
-          return 'min';
+          return `min ${this.field.min}`;
         }
       }
       if (this.field.max) {
         if ((values != null) && (values.length > this.field.max)) {
-          return 'max';
+          return `max ${this.field.max}`;
         }
       }
 

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="apos-combo">
+    <ul class="apos-input-wrapper apos-combo__select">
+      <li
+        class="apos-combo__selected"
+        v-for="selected in value.data"
+        :key="selected"
+      >
+        {{ selected }}
+        <span class="apos-combo__unselect">
+          x
+        </span>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'AposCombo',
+  props: {
+    choices: {
+      type: Array,
+      required: true
+    },
+    field: {
+      type: Object,
+      required: true
+    },
+    value: {
+      type: Object,
+      required: true
+    }
+  },
+  mounted() {
+    console.log('this.field', this.field);
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.apos-combo {
+
+}
+
+/* .apos-combo__select { */
+/*   background-color: var(--a-base-9); */
+/*   border: 1px solid var(--a-base-2); */
+/**/
+/* } */
+
+.apos-combo__selected {
+
+}
+
+</style>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
@@ -68,7 +68,7 @@ export default {
     }
   },
 
-  emits: [ 'select-item' ],
+  emits: [ 'select-items' ],
   data () {
     const showSelectAll = this.field.all !== false &&
       (!this.field.max || this.field.max > this.choices.length);
@@ -131,9 +131,9 @@ export default {
 
       return this.choices.find((choice) => choice.value === checked);
     },
-    emitSelectItem(data) {
+    emitSelectItems(data) {
       return new Promise((resolve) => {
-        this.$emit('select-item', data);
+        this.$emit('select-items', data);
         this.$nextTick(resolve);
       });
     },
@@ -142,7 +142,7 @@ export default {
         ? this.getSelectedOption('all')
         : choice;
 
-      await this.emitSelectItem(selectedChoice);
+      await this.emitSelectItems(selectedChoice);
 
       this.computeBoxHeight();
       if (this.showSelectAll) {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
@@ -1,15 +1,46 @@
 <template>
-  <div class="apos-combo">
-    <ul class="apos-input-wrapper apos-combo__select">
+  <div
+    class="apos-input-wrapper"
+    :class="{ 'apos-combo--focused': focused }"
+  >
+    <ul
+      v-click-outside-element="removeFocus"
+      class="apos-input-wrapper apos-combo__select"
+      @click="toggleFocus"
+    >
       <li
         class="apos-combo__selected"
-        v-for="selected in value.data"
-        :key="selected"
+        v-for="checked in selectedItems"
+        :key="checked"
+        @click="$emit('select-item', getSelectedOption(checked))"
       >
-        {{ selected }}
-        <span class="apos-combo__unselect">
-          x
-        </span>
+        {{ getSelectedOption(checked).label }}
+        <AposIndicator
+          icon="close-icon"
+          class="apos-combo__close-icon"
+          :icon-size="10"
+        />
+      </li>
+    </ul>
+    <AposIndicator
+      icon="menu-down-icon"
+      class="apos-input-icon"
+      :icon-size="20"
+    />
+    <ul class="apos-combo__list">
+      <li
+        :key="choice.value"
+        class="apos-combo__list-item"
+        v-for="choice in options"
+        @click="selectOption(choice)"
+      >
+        <AposIndicator
+          v-if="isSelected(choice)"
+          icon="check-bold-icon"
+          class="apos-combo__check-icon"
+          :icon-size="10"
+        />
+        {{ choice.label }}
       </li>
     </ul>
   </div>
@@ -32,25 +63,143 @@ export default {
       required: true
     }
   },
-  mounted() {
-    console.log('this.field', this.field);
+
+  emits: [ 'select-item' ],
+  data () {
+    return {
+      focused: false,
+      options: this.renderOptions()
+    };
+  },
+  computed: {
+    selectedItems() {
+      if (this.choices.length === this.value.data.length) {
+        return [ 'all' ];
+      }
+
+      return this.value.data;
+    }
+  },
+  methods: {
+    renderOptions() {
+      if (!this.field.all) {
+        return this.choices;
+      }
+
+      return [
+        {
+          label: 'Select All',
+          value: 'all'
+        },
+        ...this.choices
+      ];
+    },
+    toggleFocus() {
+      this.focused = !this.focused;
+    },
+    removeFocus() {
+      this.focused = false;
+    },
+    isSelected(choice) {
+      return this.value.data.some((val) => val === choice.value);
+    },
+    getSelectedOption(checked) {
+      if (checked === 'all') {
+        return {
+          label: 'All Selected',
+          value: 'all'
+        };
+      }
+
+      return this.choices.find((choice) => choice.value === checked);
+    },
+    selectOption(choice) {
+      const selectedChoice = this.field.all && choice === 'all'
+        ? this.getSelectedOption('all')
+        : choice;
+
+      this.$emit('select-item', selectedChoice);
+    }
   }
 };
 </script>
 
 <style lang="scss" scoped>
 .apos-combo {
-
+  font-family: var(--a-family-default);
 }
 
-/* .apos-combo__select { */
-/*   background-color: var(--a-base-9); */
-/*   border: 1px solid var(--a-base-2); */
-/**/
-/* } */
+.apos-combo__check-icon {
+  position: absolute;
+  left: 5px;
+}
+
+.apos-combo--focused {
+
+  .apos-combo__select {
+    box-shadow: 0 0 3px var(--a-base-2);
+    border-color: var(--a-base-2);
+    background-color: var(--a-base-10);
+  }
+
+  .apos-combo__list {
+    display: block;
+  }
+}
+
+.apos-combo__select {
+  display: flex;
+
+  background-color: var(--a-base-9);
+  padding: 15px 30px 15px;
+  min-height: 12px;
+  border: 1px solid var(--a-base-8);
+  border-radius: var(--a-border-radius);
+  cursor: pointer;
+  list-style: none;
+
+  &:hover {
+    border-color: var(--a-base-2);
+  }
+}
 
 .apos-combo__selected {
+  flex-wrap: wrap;
+  font-size: var(--a-type-base);
+  font-weight: var(--a-weight-base);
+  font-family: var(--a-family-default);
+  letter-spacing: var(--a-letter-base);
+  line-height: var(--a-line-base);
+  background-color: var(--a-white);
+  padding: 4px;
+  margin-right: 5px;
+  border: 1px solid var(--a-base-8)
+}
 
+.apos-combo__list {
+  display: none;
+  position: absolute;
+  width: 100%;
+  left: 0;
+  top: 44px;
+  list-style: none;
+  background-color: var(--a-white);
+  z-index: 1;
+  padding-left: 0;
+  margin: 0;
+}
+
+.apos-combo__list-item {
+  padding: 10px 10px 10px 20px;
+  cursor: pointer;
+  font-family: var(--a-family-default);
+  color: var(--a-text-primary);
+  font-size: var(--a-type-label);
+  font-weight: var(--a-weight-base);
+
+  &:hover {
+    background-color: var(--a-base-9);
+  }
 }
 
 </style>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
@@ -158,17 +158,18 @@ export default {
       const defaultSelectAllListLabel = allSelected
         ? this.$t('apostrophe:deselectAll')
         : this.$t('apostrophe:selectAll');
+      const selectedLabel = this.$t('apostrophe:allSelected');
 
       if (this.field?.all?.label) {
-        const selectAllLabel = this.$t('apostrophe:allItems', { items: this.field.all.label });
+        const selectAllLabel = this.$t(this.field.all.label);
         return {
-          selectedLabel: selectAllLabel,
+          selectedLabel,
           listLabel: allSelected ? defaultSelectAllListLabel : selectAllLabel
         };
       }
 
       return {
-        selectedLabel: this.$t('apostrophe:allSelected'),
+        selectedLabel,
         listLabel: defaultSelectAllListLabel
       };
     }

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
@@ -83,7 +83,7 @@ export default {
   computed: {
     selectedItems() {
       if (this.allItemsSelected()) {
-        return [ 'all' ];
+        return [ '__all' ];
       }
 
       return this.value.data;
@@ -103,7 +103,7 @@ export default {
       return [
         {
           label: listLabel,
-          value: 'all'
+          value: '__all'
         },
         ...this.choices
       ];
@@ -121,7 +121,7 @@ export default {
       return this.value.data.length === this.choices.length;
     },
     getSelectedOption(checked) {
-      if (checked === 'all') {
+      if (checked === '__all') {
         const { selectedLabel } = this.getSelectAllLabel();
         return {
           label: selectedLabel,
@@ -138,8 +138,8 @@ export default {
       });
     },
     async selectOption(choice) {
-      const selectedChoice = this.showSelectAll && choice === 'all'
-        ? this.getSelectedOption('all')
+      const selectedChoice = this.showSelectAll && choice === '__all'
+        ? this.getSelectedOption('__all')
         : choice;
 
       await this.emitSelectItems(selectedChoice);


### PR DESCRIPTION
[PRO-3900](https://linear.app/apostrophecms/issue/PRO-3900/as-a-user-i-can-multiple-select-from-a-large-number-of-choices-without)

## Summary

Adds a new style for the  `checkboxes` field called `combo`.
When this one is selected it renders a sort of multi select. It looks like this
![image](https://user-images.githubusercontent.com/17548370/223493968-1ba4b74c-c816-4623-9c5b-aaa3d51480c6.png)

By default, when the checkboxes are in style `combo`, a button `Select All` or `field.all.label` key that is added as first element of select options.
If the field has explicit `all: false` this button is not added. It is also not added if a max is set to the field and is below the amount of choices.

## What are the specific steps to test this change?

You can link it in any A3 project,
create a new field of type `checkboxes` with a style `combo`
Try with `all: false`, you should have no `Select All`
Try with `all: { label: 'my-locale-key' }`, you should see the right translation in the first item in options list.

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

