### PR TITLE
clone value data in oembed field to discard value when cancelling and improve ux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,11 @@ shouldn't close the link dialog etc.
 
 ### Fixes
 
+* Fix various issues on conditional fields that were occurring when adding new widgets with default values or selecting a falsy value in a field that has a conditional field relying on it.  
+Populate new or existing doc instances with default values and add an empty `null` choice to select fields that do not have a default value (required or not) and to the ones configured with dynamic choices.
 * Rich text widgets save more reliably when many actions are taken quickly just before save.
+* Fix an issue in the `oembed` field where the value was kept in memory after cancelling the widget edition, which resulted in saving the value if the widget was nested and the parent widget was saved.  
+Also improve the field UX by setting the input as readonly when fetching the video metadata in order to avoid losing its focus.
 
 ## 3.44.0 (2023-04-13)
 
@@ -63,11 +67,6 @@ those writing mocha tests of Apostrophe modules.
 
 ### Fixes
 * Fix child page slug when title is deleted
-
-### Fixes
-
-* Fix various issues on conditional fields that were occurring when adding new widgets with default values or selecting a falsy value in a field that has a conditional field relying on it.  
-Populate new or existing doc instances with default values and add an empty `null` choice to select fields that do not have a default value (required or not) and to the ones configured with dynamic choices.
 
 ## 3.43.0 (2023-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,8 @@ shouldn't close the link dialog etc.
 * Fix various issues on conditional fields that were occurring when adding new widgets with default values or selecting a falsy value in a field that has a conditional field relying on it.  
 Populate new or existing doc instances with default values and add an empty `null` choice to select fields that do not have a default value (required or not) and to the ones configured with dynamic choices.
 * Rich text widgets save more reliably when many actions are taken quickly just before save.
-* Fix an issue in the `oembed` field where the value was kept in memory after cancelling the widget edition, which resulted in saving the value if the widget was nested and the parent widget was saved.  
-Also improve the field UX by setting the input as readonly when fetching the video metadata in order to avoid losing its focus.
+* Fix an issue in the `oembed` field where the value was kept in memory after cancelling the widget editor, which resulted in saving the value if the widget was nested and the parent widget was saved.  
+Also improve the `oembed` field UX by setting the input as `readonly` rather than `disabled` when fetching the video metadata, in order to avoid losing its focus when typing.
 
 ## 3.44.0 (2023-04-13)
 

--- a/modules/@apostrophecms/oembed-field/ui/apos/components/AposInputOembed.vue
+++ b/modules/@apostrophecms/oembed-field/ui/apos/components/AposInputOembed.vue
@@ -8,10 +8,13 @@
       <div class="apos-input-wrapper">
         <input
           :class="classes"
-          v-model="next.url" type="url"
+          v-model="next.url"
+          type="url"
           :placeholder="$t(field.placeholder)"
-          :disabled="field.readOnly" :required="field.required"
-          :id="uid" :tabindex="tabindex"
+          :disabled="isReadOnly"
+          :required="field.required"
+          :id="uid"
+          :tabindex="tabindex"
         >
         <component
           v-if="icon"
@@ -46,10 +49,14 @@ export default {
         ? this.value.data : {},
       oembedResult: {},
       dynamicRatio: '',
-      oembedError: null
+      oembedError: null,
+      forceReadOnly: false
     };
   },
   computed: {
+    isReadOnly () {
+      return this.field.readOnly || this.forceReadOnly;
+    },
     tabindex () {
       return this.field.disableFocus ? '-1' : '0';
     },
@@ -104,7 +111,7 @@ export default {
       this.validateAndEmit();
     },
     async loadOembed () {
-      this.field.readOnly = true;
+      this.forceReadOnly = true;
       this.oembedResult = {};
       this.oembedError = null;
       this.dynamicRatio = '';
@@ -132,7 +139,7 @@ export default {
         this.next.title = '';
         this.next.thumbnail = '';
       } finally {
-        this.field.readOnly = false;
+        this.forceReadOnly = false;
       }
     }
   }

--- a/modules/@apostrophecms/oembed-field/ui/apos/components/AposInputOembed.vue
+++ b/modules/@apostrophecms/oembed-field/ui/apos/components/AposInputOembed.vue
@@ -11,7 +11,8 @@
           v-model="next.url"
           type="url"
           :placeholder="$t(field.placeholder)"
-          :disabled="isReadOnly"
+          :disabled="field.readOnly"
+          :readonly="tempReadOnly"
           :required="field.required"
           :id="uid"
           :tabindex="tabindex"
@@ -50,13 +51,13 @@ export default {
       oembedResult: {},
       dynamicRatio: '',
       oembedError: null,
-      forceReadOnly: false
+
+      // This variable will set the input as readonly,
+      // not disabled, in order to avoid losing focus.
+      tempReadOnly: false
     };
   },
   computed: {
-    isReadOnly () {
-      return this.field.readOnly || this.forceReadOnly;
-    },
     tabindex () {
       return this.field.disableFocus ? '-1' : '0';
     },
@@ -111,7 +112,7 @@ export default {
       this.validateAndEmit();
     },
     async loadOembed () {
-      this.forceReadOnly = true;
+      this.tempReadOnly = true;
       this.oembedResult = {};
       this.oembedError = null;
       this.dynamicRatio = '';
@@ -139,7 +140,7 @@ export default {
         this.next.title = '';
         this.next.thumbnail = '';
       } finally {
-        this.forceReadOnly = false;
+        this.tempReadOnly = false;
       }
     }
   }

--- a/modules/@apostrophecms/oembed-field/ui/apos/components/AposInputOembed.vue
+++ b/modules/@apostrophecms/oembed-field/ui/apos/components/AposInputOembed.vue
@@ -46,7 +46,7 @@ export default {
   data () {
     return {
       next: (this.value && this.value.data)
-        ? this.value.data : {},
+        ? { ...this.value.data } : {},
       oembedResult: {},
       dynamicRatio: '',
       oembedError: null,


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

- clone `this.value.data` so that `this.next` does not keep a previously-discarred value
- use `readonly` rather than `disabled` in order to avoid losing focus when typing

Issue initially raised by iCiMS.
 
## What are the specific steps to test this change?

Add a video widget to an area (or add `oembed` field to any widget).
Enable Network Throttling to slow 3G

- when you type, the input should be readonly while the call is made to the server
- when the call is finished, the focus should still be on the input and **you should be able to continue typing**
- save the widget
- edit the widget
- edit the value and **cancel** the widget edition
- edit the widget
- the value **should not be the one that was set when canceled** (should be the one that was saved)

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated --> upcoming e2e tests

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
