### PR TITLE
Fix for issue 1365. Disallow "type" property name in fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+### Fixes
+* Now errors and exits when a piece-type or widget-type module has a field object with the property "type"
+
 ### Adds
 
 * The `utilityOperations` feature of piece types now supports additional properties:

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -179,6 +179,10 @@ module.exports = {
     if (!self.options.name) {
       throw new Error('@apostrophecms/pieces require name option');
     }
+    const badFieldName = Object.keys(self.fields).indexOf('type') !== -1;
+    if (badFieldName) {
+      throw new Error('@apostrophecms/piece-type field property name cannot be "type"');
+    }
     if (!self.options.label) {
       // Englishify it
       self.options.label = _.startCase(self.options.name);

--- a/modules/@apostrophecms/widget-type/index.js
+++ b/modules/@apostrophecms/widget-type/index.js
@@ -103,6 +103,10 @@ module.exports = {
     placeholderClass: 'apos-placeholder'
   },
   init(self) {
+    const badFieldName = Object.keys(self.fields).indexOf('type') !== -1;
+    if (badFieldName) {
+      throw new Error('@apostrophecms/widget-type field property name cannot be "type"');
+    }
 
     self.enableBrowserData();
 


### PR DESCRIPTION
Fix for issue 1365.
Disallow "type" property name in _piece-type_ and _widget-type_ fields.adds.

Example:

```javascript
modules: {
  foo: {
    extend: '@apostrophecms/piece-type',
    options: {
      name: 'foo',
      label: 'Foo'
    },
    fields: {
      add: {
        type: {
          label: 'Bar',
          type: 'string'
        }
      }
    }
  }
}
```

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*

* Added a check inside `modules/piece-type.js` and `modules/widget-type.js`. If there is a field property name as "type" it will error and exit.
* Closes #1365 

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
* Unfortunately I could not write a test for this change. Reason being is when an error is thrown, I cannot check using `assert.throws` or `assert.rejects` as the error gets handled in `index.js:313-318`. `self.apos.util.error` only calls `console.error` and so I do not believe I am able to test for that either. A suggestion I have is to make a function that logs an error and rejects a promise, then in tests we could use `assert.rejects`.