### PR TITLE
fix: remove focus parent listener on destroy in area widget

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -387,6 +387,10 @@ export default {
       apos.bus.$emit('widget-focus', this.widget._id);
     }
   },
+  destroyed() {
+    // Remove the focus parent listener when unmounted
+    apos.bus.$off('widget-focus-parent', this.focusParent);
+  },
   methods: {
     // Focus parent, useful for obtrusive UI
     focusParent() {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Remove focus parent event listeners for area widget when unmounted/destroyed. Currently the event listeners are not being garbage collected and if a page contains many area widgets then performance becomes 

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a page that contains area widget
> 3. Use DevTools to observe heap
> 4. Select "preview" and "edit" repeatedly. 

In current version you will see linear growth. With this change you will see that after garbage collection you will see it return to initial size. There may still be other issues though as I've noticed very small growth still occurring but that may be due to code on my end. Will investigate more.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
