### PR TITLE
do not display errors for hidden fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ an interpolated variable. This was accomplished by setting `skipOnVariables` to 
 for i18next, solely on the front end for admin UI purposes.
 * The syntax of the method defined for dynamic `choices` now accepts a module prefix to get the method from, and the `()` suffix.  
 This has been done for consistency with the external conditions syntax shipped in the previous release. See the documentation for more information.
+* Do not display "required" errors for hidden fields.
 
 ### Fixes 
 

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -93,7 +93,7 @@ export default {
             };
           } catch (error) {
             await apos.notify(this.$t('apostrophe:errorEvaluatingExternalCondition', { name: field.name }), {
-              type: 'error',
+              type: 'danger',
               icon: 'alert-circle-icon',
               dismiss: true,
               localize: false

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -494,6 +494,11 @@ module.exports = {
             continue;
           }
 
+          const isVisible = await self.isVisible(req, schema, destination, field.name);
+          if (!isVisible) {
+            continue;
+          }
+
           // Fields that are contextual are left alone, not blanked out, if
           // they do not appear at all in the data object.
           if (field.contextual && !_.has(data, field.name)) {
@@ -523,21 +528,7 @@ module.exports = {
           }
         }
 
-        const errorsList = [];
-
-        for (const error of errors) {
-          const isVisible = await self.isVisible(req, schema, destination, error.path);
-
-          if ((error.name === 'required' || error.name === 'mandatory') && !isVisible) {
-            // It is not reasonable to enforce required for
-            // fields hidden via conditional fields
-            continue;
-          }
-
-          errorsList.push(error);
-        }
-
-        if (errorsList.length) {
+        if (errors.length) {
           throw errors;
         }
       },

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -607,8 +607,6 @@ module.exports = {
               let externalConditionResult;
 
               try {
-                console.log('fieldName', fieldName);
-                console.log('key', key);
                 externalConditionResult = await self.evaluateMethod(req, key, fieldName, fieldModuleName, object._id);
               } catch (error) {
                 throw self.apos.error('invalid', error.message);


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

"required" errors are not displayed anymore for fields that are hidden and for which the required rule does not apply.

This also fixes errors that are not correctly thrown back to the browser when a module or a method defined in an external condition key does not exist (a non-required field could have a badly formatted external condition -with an unknown module or method- and we could still save the doc).

## What are the specific steps to test this change?

Tests being covered in https://github.com/apostrophecms/testbed/pull/139

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
