### PR TITLE
lint for premature use of database queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## Unreleased
+## UNRELEASED
 
 ### Adds
 
 * Adds regex pattern feature for string fields.
+* Adds a warning if database queries involving relationships
+are made before the last `apostrophe:modulesRegistered` handler has fired.
+If you need to call Apostrophe's `find()` methods at startup,
+it is best to wait for the `@apostrophecms/doc:beforeReplicate` event.
 
 ## 3.48.0 (2023-05-26)
 

--- a/index.js
+++ b/index.js
@@ -297,6 +297,7 @@ async function apostrophe(options, telemetry, rootSpan) {
       // still need to reset parked properties
       await self.apos.page.implementParkAllInOtherLocales();
     });
+    self.ready = true;
     await self.emit('ready'); // formerly afterInit
 
     if (self.taskRan) {
@@ -632,7 +633,7 @@ async function apostrophe(options, telemetry, rootSpan) {
             `
           );
         } else {
-          warn('orphan-modules', `You have a ${self.localModules}/${name} folder, but that module is not activated in app.js and it is not a base class of any other active module. Right now that code doesn't do anything.`);
+          warn('orphan-modules', `You have a ${self.localModules}/${name} folder, but that module is not activated in app.js\nand it is not a base class of any other active module. Right now that code doesn't do anything.`);
         }
       }
       function warn(name, message) {

--- a/index.js
+++ b/index.js
@@ -297,7 +297,6 @@ async function apostrophe(options, telemetry, rootSpan) {
       // still need to reset parked properties
       await self.apos.page.implementParkAllInOtherLocales();
     });
-    self.ready = true;
     await self.emit('ready'); // formerly afterInit
 
     if (self.taskRan) {

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -1142,6 +1142,7 @@ module.exports = {
             type: module.name
           });
         }
+        self.replicateReached = true;
         // Include the criteria array in the event so that more entries can be pushed to it
         await self.emit('beforeReplicate', criteria);
         // We can skip the core work of this method if there is only one locale,

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -1000,6 +1000,9 @@ module.exports = (self) => {
     },
 
     relate: async function (req, field, objects, options) {
+      if ((!self.apos.doc?.replicateReached) && (!field.idsStorage)) {
+        self.apos.util.warnDevOnce('premature-relationship-query', 'Database queries for types with relationships may fail if made before the @apostrophecms/doc:beforeReplicate event');
+      }
       return self.relationshipDriver(req, joinr.byArray, false, objects, field.idsStorage, field.fieldsStorage, field.name, options);
     },
 
@@ -1131,6 +1134,9 @@ module.exports = (self) => {
     name: 'relationshipReverse',
     vueComponent: false,
     relate: async function (req, field, objects, options) {
+      if ((!self.apos.doc?.replicateReached) && (!field.idsStorage)) {
+        self.apos.util.warnDevOnce('premature-relationship-query', 'Database queries for types with relationships may fail if made before the @apostrophecms/doc:beforeReplicate event');
+      }
       return self.relationshipDriver(req, joinr.byArrayReverse, true, objects, field.idsStorage, field.fieldsStorage, field.name, options);
     },
     validate: function (field, options, warn, fail) {

--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -563,12 +563,11 @@ module.exports = {
       // Also see `warnDevOnce` which is less likely to irritate
       // the developer until they stop paying attention.
 
-      warnDev(msg) {
+      warnDev(...args) {
         if (process.env.NODE_ENV === 'production') {
           return;
         }
-        const args = [ '\n⚠️', ...arguments ];
-        self.warn.apply(self, args);
+        self.warn(...[ '\n⚠️ ', ...args, '\n' ]);
       },
 
       // Identical to `apos.util.warnDev`, except that the warning is
@@ -578,7 +577,7 @@ module.exports = {
       // `--all-[name]` is present on the command line. You can
       // also suppress these with `--ignore-[name]`.
 
-      warnDevOnce(name, msg) {
+      warnDevOnce(name, ...args) {
         const always = self.apos.argv[`all-${name}`];
         const hide = self.apos.argv[`ignore-${name}`];
         if (hide) {
@@ -588,13 +587,13 @@ module.exports = {
           return;
         }
         if (always || (!self.warnedDev[name])) {
-          self.warn.apply(self, Array.prototype.slice.call(arguments, 1));
+          self.warnDev(...args);
           if (!always) {
             self.warnedDev[name] = true;
             self.info(stripIndent`
               This warning appears only once to save space. Pass --all-${name}
               on the command line to see the warning for all cases.
-            `);
+            ` + '\n');
           }
         }
       },


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

See changelog

## What are the specific steps to test this change?

* Startup of existing, working projects should not print a warning
* Startup of a project that makes a query with relationships too early should print a warning (before potentially crashing)

Example: pro-4289-fail-demo branch of a3-boilerplate will print the warning and then crash (might not crash if there are no articles in the database yet at startup)

I will also submit a docs PR.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
