### PR TITLE
fast rich text save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Apostrophe from refreshing the main content zone of the page when images
 and pieces are edited, by clearing the `refresh` property of the object
 passed to the event.
 
+### Fixes
+
+* Rich text widgets save more reliably when many actions are taken quickly just before save.
+
 ## 3.44.0 (2023-04-13)
 
 ### Adds

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -248,7 +248,7 @@ export default {
           this.emitWidgetUpdate();
         }
       }
-    },
+    }
   },
   mounted() {
     const extensions = [

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -242,13 +242,13 @@ export default {
     }
   },
   watch: {
-    focused(newVal) {
+    isFocused(newVal) {
       if (!newVal) {
         if (this.pending) {
           this.emitWidgetUpdate();
         }
       }
-    }
+    },
   },
   mounted() {
     const extensions = [


### PR DESCRIPTION
Save rich text widgets on actual tiptap editor focus changes, not just blurs from widget to widget at the area level