### PR TITLE
hide relationship context menu when it has no field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Hide the suggestion help from the relationship input list when the user starts typing a search term.
 * Hide the suggestion hint from the relationship input list when the user starts typing a search term except when there are no matches to display.
+* Hide context menu on related items when the `relationship` field has no context field.
 
 ## 3.42.0 (2023-03-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Hide the suggestion help from the relationship input list when the user starts typing a search term.
 * Hide the suggestion hint from the relationship input list when the user starts typing a search term except when there are no matches to display.
-* Hide context menu on related items when the `relationship` field has no context field.
+* Disable context menu for related items when their `relationship` field has no [`fields`](https://v3.docs.apostrophecms.org/guide/relationships.html#providing-context-with-fields) configured.
 
 ## 3.42.0 (2023-03-16)
 

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
@@ -52,7 +52,7 @@
             @input="setCheckedDocs"
             @item-clicked="editRelationship"
             :value="checkedDocs"
-            :has-relationship-schema="!!(relationshipField && relationshipField.schema)"
+            :relationship-schema="relationshipField?.schema"
           />
         </div>
       </AposModalRail>

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -57,7 +57,7 @@
           :value="next"
           :duplicate="duplicate"
           :disabled="field.readOnly"
-          :has-relationship-schema="!!field.schema"
+          :relationship-schema="field.schema"
           :editor-label="field.editorLabel"
           :editor-icon="field.editorIcon"
         />

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
@@ -28,7 +28,7 @@
           :size="13"
         />
         <AposContextMenu
-          v-if="hasRelationshipEditor && more.menu.length"
+          v-if="hasRelationshipFields && more.menu.length"
           :button="more.button"
           :menu="more.menu"
           @item-clicked="$emit('item-clicked', item)"
@@ -134,9 +134,9 @@ export default {
       type: Boolean,
       default: false
     },
-    hasRelationshipSchema: {
-      type: Boolean,
-      default: false
+    relationshipSchema: {
+      type: Array,
+      default: () => null
     },
     editorLabel: {
       type: String,
@@ -178,9 +178,14 @@ export default {
     },
     hasRelationshipEditor() {
       if (this.item.attachment && this.item.attachment.group === 'images') {
-        return this.hasRelationshipSchema && this.item.attachment._isCroppable;
+        return this.relationshipSchema && this.item.attachment._isCroppable;
       }
-      return this.hasRelationshipSchema;
+      return this.relationshipSchema;
+    },
+    hasRelationshipFields() {
+      return this.hasRelationshipEditor &&
+        Array.isArray(this.relationshipSchema) &&
+        this.relationshipSchema.length;
     }
   },
   methods: {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlatList.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlatList.vue
@@ -31,7 +31,7 @@
           :parent="listId"
           :slat-count="next.length"
           :removable="removable"
-          :has-relationship-schema="hasRelationshipSchema"
+          :relationship-schema="relationshipSchema"
           :editor-label="editorLabel"
           :editor-icon="editorIcon"
         />
@@ -66,9 +66,9 @@ export default {
       type: String,
       default: null
     },
-    hasRelationshipSchema: {
-      type: Boolean,
-      default: false
+    relationshipSchema: {
+      type: Array,
+      default: () => null
     },
     editorLabel: {
       type: String,


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Hide contextual menu on relationship entries when relationship field has no field.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated 👉  https://github.com/apostrophecms/testbed/pull/144

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
