### PR TITLE
Do not restart the process when an afterSessionLogin event throws an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ by an `if` condition fails to satisfy a condition such as `min` or `max`
 or is otherwise invalid. Instead the invalid value is discarded for safety.
 Note that `required` has always been ignored when an `if` condition is not
 satisfied.
+* Errors thrown in `@apostrophecms/login:afterSessionLogin` event handlers are now properly passed back to Passport as such, avoiding a process restart.
 
 ## 3.51.1 (2023-06-23)
 

--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -892,7 +892,11 @@ module.exports = {
               if (err) {
                 return callback(err);
               }
-              await self.emit('afterSessionLogin', req);
+              try {
+                await self.emit('afterSessionLogin', req);
+              } catch (e) {
+                return callback(e);
+              }
               // Make sure no handler removed req.user
               if (req.user) {
                 // Mark the login timestamp. Middleware takes care of ensuring


### PR DESCRIPTION
Prior to this fix, an `afterSessionLogin` event handler, such as those found in certain client projects, could crash the process by throwing an error in Node 15 or newer. These errors are now properly caught and delivered to the callback of `req.login`.