### PR TITLE
check e.doc during content-changed event handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fix
+
+* Check that `e.doc` exists when handling `content-changed` event.
+
 ## 3.45.0 (2023-04-27)
 
 ### Adds

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -775,7 +775,7 @@ export default {
       window.localStorage.setItem(this.savePreferenceName, pref);
     },
     onContentChanged(e) {
-      if (this.original?._id !== e.doc._id) {
+      if (!e.doc || this.original?._id !== e.doc._id) {
         return;
       }
       if (e.doc.type !== this.docType) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Prevent error in browser console when `e.doc` is undefined when handling `content-changed` event.

## What are the specific steps to test this change?

1. Install `@apostrophecms-pro/data-set` and import a document
2. Check the browser console for error after the import

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
