### PR TITLE
task to reattach a page to the tree if the path property becomes invalid somehow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 3.50.0 (2023-06-09)
+
+### Adds
+
+* As a further fix for issues that could ensue before the improvements
+to locale renaming support that were released in 3.49.0, an
+`@apostrophecms/page:reattach` task has been added. This command line task
+takes the `_id` or `slug` of a page and reattaches it to the page tree as
+the last child of the home page. This task should not be needed in normal
+circumstances.
+
 ## 3.49.0 (2023-06-08)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 to locale renaming support that were released in 3.49.0, an
 `@apostrophecms/page:reattach` task has been added. This command line task
 takes the `_id` or `slug` of a page and reattaches it to the page tree as
-the last child of the home page. This task should not be needed in normal
-circumstances.
+the last child of the home page, even if page tree data for that page
+is corrupted. You may wish to use the `--locale` option. This task should not
+be needed in normal circumstances.
 
 ## 3.49.0 (2023-06-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ to locale renaming support that were released in 3.49.0, an
 `@apostrophecms/page:reattach` task has been added. This command line task
 takes the `_id` or `slug` of a page and reattaches it to the page tree as
 the last child of the home page, even if page tree data for that page
-is corrupted. You may wish to use the `--locale` option. This task should not
+is corrupted. You may wish to use the `--new-slug` and `--locale` options. This task should not
 be needed in normal circumstances.
 
 ## 3.49.0 (2023-06-08)

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -2007,6 +2007,32 @@ database.`);
           throw 'No page with that slug was found.';
         }
       },
+      async reattachTask(argv) {
+        if (argv._.length !== 2) {
+          throw new Error('Wrong number of arguments');
+        }
+        const slugOrId = argv._[1];
+        // Note that page moves are autopublished
+        const req = self.apos.task.getReq({
+          mode: 'draft'
+        });
+        const page = await self.findOneForEditing(req, {
+          $or: [
+            {
+              slug: slugOrId
+            },
+            {
+              _id: slugOrId
+            }
+          ]
+        });
+        if (!page) {
+          console.log(`No page with that slug or _id was found in ${req.locale}.`);
+        } else {
+          await self.move(req, page._id, '_home', 'lastChild');
+          console.log(`Reattached as the last child of the home page in ${req.locale}.`);
+        }
+      },
       // Invoked by the @apostrophecms/version module.
       //
       // Your module can add additional doc properties that should never be rolled back by pushing
@@ -2442,6 +2468,10 @@ database.`);
       unpark: {
         usage: 'Usage: node app @apostrophecms/page:unpark /page/slug\n\nThis unparks a page that was formerly locked in a specific\nposition in the page tree.',
         task: self.unparkTask
+      },
+      reattach: {
+        usage: 'Usage: node app @apostrophecms/page:reattach _id-or-slug',
+        task: self.reattachTask
       }
     };
   }

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -2046,15 +2046,19 @@ database.`);
             }).project({ rank: 1 }).sort({ rank: 1 }).toArray()).reduce((memo, page) => Math.max(memo, page.rank), 0) + 1;
             page.path = `${home.path}/${page.aposDocId}`;
             page.rank = rank;
+            const $set = {
+              path: page.path,
+              rank: page.rank,
+              aposLastTargetId: home.aposDocId,
+              aposLastPosition: 'lastChild'
+            };
+            if (argv['new-slug']) {
+              $set.slug = argv['new-slug'];
+            }
             await self.apos.doc.db.updateOne({
               _id: page._id
             }, {
-              $set: {
-                path: page.path,
-                rank: page.rank,
-                aposLastTargetId: home.aposDocId,
-                aposLastPosition: 'lastChild'
-              }
+              $set
             });
             console.log(`Reattached as the last child of the home page in ${req.locale}:${req.mode}.`);
           }


### PR DESCRIPTION
Test procedure:

* Create a grandparent page in the page tree.
* Use `node app @apostrophecms/page:reattach slug-of-that-page --new-slug=/something-new` to move it up as the last child of the home page and give it a new slug as well.
* Note that this is what actually happens in the page tree manager.

The new-slug option is currently necessary because manual slug editing is rather busted at the moment (separate issue unrelated to this PR as such).