### PR TITLE
Fix document click issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,15 @@ in the rich text editor.
 Apostrophe from refreshing the main content zone of the page when images
 and pieces are edited, by clearing the `refresh` property of the object
 passed to the event.
+* To facilitate custom click handlers, an `apos.modal.onTopOf(el1, el2)` function is now
+available to check whether an element is considered to be "on top of" another element in
+the modal stack.
 
 ### Fixes
 
 * Rich text widgets save more reliably when many actions are taken quickly just before save.
+* Apostrophe now has a custom implementation of `v-click-outside-element` which takes Apostrophe's
+modal stack into account.
 
 ## 3.44.0 (2023-04-13)
 

--- a/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
+++ b/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
@@ -31,6 +31,38 @@ export default function() {
       },
       getProperties(id) {
         return this.$refs.modals.getProperties(id);
+      },
+      // Returns true if el1 is "on top of" el2 in the
+      // modal stack, as viewed by the user. If el1 is a
+      // modal that appears later in the stack than el2
+      // (visually stacked on top), this method returns true.
+      // If el2 is `document` and el1 is a modal, this
+      // method returns true. For convenenience, if el1
+      // or el2 is not a modal, it is treated as its DOM
+      // parent modal, or as `document`. If el1 has no
+      // parent modal this method always returns false.
+      onTopOf(el1, el2) {
+        if (!el1.matches('[data-apos-modal]')) {
+          el1 = el1.closest('[data-apos-modal]') || document;
+        }
+        if (!el2.matches('[data-apos-modal]')) {
+          el2 = el2.closest('[data-apos-modal]') || document;
+        }
+        if (el1 === document) {
+          return false;
+        }
+        if (el2 === document) {
+          return true;
+        }
+        const index1 = apos.modal.stack.findIndex(modal => modal.$el === el1);
+        const index2 = apos.modal.stack.findIndex(modal => modal.$el === el2);
+        if (index1 === -1) {
+          throw new Error('apos.modal.onTopOf: el1 is not in the modal stack');
+        }
+        if (index2 === -1) {
+          throw new Error('apos.modal.onTopOf: el2 is not in the modal stack');
+        }
+        return index1 > index2;
       }
     },
     render(h) {
@@ -45,6 +77,7 @@ export default function() {
   apos.modal.execute = theAposModals.execute;
   apos.modal.getAt = theAposModals.getAt;
   apos.modal.getProperties = theAposModals.getProperties;
+  apos.modal.onTopOf = theAposModals.onTopOf;
   apos.modal.stack = [];
   apos.confirm = theAposModals.confirm;
   apos.alert = theAposModals.alert;

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -12,6 +12,7 @@
       aria-modal="true"
       :aria-labelledby="id"
       ref="modalEl"
+      data-apos-modal
     >
       <transition :name="transitionType">
         <div

--- a/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     id="apos-modals" :class="themeClass"
-    @click.stop
   >
     <component
       v-for="modal in stack" :key="modal.id"

--- a/modules/@apostrophecms/ui/ui/apos/lib/click-outside-element.js
+++ b/modules/@apostrophecms/ui/ui/apos/lib/click-outside-element.js
@@ -3,11 +3,8 @@ export default {
     Vue.directive('click-outside-element', {
       bind(el, binding) {
         el.aposClickOutsideHandler = (event) => {
-          if ((el !== event.target) && !el.contains(event.target)) {
-            console.log('FIRING');
+          if ((el !== event.target) && !el.contains(event.target) && !apos.modal.onTopOf(event.target, el)) {
             binding.value(event);
-          } else {
-            console.log('NOT FIRING');
           }
         };
         document.body.addEventListener('click', el.aposClickOutsideHandler);

--- a/modules/@apostrophecms/ui/ui/apos/lib/click-outside-element.js
+++ b/modules/@apostrophecms/ui/ui/apos/lib/click-outside-element.js
@@ -1,0 +1,20 @@
+export default {
+  install(Vue, options) {
+    Vue.directive('click-outside-element', {
+      bind(el, binding) {
+        el.aposClickOutsideHandler = (event) => {
+          if ((el !== event.target) && !el.contains(event.target)) {
+            console.log('FIRING');
+            binding.value(event);
+          } else {
+            console.log('NOT FIRING');
+          }
+        };
+        document.body.addEventListener('click', el.aposClickOutsideHandler);
+      },
+      unbind(el) {
+        document.body.removeEventListener('click', el.aposClickOutsideHandler);
+      }
+    });
+  }
+};

--- a/modules/@apostrophecms/ui/ui/apos/lib/vue.js
+++ b/modules/@apostrophecms/ui/ui/apos/lib/vue.js
@@ -1,11 +1,11 @@
 import Vue from 'vue';
-import VueClickOutsideElement from 'vue-click-outside-element';
+import ClickOutsideElement from './click-outside-element';
 import LocalizedVTooltip from './localized-v-tooltip';
 import tooltipOptions from './tooltip-options';
 import VueAposI18Next from './i18next';
 
 Vue.use(LocalizedVTooltip, tooltipOptions);
-Vue.use(VueClickOutsideElement);
+Vue.use(ClickOutsideElement);
 Vue.use(VueAposI18Next, {
   // Module aliases are not available yet when this code executes
   i18n: apos.modules['@apostrophecms/i18n']

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "v-tooltip": "^2.0.3",
     "vue": "^2.6.14",
     "vue-advanced-cropper": "^1.10.1",
-    "vue-click-outside-element": "^1.0.15",
     "vue-loader": "^15.10.0",
     "vue-material-design-icons": "~4.12.1",
     "vue-style-loader": "^4.1.2",


### PR DESCRIPTION
Address the document click issues by replacing `v-click-outside-element` with a custom implementation that is aware of modal stack relationships.