### PR TITLE
fix uses observer for select resize

### DIFF
--- a/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
@@ -77,7 +77,8 @@ export default {
       focused: false,
       boxHeight: 0,
       showSelectAll,
-      options: this.renderOptions(showSelectAll)
+      options: this.renderOptions(showSelectAll),
+      boxResizeObserver: this.getBoxResizeObserver()
     };
   },
   computed: {
@@ -90,9 +91,20 @@ export default {
     }
   },
   mounted() {
-    this.computeBoxHeight();
+    this.boxResizeObserver.observe(this.$refs.select);
+  },
+  beforeDestroy() {
+    this.boxResizeObserver.unobserve(this.$refs.select);
   },
   methods: {
+    getBoxResizeObserver() {
+      return new ResizeObserver(([ { target } ]) => {
+        if (target.offsetHeight !== this.boxHeight) {
+          this.boxHeight = target.offsetHeight;
+          console.log('this.boxHeight', this.boxHeight);
+        }
+      });
+    },
     renderOptions(showSelectAll) {
       if (!showSelectAll) {
         return this.choices;
@@ -144,15 +156,12 @@ export default {
 
       await this.emitSelectItems(selectedChoice);
 
-      this.computeBoxHeight();
       if (this.showSelectAll) {
         const { listLabel } = this.getSelectAllLabel();
         this.options[0].label = listLabel;
       }
     },
-    computeBoxHeight() {
-      this.boxHeight = this.$refs.select.offsetHeight;
-    },
+
     getSelectAllLabel() {
       const allSelected = this.allItemsSelected();
       const defaultSelectAllListLabel = allSelected

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
@@ -101,7 +101,6 @@ export default {
       return new ResizeObserver(([ { target } ]) => {
         if (target.offsetHeight !== this.boxHeight) {
           this.boxHeight = target.offsetHeight;
-          console.log('this.boxHeight', this.boxHeight);
         }
       });
     },


### PR DESCRIPTION
## Summary

Fixes initial list position not being good when component is mounted but not visible.
Uses a resize observer to perform that.

## What are the specific steps to test this change?

Check that even in another tab the list appears at the right position.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

