### PR TITLE
Fields nested following

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### Adds
+
+* Allow sub-schema fields (array and object) to follow parent schema fields using the newly introduced `following: '<parentField'` syntax, where the starting `<` indicates the parent level. For example `<parentField` follows a field in the parent level, `<<grandParentField` follows a field in the grand parent level, etc. The change is fully backward compatible with the current syntax for following fields from the same schema level.
+
 ### Changes
 * Various size and spacing adjustments in the expanded Add Content modal UI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Adds
 
-* Allow sub-schema fields (array and object) to follow parent schema fields using the newly introduced `following: '<parentField'` syntax, where the starting `<` indicates the parent level. For example `<parentField` follows a field in the parent level, `<<grandParentField` follows a field in the grand parent level, etc. The change is fully backward compatible with the current syntax for following fields from the same schema level.
+* Allow sub-schema fields (array and object) to follow parent schema fields using the newly introduced `following: '<parentField'` syntax, where the starting `<` indicates the parent level. For example `<parentField` follows a field in the parent level, `<<grandParentField` follows a field in the grandparent level, etc. The change is fully backward compatible with the current syntax for following fields from the same schema level.
 
 ### Changes
 * Various size and spacing adjustments in the expanded Add Content modal UI

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -140,13 +140,21 @@ export default {
       const fields = this.getFieldsByCategory(followedByCategory);
 
       const followingValues = {};
+      const parentFollowing = {};
+      for (const [ key, val ] of Object.entries(this.parentFollowingValues || {})) {
+        parentFollowing[`<${key}`] = val;
+      }
 
       for (const field of fields) {
         if (field.following) {
           const following = Array.isArray(field.following) ? field.following : [ field.following ];
           followingValues[field.name] = {};
           for (const name of following) {
-            followingValues[field.name][name] = this.getFieldValue(name);
+            if (name.startsWith('<')) {
+              followingValues[field.name][name] = parentFollowing[name];
+            } else {
+              followingValues[field.name][name] = this.getFieldValue(name);
+            }
           }
         }
       }

--- a/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
@@ -114,6 +114,10 @@ export default {
     docId: {
       type: String,
       default: null
+    },
+    parentFollowingValues: {
+      type: Object,
+      default: null
     }
   },
   emits: [ 'modal-result', 'safe-close' ],

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
@@ -141,6 +141,7 @@
 
 <script>
 import AposInputMixin from 'Modules/@apostrophecms/schema/mixins/AposInputMixin.js';
+import AposInputFollowingMixin from 'Modules/@apostrophecms/schema/mixins/AposInputFollowingMixin.js';
 import cuid from 'cuid';
 import { klona } from 'klona';
 import { get } from 'lodash';
@@ -149,7 +150,7 @@ import draggable from 'vuedraggable';
 export default {
   name: 'AposInputArray',
   components: { draggable },
-  mixins: [ AposInputMixin ],
+  mixins: [ AposInputMixin, AposInputFollowingMixin ],
   props: {
     generation: {
       type: Number,
@@ -342,27 +343,7 @@ export default {
       });
     },
     getFollowingValues(item) {
-      const followingValues = {};
-      const parentFollowing = {};
-      for (const [ key, val ] of Object.entries(this.followingValues || {})) {
-        parentFollowing[`<${key}`] = val;
-      }
-
-      for (const field of this.field.schema) {
-        if (field.following) {
-          const following = Array.isArray(field.following) ? field.following : [ field.following ];
-          followingValues[field.name] = {};
-          for (const name of following) {
-            if (name.startsWith('<')) {
-              followingValues[field.name][name] = parentFollowing[name];
-            } else {
-              followingValues[field.name][name] = item.schemaInput.data[name];
-            }
-          }
-        }
-      }
-
-      return followingValues;
+      return this.computeFollowingValues(item.schemaInput.data);
     }
   }
 };

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
@@ -288,7 +288,8 @@ export default {
         field: this.field,
         items: this.next,
         serverError: this.serverError,
-        docId: this.docId
+        docId: this.docId,
+        parentFollowingValues: this.followingValues
       });
       if (result) {
         this.next = result;
@@ -342,12 +343,21 @@ export default {
     },
     getFollowingValues(item) {
       const followingValues = {};
+      const parentFollowing = {};
+      for (const [ key, val ] of Object.entries(this.followingValues || {})) {
+        parentFollowing[`<${key}`] = val;
+      }
+
       for (const field of this.field.schema) {
         if (field.following) {
           const following = Array.isArray(field.following) ? field.following : [ field.following ];
           followingValues[field.name] = {};
           for (const name of following) {
-            followingValues[field.name][name] = item.schemaInput.data[name];
+            if (name.startsWith('<')) {
+              followingValues[field.name][name] = parentFollowing[name];
+            } else {
+              followingValues[field.name][name] = item.schemaInput.data[name];
+            }
           }
         }
       }

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputObject.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputObject.vue
@@ -28,10 +28,11 @@
 
 <script>
 import AposInputMixin from 'Modules/@apostrophecms/schema/mixins/AposInputMixin.js';
+import AposInputFollowingMixin from 'Modules/@apostrophecms/schema/mixins/AposInputFollowingMixin.js';
 
 export default {
   name: 'AposInputObject',
-  mixins: [ AposInputMixin ],
+  mixins: [ AposInputMixin, AposInputFollowingMixin ],
   props: {
     generation: {
       type: Number,
@@ -59,27 +60,7 @@ export default {
   },
   computed: {
     followingValuesWithParent() {
-      const followingValues = {};
-      const parentFollowing = {};
-      for (const [ key, val ] of Object.entries(this.followingValues || {})) {
-        parentFollowing[`<${key}`] = val;
-      }
-
-      for (const field of this.field.schema) {
-        if (field.following) {
-          const following = Array.isArray(field.following) ? field.following : [ field.following ];
-          followingValues[field.name] = {};
-          for (const name of following) {
-            if (name.startsWith('<')) {
-              followingValues[field.name][name] = parentFollowing[name];
-            } else {
-              followingValues[field.name][name] = this.schemaInput.data[name];
-            }
-          }
-        }
-      }
-
-      return followingValues;
+      return this.computeFollowingValues(this.schemaInput.data);
     }
   },
   watch: {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputObject.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputObject.vue
@@ -17,6 +17,7 @@
             :generation="generation"
             :doc-id="docId"
             v-model="schemaInput"
+            :following-values="followingValuesWithParent"
             ref="schema"
           />
         </div>
@@ -55,6 +56,31 @@ export default {
       },
       next
     };
+  },
+  computed: {
+    followingValuesWithParent() {
+      const followingValues = {};
+      const parentFollowing = {};
+      for (const [ key, val ] of Object.entries(this.followingValues || {})) {
+        parentFollowing[`<${key}`] = val;
+      }
+
+      for (const field of this.field.schema) {
+        if (field.following) {
+          const following = Array.isArray(field.following) ? field.following : [ field.following ];
+          followingValues[field.name] = {};
+          for (const name of following) {
+            if (name.startsWith('<')) {
+              followingValues[field.name][name] = parentFollowing[name];
+            } else {
+              followingValues[field.name][name] = this.schemaInput.data[name];
+            }
+          }
+        }
+      }
+
+      return followingValues;
+    }
   },
   watch: {
     schemaInput: {

--- a/modules/@apostrophecms/schema/ui/apos/mixins/AposInputFollowingMixin.js
+++ b/modules/@apostrophecms/schema/ui/apos/mixins/AposInputFollowingMixin.js
@@ -1,0 +1,34 @@
+/**
+ * Provides followingValues computation for fields having
+ * sub-schema (array, object).
+ */
+
+export default {
+  methods: {
+    // Accept a `data` object with field values and return an object
+    // of the following values for each field of the underlying schema.
+    computeFollowingValues(data) {
+      const followingValues = {};
+      const parentFollowing = {};
+      for (const [ key, val ] of Object.entries(this.followingValues || {})) {
+        parentFollowing[`<${key}`] = val;
+      }
+
+      for (const field of this.field.schema) {
+        if (field.following) {
+          const following = Array.isArray(field.following) ? field.following : [ field.following ];
+          followingValues[field.name] = {};
+          for (const name of following) {
+            if (name.startsWith('<')) {
+              followingValues[field.name][name] = parentFollowing[name];
+            } else {
+              followingValues[field.name][name] = data[name];
+            }
+          }
+        }
+      }
+
+      return followingValues;
+    }
+  }
+};

--- a/test/follow-ancestors.js
+++ b/test/follow-ancestors.js
@@ -1,0 +1,165 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert');
+
+describe('Schema - follow ancestor fields', function() {
+
+  let apos;
+  this.timeout(t.timeout);
+  this.slow(2000);
+
+  beforeEach(async function() {
+    return t.destroy(apos);
+  });
+
+  after(async function() {
+    return t.destroy(apos);
+  });
+
+  it('should follow a parent field in array and object', async function() {
+    apos = await t.create({
+      root: module,
+      modules: {
+        household: {
+          extend: '@apostrophecms/piece-type',
+          options: {
+            alias: 'household'
+          },
+          fields: {
+            add: {
+              petPreference: {
+                type: 'select',
+                label: 'Pet Preference',
+                choices: [
+                  {
+                    value: 'cats',
+                    label: 'Cats'
+                  },
+                  {
+                    value: 'dogs',
+                    label: 'Dogs'
+                  }
+                ],
+                required: true
+              },
+              pets: {
+                type: 'array',
+                label: 'Pets',
+                fields: {
+                  add: {
+                    name: {
+                      type: 'string',
+                      label: 'Name',
+                      // Follow one level up
+                      following: [ '<petPreference' ]
+                    }
+                  }
+                }
+              },
+              favoritePet: {
+                type: 'object',
+                label: 'Favorite Pet',
+                fields: {
+                  add: {
+                    name: {
+                      type: 'string',
+                      label: 'Name',
+                      // Follow one level up
+                      following: [ '<petPreference' ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+    const schema = apos.modules.household.schema;
+    const petField = schema.find(field => field.name === 'pets');
+    const favPetField = schema.find(field => field.name === 'favoritePet');
+    assert(petField);
+    assert.deepEqual(petField.following, [ 'petPreference' ]);
+    assert(favPetField);
+    assert.deepEqual(favPetField.following, [ 'petPreference' ]);
+  });
+
+  it('should follow a grand parent field in array and object', async function() {
+    apos = await t.create({
+      root: module,
+      modules: {
+        household: {
+          extend: '@apostrophecms/piece-type',
+          options: {
+            alias: 'household'
+          },
+          fields: {
+            add: {
+              petPreference: {
+                type: 'select',
+                label: 'Pet Preference',
+                choices: [
+                  {
+                    value: 'cats',
+                    label: 'Cats'
+                  },
+                  {
+                    value: 'dogs',
+                    label: 'Dogs'
+                  }
+                ],
+                required: true
+              },
+              rooms: {
+                type: 'array',
+                label: 'Rooms',
+                fields: {
+                  add: {
+                    pets: {
+                      type: 'array',
+                      label: 'Pets',
+                      fields: {
+                        add: {
+                          name: {
+                            type: 'string',
+                            label: 'Name',
+                            // Follow two levels up
+                            following: [ '<<petPreference' ]
+                          }
+                        }
+                      }
+                    },
+                    favoritePet: {
+                      type: 'object',
+                      label: 'Favorite Pet',
+                      fields: {
+                        add: {
+                          name: {
+                            type: 'string',
+                            label: 'Name',
+                            // Follow two levels up
+                            following: [ '<<petPreference' ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+    const schema = apos.modules.household.schema;
+    const rooms = schema.find(field => field.name === 'rooms');
+    assert(rooms);
+    assert.deepEqual(rooms.following, [ 'petPreference' ]);
+
+    const petField = rooms.schema.find(field => field.name === 'pets');
+    const favPetField = rooms.schema.find(field => field.name === 'favoritePet');
+    assert(petField);
+    assert.deepEqual(petField.following, [ '<petPreference' ]);
+    assert(favPetField);
+    assert.deepEqual(favPetField.following, [ '<petPreference' ]);
+  });
+});


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Allow nested fields (array and object schema fields) to follow field values from the parent schema.

In order to be done, the nested fields should use syntax `<fieldToFollow`, which will result following of values of a field named `fieldToFollow` from the parent schema. `<<fieldToFollow` would follow a field from the grand parent, and so on.

Here is an example, that involves an imaginary field type `stringWithSuggestions` following a parent field:
```js
module.exports = {
  extend: '@apostrophecms/piece-type',
  options: {
    name: 'household',
    fields: {
      add: {
        petPreference: {
          type: 'select',
          label: 'Pet Preference',
          choices: [
            {
              value: 'cats',
              label: 'Cats'
            },
            {
              value: 'dogs',
              label: 'Dogs'
            }
          ],
          required: true
        },
        pets: {
          type: 'array',
          label: 'Pets',
          fields: {
            add: {
              name: {
                // Custom schema field like "string" but
                // offers the user suggestions based on "preference"
                type: 'stringWithSuggestions',
                label: 'Name',
                following: [ '<petPreference' ]
              }
            },
            inline: true
          }
        }
      }
    }
  } 
};
``` 

## What are the specific steps to test this change?

Open the Testbed app -> Testing -> Households Piece. Change "Pet Preferences" field and see the chosen value change throughout the nested piece schema.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated
