### PR TITLE
update sluggo dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Changes
+
+* Updated `sluggo` to version 1.0.0.
+
 ## 3.46.0 (2023-05-03)
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "sass": "^1.52.3",
     "sass-loader": "^10.1.1",
     "server-destroy": "^1.0.1",
-    "sluggo": "^0.3.0",
+    "sluggo": "^1.0.0",
     "tinycolor2": "^1.4.2",
     "tough-cookie": "^4.0.0",
     "underscore.string": "^3.3.4",


### PR DESCRIPTION
To 1.0.0 so it is possible to specify an array of exceptions rather than just one character.