### PR TITLE
Check user permission before displaying batch operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This is useful when the goal is to allow REST API access to "guest" users who ha
 project-specific reasons to fetch access content via REST APIs.
 * `test-lib/utils.js` has new `createUser` and `loginAs` methods for the convenience of
 those writing mocha tests of Apostrophe modules.
-* `batchOperations` permissions: if a `permission` property is added to any entry in the `batchOperations` cascade of a piece-type module, this permission will be checked for every user. See `batchOperations` configuration in `modules/@apostrophecms/piece-type/index.js`. The check function `checkBatchOperationsPermissions` can be extended.
+* `batchOperations` permissions: if a `permission` property is added to any entry in the `batchOperations` cascade of a piece-type module, this permission will be checked for every user. See `batchOperations` configuration in `modules/@apostrophecms/piece-type/index.js`. The check function `checkBatchOperationsPermissions` can be extended. Please note that this permission is checked only to determine whether to offer the operation.
 
 ## 3.43.0 (2023-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is useful when the goal is to allow REST API access to "guest" users who ha
 project-specific reasons to fetch access content via REST APIs.
 * `test-lib/utils.js` has new `createUser` and `loginAs` methods for the convenience of
 those writing mocha tests of Apostrophe modules.
+* `batchOperations` permissions: if a `permission` property is added to any entry in the `batchOperations` cascade of a piece-type module, this permission will be checked for every user. See `batchOperations` configuration in `modules/@apostrophecms/piece-type/index.js`. The check function `checkBatchOperationsPermissions` can be extended.
 
 ## 3.43.0 (2023-03-29)
 

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -133,7 +133,8 @@ module.exports = {
           title: 'apostrophe:publishType',
           description: 'apostrophe:publishingBatchConfirmation',
           confirmationButton: 'apostrophe:publishingBatchConfirmationButton'
-        }
+        },
+        permission: 'edit'
       },
       archive: {
         label: 'apostrophe:archive',
@@ -149,7 +150,8 @@ module.exports = {
           title: 'apostrophe:archiveType',
           description: 'apostrophe:archivingBatchConfirmation',
           confirmationButton: 'apostrophe:archivingBatchConfirmationButton'
-        }
+        },
+        permission: 'edit'
       },
       restore: {
         label: 'apostrophe:restore',
@@ -165,7 +167,8 @@ module.exports = {
           title: 'apostrophe:restoreType',
           description: 'apostrophe:restoreBatchConfirmation',
           confirmationButton: 'apostrophe:restoreBatchConfirmationButton'
-        }
+        },
+        permission: 'edit'
       }
     },
     group: {
@@ -1054,8 +1057,13 @@ module.exports = {
           deletes.splice(0);
         }
       },
-      checkBatchOperationsPermissions(req, permission = 'edit') {
-        return self.batchOperations.filter(batchOperation => self.apos.permission.can(req, permission, self.name, batchOperation.action));
+      checkBatchOperationsPermissions(req) {
+        return self.batchOperations.filter(batchOperation => {
+          if (batchOperation.permission) {
+            return self.apos.permission.can(req, batchOperation.permission, self.name);
+          }
+          return true;
+        });
       }
     };
   },

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -1053,18 +1053,20 @@ module.exports = {
           await self.apos.doc.db.deleteMany({ _id: { $in: deletes } });
           deletes.splice(0);
         }
+      },
+      checkBatchOperationsPermissions(req, permission = 'edit') {
+        return self.batchOperations.filter(batchOperation => self.apos.permission.can(req, permission, self.name, batchOperation.action));
       }
     };
   },
   extendMethods(self) {
     return {
       getBrowserData(_super, req) {
-        const userBatchOperations = self.batchOperations.filter(batchOperation => self.apos.permission.can(req, 'edit', self.name, batchOperation.action));
         const browserOptions = _super(req);
         // Options specific to pieces and their manage modal
         browserOptions.filters = self.filters;
         browserOptions.columns = self.columns;
-        browserOptions.batchOperations = userBatchOperations;
+        browserOptions.batchOperations = self.checkBatchOperationsPermissions(req);
         browserOptions.utilityOperations = self.utilityOperations;
         browserOptions.insertViaUpload = self.options.insertViaUpload;
         browserOptions.quickCreate = !self.options.singleton && self.options.quickCreate && self.apos.permission.can(req, 'edit', self.name, 'draft');

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -1059,11 +1059,12 @@ module.exports = {
   extendMethods(self) {
     return {
       getBrowserData(_super, req) {
+        const userBatchOperations = self.batchOperations.filter(batchOperation => self.apos.permission.can(req, 'edit', self.name, batchOperation.action));
         const browserOptions = _super(req);
         // Options specific to pieces and their manage modal
         browserOptions.filters = self.filters;
         browserOptions.columns = self.columns;
-        browserOptions.batchOperations = self.batchOperations;
+        browserOptions.batchOperations = userBatchOperations;
         browserOptions.utilityOperations = self.utilityOperations;
         browserOptions.insertViaUpload = self.options.insertViaUpload;
         browserOptions.quickCreate = !self.options.singleton && self.options.quickCreate && self.apos.permission.can(req, 'edit', self.name, 'draft');


### PR DESCRIPTION
https://linear.app/apostrophecms/issue/PRO-4128/batch-operations-are-missing-permission

Batch operations are always present in the manager modal.

This is an issue when the current user does not have the required permissions to perform the action (e.g. publish).

Within apostrophe core, we can set a permission to tell the frontend what are the required operation for the item to be visible.

## Acceptance criteria

• I should see Publish batch operation only if I have the permission to publish the related content