### PR TITLE
conditional fields are not available in AposRelationshipEditor

### DIFF
--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposModalTabsMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposModalTabsMixin.js
@@ -46,7 +46,8 @@ export default {
       const tabs = [];
       for (const key in this.groups) {
         if (key !== 'utility') {
-          const conditionalFields = this.conditionalFields('other');
+          // AposRelationshipEditor does not implement AposEditorMixin with the function conditionalFields
+          const conditionalFields = this.conditionalFields?.('other') || [];
           const fields = this.groups[key].fields;
           tabs.push({
             name: key,


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

`conditionFields` does not exist in the context of `AposRelationshipEditor`

## What are the specific steps to test this change?

1. Run cypress `fields.spec.js`

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
