### PR TITLE
Default height for empty paragraphs in rich-text editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Adds
 
-* Accessibility improved for navigation inside modals and various UI elements.  
+* Accessibility improved for navigation inside modals and various UI elements.
 Pages/Docs Manager and Doc Editor modal now have better keyboard accessibility.
 They keep the focus on elements inside modals and give it back to their parent modal when closed.
-* Adds support for a new `if` property in `addContextOperation` in order to show or not a context operation based on the current document properties. 
+* Adds support for a new `if` property in `addContextOperation` in order to show or not a context operation based on the current document properties.
 * Add `update-doc-fields` event to call `AposDocEditor.updateDocFields` method
 * Add schema field `hidden` property to always hide a field
 * Hide empty schema tabs in `AposDocEditor` when all fields are hidden due to `if` conditions
@@ -39,6 +39,7 @@ to props of their choosing.
 warning if they export no code.
 * Clean up focus parent event handlers when components are destroyed. Prevents a slow degradation of performance while editing.
 Thanks to [Joshua N. Miller](https://github.com/jmiller-rise8).
+* Fixes a visual discrepancy in the rich text editor where empty paragraphs would appear smaller in preview mode compared to edit mode.
 
 ### Changes
 
@@ -139,8 +140,8 @@ are made before the last `apostrophe:modulesRegistered` handler has fired.
 If you need to call Apostrophe's `find()` methods at startup,
 it is best to wait for the `@apostrophecms/doc:beforeReplicate` event.
 * Allow `@` when a piece is a template and `/@` for page templates (doc-template-library module).
-* Adds a `prefix` option to the http frontend util module.  
-If explicitly set to `false`, prevents the prefix from being automatically added to the URL,  
+* Adds a `prefix` option to the http frontend util module.
+If explicitly set to `false`, prevents the prefix from being automatically added to the URL,
 when making calls with already-prefixed URLs for instance.
 * Adds the `redirectToFirstLocale` option to the `i18n` module to prevent users from reaching a version of their site that would not match any locale when requesting the site without a locale prefix in the URL.
 * If just one instance of a piece type should always exist (per locale if localized), the

--- a/modules/@apostrophecms/ui/ui/apos/scss/global/_widgets.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/_widgets.scss
@@ -1,3 +1,7 @@
 [data-apos-area] [data-apos-area] {
   margin: var(--a-widget-margin);
 }
+
+[data-rich-text] p:empty::after {
+  content: "\00A0";
+}

--- a/modules/@apostrophecms/ui/ui/apos/scss/global/_widgets.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/_widgets.scss
@@ -3,5 +3,5 @@
 }
 
 [data-rich-text] p:empty::after {
-  content: "\00A0";
+  content: '\00A0';
 }


### PR DESCRIPTION
## Summary

Blank lines respected in CMS rich text editor
https://linear.app/apostrophecms/issue/PRO-4526/blank-spacing-not-being-respected-in-cms-rich-text-editor

Edit mode:
<img width="1362" alt="image" src="https://github.com/apostrophecms/apostrophe/assets/11479686/c0e1686f-7c0c-4ddb-8e4f-4f0d8c61f0fc">

Preview mode:
<img width="1277" alt="image" src="https://github.com/apostrophecms/apostrophe/assets/11479686/c24eceb2-8043-4d9f-a663-64e3cb407fdf">


## What are the specific steps to test this change?

1. Run the website and log in
2. Edit a rich-text editor, add new lines by hitting the button "Enter". Publish changes.
3. Go in preview mode and check the new lines are respected out of the edit mode
4. Log out and check new lines are still present

## What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

