### PR TITLE
Allow `@` when a document is a template (doc-template-library module).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Adds
+
+* Allow `@` when a document is a template (doc-template-library module).
+
 ## 3.45.0 (2023-04-27)
 
 ### Adds
@@ -53,7 +59,7 @@ those writing mocha tests of Apostrophe modules.
 
 ### Fixes
 
-* Fix various issues on conditional fields that were occurring when adding new widgets with default values or selecting a falsy value in a field that has a conditional field relying on it.  
+* Fix various issues on conditional fields that were occurring when adding new widgets with default values or selecting a falsy value in a field that has a conditional field relying on it.
 Populate new or existing doc instances with default values and add an empty `null` choice to select fields that do not have a default value (required or not) and to the ones configured with dynamic choices.
 
 ## 3.43.0 (2023-03-29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     columns.
 * Add `apos.schema.getRelationshipQueryBuilderChoicesProjection` method to set the projection used in
     `apos.schema.relationshipQueryBuilderChoices`
+* Allow `@` when a piece is a template and `/@` for page templates (doc-template-library module).
 
 ### Changes
 
@@ -57,10 +58,6 @@ when working with the `@apostrophecms/ai-helper` module, and also helps in other
 
 * Debounce search to prevent calling search on every key stroke in the manager modal.
 * Various size and spacing adjustments in the expanded Add Content modal UI
-
-### Adds
-
-* Allow `@` when a document is a template (doc-template-library module).
 
 ## 3.45.1 (2023-04-28)
 

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="apos-media-manager-display">
-    <div class="apos-media-manager-display__grid" :class="classes">
+    <div class="apos-media-manager-display__grid">
       <AposMediaUploader
         v-if="canEdit"
         :disabled="maxReached"
@@ -116,10 +116,6 @@ export default {
       required: false,
       default: null
     },
-    classes: {
-      type: String,
-      default: null
-    },
     template: {
       type: Boolean,
       default: false
@@ -203,13 +199,6 @@ export default {
       grid-template-columns: repeat(7, 12.22%);
       gap: 2.4% 2.4%;
     }
-  }
-
-  .apos-media-manager-display__flex {
-    display: flex;
-    gap: 35px;
-    max-width: 100%;
-    flex-wrap: wrap;
   }
 
   .apos-media-manager-display__cell {

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="apos-media-manager-display">
-    <div class="apos-media-manager-display__grid">
+    <div class="apos-media-manager-display__grid" :class="classes">
       <AposMediaUploader
         v-if="canEdit"
         :disabled="maxReached"
@@ -14,6 +14,7 @@
         class="apos-media-manager-display__cell" v-for="item in items"
         :key="idFor(item)"
         :class="{'apos-is-selected': checked.includes(item._id)}"
+        :style="getCellStyles(item)"
       >
         <div class="apos-media-manager-display__checkbox">
           <AposCheckbox
@@ -114,6 +115,14 @@ export default {
       type: String,
       required: false,
       default: null
+    },
+    classes: {
+      type: String,
+      default: null
+    },
+    template: {
+      type: Boolean,
+      default: false
     }
   },
   emits: [
@@ -162,6 +171,14 @@ export default {
       }
 
     },
+    getCellStyles(item) {
+      if (this.template && item.dimensions) {
+        return {
+          width: `${item.dimensions.width}px`,
+          height: `${item.dimensions.height}px`
+        };
+      }
+    },
     addDragClass(event) {
       event.target.classList.add('apos-is-hovering');
     },
@@ -186,6 +203,13 @@ export default {
       grid-template-columns: repeat(7, 12.22%);
       gap: 2.4% 2.4%;
     }
+  }
+
+  .apos-media-manager-display__flex {
+    display: flex;
+    gap: 35px;
+    max-width: 100%;
+    flex-wrap: wrap;
   }
 
   .apos-media-manager-display__cell {

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
@@ -116,7 +116,7 @@ export default {
       required: false,
       default: null
     },
-    template: {
+    largePreview: {
       type: Boolean,
       default: false
     }
@@ -154,7 +154,7 @@ export default {
       const parentRatio = parentWidth / parentHeight;
       const itemRatio = item.dimensions.width / item.dimensions.height;
 
-      if (parentRatio < itemRatio) {
+      if ((parentRatio < itemRatio) || this.largePreview) {
         return {
           width: `${item.dimensions.width}px`,
           paddingTop: `${(item.dimensions.height / item.dimensions.width) * 100}%`
@@ -168,7 +168,7 @@ export default {
 
     },
     getCellStyles(item) {
-      if (this.template && item.dimensions) {
+      if (this.largePreview && item.dimensions) {
         return {
           width: `${item.dimensions.width}px`,
           height: `${item.dimensions.height}px`

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -150,6 +150,9 @@ module.exports = (self) => {
       if (field.page) {
         options.allow = '/';
       }
+      if (data.aposIsTemplate) {
+        options.allow = field.page ? [ '/', '@' ] : '@';
+      }
       destination[field.name] = self.apos.util.slugify(self.apos.launder.string(data[field.name], field.def), options);
 
       if (field.page) {
@@ -756,9 +759,9 @@ module.exports = (self) => {
         const { name: uniqueFieldName, label: uniqueFieldLabel } = field.schema.find(subfield => subfield.unique) || [];
         if (uniqueFieldName) {
           const duplicates = data
-            .map(item => Array.isArray(item[uniqueFieldName])
+            .map(item => (Array.isArray(item[uniqueFieldName])
               ? item[uniqueFieldName][0]._id
-              : item[uniqueFieldName])
+              : item[uniqueFieldName]))
             .filter((item, index, array) => array.indexOf(item) !== index);
           if (duplicates.length) {
             throw self.apos.error('duplicate', `${req.t(uniqueFieldLabel)} in ${req.t(field.label)} must be unique`);

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
@@ -190,11 +190,13 @@ export default {
       const options = {
         def: ''
       };
+
       if (this.field.aposIsTemplate) {
-        options.allow = '@';
+        options.allow = this.field.page ? [ '/', '@' ] : '@';
       } else if (this.field.page && !componentOnly) {
         options.allow = '/';
       }
+
       let preserveDash = false;
       // When you are typing a slug it feels wrong for hyphens you typed
       // to disappear as you go, so if the last character is not valid in a slug,
@@ -202,10 +204,12 @@ export default {
       if (this.focus && s.length && (sluggo(s.charAt(s.length - 1), options) === '')) {
         preserveDash = true;
       }
+
       s = sluggo(s, options);
       if (preserveDash) {
         s += '-';
       }
+
       if (this.field.page && !componentOnly) {
         if (!this.followingValues?.title) {
           const nextParts = this.next.split('/');
@@ -228,6 +232,7 @@ export default {
           s += '/';
         }
       }
+
       if (!componentOnly) {
         s = this.setPrefix(s);
       }
@@ -264,7 +269,20 @@ export default {
         // doc editor modal it will momentarily be tracked as archived but
         // without not have the archive prefix, so check that too.
         updated = this.isArchived && archivePrefix ? `${archivePrefix}${updated}` : updated;
+      } else if (this.field.aposIsTemplate) {
+        let prefix = '';
+        if (this.field.page) {
+          if (!updated.startsWith('/@')) {
+            prefix = '/@';
+          }
+        } else {
+          if (!updated.startsWith('@')) {
+            prefix = '@';
+          }
+        }
+        updated = prefix + updated;
       }
+
       return updated;
     },
     async checkConflict() {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
@@ -190,7 +190,9 @@ export default {
       const options = {
         def: ''
       };
-      if (this.field.page && !componentOnly) {
+      if (this.field.aposIsTemplate) {
+        options.allow = '@';
+      } else if (this.field.page && !componentOnly) {
         options.allow = '/';
       }
       let preserveDash = false;

--- a/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
@@ -153,6 +153,7 @@ export default {
       this.schema.forEach(item => {
         fields[item.name] = {};
         fields[item.name].field = item;
+        fields[item.name].field.aposIsTemplate = this.value?.data?.aposIsTemplate;
         fields[item.name].value = {
           data: this.value[item.name]
         };


### PR DESCRIPTION
Allow `@` when a document is a template (doc-template-library module).

https://linear.app/apostrophecms/issue/PRO-4125/create-the-template-library-module-with-template-query-builder