### PR TITLE
PRO-4407 fix for invalid values blocking save operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
-## Unreleased
+## UNRELEASED
 
 ### Fixes
 
 * Allows to create page without defining the page target ID, by default it takes the Home page.
+* Users are no longer blocked from saving documents when a field hidden
+by an `if` condition fails to satisfy a condition such as `min` or `max`
+or is otherwise invalid. Instead the invalid value is discarded for safety.
+Note that `required` has always been ignored when an `if` condition is not
+satisfied.
 
 ## 3.51.1 (2023-06-23)
 

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -523,15 +523,29 @@ module.exports = {
         const errorsList = [];
 
         for (const error of errors) {
-          if ((error.name === 'required' || error.name === 'mandatory')) {
+          if (error.path) {
             // `self.isVisible` will only throw for required fields that have
             // an external condition containing an unknown module or method:
             const isVisible = await self.isVisible(req, schema, destination, error.path);
 
             if (!isVisible) {
-              // It is not reasonable to enforce required for
-              // fields hidden via conditional fields
-              continue;
+              // It is not reasonable to enforce required,
+              // min, max or anything else for fields
+              // hidden via "if" as the user cannot correct it
+              // and it will not be used. If the user changes
+              // the conditional field later then they won't
+              // be able to save until the erroneous field
+              // is corrected
+              const name = error.path;
+              const field = schema.find(field => field.name === name);
+              if (field) {
+                // To protect against security issues, an invalid value
+                // for a field that is not visible should be quietly discarded.
+                // We only worry about this if the value is not valid, as otherwise
+                // it's a kindness to save the work so the user can toggle back to it
+                destination[field.name] = (field.def != undefined) ? field.def : self.fieldTypes[field.type]?.def;
+                continue;
+              }
             }
           }
 

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -543,7 +543,7 @@ module.exports = {
                 // for a field that is not visible should be quietly discarded.
                 // We only worry about this if the value is not valid, as otherwise
                 // it's a kindness to save the work so the user can toggle back to it
-                destination[field.name] = (field.def != undefined) ? field.def : self.fieldTypes[field.type]?.def;
+                destination[field.name] = klona((field.def !== undefined) ? field.def : self.fieldTypes[field.type]?.def);
                 continue;
               }
             }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

see changelog

## What are the specific steps to test this change?

* Check out the pro-4407 branch of a3-boilerplate and link this branch of apostrophe
* Create a Default page (the home page does not have that type)
* Go to the page of type Default that you created
* Edit its settings
* Set "Need Room" to "yes" and populate "Room Numbers" with a couple characters, so that "min" shows up
* Change "Need Room" to "no"
* Save. Should save successfully
* Reopen and switch "Need Room" to "yes." "Room Number" should now be blank, because it was (1) invalid and (2) locked out by a conditional at save time

## What kind of change does this PR introduce?

*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
