### PR TITLE
send external condition result in an object so that numbers work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ This has been done for consistency with the external conditions syntax shipped i
 
 * Configure Tiptap Text Align also for `DefaultNode`, not only for `paragraph` and `heading`. This is the default node created on new line.
 
+### Fixes
+
+* Send external condition result in an object so that numbers work.
+
 ## 3.41.1 (2023-03-07)
 
 No changes. Publishing to make sure 3.x is tagged `latest` in npm, rather than 2.x.

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -93,7 +93,7 @@ export default {
             };
           } catch (error) {
             await apos.notify(this.$t('apostrophe:errorEvaluatingExternalCondition', { name: field.name }), {
-              type: 'danger',
+              type: 'error',
               icon: 'alert-circle-icon',
               dismiss: true,
               localize: false
@@ -114,7 +114,7 @@ export default {
     },
 
     async evaluateExternalCondition(conditionKey, fieldId, docId) {
-      const response = await apos.http.get(
+      const { result } = await apos.http.get(
         `${apos.schema.action}/evaluate-external-condition`,
         {
           qs: {
@@ -126,7 +126,7 @@ export default {
         }
       );
 
-      return [ conditionKey, response ];
+      return [ conditionKey, result ];
     },
 
     // followedByCategory may be falsy (all fields), "other" or "utility". The returned

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1581,7 +1581,7 @@ module.exports = {
 
           try {
             const result = await self.evaluateMethod(req, conditionKey, field.name, field.moduleName, docId);
-            return result;
+            return { result };
           } catch (error) {
             throw self.apos.error('invalid', error.message);
           }

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -2015,7 +2015,7 @@ describe('Schemas', function() {
     const res = await apos.http.get('/api/v1/@apostrophecms/schema/evaluate-external-condition?fieldId=some-field-id&docId=some-doc-id&conditionKey=externalCondition(letsNotArgue)', {});
 
     assert(warnMessages.pop() === 'The method "externalCondition" defined in the "someField" field should be written without argument: "externalCondition()".');
-    assert(res === 'yes');
+    assert(res.result === 'yes');
   });
 
   it('should receive a clean error response when the evaluate-external-condition API call fails (module not found)', async function() {

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -2003,7 +2003,7 @@ describe('Schemas', function() {
     };
 
     const res = await apos.http.get('/api/v1/@apostrophecms/schema/evaluate-external-condition?fieldId=some-field-id&docId=some-doc-id&conditionKey=externalCondition()', {});
-    assert(res === 'yes');
+    assert(res.result === 'yes');
   });
 
   it('should warn when an argument is passed in the external condition key via the evaluate-external-condition API', async function() {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

- send result in an object otherwise result as a number is interpreted as empty
- change notification to error (in cypress tools, the `danger` type is not handled, it's easier and makes sense to change it to `error` here so that e2e tests pass)

## What are the specific steps to test this change?

Add an external condition that expects a number, such as:

```js
coupon: {
        label: 'Coupon',
        type: 'string',
        help: 'Enter a coupon. On the 10th order, write "ORDER10" to get a discount!',
        required: true,
        if: {
          'coupon:getOrdersCount()': 10
        }
      },
```

see https://github.com/apostrophecms/testbed/pull/139

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
