### PR TITLE
add the possibility to override the array "add item" button label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### Adds
+
+* Add the possibility to override the default "Add Item" button label by setting the `itemLabel` option of an `array` field.
+
 ### Fixes
 
 * Hide the suggestion help from the relationship input list when the user starts typing a search term.

--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -5,6 +5,7 @@
   "addItem": "Add Item",
   "addRowAfter": "Add Row After",
   "addRowBefore": "Add Row Before",
+  "addType": "Add {{ type }}",
   "addWidgetType": "Add {{ label }}",
   "admin": "Admin",
   "affirmativeLabel": "Yes, continue.",

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
@@ -118,7 +118,7 @@
         </component>
         <AposButton
           type="primary"
-          label="apostrophe:addItem"
+          :label="itemLabel"
           icon="plus-icon"
           :disabled="disableAdd()"
           :modifiers="['block']"
@@ -178,6 +178,14 @@ export default {
         ghostClass: 'apos-is-dragging',
         handle: '.apos-drag-handle'
       };
+    },
+    itemLabel() {
+      return this.field.itemLabel
+        ? {
+          key: 'apostrophe:addType',
+          type: this.$t(this.field.itemLabel)
+        }
+        : 'apostrophe:addItem';
     },
     editLabel() {
       return {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

The default "Add Item" button label can now be overridden by setting the `itemLabel` option of an `array` field.

## What are the specific steps to test this change?

Run testbed (or any Apostrophe 3 project) with the `pro-4014-change-add-item-label` version of apostrophe.
Add `itemLabel` to an array field, as below:

```js
inlineArrayField: {
        label: 'Favorite Flavors',
        itemLabel: 'Favorite Flavor', // 👈
        type: 'array',
        inline: true,
        help: 'Think Baskin Robbins',
        fields: {
          add: {
            flavor: {
              type: 'string',
              label: 'Flavor',
              required: true
            }
          }
        }
      },
```

| without `itemLabel`  | with `itemLabel` |
|-|-|
| ![image](https://user-images.githubusercontent.com/8301962/227996953-194ee551-e4b6-4dc1-adad-dfdd0b6149b8.png) | ![image](https://user-images.githubusercontent.com/8301962/227996825-aef9b62d-4ca1-4626-acfb-e3be225391bb.png) |

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated 👉 @BoDonkey FYI I think that `itemLabel` will need to be documented when released
- [x] Related tests have been updated 👉  https://github.com/apostrophecms/testbed/pull/146

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
