### PR TITLE
Fix page creation without target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* Allows to create page without defining the page target ID, by default it takes the Home page.
+
 ## 3.51.1 (2023-06-23)
 
 ## Fixes

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -1224,7 +1224,6 @@ database.`);
       // "page."
       async getTarget(req, targetId, position) {
         const criteria = self.getIdCriteria(targetId);
-        console.log('criteria', criteria);
         const target = await self.find(req, criteria).permission(false).archived(null).areas(false).ancestors({
           depth: 1,
           archived: null,
@@ -1254,9 +1253,6 @@ database.`);
       async getTargetIdAndPosition(req, pageId, targetId, position) {
         targetId = self.apos.launder.id(targetId);
         position = self.apos.launder.string(position);
-
-        console.log('targetId', targetId);
-        console.log('position', position);
 
         if (isNaN(parseInt(position)) || parseInt(position) < 0) {
           // Return an already-valid position or a potentially invalid, but

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -254,9 +254,8 @@ module.exports = {
       // This call is atomic with respect to other REST write operations on pages.
       async post(req) {
         self.publicApiCheck(req);
-        req.body._position = req.body._position || 'lastChild';
         let targetId = self.apos.launder.string(req.body._targetId);
-        let position = self.apos.launder.string(req.body._position);
+        let position = self.apos.launder.string(req.body._position || 'lastChild');
         // Here we have to normalize before calling insert because we
         // need the parent page to call newChild(). insert calls again but
         // sees there's no work to be done, so no performance hit


### PR DESCRIPTION
## Summary

Like said the the comment before the page post route. It should be possible the create a page without defining the target ID, it doesn't work currently, this PR fixes it.
It will now take the home page by default.

## What are the specific steps to test this change?

You should be able to create a page from the page post route without specifying the `_targetId` property.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

