### PR TITLE
hide sugestions hint from the relationship input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * Hide the suggestion help from the relationship input list when the user starts typing a search term.
+* Hide the suggestion hint from the relationship input list when the user starts typing a search term except when there are no matches to display.
 
 ## 3.42.0 (2023-03-16)
 

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -241,20 +241,21 @@ export default {
           qs
         }
       );
-      // filter items already selected
-      const first = !qs.autocomplete && this.suggestion;
-      const last = this.hint;
-      this.searchList = [ first ]
-        .concat((list.results || [])
-          .filter(item => !this.next.map(i => i._id).includes(item._id))
-          .map(item => ({
-            ...item,
-            disabled: this.disableUnpublished && !item.lastPublishedAt
-          }))
-        )
-        .concat(last)
-        .filter(Boolean);
 
+      const removeSelectedItem = item => !this.next.map(i => i._id).includes(item._id);
+      const formatItems = item => ({
+        ...item,
+        disabled: this.disableUnpublished && !item.lastPublishedAt
+      });
+
+      const results = (list.results || [])
+        .filter(removeSelectedItem)
+        .map(formatItems);
+
+      const suggestion = !qs.autocomplete && this.suggestion;
+      const hint = (!qs.autocomplete || !results.length) && this.hint;
+
+      this.searchList = [ suggestion, ...results, hint ].filter(Boolean);
       this.searching = false;
     },
     async input () {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

In the relationship input search suggestion list:

The suggestion help is now hidden when we start typing into the search bar, and is displayed again when the search bar is cleared.

## What are the specific steps to test this change?

| before | after |
|-------|-------|
|![image](https://user-images.githubusercontent.com/8301962/226943628-9b54c816-bbdf-4e94-b3ca-23cafd7f8a87.png)|![image](https://user-images.githubusercontent.com/8301962/226943868-d20b8746-1781-45fc-99f3-bc0f3fd53e95.png)|

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated 👉  https://github.com/apostrophecms/testbed/pull/142

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
