### PR TITLE
fix various issues on conditional fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ project-specific reasons to fetch access content via REST APIs.
 * `test-lib/utils.js` has new `createUser` and `loginAs` methods for the convenience of
 those writing mocha tests of Apostrophe modules.
 
+### Fixes
+
+* Fix various issues on conditional fields that were occurring when adding new widgets with default values, or selecting a falsy value in a field having a conditional field relying on it.  
+Populate new or existing docs instance with default values.  
+Add an empty `null` choice for select fields that do not have a default value, required or not and the ones configured with dynamic choices.
+
 ## 3.43.0 (2023-03-29)
 
 ### Adds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ those writing mocha tests of Apostrophe modules.
 ### Fixes
 
 * Fix various issues on conditional fields that were occurring when adding new widgets with default values, or selecting a falsy value in a field having a conditional field relying on it.  
-Populate new or existing docs instance with default values.  
 Add an empty `null` choice for select fields that do not have a default value, required or not and the ones configured with dynamic choices.
 
 ## 3.43.0 (2023-03-29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ those writing mocha tests of Apostrophe modules.
 
 ### Fixes
 
-* Fix various issues on conditional fields that were occurring when adding new widgets with default values, or selecting a falsy value in a field having a conditional field relying on it.  
-Add an empty `null` choice for select fields that do not have a default value, required or not and the ones configured with dynamic choices.
+* Fix various issues on conditional fields that were occurring when adding new widgets with default values or selecting a falsy value in a field that has a conditional field relying on it.  
+Populate new or existing doc instances with default values and add an empty `null` choice to select fields that do not have a default value (required or not) and to the ones configured with dynamic choices.
 
 ## 3.43.0 (2023-03-29)
 

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -482,8 +482,8 @@ export default {
         if (field.name.startsWith('_')) {
           return;
         }
-        // Do not simply check if `field.def` is truthy, this in not enough
-        // since a def as an empty string must be considered valid:
+        // Using `hasOwn` here, not simply checking if `field.def` is truthy
+        // so that `false`, `null`, `''` or `0` are taken into account:
         const hasDefaultValue = Object.hasOwn(field, 'def');
         doc[field.name] = hasDefaultValue
           ? klona(field.def)

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -464,7 +464,10 @@ export default {
             this.docType = docData.type;
           }
           this.original = klona(docData);
-          this.docFields.data = docData;
+          this.docFields.data = {
+            ...this.getDefault(),
+            ...docData
+          };
           if (this.published) {
             this.changed = detectDocChange(this.schema, this.original, this.published, { differences: true });
           }
@@ -472,6 +475,18 @@ export default {
           this.prepErrors();
         }
       }
+    },
+    getDefault() {
+      const doc = {};
+      this.schema.forEach(field => {
+        // Do not simply check if `field.def` is truthy, this in not enough
+        // since a def as an empty string must be considered valid:
+        const hasDefaultValue = Object.hasOwn(field, 'def');
+        doc[field.name] = hasDefaultValue
+          ? klona(field.def)
+          : null;
+      });
+      return doc;
     },
     async preview() {
       if (!await this.confirmAndCancel()) {

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -114,6 +114,7 @@ import AposArchiveMixin from 'Modules/@apostrophecms/ui/mixins/AposArchiveMixin'
 import AposAdvisoryLockMixin from 'Modules/@apostrophecms/ui/mixins/AposAdvisoryLockMixin';
 import AposDocErrorsMixin from 'Modules/@apostrophecms/modal/mixins/AposDocErrorsMixin';
 import { detectDocChange } from 'Modules/@apostrophecms/schema/lib/detectChange';
+import { has } from 'Modules/@apostrophecms/schema/lib/object';
 
 export default {
   name: 'AposDocEditor',
@@ -463,14 +464,24 @@ export default {
           if (docData.type !== this.docType) {
             this.docType = docData.type;
           }
+
           this.original = klona(docData);
-          this.docFields.data = docData;
+          this.docFields.data = this.schema.reduce(addDefaultValues, docData);
+
           if (this.published) {
             this.changed = detectDocChange(this.schema, this.original, this.published, { differences: true });
           }
+
           this.docReady = true;
           this.prepErrors();
         }
+      }
+
+      function addDefaultValues(memo, field) {
+        return {
+          ...memo,
+          ...(!has(memo, field.name) && has(field, 'def') && { [field.name]: field.def })
+        };
       }
     },
     async preview() {

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -479,9 +479,9 @@ export default {
     getDefault() {
       const doc = {};
       this.schema.forEach(field => {
-        // Do not simply check if `field.def` is truthy, this in not enough
-        // since a def as an empty string must be considered valid:
-        const hasDefaultValue = Object.prototype.hasOwnProperty.call(field, 'def');
+        // Using `hasOwn` here, not simply checking if `field.def` is truthy
+        // so that `false`, `null`, `''` or `0` are taken into account:
+        const hasDefaultValue = Object.hasOwn(field, 'def');
         doc[field.name] = hasDefaultValue
           ? klona(field.def)
           : null;

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -464,7 +464,10 @@ export default {
             this.docType = docData.type;
           }
           this.original = klona(docData);
-          this.docFields.data = docData;
+          this.docFields.data = {
+            ...this.getDefault(),
+            ...docData
+          };
           if (this.published) {
             this.changed = detectDocChange(this.schema, this.original, this.published, { differences: true });
           }
@@ -472,6 +475,18 @@ export default {
           this.prepErrors();
         }
       }
+    },
+    getDefault() {
+      const doc = {};
+      this.schema.forEach(field => {
+        // Do not simply check if `field.def` is truthy, this in not enough
+        // since a def as an empty string must be considered valid:
+        const hasDefaultValue = Object.prototype.hasOwnProperty.call(field, 'def');
+        doc[field.name] = hasDefaultValue
+          ? klona(field.def)
+          : null;
+      });
+      return doc;
     },
     async preview() {
       if (!await this.confirmAndCancel()) {

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -479,6 +479,9 @@ export default {
     getDefault() {
       const doc = {};
       this.schema.forEach(field => {
+        if (field.name.startsWith('_')) {
+          return;
+        }
         // Do not simply check if `field.def` is truthy, this in not enough
         // since a def as an empty string must be considered valid:
         const hasDefaultValue = Object.hasOwn(field, 'def');

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -464,10 +464,7 @@ export default {
             this.docType = docData.type;
           }
           this.original = klona(docData);
-          this.docFields.data = {
-            ...this.getDefault(),
-            ...docData
-          };
+          this.docFields.data = docData;
           if (this.published) {
             this.changed = detectDocChange(this.schema, this.original, this.published, { differences: true });
           }
@@ -475,18 +472,6 @@ export default {
           this.prepErrors();
         }
       }
-    },
-    getDefault() {
-      const doc = {};
-      this.schema.forEach(field => {
-        // Using `hasOwn` here, not simply checking if `field.def` is truthy
-        // so that `false`, `null`, `''` or `0` are taken into account:
-        const hasDefaultValue = Object.hasOwn(field, 'def');
-        doc[field.name] = hasDefaultValue
-          ? klona(field.def)
-          : null;
-      });
-      return doc;
     },
     async preview() {
       if (!await this.confirmAndCancel()) {

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -356,17 +356,13 @@ export default {
       await this.loadDoc();
       try {
         if (this.manuallyPublished) {
-          const published = await apos.http.get(this.getOnePath, {
+          this.published = await apos.http.get(this.getOnePath, {
             busy: true,
             qs: {
               archived: 'any',
               aposMode: 'published'
             }
           });
-          this.published = {
-            ...this.getDefault(),
-            ...published
-          };
         }
       } catch (e) {
         if (e.name !== 'notfound') {
@@ -379,10 +375,7 @@ export default {
         }
       }
     } else if (this.copyOf) {
-      const newInstance = klona({
-        ...this.getDefault(),
-        ...this.copyOf
-      });
+      const newInstance = klona(this.copyOf);
       delete newInstance.parked;
       newInstance.title = `Copy of ${this.copyOf.title}`;
       if (this.copyOf.slug.startsWith('/')) {
@@ -447,11 +440,6 @@ export default {
           draft: true
         });
 
-        docData = {
-          ...this.getDefault(),
-          ...docData
-        };
-
         if (docData.archived) {
           this.restoreOnly = true;
         } else {
@@ -476,7 +464,10 @@ export default {
             this.docType = docData.type;
           }
           this.original = klona(docData);
-          this.docFields.data = docData;
+          this.docFields.data = {
+            ...this.getDefault(),
+            ...docData
+          };
           if (this.published) {
             this.changed = detectDocChange(this.schema, this.original, this.published, { differences: true });
           }
@@ -648,13 +639,7 @@ export default {
     },
     async loadNewInstance () {
       this.docReady = false;
-
-      let newInstance = await this.getNewInstance();
-      newInstance = {
-        ...this.getDefault(),
-        ...newInstance
-      };
-
+      const newInstance = await this.getNewInstance();
       this.original = newInstance;
       if (newInstance && newInstance.type !== this.docType) {
         this.docType = newInstance.type;

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -114,7 +114,6 @@ import AposArchiveMixin from 'Modules/@apostrophecms/ui/mixins/AposArchiveMixin'
 import AposAdvisoryLockMixin from 'Modules/@apostrophecms/ui/mixins/AposAdvisoryLockMixin';
 import AposDocErrorsMixin from 'Modules/@apostrophecms/modal/mixins/AposDocErrorsMixin';
 import { detectDocChange } from 'Modules/@apostrophecms/schema/lib/detectChange';
-import { has } from 'Modules/@apostrophecms/schema/lib/object';
 
 export default {
   name: 'AposDocEditor',
@@ -464,24 +463,14 @@ export default {
           if (docData.type !== this.docType) {
             this.docType = docData.type;
           }
-
           this.original = klona(docData);
-          this.docFields.data = this.schema.reduce(addDefaultValues, docData);
-
+          this.docFields.data = docData;
           if (this.published) {
             this.changed = detectDocChange(this.schema, this.original, this.published, { differences: true });
           }
-
           this.docReady = true;
           this.prepErrors();
         }
-      }
-
-      function addDefaultValues(memo, field) {
-        return {
-          ...memo,
-          ...(!has(memo, field.name) && has(field, 'def') && { [field.name]: field.def })
-        };
       }
     },
     async preview() {

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -253,21 +253,13 @@ export default {
             break;
           }
 
-          // Use the default values defined in the schema fields
-          // to fix conditional fields not showing up when editing existing docs,
-          // in the case where new fields have been added to the schema
-          // but not (yet) saved to the document:
           const fieldValue = self.getFieldValue(key);
-          const fieldValueOrDef = fieldValue !== undefined
-            ? fieldValue
-            : self.schema.find(field => field.name === key).def;
 
-          if (Array.isArray(fieldValueOrDef)) {
-            result = fieldValueOrDef.includes(val);
+          if (Array.isArray(fieldValue)) {
+            result = fieldValue.includes(val);
             break;
           }
-
-          if (val !== fieldValueOrDef) {
+          if (val !== fieldValue) {
             result = false;
             break;
           }

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -195,7 +195,6 @@ export default {
     },
 
     conditionalFields(followedByCategory) {
-      console.log('conditionalFields');
       const self = this;
       const conditionalFields = {};
 
@@ -253,24 +252,11 @@ export default {
             result = false;
             break;
           }
-
-          const fieldValue = self.getFieldValue(key);
-          const fieldValueOrDef = fieldValue !== undefined
-            ? fieldValue
-            : self.schema.find(field => field.name === key).def;
-
-          console.log('key', key);
-          console.log('val', val);
-          console.log('🚀 ~ file: AposEditorMixin.js:257 ~ evaluate ~ fieldValue:', fieldValue);
-          console.log('fieldValueOrDef', fieldValueOrDef);
-          console.log('---');
-
-          if (Array.isArray(fieldValueOrDef)) {
-            result = fieldValueOrDef.includes(val);
+          if (Array.isArray(self.getFieldValue(key))) {
+            result = self.getFieldValue(key).includes(val);
             break;
           }
-
-          if (val !== fieldValueOrDef) {
+          if (val !== self.getFieldValue(key)) {
             result = false;
             break;
           }

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -253,6 +253,10 @@ export default {
             break;
           }
 
+          // Use the default values defined in the schema fields
+          // to fix conditional fields not showing up when editing existing docs,
+          // in the case where new fields have been added to the schema
+          // but not (yet) saved to the document:
           const fieldValue = self.getFieldValue(key);
           const fieldValueOrDef = fieldValue !== undefined
             ? fieldValue

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -252,11 +252,18 @@ export default {
             result = false;
             break;
           }
-          if (Array.isArray(self.getFieldValue(key))) {
-            result = self.getFieldValue(key).includes(val);
+
+          const fieldValue = self.getFieldValue(key);
+          const fieldValueOrDef = fieldValue !== undefined
+            ? fieldValue
+            : self.schema.find(field => field.name === key).def;
+
+          if (Array.isArray(fieldValueOrDef)) {
+            result = fieldValueOrDef.includes(val);
             break;
           }
-          if (val !== self.getFieldValue(key)) {
+
+          if (val !== fieldValueOrDef) {
             result = false;
             break;
           }

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -195,6 +195,7 @@ export default {
     },
 
     conditionalFields(followedByCategory) {
+      console.log('conditionalFields');
       const self = this;
       const conditionalFields = {};
 
@@ -252,11 +253,24 @@ export default {
             result = false;
             break;
           }
-          if (Array.isArray(self.getFieldValue(key))) {
-            result = self.getFieldValue(key).includes(val);
+
+          const fieldValue = self.getFieldValue(key);
+          const fieldValueOrDef = fieldValue !== undefined
+            ? fieldValue
+            : self.schema.find(field => field.name === key).def;
+
+          console.log('key', key);
+          console.log('val', val);
+          console.log('🚀 ~ file: AposEditorMixin.js:257 ~ evaluate ~ fieldValue:', fieldValue);
+          console.log('fieldValueOrDef', fieldValueOrDef);
+          console.log('---');
+
+          if (Array.isArray(fieldValueOrDef)) {
+            result = fieldValueOrDef.includes(val);
             break;
           }
-          if (val !== self.getFieldValue(key)) {
+
+          if (val !== fieldValueOrDef) {
             result = false;
             break;
           }

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -324,6 +324,9 @@ export default {
     getDefault() {
       const object = {};
       this.field.schema.forEach(field => {
+        if (field.name.startsWith('_')) {
+          return;
+        }
         // Using `hasOwn` here, not simply checking if `field.def` is truthy
         // so that `false`, `null`, `''` or `0` are taken into account:
         const hasDefaultValue = Object.hasOwn(field, 'def');

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -186,9 +186,12 @@ export default {
         this.subfields[doc._id] = doc._fields;
       }
       for (const doc of after) {
-        if (this.subfields[doc._id] && !Object.keys(doc._fields || {}).length) {
-          doc._fields = this.subfields[doc._id];
+        if (Object.keys(doc._fields || {}).length) {
+          continue;
         }
+        doc._fields = this.subfields[doc._id]
+          ? this.subfields[doc._id]
+          : this.getDefault();
       }
     }
   },
@@ -317,6 +320,18 @@ export default {
       if (this.field.editor === 'AposImageRelationshipEditor') {
         return 'apostrophe:editImageAdjustments';
       }
+    },
+    getDefault() {
+      const object = {};
+      this.field.schema.forEach(field => {
+        // Do not simply check if `field.def` is truthy, this in not enough
+        // since a def as an empty string must be considered valid:
+        const hasDefaultValue = Object.prototype.hasOwnProperty.call(field, 'def');
+        object[field.name] = hasDefaultValue
+          ? klona(field.def)
+          : null;
+      });
+      return object;
     }
   }
 };

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -324,9 +324,9 @@ export default {
     getDefault() {
       const object = {};
       this.field.schema.forEach(field => {
-        // Do not simply check if `field.def` is truthy, this in not enough
-        // since a def as an empty string must be considered valid:
-        const hasDefaultValue = Object.prototype.hasOwnProperty.call(field, 'def');
+        // Using `hasOwn` here, not simply checking if `field.def` is truthy
+        // so that `false`, `null`, `''` or `0` are taken into account:
+        const hasDefaultValue = Object.hasOwn(field, 'def');
         object[field.name] = hasDefaultValue
           ? klona(field.def)
           : null;

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSelect.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSelect.vue
@@ -43,16 +43,6 @@ export default {
       return [ this.value.duplicate && 'apos-input--error' ];
     }
   },
-  async mounted() {
-    this.prependEmptyChoice();
-    this.$nextTick(() => {
-      // this has to happen on nextTick to avoid emitting before schemaReady is
-      // set in AposSchema
-      if (this.field.required && (this.next == null) && (this.choices[0] != null)) {
-        this.next = this.choices[0].value;
-      }
-    });
-  },
   methods: {
     validate(value) {
       if (this.field.required && (value === null)) {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSelect.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSelect.vue
@@ -44,15 +44,7 @@ export default {
     }
   },
   async mounted() {
-    // Add an null option if there isn't one already
-    if (!this.field.required && !this.choices.find(choice => {
-      return choice.value === null;
-    })) {
-      this.choices.unshift({
-        label: '',
-        value: null
-      });
-    }
+    this.prependEmptyChoice();
     this.$nextTick(() => {
       // this has to happen on nextTick to avoid emitting before schemaReady is
       // set in AposSchema

--- a/modules/@apostrophecms/schema/ui/apos/lib/detectChange.js
+++ b/modules/@apostrophecms/schema/ui/apos/lib/detectChange.js
@@ -44,7 +44,7 @@ export function detectFieldChange(field, v1, v2) {
   if (isEqual(v1, v2)) {
     return false;
   } else if (!v1 && !v2) {
-    return false;
+    return v1 !== v2;
   } else if (!v1 && Array.isArray(v2) && v2.length === 0) {
     return false;
   } else {

--- a/modules/@apostrophecms/schema/ui/apos/lib/object.js
+++ b/modules/@apostrophecms/schema/ui/apos/lib/object.js
@@ -1,3 +1,0 @@
-export function has(o, k) {
-  return Object.prototype.hasOwnProperty.call(o, k);
-}

--- a/modules/@apostrophecms/schema/ui/apos/lib/object.js
+++ b/modules/@apostrophecms/schema/ui/apos/lib/object.js
@@ -1,0 +1,3 @@
+export function has(o, k) {
+  return Object.prototype.hasOwnProperty.call(o, k);
+}

--- a/modules/@apostrophecms/schema/ui/apos/mixins/AposInputChoicesMixin.js
+++ b/modules/@apostrophecms/schema/ui/apos/mixins/AposInputChoicesMixin.js
@@ -30,18 +30,9 @@ export default {
       this.choices = this.field.choices;
     }
 
-    if (this.field.type !== 'select') {
-      return;
+    if (this.field.type === 'select') {
+      this.prependEmptyChoice();
     }
-
-    this.prependEmptyChoice();
-    this.$nextTick(() => {
-      // this has to happen on nextTick to avoid emitting before schemaReady is
-      // set in AposSchema
-      if (this.field.required && this.next == null && this.choices[0] != null) {
-        this.next = this.choices[0].value;
-      }
-    });
   },
 
   methods: {
@@ -49,7 +40,7 @@ export default {
       const hasNullValue = this.choices.find(choice => choice.value === null);
 
       // Add an null option if there isn't one already
-      if (!this.field.required && !hasNullValue) {
+      if (!hasNullValue) {
         this.choices.unshift({
           label: '',
           value: null

--- a/modules/@apostrophecms/schema/ui/apos/mixins/AposInputChoicesMixin.js
+++ b/modules/@apostrophecms/schema/ui/apos/mixins/AposInputChoicesMixin.js
@@ -38,9 +38,10 @@ export default {
   methods: {
     prependEmptyChoice() {
       const hasNullValue = this.choices.find(choice => choice.value === null);
+      const hasDefaultValue = Object.prototype.hasOwnProperty.call(this.field, 'def');
 
       // Add an null option if there isn't one already
-      if (!hasNullValue) {
+      if (!hasDefaultValue && !hasNullValue) {
         this.choices.unshift({
           label: '',
           value: null

--- a/modules/@apostrophecms/schema/ui/apos/mixins/AposInputChoicesMixin.js
+++ b/modules/@apostrophecms/schema/ui/apos/mixins/AposInputChoicesMixin.js
@@ -25,9 +25,24 @@ export default {
       );
       if (response.choices) {
         this.choices = response.choices;
+        this.prependEmptyChoice();
       }
     } else {
       this.choices = this.field.choices;
+    }
+  },
+
+  methods: {
+    prependEmptyChoice() {
+      // Add an null option if there isn't one already
+      if (!this.field.required && !this.choices.find(choice => {
+        return choice.value === null;
+      })) {
+        this.choices.unshift({
+          label: '',
+          value: null
+        });
+      }
     }
   }
 };

--- a/modules/@apostrophecms/schema/ui/apos/mixins/AposInputChoicesMixin.js
+++ b/modules/@apostrophecms/schema/ui/apos/mixins/AposInputChoicesMixin.js
@@ -25,19 +25,31 @@ export default {
       );
       if (response.choices) {
         this.choices = response.choices;
-        this.prependEmptyChoice();
       }
     } else {
       this.choices = this.field.choices;
     }
+
+    if (this.field.type !== 'select') {
+      return;
+    }
+
+    this.prependEmptyChoice();
+    this.$nextTick(() => {
+      // this has to happen on nextTick to avoid emitting before schemaReady is
+      // set in AposSchema
+      if (this.field.required && this.next == null && this.choices[0] != null) {
+        this.next = this.choices[0].value;
+      }
+    });
   },
 
   methods: {
     prependEmptyChoice() {
+      const hasNullValue = this.choices.find(choice => choice.value === null);
+
       // Add an null option if there isn't one already
-      if (!this.field.required && !this.choices.find(choice => {
-        return choice.value === null;
-      })) {
+      if (!this.field.required && !hasNullValue) {
         this.choices.unshift({
           label: '',
           value: null

--- a/modules/@apostrophecms/schema/ui/apos/mixins/AposInputChoicesMixin.js
+++ b/modules/@apostrophecms/schema/ui/apos/mixins/AposInputChoicesMixin.js
@@ -37,8 +37,10 @@ export default {
 
   methods: {
     prependEmptyChoice() {
+      // Using `hasOwn` here, not simply checking if `field.def` is truthy
+      // so that `false`, `null`, `''` or `0` are taken into account:
+      const hasDefaultValue = Object.hasOwn(this.field, 'def');
       const hasNullValue = this.choices.find(choice => choice.value === null);
-      const hasDefaultValue = Object.prototype.hasOwnProperty.call(this.field, 'def');
 
       // Add an null option if there isn't one already
       if (!hasDefaultValue && !hasNullValue) {

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -142,14 +142,18 @@ export default {
     apos.area.widgetOptions = apos.area.widgetOptions.slice(1);
   },
   created() {
+    const defaults = this.getDefault();
+
     if (this.value) {
       this.original = klona(this.value);
+      this.docFields.data = klona({
+        ...defaults,
+        ...this.value
+      });
       return;
     }
 
-    const defaults = this.getDefault();
-
-    this.original = defaults;
+    this.original = klona(defaults);
     this.docFields.data = defaults;
   },
   methods: {

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -142,7 +142,15 @@ export default {
     apos.area.widgetOptions = apos.area.widgetOptions.slice(1);
   },
   created() {
-    this.original = this.value ? klona(this.value) : this.getDefault();
+    if (this.value) {
+      this.original = klona(this.value);
+      return;
+    }
+
+    const defaults = this.getDefault();
+
+    this.original = defaults;
+    this.docFields.data = defaults;
   },
   methods: {
     updateDocFields(value) {
@@ -177,7 +185,12 @@ export default {
     getDefault() {
       const widget = {};
       this.schema.forEach(field => {
-        widget[field.name] = field.def ? klona(field.def) : field.def;
+        // Do not simply check if `field.def` is truthy, this in not enough
+        // since a def as an empty string must be considered valid:
+        const hasDefaultValue = Object.prototype.hasOwnProperty.call(field, 'def');
+        widget[field.name] = hasDefaultValue
+          ? klona(field.def)
+          : null;
       });
       return widget;
     }

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -85,7 +85,7 @@ export default {
       id: this.value && this.value._id,
       original: null,
       docFields: {
-        data: { ...this.value },
+        data: {},
         hasErrors: false
       },
       modal: {
@@ -142,11 +142,16 @@ export default {
     apos.area.widgetOptions = apos.area.widgetOptions.slice(1);
   },
   created() {
+    const defaults = this.getDefault();
+
     if (this.value) {
       this.original = klona(this.value);
+      this.docFields.data = {
+        ...defaults,
+        ...this.value
+      };
       return;
     }
-    const defaults = this.getDefault();
 
     this.original = klona(defaults);
     this.docFields.data = defaults;

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -189,6 +189,9 @@ export default {
     getDefault() {
       const widget = {};
       this.schema.forEach(field => {
+        if (field.name.startsWith('_')) {
+          return;
+        }
         // Using `hasOwn` here, not simply checking if `field.def` is truthy
         // so that `false`, `null`, `''` or `0` are taken into account:
         const hasDefaultValue = Object.hasOwn(field, 'def');

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -189,9 +189,9 @@ export default {
     getDefault() {
       const widget = {};
       this.schema.forEach(field => {
-        // Do not simply check if `field.def` is truthy, this in not enough
-        // since a def as an empty string must be considered valid:
-        const hasDefaultValue = Object.prototype.hasOwnProperty.call(field, 'def');
+        // Using `hasOwn` here, not simply checking if `field.def` is truthy
+        // so that `false`, `null`, `''` or `0` are taken into account:
+        const hasDefaultValue = Object.hasOwn(field, 'def');
         widget[field.name] = hasDefaultValue
           ? klona(field.def)
           : null;

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -142,16 +142,11 @@ export default {
     apos.area.widgetOptions = apos.area.widgetOptions.slice(1);
   },
   created() {
-    const defaults = this.getDefault();
-
     if (this.value) {
       this.original = klona(this.value);
-      this.docFields.data = klona({
-        ...defaults,
-        ...this.value
-      });
       return;
     }
+    const defaults = this.getDefault();
 
     this.original = klona(defaults);
     this.docFields.data = defaults;

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -85,7 +85,7 @@ export default {
       id: this.value && this.value._id,
       original: null,
       docFields: {
-        data: { ...this.value },
+        data: {},
         hasErrors: false
       },
       modal: {
@@ -145,11 +145,14 @@ export default {
     const defaults = this.getDefault();
 
     if (this.value) {
-      this.original = klona(this.value);
-      this.docFields.data = klona({
+      this.original = klona({
         ...defaults,
         ...this.value
       });
+      this.docFields.data = {
+        ...defaults,
+        ...this.value
+      };
       return;
     }
 

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -85,7 +85,7 @@ export default {
       id: this.value && this.value._id,
       original: null,
       docFields: {
-        data: {},
+        data: { ...this.value },
         hasErrors: false
       },
       modal: {
@@ -145,14 +145,11 @@ export default {
     const defaults = this.getDefault();
 
     if (this.value) {
-      this.original = klona({
+      this.original = klona(this.value);
+      this.docFields.data = klona({
         ...defaults,
         ...this.value
       });
-      this.docFields.data = {
-        ...defaults,
-        ...this.value
-      };
       return;
     }
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Closes https://github.com/apostrophecms/apostrophe/issues/4049

Fixes:

**Empty choice** (covered by e2e tests https://github.com/apostrophecms/testbed/pull/150)

- Add empty choice for dynamic optional select field type
- Add empty choice for required select fields, if they have no `def` option

**Falsy value selection** (covered by e2e tests https://github.com/apostrophecms/testbed/pull/151)

- Choosing a falsy value should triggers a change, and update conditional display
  - when choosing `false` in a boolean field that had no preset value (ie. field not required)
  - when choosing a falsy value in a select after an empty choice was selected (ie. a `null` choice)

**Default values** (covered by e2e tests https://github.com/apostrophecms/testbed/pull/151)

- Populate new widget instances and existing widgets with default values
  - Set default `null` values in new widgets instances to be consistent with what's is done in `AposDocEditor`
- Populate existing docs with default values
- Add default arrays and objects values to `docFields.data` of the Doc and Widget
- Add default relationship subfields values to `docFields.data` of the Doc and Widget

## What are the specific steps to test this change?

For a widget, and a doc (piece for instance):

1. add a new widget or doc
- all the fields should be populated with default values.
- the editor `this.docFields.data` should contain the default values, even the ones of the array (inline or not), nested arrays, objects, nested objects, and relationship subfields.

2. add new conditional fields to the schema of the widget or doc (conditional field _and_ the field it's relying on)
- the defaults values for these new fields should be populated in `this.docFields.data`
- the conditional fields should work with those default values

3. add a select field with a conditional field relying on it (with 2 falsy choices such as `null` and `false`)
- the conditional field should be displayed if set to be displayed on `false` or `null`, after changing the select from `false` to `null` or vice versa.
4. instead of a select, use a boolean field with no default value
- selecting `No` from nothing (ie: boolean fields has no default value) should display the conditional fields configured to be shown with `false` on the boolean field

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated -> https://github.com/apostrophecms/testbed/pull/150, https://github.com/apostrophecms/testbed/pull/151

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
