### PR TITLE
change browser url according to the doc slug of the chosen mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Adds the possibility to add custom admin bars via the `addBar()` method from the `admin-bar` module.
 
+### Changes
+
+* Browser URL now changes to reflect the slug of the document according to the mode that is being viewed.
+
 ## 3.50.0 (2023-06-09)
 
 ### Adds

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
@@ -684,8 +684,6 @@ export default {
     urlDiffers(url) {
       // URL might or might not include hostname part
       url = url.replace(/^https?:\/\/.*?\//, '/');
-      console.log('debug: url', url);
-      console.log('debug: browser url', window.location.pathname + (window.location.search || ''));
       if (url === (window.location.pathname + (window.location.search || ''))) {
         return false;
       } else {

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
@@ -525,9 +525,6 @@ export default {
         return;
       }
 
-      console.log('debug: ---');
-      console.log('debug: this.draftMode', this.draftMode);
-
       const { action } = window.apos.modules[this.context.type];
       const doc = await apos.http.get(`${action}/${this.context.aposDocId}`, {
         qs: {
@@ -537,11 +534,8 @@ export default {
       });
 
       if (this.urlDiffers(doc._url)) {
-        console.log('debug: ==> CHANGING BROWSER URL TO', doc._url);
         // Slug changed, change browser URL to reflect the actual url of the doc
-        // window.location.assign(doc._url);
         history.replaceState(null, '', doc._url);
-        return;
       }
 
       const qs = {

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
@@ -547,8 +547,7 @@ export default {
         } : {})
       };
 
-      const url = apos.http.addQueryToUrl(doc._url, qs);
-      const content = await apos.http.get(url, {
+      const content = await apos.http.get(doc._url, {
         qs,
         headers: {
           'Cache-Control': 'no-cache'

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
@@ -537,9 +537,10 @@ export default {
       });
 
       if (this.urlDiffers(doc._url)) {
-        console.log('debug: ==> REDIRECTING TO', doc._url);
-        // Slug changed, must navigate
-        window.location.assign(doc._url);
+        console.log('debug: ==> CHANGING BROWSER URL TO', doc._url);
+        // Slug changed, change browser URL to reflect the actual url of the doc
+        // window.location.assign(doc._url);
+        history.replaceState(null, '', doc._url);
         return;
       }
 

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
@@ -525,14 +525,8 @@ export default {
         return;
       }
 
-      const qs = {
-        ...apos.http.parseQuery(window.location.search),
-        aposRefresh: '1',
-        aposMode: this.draftMode,
-        ...(this.editMode ? {
-          aposEdit: '1'
-        } : {})
-      };
+      console.log('debug: ---');
+      console.log('debug: this.draftMode', this.draftMode);
 
       const { action } = window.apos.modules[this.context.type];
       const doc = await apos.http.get(`${action}/${this.context.aposDocId}`, {
@@ -541,6 +535,22 @@ export default {
           project: { _url: 1 }
         }
       });
+
+      if (this.urlDiffers(doc._url)) {
+        console.log('debug: ==> REDIRECTING TO', doc._url);
+        // Slug changed, must navigate
+        window.location.assign(doc._url);
+        return;
+      }
+
+      const qs = {
+        ...apos.http.parseQuery(window.location.search),
+        aposRefresh: '1',
+        aposMode: this.draftMode,
+        ...(this.editMode ? {
+          aposEdit: '1'
+        } : {})
+      };
 
       const url = apos.http.addQueryToUrl(doc._url, qs);
       const content = await apos.http.get(url, {
@@ -679,6 +689,8 @@ export default {
     urlDiffers(url) {
       // URL might or might not include hostname part
       url = url.replace(/^https?:\/\/.*?\//, '/');
+      console.log('debug: url', url);
+      console.log('debug: browser url', window.location.pathname + (window.location.search || ''));
       if (url === (window.location.pathname + (window.location.search || ''))) {
         return false;
       } else {


### PR DESCRIPTION
Change the URL of the browser so that it reflects the slug of the document and its current mode (draft vs. published).

e2e test: https://github.com/apostrophecms/testbed/pull/178

https://linear.app/apostrophecms/issue/PRO-4327/change-the-browser-url-to-reflect-the-document-mode