### PR TITLE
RT Placeholder not appearing without insert menu

### DIFF
--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -302,7 +302,7 @@ export default {
           const text = this.$t(this.placeholderText);
           return text;
         },
-        emptyNodeClass: this.insert.length ? 'apos-is-empty' : 'apos-is-empty-without-insert'
+        emptyNodeClass: 'apos-is-empty'
       }),
       FloatingMenu
     ]


### PR DESCRIPTION
tiny follow up to the RT rodeo: we were using different classes for placeholders with and without insert menus, but the markup and style is the same, only the placeholder text changes.

This makes them use the same class and fixes the case where no placeholder would appear without an insert menu