### PR TITLE
Pro 3987 combobox keyboard accessibility

### DIFF
--- a/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
@@ -7,6 +7,8 @@
       @click="toggleList"
       tabindex="0"
       @keydown.prevent.space="toggleList"
+      @keydown.prevent.up="toggleList"
+      @keydown.prevent.down="toggleList"
     >
       <li
         class="apos-combo__selected"
@@ -34,9 +36,11 @@
       :style="{top: boxHeight + 'px'}"
       tabindex="0"
       @keydown.prevent.space="selectOption(options[focusedItemIndex])"
+      @keydown.prevent.enter="selectOption(options[focusedItemIndex])"
       @keydown.prevent.arrow-down="focusListItem()"
       @keydown.prevent.arrow-up="focusListItem(true)"
       @keydown.prevent.delete="closeList(null, true)"
+      @keydown.prevent.stop.esc="closeList(null, true)"
       @blur="closeList()"
     >
       <li
@@ -117,18 +121,22 @@ export default {
         });
       } else {
         this.$refs.select.focus();
-        this.focusedItemIndex = null;
+        this.resetList();
       }
     },
     closeList(_, focusSelect) {
       this.showedList = false;
-      this.focusedItemIndex = null;
+      this.resetList();
 
       if (focusSelect) {
         this.$nextTick(() => {
           this.$refs.select.focus();
         });
       }
+    },
+    resetList() {
+      this.focusedItemIndex = null;
+      this.$refs.list.scrollTo({ top: 0 });
     },
     getBoxResizeObserver() {
       return new ResizeObserver(([ { target } ]) => {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
@@ -1,7 +1,10 @@
 <template>
-  <div class="apos-primary-scrollbar apos-input-wrapper">
+  <div class="apos-primary-scrollbar apos-input-wrapper" aria-haspopup="menu">
     <ul
       ref="select"
+      role="button"
+      :aria-expanded="showedList.toString()"
+      :aria-controls="`${field._id}-combo`"
       v-click-outside-element="closeList"
       class="apos-input-wrapper apos-combo__select"
       @click="toggleList"
@@ -30,7 +33,9 @@
       :icon-size="20"
     />
     <ul
+      :id="`${field._id}-combo`"
       ref="list"
+      role="menu"
       class="apos-combo__list"
       :class="{'apos-combo__list--showed': showedList}"
       :style="{top: boxHeight + 'px'}"
@@ -46,6 +51,7 @@
       <li
         :key="choice.value"
         class="apos-combo__list-item"
+        role="menuitemcheckbox"
         :class="{focused: focusedItemIndex === i}"
         v-for="(choice, i) in options"
         @click.stop="selectOption(choice)"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCombo.vue
@@ -83,7 +83,6 @@ export default {
       (!this.field.max || this.field.max > this.choices.length);
 
     return {
-      focused: false,
       showedList: false,
       boxHeight: 0,
       showSelectAll,
@@ -220,19 +219,20 @@ export default {
           : fallback;
       }
 
-      const focusedItemPos = 32 * this.focusedItemIndex;
+      const itemHeight = this.$refs.list.querySelector('li')?.clientHeight || 32;
+      const focusedItemPos = itemHeight * this.focusedItemIndex;
       const { clientHeight, scrollTop } = this.$refs.list;
       const listVisibility = clientHeight + scrollTop;
-      if (focusedItemPos + 32 > listVisibility) {
+      const scrollTo = (top) => {
         this.$refs.list.scrollTo({
-          top: (focusedItemPos + 32) - clientHeight,
+          top,
           behavior: 'smooth'
         });
+      };
+      if (focusedItemPos + itemHeight > listVisibility) {
+        scrollTo((focusedItemPos + itemHeight) - clientHeight);
       } else if (focusedItemPos < (listVisibility - clientHeight)) {
-        this.$refs.list.scrollTo({
-          top: focusedItemPos,
-          behavior: 'smooth'
-        });
+        scrollTo(focusedItemPos);
       }
     }
   }


### PR DESCRIPTION
[PRO-3987](https://linear.app/apostrophecms/issue/PRO-3987/combobox-ui-needs-basic-keyboard-accessibility)

## Summary

Adds accessibility for the new combo checkboxes field:
* tab navigation
* space to open or close list
* arrow to navigate through select items
* auto scroll when item not visible

Changelog will be updated when the feature branch is merged.

## What are the specific steps to test this change?

* Use the new field
* navigate from other fields to this one with tab
* Once focus click space to open the list
* navigate the list with arrows and space to add an item
* backspace should close the list
* tab should work also when list open and close it

## What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

