### PR TITLE
Pro 3901 localize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Adds
 
+* Check appropriate permission for context operation and manager modal action. We now check if the current user can edit
+    the document to be able to perform a copy, discard a draft.
 * Add `_edit: true` to the list of locales the current user can edit in `@apostrophecms/i18n`.
 
 ## 3.43.0 (2023-03-29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Adds
 
+* We now check the view permission instead of the edit permission when we load the page tree.
+* The editor modal can now be opened in read-only mode if the current user can not edit the current document.
 * Check appropriate permission for context operation and manager modal action. We now check if the current user can edit
     the document to be able to perform a copy, discard a draft.
 * Add `_edit: true` to the list of locales the current user can edit in `@apostrophecms/i18n`.

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
@@ -79,10 +79,11 @@ export default {
   },
   computed: {
     contextBarActive() {
-      return window.apos.adminBar.contextBar && this.canEdit;
+      return window.apos.adminBar.contextBar && (this.canEdit || this.moduleOptions.canLocalize);
     },
     canEdit() {
-      return this.context._edit || ((this.context.aposLocale && this.context.aposLocale.endsWith(':published')) && this.draftIsEditable);
+      return this.context._edit || ((this.context.aposLocale && this.context.aposLocale.endsWith(':published')) &&
+        this.draftIsEditable);
     },
     classes() {
       if (!this.contextBarActive) {

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1424,8 +1424,13 @@ module.exports = {
           label,
           pluralLabel,
           relatedDocument: self.options.relatedDocument,
+          canEdit: self.apos.permission.can(req, 'edit', self.name, 'draft'),
           canPublish: self.apos.permission.can(req, 'publish', self.name)
         };
+        browserOptions.canLocalize = browserOptions.canEdit &&
+          self.options.localized &&
+          Object.keys(self.apos.i18n.locales).length > 1 &&
+          Object.values(self.apos.i18n.locales).some(locale => locale._edit);
         browserOptions.action = self.action;
         browserOptions.schema = self.allowedSchema(req);
         browserOptions.localized = self.isLocalized();

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
@@ -233,13 +233,16 @@ export default {
       }
     },
     canDismissSubmission() {
-      return this.context.submitted && (this.canPublish || (this.context.submitted.byId === apos.login.user._id));
+      return this.canEdit && this.context.submitted && (this.canPublish || (this.context.submitted.byId === apos.login.user._id));
     },
     canDiscardDraft() {
       if (!this.manuallyPublished) {
         return false;
       }
       if (!this.context._id) {
+        return false;
+      }
+      if (!this.canEdit) {
         return false;
       }
       return (
@@ -251,10 +254,11 @@ export default {
       );
     },
     canLocalize() {
-      return (Object.keys(apos.i18n.locales).length > 1) && this.moduleOptions.localized && this.context._id;
+      return this.canEdit && (Object.keys(apos.i18n.locales).length > 1) && this.moduleOptions.localized && this.context._id;
     },
     canArchive() {
       return (
+        this.canEdit &&
         this.context._id &&
         !this.moduleOptions.singleton &&
         !this.context.archived &&
@@ -264,6 +268,7 @@ export default {
     },
     canUnpublish() {
       return (
+        this.canEdit &&
         !this.context.parked &&
         this.moduleOptions.canPublish &&
         this.context.lastPublishedAt &&
@@ -275,6 +280,7 @@ export default {
     },
     canRestore() {
       return (
+        this.canEdit &&
         this.context._id &&
         this.context.archived &&
         ((this.moduleOptions.canPublish && this.context.lastPublishedAt) || !this.manuallyPublished)

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
@@ -181,6 +181,10 @@ export default {
       return menu;
     },
     customMenusByContext() {
+      if (!this.canEdit) {
+        return [];
+      }
+
       const menus = this.customOperationsByContext
         .map(op => ({
           label: op.label,
@@ -254,9 +258,8 @@ export default {
       );
     },
     canLocalize() {
-      return (Object.keys(apos.i18n.locales).length > 1) &&
-        this.moduleOptions.localized && this.context._id &&
-        Object.values(apos.i18n.locales).some(locale => locale._edit);
+      return this.moduleOptions.canLocalize &&
+        this.context._id;
     },
     canArchive() {
       return (
@@ -278,7 +281,10 @@ export default {
       );
     },
     canCopy() {
-      return this.canEdit && !this.moduleOptions.singleton && this.context._id;
+      return this.canEdit &&
+        this.moduleOptions.canEdit &&
+        !this.moduleOptions.singleton &&
+        this.context._id;
     },
     canRestore() {
       return (

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
@@ -254,7 +254,9 @@ export default {
       );
     },
     canLocalize() {
-      return this.canEdit && (Object.keys(apos.i18n.locales).length > 1) && this.moduleOptions.localized && this.context._id;
+      return (Object.keys(apos.i18n.locales).length > 1) &&
+        this.moduleOptions.localized && this.context._id &&
+        Object.values(apos.i18n.locales).some(locale => locale._edit);
     },
     canArchive() {
       return (

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -162,6 +162,7 @@ export default {
         ref: null
       },
       published: null,
+      readOnly: false,
       restoreOnly: false,
       saveMenu: null,
       generation: 0
@@ -174,14 +175,24 @@ export default {
     followingUtils() {
       return this.followingValues('utility');
     },
+    canEdit() {
+      if (this.original && this.original._id) {
+        return this.original._edit || this.moduleOptions.canEdit;
+      }
+
+      return this.moduleOptions.canEdit;
+    },
     canPublish() {
       if (this.original && this.original._id) {
-        return this.original._publish;
+        return this.original._publish || this.moduleOptions.canPublish;
       }
 
       return this.moduleOptions.canPublish;
     },
     saveDisabled() {
+      if (!this.canEdit) {
+        return true;
+      }
       if (this.restoreOnly) {
         // Can always restore if it's a read-only view of the archive
         return false;
@@ -438,6 +449,8 @@ export default {
         } else {
           this.restoreOnly = false;
         }
+        const canEdit = docData._edit || this.moduleOptions.canEdit;
+        this.readOnly = canEdit === false;
       } catch {
         await apos.notify('apostrophe:loadDocFailed', {
           type: 'warning',

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -432,10 +432,6 @@ export default {
     async loadDoc() {
       let docData;
       try {
-        if (!await this.lock(this.getOnePath, this.docId)) {
-          await this.lockNotAvailable();
-          return;
-        }
         docData = await apos.http.get(this.getOnePath, {
           busy: true,
           qs: {
@@ -451,6 +447,10 @@ export default {
         }
         const canEdit = docData._edit || this.moduleOptions.canEdit;
         this.readOnly = canEdit === false;
+        if (canEdit && !await this.lock(this.getOnePath, this.docId)) {
+          await this.lockNotAvailable();
+          return;
+        }
       } catch {
         await apos.notify('apostrophe:loadDocFailed', {
           type: 'warning',

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -158,7 +158,7 @@ export default {
       return window.apos.modules[this.activeMedia.type] || {};
     },
     canLocalize() {
-      return (Object.keys(apos.i18n.locales).length > 1) && this.moduleOptions.localized && this.activeMedia._id;
+      return this.moduleOptions.canLocalize && this.activeMedia._id;
     },
     moreMenu() {
       const menu = [ {

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -24,6 +24,7 @@ export default {
       },
       serverErrors: null,
       restoreOnly: false,
+      readOnly: false,
       changed: [],
       externalConditionsResults: {}
     };
@@ -32,7 +33,7 @@ export default {
   computed: {
     schema() {
       let schema = (this.moduleOptions.schema || []).filter(field => apos.schema.components.fields[field.type]);
-      if (this.restoreOnly) {
+      if (this.restoreOnly || this.readOnly) {
         schema = klona(schema);
         for (const field of schema) {
           field.readOnly = true;

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposModalTabsMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposModalTabsMixin.js
@@ -48,10 +48,11 @@ export default {
         if (key !== 'utility') {
           tabs.push({
             name: key,
-            label: this.groups[key].label
+            label: this.groups[key].label,
+            fields: this.groups[key].fields
           });
         }
-      };
+      }
 
       return tabs;
     }

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -133,7 +133,7 @@ module.exports = {
           const autocomplete = self.apos.launder.string(req.query.autocomplete);
 
           if (autocomplete.length) {
-            if (!self.apos.permission.can(req, 'edit', '@apostrophecms/any-page-type')) {
+            if (!self.apos.permission.can(req, 'view', '@apostrophecms/any-page-type')) {
               throw self.apos.error('forbidden');
             }
             return {
@@ -145,7 +145,7 @@ module.exports = {
           }
 
           if (all) {
-            if (!self.apos.permission.can(req, 'edit', '@apostrophecms/any-page-type')) {
+            if (!self.apos.permission.can(req, 'view', '@apostrophecms/any-page-type')) {
               throw self.apos.error('forbidden');
             }
             const page = await self.getRestQuery(req).permission(false).and({ level: 0 }).children({

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -819,6 +819,11 @@ database.`);
         // A list of all valid page types, including parked pages etc. This is
         // not a menu of choices for creating a page manually
         browserOptions.validPageTypes = self.apos.instancesOf('@apostrophecms/page-type').map(module => module.__meta.name);
+        browserOptions.canEdit = self.apos.permission.can(req, 'edit', '@apostrophecms/any-page-type', 'draft');
+        browserOptions.canLocalize = browserOptions.canEdit &&
+          browserOptions.localized &&
+          Object.keys(self.apos.i18n.locales).length > 1 &&
+          Object.values(self.apos.i18n.locales).some(locale => locale._edit);
         return browserOptions;
       },
       // Returns a query that finds pages the current user can edit

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -1074,7 +1074,6 @@ module.exports = {
         browserOptions.showDiscardDraft = self.options.showDiscardDraft;
         browserOptions.canEdit = self.apos.permission.can(req, 'edit', self.name, 'draft');
         browserOptions.canPublish = self.apos.permission.can(req, 'edit', self.name, 'publish');
-        browserOptions.canLocalize = self.options.localized && Object.keys(self.apos.i18n.locales).length > 1 && Object.values(self.apos.i18n.locales).some(locale => locale._edit);
         _.defaults(browserOptions, {
           components: {}
         });

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -1074,7 +1074,7 @@ module.exports = {
         browserOptions.showDiscardDraft = self.options.showDiscardDraft;
         browserOptions.canEdit = self.apos.permission.can(req, 'edit', self.name, 'draft');
         browserOptions.canPublish = self.apos.permission.can(req, 'edit', self.name, 'publish');
-        browserOptions.canLocalize = self.options.localized && Object.keys(self.apos.i18n.locales).length > 1 && self.apos.permission.can(req, 'view', self.name, 'publish');
+        browserOptions.canLocalize = self.options.localized && Object.keys(self.apos.i18n.locales).length > 1 && Object.values(self.apos.i18n.locales).some(locale => locale._edit);
         _.defaults(browserOptions, {
           components: {}
         });

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManagerDisplay.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManagerDisplay.vue
@@ -164,10 +164,10 @@ export default {
   methods: {
     canEdit(item) {
       if (item._id) {
-        return item._edit;
+        return item._edit || this.options.canLocalize;
       }
 
-      return this.options.canEdit;
+      return this.options.canEdit || this.options.canLocalize;
     },
     over(id) {
       this.state[id].hover = true;

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManagerDisplay.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManagerDisplay.vue
@@ -78,7 +78,7 @@
           />
         </td>
         <!-- append the context menu -->
-        <td v-if="canEdit(item)" class="apos-table__cell apos-table__cell--context-menu">
+        <td class="apos-table__cell apos-table__cell--context-menu">
           <AposCellContextMenu
             :state="state[item._id]" :item="item"
             :draft="item"


### PR DESCRIPTION
<!-- Please dohttps://github.com/apostrophecms/apostrophe/compare/feature/per-locale-permission...pro-3901-localize?expand=1n't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

* Hide document versions if the current user cannot edit
* Hide discard draft if the current user cannot edit
* Hide quick create if the current user cannot edit
* Hide localize if the current user cannot localize

## What are the specific steps to test this change?

N.A.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Fixes 
* https://linear.app/apostrophecms/issue/PRO-4081/menu-in-admin-bar-shows-up-for-types-you-only-have-per-doc-permissions
* https://linear.app/apostrophecms/issue/PRO-4042/document-versions-appears-for-documents-i-cant-edit-in-page-manager
* https://linear.app/apostrophecms/issue/PRO-4041/discard-draft-appears-for-documents-i-cant-edit-in-page-manager-maybe
* https://linear.app/apostrophecms/issue/PRO-3901/as-an-editor-who-can-edit-in-locale-a-i-can-view-and-localize-drafts
