### PR TITLE
Hotfix: do not refresh the main content area while a widget editor modal is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.45.2 (2023-05-02)
+
+### Fixes
+
+* Adding or editing a piece no longer immediately refreshes the main content area if a widget editor
+is open. This prevents interruption of the widget editing process.
+
 ## 3.45.1 (2023-04-28)
 
 ### Fixes

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -593,7 +593,7 @@ export default {
       }
     }
   }
-}
+};
 
 function cancelRefresh(refreshOptions) {
   refreshOptions.refresh = false;

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -363,6 +363,7 @@ export default {
       if (!this.widgetIsContextual(widget.type)) {
         const componentName = this.widgetEditorComponent(widget.type);
         apos.area.activeEditor = this;
+        apos.bus.$on('apos-refreshing', cancelRefresh);
         const result = await apos.modal.execute(componentName, {
           value: widget,
           options: this.widgetOptionsByType(widget.type),
@@ -370,8 +371,12 @@ export default {
           docId: this.docId
         });
         apos.area.activeEditor = null;
+        apos.bus.$off('apos-refreshing', cancelRefresh);
         if (result) {
           return this.update(result);
+        }
+        function cancelRefresh(refreshOptions) {
+          refreshOptions.refresh = false;
         }
       }
     },

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -375,9 +375,6 @@ export default {
         if (result) {
           return this.update(result);
         }
-        function cancelRefresh(refreshOptions) {
-          refreshOptions.refresh = false;
-        }
       }
     },
     clone(index) {
@@ -596,8 +593,11 @@ export default {
       }
     }
   }
-};
+}
 
+function cancelRefresh(refreshOptions) {
+  refreshOptions.refresh = false;
+}
 </script>
 
 <style lang="scss" scoped>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "3.45.1",
+  "version": "3.45.2",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is a hotfix for an issue discovered when working with the AI helper module, but it has other benefits.

Normally, if you go into the admin bar and edit and save or insert a piece, the main content area of the page should refresh in case that piece is displayed on the page.

However, if a widget editor dialog box is currently open on the page or lower in the modal stack, this is never a good thing because the editing experience is interrupted and the modified piece is generally one that saving the modal will display immediately. Without this fix it doesn't get displayed at all until the page is manually refreshed.

We didn't notice this because uploading images the normal way happens to not trigger this event mechanism, whereas the way AI inserts an image does. But inserting and editing other pieces types also does, so the benefits go beyond a hotfix for the AI helper.