### PR TITLE
Bump jsdom version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14, 16, 18]
-        mongodb-version: [4.2, 5.0]
+        node-version: [16, 18]
+        mongodb-version: [4.4, 5.0, 6.0]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,21 @@
 
 ## UNRELEASED
 
-### fixes
+### Changes
+
+* Since Node 14 and MongoDB 4.2 have reached their own end-of-support dates,
+we are **no longer supporting them for A3.** Note that our dependency on
+`jsdom` 22 is incompatible with Node 14. Node 16 and Node 18 are both
+still supported. However, because Node 16 reaches its
+end-of-life date quite soon (September), testing and upgrading directly
+to Node 18 is strongly recommended.
+* Updated `sluggo` to version 1.0.0.
+* Updated `jsdom` to version `22.0.0` to address an installation warning about the `word-wrap` module.
+
+### Fixes
 
 * Fix `extendQueries` to use super pattern for every function in builders and methods (and override properties that are not functions).
 
-### Changes
-
-* Updated `sluggo` to version 1.0.0.
-* Updated `jsdom` to version `22.0.0` to address an installation warning about the `word-wrap` module.
 
 ## 3.46.0 (2023-05-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * Updated `sluggo` to version 1.0.0.
+* Updated `jsdom` to version `22.0.0` to address an installation warning about the `word-wrap` module.
 
 ## 3.46.0 (2023-05-03)
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "git@github.com:apostrophecms/apostrophe.git"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=16.0.0"
   },
   "keywords": [
     "apostrophe",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "i18next-http-middleware": "^3.1.5",
     "import-fresh": "^3.3.0",
     "is-wsl": "^2.2.0",
-    "jsdom": "^17.0.0",
+    "jsdom": "^22.0.0",
     "klona": "^2.0.4",
     "launder": "^1.4.0",
     "lodash": "^4.17.20",


### PR DESCRIPTION
This eliminates a snyk vulnerability warning about word-wrap. I have tested that svg uploads, which depends on this for sanitization, still work.