### PR TITLE
PRO-4543 settings module

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -46,6 +46,7 @@ module.exports = {
     '@apostrophecms/video-widget': {},
     '@apostrophecms/ui': {},
     '@apostrophecms/user': {},
+    '@apostrophecms/settings': {},
     '@apostrophecms/image': {},
     '@apostrophecms/image-tag': {},
     '@apostrophecms/file': {},

--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -420,6 +420,7 @@
   "selectPage": "Select Page",
   "selectedMenuItem": "✓ {{ label }}",
   "sentenceJoiner": " ",
+  "settings": "Manage Settings",
   "shareDraft": "Share Draft",
   "shareDraftCopyLink": "Copy draft link",
   "shareDraftDescription": "Enabling draft sharing will allow anyone with this link to view the current draft",

--- a/modules/@apostrophecms/settings/index.js
+++ b/modules/@apostrophecms/settings/index.js
@@ -1,0 +1,207 @@
+module.exports = {
+  options: {
+    alias: 'settings',
+    subforms: {},
+    // XXX not implemented until Phase 2
+    groups: {}
+  },
+
+  init(self) {
+    self.userSchema = [];
+    self.subforms = [];
+    self.initSubforms();
+    self.enableBrowserData();
+    self.addToAdminBar();
+  },
+
+  handlers(self) {
+    return {
+      'apostrophe:modulesRegistered': {
+        addModal() {
+          self.addSettingsModal();
+        }
+      }
+    };
+  },
+
+  methods(self) {
+    return {
+      hasSchema() {
+        return self.userSchema.length > 0;
+      },
+
+      // Initialize the subforms configuration
+      initSubforms() {
+        self.userSchema = self.inferUserSchema();
+
+        for (const [ name, config ] of Object.entries(self.options.subforms)) {
+          const schema = self.getSubformSchema(name);
+          const label = config.label || schema[0]?.label;
+          self.subforms.push({
+            ...config,
+            name,
+            label,
+            schema
+          });
+        }
+      },
+
+      // Get the subset of the user schema that is relevant to the configured
+      // subforms.
+      inferUserSchema() {
+        const schema = [];
+        const subforms = self.options.subforms;
+        const userSchema = self.apos.user.schema;
+        const allSettingsFields = [
+          ...new Set(
+            Object.keys(subforms)
+              .reduce((acc, subform) => {
+                return acc.concat(subforms[subform].fields);
+              }, [])
+          )
+        ];
+        self.validateSettingsSchema(allSettingsFields, userSchema);
+
+        for (const field of userSchema) {
+          if (allSettingsFields.includes(field.name)) {
+            schema.push(field);
+          }
+        }
+        return schema;
+      },
+
+      // Validate that the fields configured in the settings module exist in the
+      // user schema and are not forbidden.
+      // XXX Temporary (Phase 2,3) extend the forbidden protected fields.
+      validateSettingsSchema(settingsFieldNames, userSchema) {
+        const forbiddenFields = [
+          'role',
+          // These will be allowed in Phase 2 and 3
+          'username',
+          'password',
+          'email'
+        ];
+        for (const name of settingsFieldNames) {
+          if (!userSchema.some(field => field.name === name)) {
+            throw new Error(`[@apostrophecms/settings] The field "${name}" is not a valid user field.`);
+          }
+          if (forbiddenFields.includes(name)) {
+            throw new Error(`[@apostrophecms/settings] The field "${name}" is forbidden.`);
+          }
+        }
+      },
+
+      // Get subform fields by subform name.
+      getSubformSchema(name) {
+        const subform = self.options.subforms[name];
+        if (!subform) {
+          throw self.apos.error('notfound', `Subform "${name}" not found.`);
+        }
+        return subform.fields.map(fieldName => {
+          return self.userSchema.find(field => field.name === fieldName);
+        });
+      },
+
+      getSubform(name) {
+        return self.subforms.find(subform => subform.name === name);
+      },
+
+      addToAdminBar() {
+        if (!self.hasSchema()) {
+          return;
+        }
+        self.apos.adminBar.add(
+          `${self.__meta.name}:settings`,
+          'apostrophe:settings',
+          false,
+          {
+            user: true
+          }
+        );
+      },
+
+      addSettingsModal() {
+        if (!self.hasSchema()) {
+          return;
+        }
+        self.apos.modal.add(
+          `${self.__meta.name}:settings`,
+          self.getComponentName('settingsModal', 'AposSettingsManager'),
+          { moduleName: self.__meta.name }
+        );
+      },
+
+      getBrowserData(req) {
+        return {
+          subforms: self.subforms,
+          action: self.action
+        };
+      }
+    };
+  },
+
+  restApiRoutes(self) {
+    return {
+      async getAll(req) {
+        if (!self.hasSchema() || !req.user) {
+          throw self.apos.error('notfound');
+        }
+        const user = await self.apos.user
+          .find(req, { _id: req.user._id })
+          .permission(false)
+          .toObject();
+
+        if (!user) {
+          throw self.apos.error('notfound');
+        }
+
+        const values = {
+          _id: user._id
+        };
+        for (const field of self.userSchema) {
+          values[field.name] = user[field.name];
+        }
+        return values;
+      }
+    };
+  },
+
+  apiRoutes(self) {
+    return {
+      patch: {
+        ':subform': async (req) => {
+          if (!self.hasSchema() || !req.user) {
+            throw self.apos.error('notfound');
+          }
+          const subform = self.getSubform(
+            self.apos.launder.string(req.params.subform)
+          );
+
+          if (!subform || !subform.schema.length) {
+            throw self.apos.error('notfound');
+          }
+
+          const user = await self.apos.user
+            .find(req, { _id: req.user._id })
+            .permission(false)
+            .toObject();
+
+          if (!user) {
+            throw self.apos.error('notfound');
+          }
+
+          await self.apos.schema.convert(req, subform.schema, req.body, user);
+          await self.apos.user.update(req, user, { permissions: false });
+
+          const values = {
+            _id: user._id
+          };
+          for (const field of subform.schema) {
+            values[field.name] = user[field.name];
+          }
+          return values;
+        }
+      }
+    };
+  }
+};

--- a/modules/@apostrophecms/settings/ui/apos/components/AposSettingsManager.vue
+++ b/modules/@apostrophecms/settings/ui/apos/components/AposSettingsManager.vue
@@ -12,6 +12,7 @@
       <AposButton
         type="default"
         label="apostrophe:close"
+        :disabled="busy"
         @click="close"
       />
     </template>
@@ -19,23 +20,23 @@
       <AposModalBody class="apos-settings__group">
         <template #bodyMain>
           <!-- TODO PHASE 2 groups -->
-          <ul class="apos-settings__group-items">
+          <!-- <ul class="apos-settings__group-items">
             <li
               class="apos-settings__group-item apos-is-active"
             >
               Preferences
             </li>
-          </ul>
+          </ul> -->
         </template>
       </AposModalBody>
     </template>
     <template #main>
       <AposModalBody v-if="docReady" class="apos-settings__content">
         <template #bodyMain>
-          <h2 class="apos-settings__heading">
-            <!-- TODO PHASE 2 active group name -->
+          <!-- TODO PHASE 2 active group name -->
+          <!-- <h2 class="apos-settings__heading">
             Preferences
-          </h2>
+          </h2> -->
           <!-- TODO PHASE 2 groups -->
           <AposSubform
             v-for="subform in subforms"
@@ -53,11 +54,11 @@
 </template>
 
 <script>
-import TheAposSettingsLogic from 'Modules/@apostrophecms/settings/logic/TheAposSettings';
+import AposSettingsManagerLogic from 'Modules/@apostrophecms/settings/logic/AposSettingsManager';
 
 export default {
   name: 'AposSettingsManager',
-  mixins: [ TheAposSettingsLogic ],
+  mixins: [ AposSettingsManagerLogic ],
   emits: [ 'safe-close', 'modal-result' ]
 };
 </script>

--- a/modules/@apostrophecms/settings/ui/apos/components/AposSettingsManager.vue
+++ b/modules/@apostrophecms/settings/ui/apos/components/AposSettingsManager.vue
@@ -1,0 +1,123 @@
+<template>
+  <AposModal
+    class="apos-settings-manager"
+    :modal="modal"
+    modal-title="Manage Settings"
+    @esc="close"
+    @inactive="modal.active = false"
+    @show-modal="modal.showModal = true"
+    @no-modal="$emit('safe-close')"
+  >
+    <template #secondaryControls>
+      <AposButton
+        type="default"
+        label="apostrophe:close"
+        @click="close"
+      />
+    </template>
+    <template #leftRail>
+      <AposModalBody class="apos-settings__group">
+        <template #bodyMain>
+          <!-- TODO PHASE 2 groups -->
+          <ul class="apos-settings__group-items">
+            <li
+              class="apos-settings__group-item apos-is-active"
+            >
+              Preferences
+            </li>
+          </ul>
+        </template>
+      </AposModalBody>
+    </template>
+    <template #main>
+      <AposModalBody v-if="docReady" class="apos-settings__content">
+        <template #bodyMain>
+          <h2 class="apos-settings__heading">
+            <!-- TODO PHASE 2 active group name -->
+            Preferences
+          </h2>
+          <!-- TODO PHASE 2 groups -->
+          <AposSubform
+            v-for="subform in subforms"
+            :key="subform.name"
+            :busy="busy"
+            :errors="errors"
+            :subform="subform"
+            :values="values.data[subform.name]"
+            @submit="submit"
+          />
+        </template>
+      </AposModalBody>
+    </template>
+  </AposModal>
+</template>
+
+<script>
+import TheAposSettingsLogic from 'Modules/@apostrophecms/settings/logic/TheAposSettings';
+
+export default {
+  name: 'AposSettingsManager',
+  mixins: [ TheAposSettingsLogic ],
+  emits: [ 'safe-close', 'modal-result' ]
+};
+</script>
+
+<style lang="scss" scoped>
+.apos-settings-manager {
+  @include type-base;
+
+  ::v-deep .apos-modal__inner {
+    // TODO decide on 1/2 vs 2/3
+    // $width: calc(100vw / 2);
+    $width: calc(calc(100vw / 3) * 2);
+    $vertical-spacing: 95px;
+    $horizontal-spacing: calc(calc(100vw - #{$width}) / 2);
+
+    top: $vertical-spacing;
+    right: $horizontal-spacing;
+    bottom: $vertical-spacing;
+    left: $horizontal-spacing;
+    width: $width;
+    height: calc(100vh - #{$vertical-spacing * 2});
+  }
+
+  ::v-deep .apos-modal__main--with-left-rail {
+    grid-template-columns: 25% 75%;
+  }
+
+  ::v-deep .apos-modal__body-inner {
+    padding: $spacing-triple $spacing-triple $spacing-double;
+  }
+
+  ::v-deep .apos-busy__spinner {
+    display: inline-block;
+  }
+}
+
+.apos-settings__heading {
+  @include type-title;
+  margin: 0 0 $spacing-double 0;
+}
+
+.apos-settings__content {
+  padding-top: 0;
+  padding-left: 0;
+}
+
+.apos-settings__group {
+  padding: 0;
+  border-right: 1px solid var(--a-base-9);
+}
+
+.apos-settings__group-items {
+  @include apos-list-reset();
+}
+
+.apos-settings__group-item {
+  @include type-base;
+  margin-bottom: $spacing-base + $spacing-half;
+  &.apos-is-active {
+    color: var(--a-primary);
+  }
+}
+</style>

--- a/modules/@apostrophecms/settings/ui/apos/components/AposSubform.vue
+++ b/modules/@apostrophecms/settings/ui/apos/components/AposSubform.vue
@@ -1,0 +1,128 @@
+<template>
+  <div class="apos-subform">
+    <AposSchema
+      :class="{ 'apos-subform__disabled': busy }"
+      data-apos-test="subformSchema"
+      :data-apos-test-name="subform.name"
+      ref="schema"
+      :trigger-validation="triggerValidation"
+      :schema="schema"
+      :value="docFields"
+      :following-values="followingValues()"
+      :conditional-fields="conditionalFields()"
+      :server-errors="serverErrors"
+      @input="updateDocFields"
+      @validate="triggerValidate"
+    />
+    <div class="apos-subform__controls">
+      <AposButton
+        data-apos-test="subformCancel"
+        :disabled="busy"
+        type="subtle"
+        label="apostrophe:cancel"
+        @click="cancel"
+      />
+      <AposButton
+        data-apos-test="subformSubmit"
+        :disabled="busy || docFields.hasErrors"
+        type="primary"
+        label="apostrophe:save"
+        @click="submit"
+      />
+    </div>
+  </div>
+</template>
+<script>
+import { klona } from 'klona';
+import AposEditorMixin from 'Modules/@apostrophecms/modal/mixins/AposEditorMixin';
+
+export default {
+  name: 'AposSubform',
+  mixins: [ AposEditorMixin ],
+  props: {
+    errors: {
+      type: Object,
+      default: null
+    },
+    subform: {
+      type: Object,
+      required: true
+    },
+    values: {
+      type: Object,
+      required: true
+    },
+    busy: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: [ 'submit', 'cancel' ],
+  data() {
+    return {
+      docFields: {
+        data: {},
+        hasErrors: false
+      },
+      triggerValidation: false,
+      apiError: false
+    };
+  },
+
+  computed: {
+    schema() {
+      return (this.subform.schema ?? []);
+    },
+    serverError() {
+      return this.error || this.apiError;
+    }
+  },
+
+  watch: {
+    values(newValues) {
+      this.docFields.data = klona(newValues);
+    },
+    errors(newErrors) {
+      this.serverErrors = newErrors;
+    }
+  },
+  // If we don't do for this, we get stale values.
+  created() {
+    this.docFields.data = klona(this.values);
+  },
+  methods: {
+    updateDocFields(value) {
+      this.docFields = value;
+    },
+    async submit() {
+      this.triggerValidation = true;
+      this.$nextTick(async () => {
+        if (this.docFields.hasErrors) {
+          this.triggerValidation = false;
+          return;
+        }
+        this.$emit('submit', {
+          name: this.subform.name,
+          values: this.docFields.data
+        });
+      });
+    },
+    async cancel() {
+      this.$emit('cancel');
+    }
+  }
+};
+</script>
+<style lang="scss">
+.apos-subform__controls {
+  display: flex;
+  justify-content: flex-end;
+  gap: $spacing-base;
+  max-width: $input-max-width;
+}
+
+.apos-subform__disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+</style>

--- a/modules/@apostrophecms/settings/ui/apos/components/AposSubform.vue
+++ b/modules/@apostrophecms/settings/ui/apos/components/AposSubform.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- Preview mode and toggle preview/form. -->
   <div class="apos-subform">
     <AposSchema
       :class="{ 'apos-subform__disabled': busy }"
@@ -33,84 +34,12 @@
   </div>
 </template>
 <script>
-import { klona } from 'klona';
-import AposEditorMixin from 'Modules/@apostrophecms/modal/mixins/AposEditorMixin';
+import AposSubformLogic from 'Modules/@apostrophecms/settings/logic/AposSubform';
 
 export default {
   name: 'AposSubform',
-  mixins: [ AposEditorMixin ],
-  props: {
-    errors: {
-      type: Object,
-      default: null
-    },
-    subform: {
-      type: Object,
-      required: true
-    },
-    values: {
-      type: Object,
-      required: true
-    },
-    busy: {
-      type: Boolean,
-      default: false
-    }
-  },
-  emits: [ 'submit', 'cancel' ],
-  data() {
-    return {
-      docFields: {
-        data: {},
-        hasErrors: false
-      },
-      triggerValidation: false,
-      apiError: false
-    };
-  },
+  mixins: [ AposSubformLogic ]
 
-  computed: {
-    schema() {
-      return (this.subform.schema ?? []);
-    },
-    serverError() {
-      return this.error || this.apiError;
-    }
-  },
-
-  watch: {
-    values(newValues) {
-      this.docFields.data = klona(newValues);
-    },
-    errors(newErrors) {
-      this.serverErrors = newErrors;
-    }
-  },
-  // If we don't do for this, we get stale values.
-  created() {
-    this.docFields.data = klona(this.values);
-  },
-  methods: {
-    updateDocFields(value) {
-      this.docFields = value;
-    },
-    async submit() {
-      this.triggerValidation = true;
-      this.$nextTick(async () => {
-        if (this.docFields.hasErrors) {
-          this.triggerValidation = false;
-          return;
-        }
-        this.$emit('submit', {
-          name: this.subform.name,
-          values: this.docFields.data
-        });
-      });
-    },
-    async cancel() {
-      this.$emit('cancel');
-    }
-  }
 };
 </script>
 <style lang="scss">

--- a/modules/@apostrophecms/settings/ui/apos/logic/AposSettingsManager.js
+++ b/modules/@apostrophecms/settings/ui/apos/logic/AposSettingsManager.js
@@ -8,13 +8,16 @@ export default {
         active: false,
         showModal: false
       },
+      values: {
+        data: {}
+      },
       docReady: false,
       // Object same as serverErrors (AposEditorMixin)
       errors: null,
-      busy: false,
-      values: {
-        data: {}
-      }
+      busy: false
+      // TODO updated state (changed with timeOut) when save is successful,
+      // sent to the Subform component.
+      // updatedState: false
     };
   },
   computed: {
@@ -34,11 +37,8 @@ export default {
   },
   methods: {
     close() {
-      if (!this.modal.busy) {
-        this.modal.showModal = false;
-      }
+      this.modal.showModal = false;
     },
-
     async submit(event) {
       this.errors = null;
       this.busy = true;
@@ -56,12 +56,13 @@ export default {
           fallback: this.$t('apos-signup:error')
         });
       } finally {
-        setTimeout(() => {
-          this.busy = false;
-        }, 1000);
+        this.busy = false;
+        // FIXME here for testing reasons, remove in the next ticket.
+        // setTimeout(() => {
+        //   this.busy = false;
+        // }, 1000);
       }
     },
-
     async loadData() {
       const result = await apos.http.get(this.action, {
         busy: true
@@ -70,7 +71,6 @@ export default {
       this.setSubformValues(result);
       this.docReady = true;
     },
-
     setSubformValues(values) {
       const newValues = {};
       for (const subform of this.subforms) {
@@ -81,7 +81,6 @@ export default {
       }
       this.values.data = newValues;
     },
-
     async handleSaveError(e, { fallback }) {
       console.error(e);
       if (e.body && e.body.data && e.body.data.errors) {

--- a/modules/@apostrophecms/settings/ui/apos/logic/AposSubform.js
+++ b/modules/@apostrophecms/settings/ui/apos/logic/AposSubform.js
@@ -1,0 +1,82 @@
+// FIXME move to the Schema module during the next task.
+// TODO docs.
+// TODO preview mode.
+import { klona } from 'klona';
+import AposEditorMixin from 'Modules/@apostrophecms/modal/mixins/AposEditorMixin';
+
+export default {
+  name: 'AposSubform',
+  mixins: [ AposEditorMixin ],
+  props: {
+    errors: {
+      type: Object,
+      default: null
+    },
+    subform: {
+      type: Object,
+      required: true
+    },
+    values: {
+      type: Object,
+      required: true
+    },
+    busy: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: [ 'submit', 'cancel' ],
+  data() {
+    return {
+      docFields: {
+        data: {},
+        hasErrors: false
+      },
+      triggerValidation: false
+    };
+  },
+
+  computed: {
+    schema() {
+      return (this.subform.schema ?? []);
+    },
+    serverError() {
+      return this.error || !!this.serverErrors;
+    }
+  },
+
+  watch: {
+    values(newValues) {
+      this.docFields.data = klona(newValues);
+    },
+    errors(newErrors) {
+      this.serverErrors = newErrors;
+    }
+  },
+  // If we don't do for this, we get stale values.
+  created() {
+    this.docFields.data = klona(this.values);
+  },
+  methods: {
+    updateDocFields(value) {
+      this.docFields = value;
+    },
+    async submit() {
+      this.triggerValidation = true;
+      this.$nextTick(async () => {
+        if (this.docFields.hasErrors) {
+          this.triggerValidation = false;
+          return;
+        }
+        this.$emit('submit', {
+          name: this.subform.name,
+          values: this.docFields.data
+        });
+      });
+    },
+    async cancel() {
+      // TODO set preview mode on.
+      this.$emit('cancel');
+    }
+  }
+};

--- a/modules/@apostrophecms/settings/ui/apos/logic/TheAposSettings.js
+++ b/modules/@apostrophecms/settings/ui/apos/logic/TheAposSettings.js
@@ -1,0 +1,104 @@
+export default {
+  name: 'AposSettingsManager',
+  emits: [ 'safe-close', 'modal-result' ],
+  data() {
+    return {
+      modal: {
+        busy: false,
+        active: false,
+        showModal: false
+      },
+      docReady: false,
+      // Object same as serverErrors (AposEditorMixin)
+      errors: null,
+      busy: false,
+      values: {
+        data: {}
+      }
+    };
+  },
+  computed: {
+    moduleOptions() {
+      return apos.settings;
+    },
+    action() {
+      return this.moduleOptions.action;
+    },
+    subforms() {
+      return this.moduleOptions.subforms;
+    }
+  },
+  async mounted() {
+    this.modal.active = true;
+    await this.loadData();
+  },
+  methods: {
+    close() {
+      if (!this.modal.busy) {
+        this.modal.showModal = false;
+      }
+    },
+
+    async submit(event) {
+      this.errors = null;
+      this.busy = true;
+      try {
+        const values = await apos.http.patch(
+            `${this.action}/${event.name}`,
+            {
+              busy: false,
+              body: event.values
+            }
+        );
+        this.values.data[event.name] = values;
+      } catch (e) {
+        await this.handleSaveError(e, {
+          fallback: this.$t('apos-signup:error')
+        });
+      } finally {
+        setTimeout(() => {
+          this.busy = false;
+        }, 1000);
+      }
+    },
+
+    async loadData() {
+      const result = await apos.http.get(this.action, {
+        busy: true
+      });
+
+      this.setSubformValues(result);
+      this.docReady = true;
+    },
+
+    setSubformValues(values) {
+      const newValues = {};
+      for (const subform of this.subforms) {
+        newValues[subform.name] = {};
+        for (const field of subform.schema) {
+          newValues[subform.name][field.name] = values[field.name];
+        }
+      }
+      this.values.data = newValues;
+    },
+
+    async handleSaveError(e, { fallback }) {
+      console.error(e);
+      if (e.body && e.body.data && e.body.data.errors) {
+        const serverErrors = {};
+        let first;
+        e.body.data.errors.forEach(e => {
+          first = first || e;
+          serverErrors[e.path] = e;
+        });
+        this.errors = serverErrors;
+      } else {
+        await apos.notify((e.body && e.body.message) || fallback, {
+          type: 'danger',
+          icon: 'alert-circle-icon',
+          dismiss: true
+        });
+      }
+    }
+  }
+};

--- a/test/settings.js
+++ b/test/settings.js
@@ -1,0 +1,157 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert/strict');
+
+describe('user settings', function () {
+  this.timeout(t.timeout);
+
+  let apos;
+
+  beforeEach(async function() {
+    await t.destroy(apos);
+    apos = null;
+  });
+
+  after(async function() {
+    return t.destroy(apos);
+  });
+
+  it('should have settings module', async function() {
+    apos = await t.create({
+      root: module
+    });
+    assert(apos.modules['@apostrophecms/settings'], 'module not found');
+    assert(apos.settings, 'module alias not found');
+    assert.deepEqual(apos.settings.options.subforms, {});
+    assert.deepEqual(apos.settings.options.groups, {});
+    assert.deepEqual(apos.settings.subforms, []);
+    assert.deepEqual(apos.settings.userSchema, []);
+    assert.equal(apos.settings.hasSchema(), false);
+  });
+
+  it('should panic on non-existing or forbidden user field in subforms', async function () {
+    apos = await t.create({
+      root: module
+    });
+
+    apos.settings.options.subforms = {
+      test: {
+        fields: [ 'nonExistingField' ]
+      }
+    };
+    assert.throws(
+      apos.settings.initSubforms,
+      {
+        message: '[@apostrophecms/settings] The field "nonExistingField" is not a valid user field.'
+      }
+    );
+
+    const testFields = [
+      'role',
+      'username',
+      'password',
+      'email'
+    ];
+
+    for (const field of testFields) {
+      apos.settings.options.subforms = {
+        test: {
+          fields: [ field ]
+        }
+      };
+      assert.throws(
+        apos.settings.initSubforms,
+        {
+          message: `[@apostrophecms/settings] The field "${field}" is forbidden.`
+        }
+      );
+    }
+  });
+
+  // It should process settings schema and register the subset of the user schema that
+  // is relevant to the configured subforms.
+  it('should init subforms', async function () {
+    apos = await t.create({
+      root: module,
+      modules: {
+        '@apostrophecms/i18n': {
+          options: {
+            adminLocales: [
+              {
+                label: 'English',
+                value: 'en'
+              },
+              {
+                label: 'French',
+                value: 'fr'
+              }
+            ]
+          }
+        },
+        '@apostrophecms/user': {
+          fields: {
+            add: {
+              firstName: {
+                type: 'string',
+                label: 'First Name'
+              },
+              lastName: {
+                type: 'string',
+                label: 'Last Name'
+              }
+            }
+          }
+        },
+        '@apostrophecms/settings': {
+          options: {
+            subforms: {
+              name: {
+                label: 'Name',
+                fields: [ 'firstName', 'lastName' ],
+                preview: '{{ firstName }} {{ lastName }}'
+              },
+              adminLocale: {
+                fields: [ 'adminLocale' ]
+              }
+            }
+          }
+        }
+      }
+    });
+
+    // Schema is processed
+    const schema = apos.settings.userSchema;
+    assert.equal(apos.settings.hasSchema(), true);
+    assert.equal(schema.length, 3);
+    assert(schema.some(field => field.name === 'firstName'));
+    assert(schema.some(field => field.name === 'lastName'));
+    assert(schema.some(field => field.name === 'adminLocale'));
+
+    const nameSchema = apos.settings.getSubformSchema('name');
+    assert.equal(nameSchema.length, 2);
+    assert(nameSchema.some(field => field.name === 'firstName'));
+    assert(nameSchema.some(field => field.name === 'lastName'));
+
+    const adminLocaleSchema = apos.settings.getSubformSchema('adminLocale');
+    assert.equal(adminLocaleSchema.length, 1);
+    assert(adminLocaleSchema.some(field => field.name === 'adminLocale'));
+
+    // Subforms are initialized
+    const subforms = apos.settings.subforms;
+    assert.equal(subforms.length, 2);
+
+    const nameSubform = subforms.find(subform => subform.name === 'name');
+    assert.equal(nameSubform.label, 'Name');
+    assert.equal(nameSubform.preview, '{{ firstName }} {{ lastName }}');
+    assert.deepEqual(nameSubform.schema, nameSchema);
+
+    const adminLocaleSubform = subforms.find(subform => subform.name === 'adminLocale');
+    assert.equal(adminLocaleSubform.label, adminLocaleSchema[0].label);
+    assert.equal(adminLocaleSubform.preview, undefined);
+    assert.deepEqual(adminLocaleSubform.schema, adminLocaleSchema);
+
+    // Appropriate browser data is sent
+    const browserData = apos.settings.getBrowserData();
+    assert.deepEqual(browserData.subforms, subforms);
+    assert.equal(browserData.action, '/api/v1/@apostrophecms/settings');
+  });
+});


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Add `@apostrophecms/settings` module. Implement settings configuration per logged in user (UI and backend). 
Although fully functional, the final UI will be done in a following ticket. 


## What are the specific steps to test this change?

Use Testbed branch `feature-user-settings`, link Apostrophe locally while in the current branch. Boot the app, force rebuild (`CI=1 APOS_DEV=1 npx nodemon`)

"Manage Settings" should be visible above the "Logout" menu item (top right user menu). Clicking it should open "Manage Settings" modal. "UI Language" schema should be visible. Changing it should change the current user "UI Language" field (can be checked in the users piece). Re-opening the settings manager should show the new "UI language" setting by default.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
