### PR TITLE
fix for dcad-1209

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+Does not display `(undefined)` if the outer array item is new when an array is nested in another array and the parent object appears in the
+breadcrumb trail while editing the nested array.
+
 ## 2.227.0 (2023-03-16)
 
 ### Adds

--- a/lib/modules/apostrophe-modal/public/js/modal.js
+++ b/lib/modules/apostrophe-modal/public/js/modal.js
@@ -582,7 +582,8 @@ apos.define('apostrophe-modal', {
           // Check if we came from an array.  If we did, we can
           // also provide the name of the item that we are within.
           if (i > 0 && slides[i - 1].arrayItems && slides[i - 1].arrayItems.length > 0 && slides[i - 1].options.field.titleField) {
-            $li.text(slide.options.field.label + ' (' + slides[i - 1].arrayItems[slides[i - 1].active][slides[i - 1].options.field.titleField] + ')');
+            const titleFieldValue = slides[i - 1].arrayItems[slides[i - 1].active][slides[i - 1].options.field.titleField];
+            $li.text(slide.options.field.label + (titleFieldValue ? ` (${titleFieldValue})` : ''));
           } else {
             $li.text(slide.options.field.label);
           }


### PR DESCRIPTION
Avoid displaying "(undefined)" in the breadcrumb trail when an array item is nested in another array item, which is new and has never been saved (that is, the outer item has never been saved and its sub-array is being edited)

See also dcad-1209 branch of apostrophe-enterprise-testbed, in which this can be tested by creating a new "product", going to the "info" tab and hitting "edit" for address. I don't plan to land a PR for that branch
