### PR TITLE
PRO-4529: i18n admin locales and user adminLocale field

### DIFF
--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -464,6 +464,8 @@
   "type": "Type",
   "typeWithCount": "{{ type }} ({{ count }})",
   "unableToSwitchModes": "Unable to switch modes.",
+  "uiLanguageLabel": "UI Language",
+  "uiLanguageWebsite": "Same as Website",
   "undo": "Undo",
   "undoFailed": "The operation could not be undone.",
   "undoPublish": "Undo Publish",

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -589,13 +589,13 @@ module.exports = {
         }
       },
       getBrowserData(req) {
-        const uiLocale = req.user?.adminLocale === ''
+        const adminLocale = req.user?.adminLocale === ''
           ? req.locale
           : req.user?.adminLocale || self.defaultAdminLocale || req.locale;
         const i18n = {
-          [uiLocale]: self.getBrowserBundles(uiLocale)
+          [adminLocale]: self.getBrowserBundles(adminLocale)
         };
-        if (uiLocale !== self.defaultLocale) {
+        if (adminLocale !== self.defaultLocale) {
           i18n[self.defaultLocale] = self.getBrowserBundles(self.defaultLocale);
         }
         // In case the default locale also has inadequate admin UI phrases
@@ -605,7 +605,7 @@ module.exports = {
         const result = {
           i18n,
           locale: req.locale,
-          adminLocale: uiLocale,
+          adminLocale,
           defaultLocale: self.defaultLocale,
           defaultNamespace: self.defaultNamespace,
           locales: self.locales,

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -55,6 +55,12 @@ module.exports = {
     self.locales = self.getLocales();
     self.hostnamesInUse = Object.values(self.locales).find(locale => locale.hostname);
     self.defaultLocale = self.options.defaultLocale || Object.keys(self.locales)[0];
+    // Contains label/value object for each locale
+    self.adminLocales = self.options.adminLocales || [];
+    // Contains only the string value of the default admin locale (e.g. 'en').
+    // If adminLocales are configured, it should be one of them. Otherwise,
+    // it can be any valid locale string identifier.
+    self.defaultAdminLocale = self.options.defaultAdminLocale || null;
     // Lint the locale configurations
     for (const [ key, options ] of Object.entries(self.locales)) {
       if (!options) {
@@ -69,6 +75,15 @@ module.exports = {
       if (options.prefix && options.prefix.match(/\/.*?\//)) {
         throw self.apos.error('invalid', `Locale prefixes must not contain more than one forward slash ("/").\nUse hyphens as separators. Check locale "${key}".`);
       }
+    }
+    if (!Array.isArray(self.adminLocales)) {
+      throw self.apos.error('invalid', 'The "adminLocales" option must be an array.');
+    }
+    if (self.defaultAdminLocale && typeof self.defaultAdminLocale !== 'string') {
+      throw self.apos.error('invalid', 'The "defaultAdminLocale" option must be a string.');
+    }
+    if (self.defaultAdminLocale && self.adminLocales.length && !self.adminLocales.some(al => al.value === self.defaultAdminLocale)) {
+      throw self.apos.error('invalid', `The value of "defaultAdminLocale" "${self.defaultAdminLocale}" doesn't match any of the existing "adminLocales" values.`);
     }
     const fallbackLng = [ self.defaultLocale ];
     // In case the default locale also has inadequate admin UI phrases
@@ -574,10 +589,13 @@ module.exports = {
         }
       },
       getBrowserData(req) {
+        const uiLocale = req.user?.adminLocale === ''
+          ? req.locale
+          : req.user?.adminLocale || self.defaultAdminLocale || req.locale;
         const i18n = {
-          [req.locale]: self.getBrowserBundles(req.locale)
+          [uiLocale]: self.getBrowserBundles(uiLocale)
         };
-        if (req.locale !== self.defaultLocale) {
+        if (uiLocale !== self.defaultLocale) {
           i18n[self.defaultLocale] = self.getBrowserBundles(self.defaultLocale);
         }
         // In case the default locale also has inadequate admin UI phrases
@@ -587,6 +605,7 @@ module.exports = {
         const result = {
           i18n,
           locale: req.locale,
+          adminLocale: uiLocale,
           defaultLocale: self.defaultLocale,
           defaultNamespace: self.defaultNamespace,
           locales: self.locales,

--- a/modules/@apostrophecms/ui/ui/apos/lib/i18next.js
+++ b/modules/@apostrophecms/ui/ui/apos/lib/i18next.js
@@ -17,7 +17,7 @@ export default {
     }
 
     i18next.init({
-      lng: canonicalize(i18n.locale),
+      lng: canonicalize(i18n.adminLocale),
       fallbackLng,
       resources: {},
       debug: i18n.debug,
@@ -45,15 +45,15 @@ export default {
       }
     });
 
-    for (const [ ns, phrases ] of Object.entries(i18n.i18n[i18n.locale])) {
-      i18next.addResourceBundle(canonicalize(i18n.locale), ns, phrases, true, true);
+    for (const [ ns, phrases ] of Object.entries(i18n.i18n[i18n.adminLocale])) {
+      i18next.addResourceBundle(canonicalize(i18n.adminLocale), ns, phrases, true, true);
     }
-    if (i18n.locale !== i18n.defaultLocale) {
+    if (i18n.adminLocale !== i18n.defaultLocale) {
       for (const [ ns, phrases ] of Object.entries(i18n.i18n[i18n.defaultLocale])) {
         i18next.addResourceBundle(canonicalize(i18n.defaultLocale), ns, phrases, true, true);
       }
     }
-    if ((i18n.locale !== 'en') && (i18n.defaultLocale !== 'en')) {
+    if ((i18n.adminLocale !== 'en') && (i18n.defaultLocale !== 'en')) {
       for (const [ ns, phrases ] of Object.entries(i18n.i18n.en)) {
         i18next.addResourceBundle('en', ns, phrases, true, true);
       }
@@ -85,7 +85,7 @@ export default {
         return '';
       }
       const result = i18next.t(key, {
-        lng: i18n.locale,
+        lng: i18n.adminLocale,
         ...options
       });
       if (i18n.show) {

--- a/modules/@apostrophecms/user/index.js
+++ b/modules/@apostrophecms/user/index.js
@@ -28,6 +28,11 @@
 // You may also call `apos.user.addSecret('name')` to add a new
 // secret property. This is convenient when implementing a module
 // such as `@apostrophecms/signup`.
+//
+// ### `adminLocale` schema field
+// A select field auto-created by the module, allowing the user to choose
+// their preferred language for the admin UI. It will be added only if
+// @apostrophecms/i18n is configured with `adminLocales`.
 
 const credentials = require('credentials');
 const prompts = require('prompts');
@@ -49,7 +54,27 @@ module.exports = {
     showPermissions: true,
     relationshipSuggestionIcon: 'account-box-icon'
   },
-  fields(self) {
+  fields(self, options) {
+    const fields = {};
+    // UI Locale
+    const locales = [ ...options.apos.i18n.adminLocales ];
+    if (locales.length > 0) {
+      const def = options.apos.i18n.defaultAdminLocale || '';
+      fields.localeField = {
+        type: 'select',
+        name: 'adminLocale',
+        label: 'apostrophe:uiLanguageLabel',
+        choices: [
+          {
+            label: 'apostrophe:uiLanguageWebsite',
+            value: ''
+          },
+          ...locales
+        ],
+        def
+      };
+    }
+
     return {
       add: {
         title: {
@@ -98,14 +123,16 @@ module.exports = {
           ],
           def: 'guest',
           required: true
-        }
+        },
+        ...fields
       },
       remove: [ 'visibility' ],
       group: {
         basics: {
           label: 'apostrophe:basics',
           fields: [
-            'title'
+            'title',
+            'adminLocale'
           ]
         },
         utility: {

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -174,6 +174,18 @@ describe('static i18n', function() {
       assert.strictEqual(browserData.locale, 'fr');
       assert.strictEqual(browserData.adminLocale, 'en');
     }
+
+    {
+      // When user sets Same as Website
+      const browserData = apos.i18n.getBrowserData(apos.task.getReq({
+        locale: 'fr',
+        user: {
+          adminLocale: ''
+        }
+      }));
+      assert.strictEqual(browserData.locale, 'fr');
+      assert.strictEqual(browserData.adminLocale, 'fr');
+    }
   });
 
   it('should respect defaultAdminLocale when adminLocales are configured', async function () {
@@ -205,10 +217,24 @@ describe('static i18n', function() {
     assert(field);
     assert.strictEqual(field.def, 'fr');
 
-    // adminLocale is defaultAdminLocale even if user.adminLocale is not present
-    const browserData = apos.i18n.getBrowserData(apos.task.getReq());
-    assert.strictEqual(browserData.locale, 'en');
-    assert.strictEqual(browserData.adminLocale, 'fr');
+    {
+      // adminLocale is defaultAdminLocale even if user.adminLocale is not present
+      const browserData = apos.i18n.getBrowserData(apos.task.getReq());
+      assert.strictEqual(browserData.locale, 'en');
+      assert.strictEqual(browserData.adminLocale, 'fr');
+    }
+
+    {
+      // adminLocale is set to Same as Website
+      const browserData = apos.i18n.getBrowserData(apos.task.getReq({
+        locale: 'en',
+        user: {
+          adminLocale: ''
+        }
+      }));
+      assert.strictEqual(browserData.locale, 'en');
+      assert.strictEqual(browserData.adminLocale, 'en');
+    }
   });
 
   it('should respect defaultAdminLocale when adminLocales are NOT configured', async function () {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Adds support for UI language (static i18n), introducing `adminLocales` and `defaultAdminLocale` options. Those are independent from the `locales` options (no interception required). Adds `adminLocale` user field, when `i18n.options.adminLocales` option is configured. Setting the user field shows the preferred interface language, not matter the current site locale.

**NOTE:** `defaultAdminLocale` will work independently of `adminLocales`. Even if no  `adminLocales` option is set, `defaultAdminLocale: 'fr'` will force the admin UI to be shown always in French, no matter of the current site `locale`. However, if `adminLocales` is configured, `defaultAdminLocale`, if set, should match an item from it. This is done to avoid user confusion. In this case, creating new User will auto select the default admin language. Current users, not having the `adminLocale` field (undefined) will also see the default admin language.
Not setting the `defaultAdminLocale` option will result in the usual behavior (BC) - UI language per current site locale.

## What are the specific steps to test this change?

Open the branch `feature-user-settings` on Testbed. Inspect `@apostrophecms/i18n` module configuration. Link your local core instance (in this branch), you should see `UI Language` field in any user record. Changing it should change the UI language (after reload).

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
