### PR TITLE
double click breadcrumb to edit, ui cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## UNRELEASED
 
+### Changes
+* Foreign widget UI no longer uses inverted theme styles.
+### Adds
+* Allows users to double-click a widgets's breadcrumb type and open it's editor.
+
 ### Fixes
 
 * Allows to create page without defining the page target ID, by default it takes the Home page.

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -41,13 +41,13 @@
           <li class="apos-area-widget__breadcrumb" data-apos-widget-breadcrumb="0">
             <AposButton
               type="quiet"
-              @click="foreign ? $emit('edit', i) : false"
+              @click="foreign ? $emit('edit', i) : null"
+              @dblclick.native="(!foreign && !isContextual) ? $emit('edit', i) : null"
               :label="foreign ? {
                 key: 'apostrophe:editWidgetType',
                 label: $t(widgetLabel)
               } : widgetLabel"
               tooltip="apostrophe:editWidgetForeignTooltip"
-              :icon="foreign ? 'earth-icon' : null"
               :icon-size="11"
               :modifiers="['no-motion']"
             />
@@ -76,6 +76,7 @@
         :class="ui.controls"
       >
         <AposWidgetControls
+          v-if="!foreign"
           :first="i === 0"
           :last="i === next.length - 1"
           :options="{ contextual: isContextual }"
@@ -272,7 +273,8 @@ export default {
       };
     },
     widgetIcon() {
-      return this.contextMenuOptions.menu.filter(item => item.name === this.widget.type)[0]?.icon || 'shape-icon';
+      const natural = this.contextMenuOptions.menu.filter(item => item.name === this.widget.type)[0]?.icon || 'shape-icon';
+      return this.foreign ? 'earth-icon' : natural;
     },
     widgetLabel() {
       const moduleName = `${this.widget.type}-widget`;
@@ -694,7 +696,7 @@ export default {
 
   .apos-area-widget__label {
     position: absolute;
-    top: -8px;
+    top: 0;
     right: 0;
     display: flex;
     transform: translateY(-100%);
@@ -709,18 +711,11 @@ export default {
     @include apos-list-reset();
     display: flex;
     align-items: center;
-    margin: 0;
+    margin: 0 0 8px;
     padding: 4px 6px;
     background-color: var(--a-background-primary);
     border: 1px solid var(--a-primary-transparent-50);
     border-radius: 8px;
-  }
-
-  .apos-area-widget-wrapper--foreign .apos-area-widget-inner .apos-area-widget__breadcrumbs {
-    background-color: var(--a-background-inverted);
-    & ::v-deep .apos-button__content {
-      color: var(--a-text-inverted);
-    }
   }
 
   .apos-area-widget__breadcrumb,
@@ -730,9 +725,6 @@ export default {
     white-space: nowrap;
     color: var(--a-base-1);
     transition: background-color 0.3s var(--a-transition-timing-bounce);
-    &:hover {
-      cursor: pointer;
-    }
   }
 
   .apos-area-widget__breadcrumbs:hover .apos-area-widget__breadcrumb,

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="apos-area-modify-controls">
     <AposButtonGroup
-      :modifiers="groupModifiers"
+      :modifiers="[ 'vertical' ]"
     >
       <AposButton
         v-if="!foreign"
@@ -124,15 +124,6 @@ export default {
     };
   },
   computed: {
-    groupModifiers() {
-      const mods = [ 'vertical' ];
-
-      if (this.foreign) {
-        mods.push('invert');
-      }
-
-      return mods;
-    },
     upButton() {
       return {
         ...this.buttonDefaults,


### PR DESCRIPTION
## Summary

 - Adds double-click handler to widget breadcrumb to open their editor
 - Removes inverted theme style from foreign widgets
 - Hides area controls completely for foreign widgets (we were already skipping every widget control for foreign, so this just removes the ui fragment)
 - Fixes bug where a widget's breadcrumb was un-hoverable if the widget wasn't explicitly focused

## What are the specific steps to test this change?

1. link to a3-demo and `npm run dev`
2. find a local widget that isn't `contextual`
3. double click the breadcrumb to edit 


## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other
