### PR TITLE
Permission support context operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Adds
 
-* Adds support for `permission` property in `addContextOperation`, this one can be a string or an array. Validates `addContextOperation` configuration.
+* Adds support for `conditions` property in `addContextOperation`, this one must be an array. Validates `addContextOperation` configuration.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### Adds
+
+* Adds support for `permission` property in `addContextOperation`, this one can be a string or an array. Validates `addContextOperation` configuration.
+
 ### Fixes
 
 * Allows to create page without defining the page target ID, by default it takes the Home page.

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
@@ -199,8 +199,14 @@ export default {
         if (typeof op.manuallyPublished === 'boolean' && op.manuallyPublished !== this.manuallyPublished) {
           return false;
         }
+
         if (typeof op.hasUrl === 'boolean' && op.hasUrl !== this.hasUrl) {
           return false;
+        }
+
+        if (op.permission) {
+          const computed = `can${op.permission.charAt(0).toUpperCase()}${op.permission.substr(1)}`;
+          return this[computed];
         }
 
         return op.context === 'update' && this.isUpdateOperation;

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
@@ -195,21 +195,32 @@ export default {
       return menus;
     },
     customOperationsByContext() {
-      return this.customOperations.filter(op => {
-        if (typeof op.manuallyPublished === 'boolean' && op.manuallyPublished !== this.manuallyPublished) {
+      return this.customOperations.filter(({
+        manuallyPublished, hasUrl, permission, context
+      }) => {
+        if (typeof manuallyPublished === 'boolean' && manuallyPublished !== this.manuallyPublished) {
           return false;
         }
 
-        if (typeof op.hasUrl === 'boolean' && op.hasUrl !== this.hasUrl) {
+        if (typeof hasUrl === 'boolean' && hasUrl !== this.hasUrl) {
           return false;
         }
 
-        if (op.permission) {
-          const computed = `can${op.permission.charAt(0).toUpperCase()}${op.permission.substr(1)}`;
-          return this[computed];
+        if (permission) {
+          const permissions = typeof permission === 'string' ? [ permission ] : permission;
+          const notAllowed = permissions.some((perm) => {
+            const formatted = perm.split('-')
+              .map((part) => part.charAt(0).toUpperCase() + part.substr(1))
+              .join('');
+            return !this[`can${formatted}`];
+          });
+
+          if (notAllowed) {
+            return false;
+          }
         }
 
-        return op.context === 'update' && this.isUpdateOperation;
+        return context === 'update' && this.isUpdateOperation;
       });
     },
     moduleName() {

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
@@ -196,7 +196,7 @@ export default {
     },
     customOperationsByContext() {
       return this.customOperations.filter(({
-        manuallyPublished, hasUrl, permission, context
+        manuallyPublished, hasUrl, conditions, context
       }) => {
         if (typeof manuallyPublished === 'boolean' && manuallyPublished !== this.manuallyPublished) {
           return false;
@@ -206,14 +206,8 @@ export default {
           return false;
         }
 
-        if (permission) {
-          const permissions = typeof permission === 'string' ? [ permission ] : permission;
-          const notAllowed = permissions.some((perm) => {
-            const formatted = perm.split('-')
-              .map((part) => part.charAt(0).toUpperCase() + part.substr(1))
-              .join('');
-            return !this[`can${formatted}`];
-          });
+        if (conditions) {
+          const notAllowed = conditions.some((action) => !this[action]);
 
           if (notAllowed) {
             return false;

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -1168,7 +1168,9 @@ module.exports = {
       // the menu will be shown only for docs which have `autopublish: false` and
       // `localized: true` options.
       // `permission` defines the needed permission for the current doc to display
-      // the operation, available values are `edit` and `publish`.
+      // the operation, it can be a string or an array of these available values:
+      // 'publish', 'edit', 'dismiss-submission', 'discard-draft', 'localize',
+      // 'archive', 'unpublish', 'copy', 'restore'.
       addContextOperation(moduleName, operation) {
         validate(operation);
         self.contextOperations = [
@@ -1181,12 +1183,34 @@ module.exports = {
         ];
 
         function validate (op) {
-          const allowedPermissions = [ 'edit', 'publish' ];
+          const allowedPermissions = [
+            'publish',
+            'edit',
+            'dismiss-submission',
+            'discard-draft',
+            'localize',
+            'archive',
+            'unpublish',
+            'copy',
+            'restore'
+          ];
+
           if (!op.action || !op.context || !op.label || !op.modal) {
             throw self.apos.error('invalid', 'addContextOperation requires action, context, label and modal properties');
           }
-          if (op.permission && !allowedPermissions.includes(op.permission)) {
-            throw self.apos.error('invalid', `The permission property in addContextOperation can only be set to edit or publish, ${op.permission} is not allowed`);
+          if (!op.permission) {
+            return;
+          }
+
+          if (typeof op.permission !== 'string' && !Array.isArray(op.permission)) {
+            throw self.apos.error('invalid', 'The permission property in addContextOperation must be a string or an array.');
+          }
+
+          if (
+            (typeof op.permission === 'string' && !allowedPermissions.includes(op.permission)) ||
+            (Array.isArray(op.permission) && op.permission.some((perm) => !allowedPermissions.includes(perm)))
+          ) {
+            throw self.apos.error('invalid', `The permission property in addContextOperation can only be set to a string or an array of these values: \n${allowedPermissions.join('\n')}.`);
           }
         }
       },

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -1153,9 +1153,10 @@ module.exports = {
       //   context: 'update',
       //   action: 'someAction',
       //   modal: 'ModalComponent',
-      //   label: 'Context Menu Label'
+      //   label: 'Context Menu Label',
+      //   permission: 'edit'
       // }
-      // All properties are required.
+      // All properties are required except permission.
       // The only supported `context` for now is `update`.
       // `action` is the operation identifier and should be globally unique.
       // Overriding existing custom actions is possible (the last wins).
@@ -1166,7 +1167,10 @@ module.exports = {
       // An optional `manuallyPublished` boolean property is supported - if true
       // the menu will be shown only for docs which have `autopublish: false` and
       // `localized: true` options.
+      // `permission` defines the needed permission for the current doc to display
+      // the operation, available values are `edit` and `publish`.
       addContextOperation(moduleName, operation) {
+        validate(operation);
         self.contextOperations = [
           ...self.contextOperations
             .filter(op => op.action !== operation.action),
@@ -1175,6 +1179,16 @@ module.exports = {
             moduleName
           }
         ];
+
+        function validate (op) {
+          const allowedPermissions = [ 'edit', 'publish' ];
+          if (!op.action || !op.context || !op.label || !op.modal) {
+            throw self.apos.error('invalid', 'addContextOperation requires action, context, label and modal properties');
+          }
+          if (op.permission && !allowedPermissions.includes(op.permission)) {
+            throw self.apos.error('invalid', `The permission property in addContextOperation can only be set to edit or publish, ${op.permission} is not allowed`);
+          }
+        }
       },
       getBrowserData(req) {
         return {

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -1167,8 +1167,8 @@ module.exports = {
       // An optional `manuallyPublished` boolean property is supported - if true
       // the menu will be shown only for docs which have `autopublish: false` and
       // `localized: true` options.
-      // `permission` defines the needed permission for the current doc to display
-      // the operation, it can be a string or an array of these available values:
+      // `permission` defines the needed permission action to be run on the current doc
+      // in order to display the operation. It can be a string or an array of these available values:
       // 'publish', 'edit', 'dismiss-submission', 'discard-draft', 'localize',
       // 'archive', 'unpublish', 'copy', 'restore'.
       addContextOperation(moduleName, operation) {

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -1154,9 +1154,9 @@ module.exports = {
       //   action: 'someAction',
       //   modal: 'ModalComponent',
       //   label: 'Context Menu Label',
-      //   permission: 'edit'
+      //   conditions: ['canEdit']
       // }
-      // All properties are required except permission.
+      // All properties are required except conditions.
       // The only supported `context` for now is `update`.
       // `action` is the operation identifier and should be globally unique.
       // Overriding existing custom actions is possible (the last wins).
@@ -1167,10 +1167,11 @@ module.exports = {
       // An optional `manuallyPublished` boolean property is supported - if true
       // the menu will be shown only for docs which have `autopublish: false` and
       // `localized: true` options.
-      // `permission` defines the needed permission action to be run on the current doc
-      // in order to display the operation. It can be a string or an array of these available values:
-      // 'publish', 'edit', 'dismiss-submission', 'discard-draft', 'localize',
-      // 'archive', 'unpublish', 'copy', 'restore'.
+      // `conditions` defines the needed permission actions to be run on the current doc
+      // in order to display the operation.
+      // It must be an array containing one or multiple of these available values:
+      // 'canPublish', 'canEdit', 'canDismissSubmission', 'canDiscardDraft',
+      // 'canLocalize', 'canArchive', 'canUnpublish', 'canCopy', 'canRestore'.
       addContextOperation(moduleName, operation) {
         validate(operation);
         self.contextOperations = [
@@ -1182,35 +1183,36 @@ module.exports = {
           }
         ];
 
-        function validate (op) {
-          const allowedPermissions = [
-            'publish',
-            'edit',
-            'dismiss-submission',
-            'discard-draft',
-            'localize',
-            'archive',
-            'unpublish',
-            'copy',
-            'restore'
+        function validate ({
+          action, context, label, modal, conditions
+        }) {
+          const allowedConditions = [
+            'canPublish',
+            'canEdit',
+            'canDismissSubmission',
+            'canDiscardDraft',
+            'canLocalize',
+            'canArchive',
+            'canUnpublish',
+            'canCopy',
+            'canRestore'
           ];
 
-          if (!op.action || !op.context || !op.label || !op.modal) {
+          if (!action || !context || !label || !modal) {
             throw self.apos.error('invalid', 'addContextOperation requires action, context, label and modal properties');
           }
-          if (!op.permission) {
+
+          if (!conditions) {
             return;
           }
 
-          if (typeof op.permission !== 'string' && !Array.isArray(op.permission)) {
-            throw self.apos.error('invalid', 'The permission property in addContextOperation must be a string or an array.');
-          }
-
           if (
-            (typeof op.permission === 'string' && !allowedPermissions.includes(op.permission)) ||
-            (Array.isArray(op.permission) && op.permission.some((perm) => !allowedPermissions.includes(perm)))
+            !Array.isArray(conditions) ||
+            conditions.some((perm) => !allowedConditions.includes(perm))
           ) {
-            throw self.apos.error('invalid', `The permission property in addContextOperation can only be set to a string or an array of these values: \n${allowedPermissions.join('\n')}.`);
+            throw self.apos.error(
+              'invalid', `The conditions property in addContextOperation must be an array containing one or multiple of these values:\n\t${allowedConditions.join('\n\t')}.`
+            );
           }
         }
       },


### PR DESCRIPTION
[PRO-4026](https://linear.app/apostrophecms/issue/PRO-4026/as-an-admin-i-want-to-decide-who-has-permission-to-create-delete)

## Summary

To finish the work of the ticket above we need to allow `permission` property to the method `addContextOperation`.
This method can be a string or an array.
The available values are the ones that have a can method associated in `AposDocContextMenu`.
A validate function has been added to the method `addContextOperation` to save precious time to the user in case of bad configuration.

What it does is that it checks the permission value, if I set it to `edit` it will run the method `canEdit` in the vue component and shows the operation button only if this one returns `true`. 
Since we supports arrays too, we can check multiple permissions here. eg. if I set permission too `['archive', 'restore']` it will check both computed: `canArchive` and `canRestore`.

I might have over-engineered this feature depending on the need but it feels like it offers to developers a complete way to handle permissions in `addContextOperation`. 

## What are the specific steps to test this change?

Configure `addContextOperation`  with the property `permission`.
This one should work with a string or an array.
An error should be thrown if the permission value is not valid.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
