### PR TITLE
Core API, formatting by env, req support, tear down

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -1,5 +1,6 @@
 module.exports = {
   modules: {
+    '@apostrophecms/log': {},
     '@apostrophecms/error': {},
     '@apostrophecms/util': {},
     '@apostrophecms/i18n': {},

--- a/modules/@apostrophecms/log/index.js
+++ b/modules/@apostrophecms/log/index.js
@@ -156,13 +156,13 @@ module.exports = {
         for (const [ module, config ] of Object.entries(self.filters)) {
           for (const [ type, value ] of Object.entries(config)) {
             if (value === true || value === '*') {
-              self.filters[module][type] = (type === 'severity')
+              config[type] = (type === 'severity')
                 ? self.getDefaultSeverity(false)
                 : [ '*' ];
             }
-            if (!Array.isArray(self.filters[module][type])) {
+            if (!Array.isArray(config[type])) {
               throw new Error(
-                `Invalid ${type} filter for module ${module}: ${JSON.stringify(self.filters[module][type])}`
+                `Invalid ${type} filter for module ${module}: ${JSON.stringify(config[type])}`
               );
             }
           }

--- a/modules/@apostrophecms/log/index.js
+++ b/modules/@apostrophecms/log/index.js
@@ -1,0 +1,255 @@
+// Structured logging for Apostrophe.
+//
+// This module is generic, low level implementation. For logging inside of a module,
+// see `logInfo`, `logError`, etc. methods in `@apostrophecms/module`.
+//
+// ### `logger`
+//
+// Optional. It can be an object or a function.
+// If a function it accepts `apos` and returns an object with
+// at least `info`, `debug`, `warn` and `error` methods. If a `destroy` method
+// is present it will be invoked and awaited (Promise) when Apostrophe is shut down.
+// If an object it must have at least `info`, `debug`, `warn` and `error` methods.
+// If this option is not supplied, logs are simply written to the Node.js `console`.
+// Calls to `apos.utils.info`, `apos.utils.error`, etc. or module level `self.logInfo`,
+// `self.logError`, etc are routed through this object by Apostrophe.
+// This provides compatibility out of the box with many popular
+// logging modules, including`pino`, `winston`, etc.
+//
+// ## Options
+//
+// ### `messageAs`
+//
+// When the messageAs option is set, the message argument to apos.util.info, etc.
+// is bundled into the second, object - based argument as a property of the name
+// given, and only the object argument is passed to Pino. If there is
+// no object-based argument an object is created.
+// Example:
+// ```js
+// {
+//   options: {
+//     messageAs: 'msg'
+//   }
+// }
+// ```
+// The resulting util log call will be:
+// ```js
+// self.apos.util.error({
+//   msg: '@apostrophecms/login: incorrect-username: User admin failed to log in',
+//   type: 'incorrect-username'
+//   module: '@apostrophecms/login'
+// });
+// ```
+//
+// ### `filter`
+//
+// By module name, or `*` we can specify any mix of severity levels and
+// specific event types, and entries are kept if *either* criterion is met.
+// Example:
+// ```js
+// {
+//   options: {
+//     filter: {
+//       // Log all errors and warnings from any module
+//       '*': {
+//         severity: [ 'warn', 'error' ]
+//       },
+//       // Log specific event types from the login module
+//       '@apostrophecms/login': {
+//         events: [ 'incorrect-username', 'incorrect-password' ]
+//       }
+//     }
+//   }
+// }
+// ```
+// In this example, all errors and warnings from any module, but
+// only the specific event types (no matter the severity) from the login
+// module, are logged.
+//
+// ## Environment Variables
+//
+// ### `APOS_FILTER_LOGS`
+//
+// If set, this environment variable overrides the `filter` option.
+// Example:
+// ```sh
+// # same as the `filter` example above
+// export APOS_FILTER_LOGS='*:severity:warn,error;@apostrophecms/login:events:incorrect-username,incorrect-password'
+// # log everything
+// export APOS_FILTER_LOGS='*'
+// ```
+//
+
+const _ = require('lodash');
+
+module.exports = {
+  options: {
+    alias: 'structuredLog'
+  },
+  init(self) {
+  },
+  methods(self) {
+    return {
+      // Logger for a module factory.
+      // The created logger object contains `debug`, `info`, `warn` and `error` methods,
+      // each suuporting the following signature:
+      // - (eventType)
+      // - (eventType, data)
+      // - (eventType, message)
+      // - (eventType, message, data)
+      // - (req, eventType[, message, data]) message and data are optional
+      getLoggerForModule(moduleSelf) {
+        return {
+          debug: (...args) => {
+            self.logEntry(moduleSelf, 'debug', ...args);
+          },
+          info: (...args) => {
+            self.logEntry(moduleSelf, 'info', ...args);
+          },
+          warn: (...args) => {
+            self.logEntry(moduleSelf, 'warn', ...args);
+          },
+          error: (...args) => {
+            self.logEntry(moduleSelf, 'error', ...args);
+          }
+        };
+      },
+      // Internal module, do not use it directly. See `@apostrophecms/module` for
+      // module level logging methods - logInfo, logError, etc.
+      logEntry(moduleSelf, severity, req, eventType, message, data) {
+        const args = self.processLoggerArgs(
+          moduleSelf,
+          severity,
+          req,
+          eventType,
+          message,
+          data
+        );
+        if (self.shouldKeepEntry(data)) {
+          self.apos.util[severity](...args);
+        }
+      },
+      // Do a minimal computation and validation of the arguemnts - logs should
+      // be fast. The function exepects 4 or 5 arguments (without counting the first optional `moduleSelf` argument),
+      // but all of the below will work:
+      // processLogArgs(moduleSelf, severity = 'info', eventType = 'event-type');
+      // processLogArgs(moduleSelf, severity = 'info', eventType = 'event-type', data = { module: 'my-module' });
+      // processLogArgs(moduleSelf, severity = 'info', eventType = 'event-type', message = 'message', data = { module: 'my-module' });
+      // processLogArgs(moduleSelf, severity = 'info', req, eventType = 'event-type', [...messageAndOrData]);
+      //
+      // If `moduleSelf` is provided, it is used to extract the module name from
+      // the `__meta` property.
+      // `severity` and `eventType` are required.
+      // `req`, `message` and `data` are optional.
+      // `req` is an apos request object. If provided, the `data` argument will be
+      // enriched with additional information from the request.
+      // `data.module` is recognized as a special property and is used to refortmat
+      // the message.
+      // `data.severity` is always set to the value of the `severity` argument.
+      // `data.type` is always set to the value of the `eventType` argument.
+      // message is optional, if not provided it is generated from the eventType and data.module.
+      // Optional message values:
+      // - `module: eventType: message`
+      // - `eventType: message`: (missing module)
+      // - `module: eventType`: (missing message)
+      // - `eventType`: (missing module and message)
+      //
+      // Returns [ data ] or [ message, data ] depending on option.messageAs.
+      // `data` is always an object containing at least a `type` and `severity` properties.
+      processLoggerArgs(...allArgs) {
+        const args = allArgs.slice(1);
+        const moduleSelf = allArgs[0];
+        let severity;
+        let req;
+        let eventType;
+        let message;
+        let data;
+
+        // Detect `req` argument with a simple duck type check - apos `req` object
+        // has always a translate `t` function.
+        if (args[1] && typeof args[1].t === 'function') {
+          [ severity, req, eventType, message, data ] = args;
+        } else {
+          [ severity, eventType, message, data ] = args;
+        }
+
+        if (!_.isString(eventType)) {
+          throw new Error('Event type must be a string');
+        }
+        if (_.isPlainObject(message)) {
+          data = message;
+          message = undefined;
+        }
+        data = data ? { ...data } : {};
+        data.type = eventType;
+        data.severity = severity;
+        if (moduleSelf) {
+          data.module = moduleSelf.__meta?.name;
+        }
+
+        if (_.isString(message) && message.trim().length > 0) {
+          message = data.module
+            ? `${data.module}: ${eventType}: ${message}`
+            : `${eventType}: ${message}`;
+        } else {
+          message = data.module
+            ? `${data.module}: ${eventType}`
+            : eventType;
+        }
+
+        data = self.processRequestData(req, data);
+
+        if (self.options.messageAs) {
+          data[self.options.messageAs] = message;
+          return [ data ];
+        }
+
+        return [ message, data ];
+      },
+
+      // Enrich the `data` argument with additional information from the request.
+      processRequestData(req, data) {
+        if (!req) {
+          return data;
+        }
+        return {
+          // https://expressjs.com/en/api.html#req.originalUrl
+          url: req.originalUrl,
+          path: req.path,
+          ip: req.ip,
+          query: req.query,
+          requestId: req.requestId || self.apos.util.generateId(),
+          ...data
+        };
+      },
+
+      // Assess the module filter configuration and determine if the log
+      // should be kept or rejected.
+      //
+      // `data` argument should be an object returned from `processLogArgs(...)`.
+      shouldKeepEntry(data) {
+        // FIXME implement
+        return true;
+      },
+
+      formatLogByEnv(args) {
+        const formatObj = process.env.NODE_ENV === 'production'
+          ? JSON.stringify
+          : (obj) => JSON.stringify(obj, null, 2);
+        const formatString = process.env.NODE_ENV !== 'production' && args.length > 1
+          ? (str) => str.replace(/\n/g, '\n  ')
+          : (str) => str;
+
+        return args.map((arg) => {
+          if (_.isString(arg)) {
+            return formatString(arg);
+          }
+          if (_.isPlainObject(arg)) {
+            return formatObj(arg);
+          }
+          return arg;
+        });
+      }
+    };
+  }
+};

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -75,7 +75,7 @@ module.exports = {
     // Routes in their final ready-to-add-to-Express form
     self._routes = [];
 
-    // Add structured logging if we passed the util module.
+    // Enable structured logging after util module is initialized.
     if (self.apos.util && (self.apos.util !== self)) {
       self.__structuredLoggingEnabled = true;
     }

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -74,6 +74,11 @@ module.exports = {
     // Routes in their final ready-to-add-to-Express form
     self._routes = [];
 
+    // Add structured logging if we passed the util module.
+    if (self.apos.util && (self.apos.util !== self)) {
+      self.logger = self.apos.structuredLog.getLoggerForModule(self);
+    }
+
     // Add i18next phrases if we started up after the i18n module,
     // which will call this for us if we start up before it
     if (self.apos.i18n && (self.apos.i18n !== self)) {
@@ -172,6 +177,51 @@ module.exports = {
           }
           return async req => route(req, req.params._id);
         }
+      },
+
+      // Per module log handlers.
+      // Usage (same arguments for all log handlers):
+      // self.logError('event-type');
+      // self.logError('event-type', { key: 'value' });
+      // self.logError('event-type', 'some message');
+      // self.logError('event-type', 'some message', { key: 'value' });
+      // self.logError(req, ...); - with any of the above argument variations.
+      // Event type is required and can be any string.
+      // If `req` is provided, the `data` object argument will be enriched with additional
+      // information from the request.
+      // Example:
+      // self.logError('event-type', 'some message', { key: 'value' });
+      // will log:
+      // 'current-module-name: event-type: some message',
+      // {
+      //   type: 'event-type',
+      //   severity: 'error',
+      //   module: 'current-module-name',
+      //   key: 'value',
+      // }
+      // If the option `messageAs` of `@apostrophecms/log` is set to 'msg',
+      // the result of the above log entry will be:
+      // {
+      //   type: 'event-type',
+      //   severity: 'error',
+      //   module: 'current-module-name',
+      //   key: 'value',
+      //   msg: 'current-module-name: event-type: some message',
+      // }
+      // If `filter` option is set, the log entry will be logged only if the
+      // `severity` or `eventType` match any filter. For more information about
+      // filters see `@apostrophecms/log` module.
+      logDebug(...args) {
+        self.logger.debug(...args);
+      },
+      logInfo(...args) {
+        self.logger.info(...args);
+      },
+      logWarn(...args) {
+        self.logger.warn(...args);
+      },
+      logError(...args) {
+        self.logger.error(...args);
       },
 
       routeWrappers: {

--- a/modules/@apostrophecms/module/lib/log.js
+++ b/modules/@apostrophecms/module/lib/log.js
@@ -1,0 +1,68 @@
+// Per module log handlers.
+// Usage (same arguments for all log handlers):
+// ```js
+// self.logError('event-type');
+// self.logError('event-type', { key: 'value' });
+// self.logError('event-type', 'some message');
+// self.logError('event-type', 'some message', { key: 'value' });
+// Prepend `req` followed by any of the above argument variations.
+// self.logError(req, ...);
+// ```
+//
+// Event type is required and can be any string.
+// If `req` is provided, the `data` object argument will be enriched with
+// additional information from the request.
+// Example:
+// self.logError('event-type', 'some message', { key: 'value' });
+// will log:
+// 'current-module-name: event-type: some message',
+// {
+//   type: 'event-type',
+//   severity: 'error',
+//   module: 'current-module-name',
+//   key: 'value',
+// }
+// If the option `messageAs` of `@apostrophecms/log` is set to 'msg',
+// the result of the above log entry will be:
+// {
+//   type: 'event-type',
+//   severity: 'error',
+//   module: 'current-module-name',
+//   key: 'value',
+//   msg: 'current-module-name: event-type: some message',
+// }
+//
+// If `filter` option is set, the log entry will be logged only if the
+// `severity` or `eventType` match any filter. For more information about
+// filters see `@apostrophecms/log` module.
+module.exports = function (self) {
+  const exception = new Error(
+    `Structured logging is not available for module "${self.__meta.name}".`
+  );
+  return {
+    logDebug(...args) {
+      if (!self.__structuredLoggingEnabled) {
+        throw exception;
+      }
+      self.apos.structuredLog.logEntry(self, 'debug', ...args);
+    },
+    logInfo(...args) {
+      if (!self.__structuredLoggingEnabled) {
+        throw exception;
+      }
+      self.apos.structuredLog.logEntry(self, 'info', ...args);
+    },
+    logWarn(...args) {
+      if (!self.__structuredLoggingEnabled) {
+        throw exception;
+      }
+      self.apos.structuredLog.logEntry(self, 'warn', ...args);
+    },
+    logError(...args) {
+      if (!self.__structuredLoggingEnabled) {
+        throw exception;
+      }
+      self.apos.structuredLog.logEntry(self, 'error', ...args);
+    }
+  };
+};

--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -46,6 +46,17 @@ module.exports = {
     self.warnedDev = {};
     return self.enableLogger();
   },
+  handlers(self) {
+    return {
+      'apostrophe:destroy': {
+        async destroyLogger() {
+          if (self.logger.destroy) {
+            await self.logger.destroy();
+          }
+        }
+      }
+    };
+  },
   methods(self) {
     return {
       // generate a unique identifier for a new page or other object.

--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -842,7 +842,7 @@ module.exports = {
       // for legacy calls and when `@apostrophecms/log` has been configured
       // with `messageAs: 'someKey'`.
       // This change is backwards compatible with the previous behavior because
-      // `messageAs` is newly introduced option. Custom loggers should adapt
+      // `messageAs` is a newly introduced option. Custom loggers should adapt
       // to this change when using `messageAs`.
       // `args` is the argument array passed to the any log method.
       // The result (when required) is an array with a single object.

--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -504,7 +504,20 @@ module.exports = {
         }
       },
       enableLogger() {
-        self.logger = self.options.logger ? self.options.logger(self.apos) : require('./lib/logger.js')(self.apos);
+        // Legacy, configured via this module.
+        if (self.options.logger) {
+          self.logger = self.options.logger(self.apos);
+          return;
+        }
+        // New, configured via the `log` module.
+        const logOpts = self.apos.structuredLog.options;
+        if (logOpts.logger) {
+          self.logger = typeof logOpts.logger === 'function'
+            ? logOpts.logger(self.apos)
+            : logOpts.logger;
+          return;
+        }
+        self.logger = require('./lib/logger.js')(self.apos);
       },
       // Log a message. The default
       // implementation wraps `console.log` and passes on

--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -541,11 +541,12 @@ module.exports = {
       // If the logger has no `log` method, the `info` method
       // is used. This allows an instance of `bole` or similar
       // to be used directly.
-      log(msg) {
+      log(...args) {
+        // kept for bc
         if (!self.logger.log) {
-          return self.logger.info.apply(self.logger.info, arguments);
+          return self.logger.info(...self.convertLegacyLogPayload(args));
         }
-        self.logger.log.apply(self.logger, arguments);
+        self.logger.log(...self.convertLegacyLogPayload(args));
       },
       // Log an informational message. The default
       // implementation wraps `console.info` and passes on
@@ -554,8 +555,8 @@ module.exports = {
       // Overrides should be written with support for
       // substitution strings in mind. See the
       // `console.log` documentation.
-      info(msg) {
-        self.logger.info.apply(self.logger, arguments);
+      info(...args) {
+        self.logger.info(...self.convertLegacyLogPayload(args));
       },
       // Log a debug message. The default implementation wraps
       // `console.debug` if available, otherwise `console.log`,
@@ -564,8 +565,8 @@ module.exports = {
       // Overrides should be written with support for
       // substitution strings in mind. See the
       // `console.warn` documentation.
-      debug(msg) {
-        self.logger.debug.apply(self.logger, arguments);
+      debug(...args) {
+        self.logger.debug(...self.convertLegacyLogPayload(args));
       },
       // Log a warning. The default implementation wraps
       // `console.warn` and passes on all arguments,
@@ -578,8 +579,8 @@ module.exports = {
       // The intention is that `apos.util.warn` should be
       // called for situations less dire than
       // `apos.util.error`.
-      warn(msg) {
-        self.logger.warn.apply(self.logger, arguments);
+      warn(...args) {
+        self.logger.warn(...self.convertLegacyLogPayload(args));
       },
 
       // Identical to `apos.util.warn`, except that the warning is
@@ -629,8 +630,8 @@ module.exports = {
       // Overrides should be written with support for
       // substitution strings in mind. See the
       // `console.error` documentation.
-      error(msg) {
-        self.logger.error.apply(self.logger, arguments);
+      error(...args) {
+        self.logger.error(...self.convertLegacyLogPayload(args));
       },
       // Performance profiling method. At the start of the operation you want
       // to profile, call with req (may be null or omitted entirely) and a
@@ -835,6 +836,46 @@ module.exports = {
       },
       omit(source, keys) {
         return _.omit(source, keys);
+      },
+
+      // Internal method. Attempt to convert the log payload to an object
+      // for legacy calls and when `@apostrophecms/log` has been configured
+      // with `messageAs: 'someKey'`.
+      // This change is backwards compatible with the previous behavior because
+      // `messageAs` is newly introduced option. Custom loggers should adapt
+      // to this change when using `messageAs`.
+      // `args` is the argument array passed to the any log method.
+      // The result (when required) is an array with a single object.
+      // First string argument (if available) is used as `message`.
+      // First object argument is used as result object.
+      // All other arguments are passed as `args` property of the result object.
+      convertLegacyLogPayload(args) {
+        const messageAs = self.apos.structuredLog.options.messageAs;
+        if (!messageAs || args.length === 0) {
+          return args;
+        }
+        // Already formatted by the structured log module. Nothing we can do if not.
+        if (args.length === 1 && _.isPlainObject(args[0])) {
+          return args;
+        }
+
+        // Should also handle apos.util.warnDev() calls.
+        const messageIndex = args
+          .findIndex(arg => typeof arg === 'string' && arg.trim() && arg !== '\n⚠️ ');
+        const firstObjectIndex = args.findIndex(arg => _.isPlainObject(arg));
+        const message = messageIndex !== -1 ? args[messageIndex] : null;
+        const firstObject = firstObjectIndex !== -1 ? { ...args[firstObjectIndex] } : {};
+
+        if (message) {
+          firstObject[messageAs] = message;
+        }
+        const rest = args
+          .filter((arg, index) => ![ messageIndex, firstObjectIndex ].includes(index));
+        if (rest.length) {
+          firstObject.args = rest;
+        }
+
+        return [ firstObject ];
       }
     };
   },

--- a/modules/@apostrophecms/util/lib/logger.js
+++ b/modules/@apostrophecms/util/lib/logger.js
@@ -1,7 +1,9 @@
 // Default logger. You may pass an alternate implementation
 // as the `logger` top-level option when configuring Apostrophe.
 
-module.exports = function(apos) {
+module.exports = function (apos) {
+  const logModule = apos.structuredLog;
+
   return {
     // Log a message. The default
     // implementation wraps `console.log` and passes on
@@ -11,9 +13,9 @@ module.exports = function(apos) {
     // substitution strings in mind. See the
     // `console.log` documentation.
 
-    log: function(msg) {
+    log: function(...args) {
       // eslint-disable-next-line no-console
-      console.log.apply(console, arguments);
+      console.log(...logModule.formatLogByEnv(args));
     },
 
     // Log an informational message.
@@ -22,9 +24,9 @@ module.exports = function(apos) {
     // substitution strings in mind. See the
     // `console.log` documentation.
 
-    info: function(msg) {
+    info: function(...args) {
       // eslint-disable-next-line no-console
-      console.info.apply(console, arguments);
+      console.info(...logModule.formatLogByEnv(args));
     },
 
     // Log a debug message. Invokes
@@ -35,14 +37,14 @@ module.exports = function(apos) {
     // substitution strings in mind. See the
     // `console.log` documentation.
 
-    debug: function(msg) {
+    debug: function(...args) {
       // eslint-disable-next-line no-console
       if (console.debug) {
         // eslint-disable-next-line no-console
-        console.debug.apply(console, arguments);
+        console.debug(...logModule.formatLogByEnv(args));
       } else {
         // eslint-disable-next-line no-console
-        console.log.apply(console, arguments);
+        console.log(...logModule.formatLogByEnv(args));
       }
     },
 
@@ -54,9 +56,9 @@ module.exports = function(apos) {
     // substitution strings in mind. See the
     // `console.error` documentation.
 
-    error: function(msg) {
+    error: function(...args) {
       // eslint-disable-next-line no-console
-      console.error.apply(console, arguments);
+      console.error(...logModule.formatLogByEnv(args));
     },
     // Log a warning. The default implementation wraps
     // `console.warn` and passes on all arguments,
@@ -70,9 +72,9 @@ module.exports = function(apos) {
     // called for situations less dire than
     // `apos.util.error`.
 
-    warn: function(msg) {
+    warn: function(...args) {
       // eslint-disable-next-line no-console
-      console.warn.apply(console, arguments);
+      console.warn(...logModule.formatLogByEnv(args));
     }
   };
 };

--- a/modules/@apostrophecms/util/lib/logger.js
+++ b/modules/@apostrophecms/util/lib/logger.js
@@ -39,13 +39,7 @@ module.exports = function (apos) {
 
     debug: function(...args) {
       // eslint-disable-next-line no-console
-      if (console.debug) {
-        // eslint-disable-next-line no-console
-        console.debug(...logModule.formatLogByEnv(args));
-      } else {
-        // eslint-disable-next-line no-console
-        console.log(...logModule.formatLogByEnv(args));
-      }
+      console.debug(...logModule.formatLogByEnv(args));
     },
 
     // Log an error message. The default implementation
@@ -77,7 +71,7 @@ module.exports = function (apos) {
       console.warn(...logModule.formatLogByEnv(args));
     },
 
-    // Automatically tear down if available.
+    // Automatically tear down the logger if available.
 
     async destroy() {
       // Nothing to do

--- a/modules/@apostrophecms/util/lib/logger.js
+++ b/modules/@apostrophecms/util/lib/logger.js
@@ -75,6 +75,12 @@ module.exports = function (apos) {
     warn: function(...args) {
       // eslint-disable-next-line no-console
       console.warn(...logModule.formatLogByEnv(args));
+    },
+
+    // Automatically tear down if available.
+
+    async destroy() {
+      // Nothing to do
     }
   };
 };

--- a/test/log.js
+++ b/test/log.js
@@ -15,7 +15,7 @@ describe('structured logging', function () {
 
   let apos;
 
-  after(async function () {
+  after(function () {
     return t.destroy(apos);
   });
 
@@ -27,6 +27,11 @@ describe('structured logging', function () {
       });
     });
 
+    after(async function () {
+      await t.destroy(apos);
+      apos = null;
+    });
+
     it('should register structured log and module log handlers', function () {
       assert(apos.structuredLog);
       assert(apos.testModule);
@@ -34,13 +39,117 @@ describe('structured logging', function () {
       assert.equal(typeof apos.testModule.logInfo, 'function');
       assert.equal(typeof apos.testModule.logWarn, 'function');
       assert.equal(typeof apos.testModule.logError, 'function');
+      assert.deepEqual(apos.structuredLog.filters, {
+        '*': { severity: [ 'debug', 'info', 'warn', 'error' ] }
+      });
     });
 
     it('should format entries', function () {
-      // apos.structuredLog.
+      // id spy
+      const id = apos.util.generateId;
+      apos.util.generateId = () => 'test-id';
+      let savedArgs = [];
+
+      // ### DEBUG
+      const debug = console.debug;
+      console.debug = (...args) => {
+        savedArgs = args;
+      };
+
+      // Validate formatting
+      savedArgs = [];
+      apos.testModule.logDebug('event-type');
+      assert.equal(savedArgs[0], 'test-module: event-type\n');
+      assert.equal(
+        savedArgs[1],
+`{
+  "type": "event-type",
+  "severity": "debug",
+  "module": "test-module"
+}`
+      );
+
+      // Message as
+      savedArgs = [];
+      apos.structuredLog.options.messageAs = 'msg';
+      apos.testModule.logDebug('event-type', 'some message');
+      assert.equal(
+        savedArgs[0],
+`{
+  "type": "event-type",
+  "severity": "debug",
+  "module": "test-module",
+  "msg": "test-module: event-type: some message"
+}`
+      );
+      assert.equal(typeof savedArgs[1], 'undefined');
+      delete apos.structuredLog.options.messageAs;
+
+      // ### INFO
+      const info = console.info;
+      console.info = (...args) => {
+        savedArgs = args;
+      };
+
+      // Validate formatting
+      savedArgs = [];
+      apos.testModule.logInfo('event-type');
+      assert.equal(savedArgs[0], 'test-module: event-type\n');
+      assert.equal(
+        savedArgs[1],
+`{
+  "type": "event-type",
+  "severity": "info",
+  "module": "test-module"
+}`
+      );
+
+      // ### WARN
+      const warn = console.warn;
+      console.warn = (...args) => {
+        savedArgs = args;
+      };
+
+      // Validate formatting
+      savedArgs = [];
+      apos.testModule.logWarn('event-type');
+      assert.equal(savedArgs[0], 'test-module: event-type\n');
+      assert.equal(
+        savedArgs[1],
+`{
+  "type": "event-type",
+  "severity": "warn",
+  "module": "test-module"
+}`
+      );
+
+      // ### ERROR
+      const error = console.error;
+      console.error = (...args) => {
+        savedArgs = args;
+      };
+
+      // Validate formatting
+      savedArgs = [];
+      apos.testModule.logError('event-type');
+      assert.equal(savedArgs[0], 'test-module: event-type\n');
+      assert.equal(
+        savedArgs[1],
+`{
+  "type": "event-type",
+  "severity": "error",
+  "module": "test-module"
+}`
+      );
+
+      apos.util.generateId = id;
+      console.debug = debug;
+      console.info = info;
+      console.warn = warn;
+      console.error = error;
     });
 
-    it.only('should log formatted entry: logDebug', function () {
+    it('should log formatted entry: logDebug', function () {
       // id spy
       const id = apos.util.generateId;
       apos.util.generateId = () => 'test-id';
@@ -189,6 +298,342 @@ describe('structured logging', function () {
 
       apos.util.logger.debug = debug;
       apos.util.generateId = id;
+    });
+
+    it('should log formatted entry: logInfo', function () {
+      // id spy
+      const id = apos.util.generateId;
+      apos.util.generateId = () => 'test-id';
+
+      // debug spy
+      const info = apos.util.logger.info;
+      let savedArgs = [];
+      apos.util.logger.info = (...args) => {
+        savedArgs = args;
+      };
+
+      // Validate
+      assert.throws(() => {
+        apos.testModule.logInfo();
+      }, function (err) {
+        assert.equal(err.message, 'Event type must be a string');
+        return true;
+      });
+
+      // Format
+      apos.testModule.logInfo('event-type', 'a message', { foo: 'bar' });
+      assert.equal(savedArgs[0], 'test-module: event-type: a message');
+      assert.deepEqual(savedArgs[1], {
+        type: 'event-type',
+        severity: 'info',
+        module: 'test-module',
+        foo: 'bar'
+      });
+
+      apos.testModule.logInfo(apos.task.getReq({
+        originalUrl: '/module/test',
+        path: '/test',
+        ip: '1.2.3.4',
+        query: { foo: 'bar' }
+      }), 'event-type', 'some message', { foo: 'bar' });
+      assert.equal(savedArgs[0], 'test-module: event-type: some message');
+      assert.deepEqual(savedArgs[1], {
+        url: '/module/test',
+        path: '/test',
+        ip: '1.2.3.4',
+        query: { foo: 'bar' },
+        requestId: 'test-id',
+        type: 'event-type',
+        severity: 'info',
+        module: 'test-module',
+        foo: 'bar'
+      });
+
+      apos.util.logger.info = info;
+      apos.util.generateId = id;
+    });
+
+    it('should log formatted entry: logWarn', function () {
+      // id spy
+      const id = apos.util.generateId;
+      apos.util.generateId = () => 'test-id';
+
+      // debug spy
+      const warn = apos.util.logger.warn;
+      let savedArgs = [];
+      apos.util.logger.warn = (...args) => {
+        savedArgs = args;
+      };
+
+      // Validate
+      assert.throws(() => {
+        apos.testModule.logWarn();
+      }, function (err) {
+        assert.equal(err.message, 'Event type must be a string');
+        return true;
+      });
+
+      // Format
+      apos.testModule.logWarn('event-type', 'a message', { foo: 'bar' });
+      assert.equal(savedArgs[0], 'test-module: event-type: a message');
+      assert.deepEqual(savedArgs[1], {
+        type: 'event-type',
+        severity: 'warn',
+        module: 'test-module',
+        foo: 'bar'
+      });
+
+      apos.testModule.logWarn(apos.task.getReq({
+        originalUrl: '/module/test',
+        path: '/test',
+        ip: '1.2.3.4',
+        query: { foo: 'bar' }
+      }), 'event-type', 'some message', { foo: 'bar' });
+      assert.equal(savedArgs[0], 'test-module: event-type: some message');
+      assert.deepEqual(savedArgs[1], {
+        url: '/module/test',
+        path: '/test',
+        ip: '1.2.3.4',
+        query: { foo: 'bar' },
+        requestId: 'test-id',
+        type: 'event-type',
+        severity: 'warn',
+        module: 'test-module',
+        foo: 'bar'
+      });
+
+      apos.util.logger.warn = warn;
+      apos.util.generateId = id;
+    });
+
+    it('should log formatted entry: logError', function () {
+      // id spy
+      const id = apos.util.generateId;
+      apos.util.generateId = () => 'test-id';
+
+      // debug spy
+      const error = apos.util.logger.error;
+      let savedArgs = [];
+      apos.util.logger.error = (...args) => {
+        savedArgs = args;
+      };
+
+      // Validate
+      assert.throws(() => {
+        apos.testModule.logError();
+      }, function (err) {
+        assert.equal(err.message, 'Event type must be a string');
+        return true;
+      });
+
+      // Format
+      apos.testModule.logError('event-type', 'a message', { foo: 'bar' });
+      assert.equal(savedArgs[0], 'test-module: event-type: a message');
+      assert.deepEqual(savedArgs[1], {
+        type: 'event-type',
+        severity: 'error',
+        module: 'test-module',
+        foo: 'bar'
+      });
+
+      apos.testModule.logError(apos.task.getReq({
+        originalUrl: '/module/test',
+        path: '/test',
+        ip: '1.2.3.4',
+        query: { foo: 'bar' }
+      }), 'event-type', 'some message', { foo: 'bar' });
+      assert.equal(savedArgs[0], 'test-module: event-type: some message');
+      assert.deepEqual(savedArgs[1], {
+        url: '/module/test',
+        path: '/test',
+        ip: '1.2.3.4',
+        query: { foo: 'bar' },
+        requestId: 'test-id',
+        type: 'event-type',
+        severity: 'error',
+        module: 'test-module',
+        foo: 'bar'
+      });
+
+      apos.util.logger.error = error;
+      apos.util.generateId = id;
+    });
+
+    it.only('should filter entries', async function () {
+      await t.destroy(apos);
+      apos = await t.create({
+        modules: {
+          ...testModule,
+          '@apostrophecms/log': {
+            options: {
+              filter: {
+                '*': {
+                  severity: [ 'error' ],
+                  events: [ 'type1' ]
+                },
+                'test-module': {
+                  severity: [ 'debug' ],
+                  events: [ 'type2' ]
+                }
+              }
+            }
+          }
+        }
+      });
+
+      assert.deepEqual(apos.structuredLog.filters, {
+        '*': {
+          severity: [ 'error' ],
+          events: [ 'type1' ]
+        },
+        'test-module': {
+          severity: [ 'debug' ],
+          events: [ 'type2' ]
+        }
+      });
+
+      let savedArgs = [];
+      const debug = apos.util.logger.debug;
+      apos.util.logger.debug = (...args) => {
+        savedArgs = args;
+      };
+      const info = apos.util.logger.info;
+      apos.util.logger.info = (...args) => {
+        savedArgs = args;
+      };
+      const warn = apos.util.logger.warn;
+      apos.util.logger.warn = (...args) => {
+        savedArgs = args;
+      };
+      const error = apos.util.logger.error;
+      apos.util.logger.error = (...args) => {
+        savedArgs = args;
+      };
+
+      // ### DEBUG
+      apos.global.logDebug('type2');
+      assert.deepEqual(savedArgs, []);
+
+      savedArgs = [];
+      apos.global.logDebug('type1');
+      console.log(savedArgs);
+
+    });
+  });
+
+  describe('production', function () {
+    before(async function () {
+      process.env.NODE_ENV = 'production';
+      apos = await t.create({
+        modules: { ...testModule }
+      });
+    });
+
+    after(async function () {
+      delete process.env.NODE_ENV;
+      await t.destroy(apos);
+      apos = null;
+    });
+
+    it('should set filter configuration', function () {
+      assert.deepEqual(apos.structuredLog.filters, {
+        '*': { severity: [ 'warn', 'error' ] }
+      });
+    });
+
+    it('should filter and format entries', function () {
+      // id spy
+      const id = apos.util.generateId;
+      apos.util.generateId = () => 'test-id';
+      let savedArgs = [];
+
+      // ### DEBUG
+      const debug = console.debug;
+      console.debug = (...args) => {
+        savedArgs = args;
+      };
+
+      // Validate formatting
+      savedArgs = [];
+      apos.testModule.logDebug('event-type');
+      assert.equal(typeof savedArgs[0], 'undefined');
+      assert.equal(typeof savedArgs[1], 'undefined');
+
+      // Message as
+      savedArgs = [];
+      apos.structuredLog.options.messageAs = 'msg';
+      apos.testModule.logDebug('event-type', 'some message');
+      assert.equal(typeof savedArgs[0], 'undefined');
+      assert.equal(typeof savedArgs[1], 'undefined');
+      delete apos.structuredLog.options.messageAs;
+
+      // ### INFO
+      const info = console.info;
+      console.info = (...args) => {
+        savedArgs = args;
+      };
+
+      // Validate formatting
+      savedArgs = [];
+      apos.testModule.logInfo('event-type');
+      assert.equal(typeof savedArgs[0], 'undefined');
+      assert.equal(typeof savedArgs[1], 'undefined');
+
+      // ### WARN
+      const warn = console.warn;
+      console.warn = (...args) => {
+        savedArgs = args;
+      };
+
+      // Validate formatting
+      savedArgs = [];
+      apos.testModule.logWarn('event-type');
+      assert.equal(savedArgs[0], 'test-module: event-type');
+      assert.equal(
+        savedArgs[1],
+        '{"type":"event-type","severity":"warn","module":"test-module"}'
+      );
+
+      // ### ERROR
+      const error = console.error;
+      console.error = (...args) => {
+        savedArgs = args;
+      };
+
+      // Validate formatting
+      savedArgs = [];
+      apos.testModule.logError('event-type');
+      assert.equal(savedArgs[0], 'test-module: event-type');
+      assert.equal(
+        savedArgs[1],
+        '{"type":"event-type","severity":"error","module":"test-module"}'
+      );
+
+      apos.util.generateId = id;
+      console.debug = debug;
+      console.info = info;
+      console.warn = warn;
+      console.error = error;
+    });
+
+    it('should override default filter configuration', async function () {
+      await t.destroy(apos);
+      apos = await t.create({
+        modules: {
+          ...testModule,
+          '@apostrophecms/log': {
+            options: {
+              filter: {
+                '*': { severity: [ 'info', 'warn', 'error' ] }
+              }
+            }
+          }
+        }
+      });
+
+      assert.deepEqual(apos.structuredLog.filters, {
+        '*': { severity: [ 'info', 'warn', 'error' ] }
+      });
     });
   });
 });

--- a/test/log.js
+++ b/test/log.js
@@ -44,7 +44,7 @@ describe('structured logging', function () {
       });
     });
 
-    it('should format entries', function () {
+    it('should format entries for readability', function () {
       // id spy
       const id = apos.util.generateId;
       apos.util.generateId = () => 'test-id';
@@ -63,9 +63,9 @@ describe('structured logging', function () {
       assert.equal(
         savedArgs[1],
 `{
+  "module": "test-module",
   "type": "event-type",
-  "severity": "debug",
-  "module": "test-module"
+  "severity": "debug"
 }`
       );
 
@@ -76,10 +76,10 @@ describe('structured logging', function () {
       assert.equal(
         savedArgs[0],
 `{
-  "type": "event-type",
-  "severity": "debug",
+  "msg": "test-module: event-type: some message",
   "module": "test-module",
-  "msg": "test-module: event-type: some message"
+  "type": "event-type",
+  "severity": "debug"
 }`
       );
       assert.equal(typeof savedArgs[1], 'undefined');
@@ -98,9 +98,9 @@ describe('structured logging', function () {
       assert.equal(
         savedArgs[1],
 `{
+  "module": "test-module",
   "type": "event-type",
-  "severity": "info",
-  "module": "test-module"
+  "severity": "info"
 }`
       );
 
@@ -117,9 +117,9 @@ describe('structured logging', function () {
       assert.equal(
         savedArgs[1],
 `{
+  "module": "test-module",
   "type": "event-type",
-  "severity": "warn",
-  "module": "test-module"
+  "severity": "warn"
 }`
       );
 
@@ -136,11 +136,74 @@ describe('structured logging', function () {
       assert.equal(
         savedArgs[1],
 `{
+  "module": "test-module",
   "type": "event-type",
-  "severity": "error",
-  "module": "test-module"
+  "severity": "error"
 }`
       );
+
+      // With req
+      savedArgs = [];
+      apos.testModule.logError(
+        apos.task.getReq({
+          originalUrl: '/module/test',
+          path: '/test',
+          method: 'GET',
+          ip: '1.2.3.4',
+          query: { foo: 'bar' }
+        }),
+        'event-type'
+      );
+      assert.equal(savedArgs[0], 'test-module: event-type\n');
+      assert.equal(
+        savedArgs[1],
+`{
+  "module": "test-module",
+  "type": "event-type",
+  "severity": "error",
+  "url": "/module/test",
+  "path": "/test",
+  "method": "GET",
+  "ip": "1.2.3.4",
+  "query": {
+    "foo": "bar"
+  },
+  "requestId": "test-id"
+}`
+      );
+
+      // With req and message as
+      savedArgs = [];
+      apos.structuredLog.options.messageAs = 'message';
+      apos.testModule.logError(
+        apos.task.getReq({
+          originalUrl: '/module/test',
+          path: '/test',
+          method: 'GET',
+          ip: '1.2.3.4',
+          query: { foo: 'bar' }
+        }),
+        'event-type'
+      );
+      assert.equal(savedArgs.length, 1);
+      assert.equal(
+        savedArgs[0],
+`{
+  "message": "test-module: event-type",
+  "module": "test-module",
+  "type": "event-type",
+  "severity": "error",
+  "url": "/module/test",
+  "path": "/test",
+  "method": "GET",
+  "ip": "1.2.3.4",
+  "query": {
+    "foo": "bar"
+  },
+  "requestId": "test-id"
+}`
+      );
+      delete apos.structuredLog.options.messageAs;
 
       apos.util.generateId = id;
       console.debug = debug;
@@ -225,6 +288,7 @@ describe('structured logging', function () {
       apos.testModule.logDebug(apos.task.getReq({
         originalUrl: '/module/test',
         path: '/test',
+        method: 'GET',
         ip: '1.2.3.4',
         query: { foo: 'bar' }
       }), 'event-type');
@@ -232,6 +296,7 @@ describe('structured logging', function () {
       assert.deepEqual(savedArgs[1], {
         url: '/module/test',
         path: '/test',
+        method: 'GET',
         ip: '1.2.3.4',
         query: { foo: 'bar' },
         requestId: 'test-id',
@@ -243,6 +308,7 @@ describe('structured logging', function () {
       apos.testModule.logDebug(apos.task.getReq({
         originalUrl: '/module/test',
         path: '/test',
+        method: 'GET',
         ip: '1.2.3.4',
         query: { foo: 'bar' }
       }), 'event-type', 'some message');
@@ -250,6 +316,7 @@ describe('structured logging', function () {
       assert.deepEqual(savedArgs[1], {
         url: '/module/test',
         path: '/test',
+        method: 'GET',
         ip: '1.2.3.4',
         query: { foo: 'bar' },
         requestId: 'test-id',
@@ -261,6 +328,7 @@ describe('structured logging', function () {
       apos.testModule.logDebug(apos.task.getReq({
         originalUrl: '/module/test',
         path: '/test',
+        method: 'GET',
         ip: '1.2.3.4',
         query: { foo: 'bar' }
       }), 'event-type', 'some message', { foo: 'bar' });
@@ -268,6 +336,7 @@ describe('structured logging', function () {
       assert.deepEqual(savedArgs[1], {
         url: '/module/test',
         path: '/test',
+        method: 'GET',
         ip: '1.2.3.4',
         query: { foo: 'bar' },
         requestId: 'test-id',
@@ -280,6 +349,7 @@ describe('structured logging', function () {
       apos.testModule.logDebug(apos.task.getReq({
         originalUrl: '/module/test',
         path: '/test',
+        method: 'GET',
         ip: '1.2.3.4',
         query: { foo: 'bar' }
       }), 'event-type', { foo: 'bar' });
@@ -287,6 +357,7 @@ describe('structured logging', function () {
       assert.deepEqual(savedArgs[1], {
         url: '/module/test',
         path: '/test',
+        method: 'GET',
         ip: '1.2.3.4',
         query: { foo: 'bar' },
         requestId: 'test-id',
@@ -333,6 +404,7 @@ describe('structured logging', function () {
       apos.testModule.logInfo(apos.task.getReq({
         originalUrl: '/module/test',
         path: '/test',
+        method: 'GET',
         ip: '1.2.3.4',
         query: { foo: 'bar' }
       }), 'event-type', 'some message', { foo: 'bar' });
@@ -340,6 +412,7 @@ describe('structured logging', function () {
       assert.deepEqual(savedArgs[1], {
         url: '/module/test',
         path: '/test',
+        method: 'GET',
         ip: '1.2.3.4',
         query: { foo: 'bar' },
         requestId: 'test-id',
@@ -386,6 +459,7 @@ describe('structured logging', function () {
       apos.testModule.logWarn(apos.task.getReq({
         originalUrl: '/module/test',
         path: '/test',
+        method: 'GET',
         ip: '1.2.3.4',
         query: { foo: 'bar' }
       }), 'event-type', 'some message', { foo: 'bar' });
@@ -393,6 +467,7 @@ describe('structured logging', function () {
       assert.deepEqual(savedArgs[1], {
         url: '/module/test',
         path: '/test',
+        method: 'GET',
         ip: '1.2.3.4',
         query: { foo: 'bar' },
         requestId: 'test-id',
@@ -439,6 +514,7 @@ describe('structured logging', function () {
       apos.testModule.logError(apos.task.getReq({
         originalUrl: '/module/test',
         path: '/test',
+        method: 'GET',
         ip: '1.2.3.4',
         query: { foo: 'bar' }
       }), 'event-type', 'some message', { foo: 'bar' });
@@ -446,6 +522,7 @@ describe('structured logging', function () {
       assert.deepEqual(savedArgs[1], {
         url: '/module/test',
         path: '/test',
+        method: 'GET',
         ip: '1.2.3.4',
         query: { foo: 'bar' },
         requestId: 'test-id',
@@ -781,6 +858,20 @@ describe('structured logging', function () {
       apos.util.logger.warn = warn;
       apos.util.logger.error = error;
     });
+
+    it('it should shutdown logger', async function () {
+      await t.destroy(apos);
+      apos = await t.create({});
+
+      let called = false;
+      apos.util.logger.destroy = async () => {
+        called = true;
+      };
+      await t.destroy(apos);
+      apos = null;
+
+      assert.equal(called, true);
+    });
   });
 
   describe('production', function () {
@@ -853,7 +944,7 @@ describe('structured logging', function () {
       assert.equal(savedArgs[0], 'test-module: event-type');
       assert.equal(
         savedArgs[1],
-        '{"type":"event-type","severity":"warn","module":"test-module"}'
+        '{"module":"test-module","type":"event-type","severity":"warn"}'
       );
 
       // ### ERROR
@@ -868,7 +959,7 @@ describe('structured logging', function () {
       assert.equal(savedArgs[0], 'test-module: event-type');
       assert.equal(
         savedArgs[1],
-        '{"type":"event-type","severity":"error","module":"test-module"}'
+        '{"module":"test-module","type":"event-type","severity":"error"}'
       );
 
       apos.util.generateId = id;

--- a/test/log.js
+++ b/test/log.js
@@ -1,0 +1,194 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert/strict');
+
+const testModule = {
+  'test-module': {
+    options: {
+      alias: 'testModule'
+    },
+    init() { }
+  }
+};
+
+describe('structured logging', function () {
+  this.timeout(t.timeout);
+
+  let apos;
+
+  after(async function () {
+    return t.destroy(apos);
+  });
+
+  describe('defaults', function () {
+
+    before(async function () {
+      apos = await t.create({
+        modules: { ...testModule }
+      });
+    });
+
+    it('should register structured log and module log handlers', function () {
+      assert(apos.structuredLog);
+      assert(apos.testModule);
+      assert.equal(typeof apos.testModule.logDebug, 'function');
+      assert.equal(typeof apos.testModule.logInfo, 'function');
+      assert.equal(typeof apos.testModule.logWarn, 'function');
+      assert.equal(typeof apos.testModule.logError, 'function');
+    });
+
+    it('should format entries', function () {
+      // apos.structuredLog.
+    });
+
+    it.only('should log formatted entry: logDebug', function () {
+      // id spy
+      const id = apos.util.generateId;
+      apos.util.generateId = () => 'test-id';
+
+      // debug spy
+      const debug = apos.util.logger.debug;
+      let savedArgs = [];
+      apos.util.logger.debug = (...args) => {
+        savedArgs = args;
+      };
+
+      // Validate
+      assert.throws(() => {
+        apos.testModule.logDebug();
+      }, function (err) {
+        assert.equal(err.message, 'Event type must be a string');
+        return true;
+      });
+      assert.throws(() => {
+        apos.testModule.logDebug(apos.task.getReq());
+      }, function (err) {
+        assert.equal(err.message, 'Event type must be a string');
+        return true;
+      });
+      assert.throws(() => {
+        apos.testModule.logDebug(null);
+      }, function (err) {
+        assert.equal(err.message, 'Event type must be a string');
+        return true;
+      });
+      assert.throws(() => {
+        apos.testModule.logDebug(1);
+      }, function (err) {
+        assert.equal(err.message, 'Event type must be a string');
+        return true;
+      });
+
+      // Format
+      apos.testModule.logDebug('event-type');
+      assert.equal(savedArgs[0], 'test-module: event-type');
+      assert.deepEqual(savedArgs[1], {
+        type: 'event-type',
+        severity: 'debug',
+        module: 'test-module'
+      });
+
+      apos.testModule.logDebug('event-type', 'a message');
+      assert.equal(savedArgs[0], 'test-module: event-type: a message');
+      assert.deepEqual(savedArgs[1], {
+        type: 'event-type',
+        severity: 'debug',
+        module: 'test-module'
+      });
+
+      apos.testModule.logDebug('event-type', 'a message', { foo: 'bar' });
+      assert.equal(savedArgs[0], 'test-module: event-type: a message');
+      assert.deepEqual(savedArgs[1], {
+        type: 'event-type',
+        severity: 'debug',
+        module: 'test-module',
+        foo: 'bar'
+      });
+
+      apos.testModule.logDebug('event-type', { foo: 'bar' });
+      assert.equal(savedArgs[0], 'test-module: event-type');
+      assert.deepEqual(savedArgs[1], {
+        type: 'event-type',
+        severity: 'debug',
+        module: 'test-module',
+        foo: 'bar'
+      });
+
+      apos.testModule.logDebug(apos.task.getReq({
+        originalUrl: '/module/test',
+        path: '/test',
+        ip: '1.2.3.4',
+        query: { foo: 'bar' }
+      }), 'event-type');
+      assert.equal(savedArgs[0], 'test-module: event-type');
+      assert.deepEqual(savedArgs[1], {
+        url: '/module/test',
+        path: '/test',
+        ip: '1.2.3.4',
+        query: { foo: 'bar' },
+        requestId: 'test-id',
+        type: 'event-type',
+        severity: 'debug',
+        module: 'test-module'
+      });
+
+      apos.testModule.logDebug(apos.task.getReq({
+        originalUrl: '/module/test',
+        path: '/test',
+        ip: '1.2.3.4',
+        query: { foo: 'bar' }
+      }), 'event-type', 'some message');
+      assert.equal(savedArgs[0], 'test-module: event-type: some message');
+      assert.deepEqual(savedArgs[1], {
+        url: '/module/test',
+        path: '/test',
+        ip: '1.2.3.4',
+        query: { foo: 'bar' },
+        requestId: 'test-id',
+        type: 'event-type',
+        severity: 'debug',
+        module: 'test-module'
+      });
+
+      apos.testModule.logDebug(apos.task.getReq({
+        originalUrl: '/module/test',
+        path: '/test',
+        ip: '1.2.3.4',
+        query: { foo: 'bar' }
+      }), 'event-type', 'some message', { foo: 'bar' });
+      assert.equal(savedArgs[0], 'test-module: event-type: some message');
+      assert.deepEqual(savedArgs[1], {
+        url: '/module/test',
+        path: '/test',
+        ip: '1.2.3.4',
+        query: { foo: 'bar' },
+        requestId: 'test-id',
+        type: 'event-type',
+        severity: 'debug',
+        module: 'test-module',
+        foo: 'bar'
+      });
+
+      apos.testModule.logDebug(apos.task.getReq({
+        originalUrl: '/module/test',
+        path: '/test',
+        ip: '1.2.3.4',
+        query: { foo: 'bar' }
+      }), 'event-type', { foo: 'bar' });
+      assert.equal(savedArgs[0], 'test-module: event-type');
+      assert.deepEqual(savedArgs[1], {
+        url: '/module/test',
+        path: '/test',
+        ip: '1.2.3.4',
+        query: { foo: 'bar' },
+        requestId: 'test-id',
+        type: 'event-type',
+        severity: 'debug',
+        module: 'test-module',
+        foo: 'bar'
+      });
+
+      apos.util.logger.debug = debug;
+      apos.util.generateId = id;
+    });
+  });
+});

--- a/test/log.js
+++ b/test/log.js
@@ -961,4 +961,280 @@ describe('structured logging', function () {
       });
     });
   });
+
+  describe('legacy logging with :messageAs"', function () {
+    before(async function () {
+      await t.destroy(apos);
+      apos = await t.create({
+        modules: {
+          '@apostrophecms/log': {
+            options: {
+              messageAs: 'msg'
+            }
+          }
+        }
+      });
+    });
+
+    after(async function () {
+      delete process.env.APOS_FILTER_LOGS;
+      await t.destroy(apos);
+      apos = null;
+    });
+
+    it('should log object: debug', function () {
+      let savedArgs = [];
+      const saved = apos.util.logger.debug;
+      apos.util.logger.debug = (...args) => {
+        savedArgs = args;
+      };
+
+      savedArgs = [];
+      apos.util.debug('some message');
+      assert.deepEqual(savedArgs, [ { msg: 'some message' } ]);
+
+      savedArgs = [];
+      apos.util.debug({ foo: 'bar' });
+      assert.deepEqual(savedArgs, [ { foo: 'bar' } ]);
+
+      savedArgs = [];
+      apos.util.debug('some message', { foo: 'bar' });
+      assert.deepEqual(savedArgs, [ {
+        foo: 'bar',
+        msg: 'some message'
+      } ]);
+
+      savedArgs = [];
+      apos.util.debug('some message', 'more', { foo: 'bar' });
+      assert.deepEqual(savedArgs, [ {
+        foo: 'bar',
+        msg: 'some message',
+        args: [ 'more' ]
+      } ]);
+
+      savedArgs = [];
+      apos.util.debug({ foo: 'bar' }, 'some message', 'more');
+      assert.deepEqual(savedArgs, [ {
+        foo: 'bar',
+        msg: 'some message',
+        args: [ 'more' ]
+      } ]);
+
+      apos.util.logger.debug = saved;
+    });
+
+    it('should log object: log', function () {
+      let savedArgs = [];
+      const saved = apos.util.logger.log;
+      apos.util.logger.log = (...args) => {
+        savedArgs = args;
+      };
+
+      savedArgs = [];
+      apos.util.log('some message');
+      assert.deepEqual(savedArgs, [ { msg: 'some message' } ]);
+
+      savedArgs = [];
+      apos.util.log({ foo: 'bar' });
+      assert.deepEqual(savedArgs, [ { foo: 'bar' } ]);
+
+      savedArgs = [];
+      apos.util.log('some message', { foo: 'bar' });
+      assert.deepEqual(savedArgs, [ {
+        foo: 'bar',
+        msg: 'some message'
+      } ]);
+
+      savedArgs = [];
+      apos.util.log('some message', 'more', { foo: 'bar' });
+      assert.deepEqual(savedArgs, [ {
+        foo: 'bar',
+        msg: 'some message',
+        args: [ 'more' ]
+      } ]);
+
+      savedArgs = [];
+      apos.util.log({ foo: 'bar' }, 'some message', 'more');
+      assert.deepEqual(savedArgs, [ {
+        foo: 'bar',
+        msg: 'some message',
+        args: [ 'more' ]
+      } ]);
+
+      apos.util.logger.log = saved;
+    });
+
+    it('should log object: info', function () {
+      let savedArgs = [];
+      const saved = apos.util.logger.info;
+      apos.util.logger.info = (...args) => {
+        savedArgs = args;
+      };
+
+      savedArgs = [];
+      apos.util.info('some message');
+      assert.deepEqual(savedArgs, [ { msg: 'some message' } ]);
+
+      savedArgs = [];
+      apos.util.info({ foo: 'bar' });
+      assert.deepEqual(savedArgs, [ { foo: 'bar' } ]);
+
+      savedArgs = [];
+      apos.util.info('some message', { foo: 'bar' });
+      assert.deepEqual(savedArgs, [ {
+        foo: 'bar',
+        msg: 'some message'
+      } ]);
+
+      savedArgs = [];
+      apos.util.info('some message', 'more', { foo: 'bar' });
+      assert.deepEqual(savedArgs, [ {
+        foo: 'bar',
+        msg: 'some message',
+        args: [ 'more' ]
+      } ]);
+
+      savedArgs = [];
+      apos.util.info({ foo: 'bar' }, 'some message', 'more');
+      assert.deepEqual(savedArgs, [ {
+        foo: 'bar',
+        msg: 'some message',
+        args: [ 'more' ]
+      } ]);
+
+      apos.util.logger.info = saved;
+    });
+
+    it('should log object: warn', function () {
+      let savedArgs = [];
+      const saved = apos.util.logger.warn;
+      apos.util.logger.warn = (...args) => {
+        savedArgs = args;
+      };
+
+      savedArgs = [];
+      apos.util.warn('some message');
+      assert.deepEqual(savedArgs, [ { msg: 'some message' } ]);
+
+      savedArgs = [];
+      apos.util.warn({ foo: 'bar' });
+      assert.deepEqual(savedArgs, [ { foo: 'bar' } ]);
+
+      savedArgs = [];
+      apos.util.warn('some message', { foo: 'bar' });
+      assert.deepEqual(savedArgs, [ {
+        foo: 'bar',
+        msg: 'some message'
+      } ]);
+
+      savedArgs = [];
+      apos.util.warn('some message', 'more', { foo: 'bar' });
+      assert.deepEqual(savedArgs, [ {
+        foo: 'bar',
+        msg: 'some message',
+        args: [ 'more' ]
+      } ]);
+
+      savedArgs = [];
+      apos.util.warn({ foo: 'bar' }, 'some message', 'more');
+      assert.deepEqual(savedArgs, [ {
+        foo: 'bar',
+        msg: 'some message',
+        args: [ 'more' ]
+      } ]);
+
+      apos.util.logger.warn = saved;
+    });
+
+    it('should log object: error', function () {
+      let savedArgs = [];
+      const saved = apos.util.logger.error;
+      apos.util.logger.error = (...args) => {
+        savedArgs = args;
+      };
+
+      savedArgs = [];
+      apos.util.error('some message');
+      assert.deepEqual(savedArgs, [ { msg: 'some message' } ]);
+
+      savedArgs = [];
+      apos.util.error({ foo: 'bar' });
+      assert.deepEqual(savedArgs, [ { foo: 'bar' } ]);
+
+      savedArgs = [];
+      apos.util.error('some message', { foo: 'bar' });
+      assert.deepEqual(savedArgs, [ {
+        foo: 'bar',
+        msg: 'some message'
+      } ]);
+
+      savedArgs = [];
+      apos.util.error('some message', 'more', { foo: 'bar' });
+      assert.deepEqual(savedArgs, [ {
+        foo: 'bar',
+        msg: 'some message',
+        args: [ 'more' ]
+      } ]);
+
+      savedArgs = [];
+      apos.util.error({ foo: 'bar' }, 'some message', 'more');
+      assert.deepEqual(savedArgs, [ {
+        foo: 'bar',
+        msg: 'some message',
+        args: [ 'more' ]
+      } ]);
+
+      apos.util.logger.error = saved;
+    });
+
+    it('should log object: warnDev', function () {
+      let savedArgs = [];
+      const saved = apos.util.logger.warn;
+      apos.util.logger.warn = (...args) => {
+        savedArgs = args;
+      };
+
+      savedArgs = [];
+      apos.util.warnDev('some message');
+      assert.deepEqual(savedArgs, [ {
+        msg: 'some message',
+        args: [ '\n⚠️ ', '\n' ]
+      } ]);
+
+      savedArgs = [];
+      apos.util.warnDev({ foo: 'bar' });
+      assert.deepEqual(savedArgs, [ {
+        foo: 'bar',
+        args: [ '\n⚠️ ', '\n' ]
+      }
+      ]);
+
+      savedArgs = [];
+      apos.util.warnDev('some message', { foo: 'bar' });
+      assert.deepEqual(savedArgs, [ {
+        foo: 'bar',
+        msg: 'some message',
+        args: [ '\n⚠️ ', '\n' ]
+      } ]);
+
+      savedArgs = [];
+      apos.util.warnDev('some message', 'more', { foo: 'bar' });
+      assert.deepEqual(savedArgs, [ {
+        foo: 'bar',
+        msg: 'some message',
+        args: [ '\n⚠️ ', 'more', '\n' ]
+      } ]);
+
+      savedArgs = [];
+      apos.util.warnDev({ foo: 'bar' }, 'some message', 'more');
+      assert.deepEqual(savedArgs, [ {
+        foo: 'bar',
+        msg: 'some message',
+        args: [ '\n⚠️ ', 'more', '\n' ]
+      } ]);
+
+      apos.util.logger.warn = saved;
+    });
+
+  });
 });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

- Add structured logging API - `logDebug`, `logInfo`, logWarn` and `logError` (can be used in any module):
```js
self.logError('event-type');
self.logError('event-type', { some: 'data' });
self.logError('event-type', 'some message', { some: 'data' });
// prepend `req` to also log valuable request data, followed by any of the above arguments
self.logError(req, ...);
```
- Custom loggers can now be destroyed - provide `async destroy()` method.
- Default logger now stringifies objects.
- Production and non-production default policy is applied for structured logging.
- Filtering by severity and event type per module can be configured for structured logging.
- Format logs for readability in non-production environments.

Closes PRO-4479, PRO-4480, PRO-4481, PRO-4482, PRO-4483, PRO-4486, PRO-4487.

## What are the specific steps to test this change?

See the above mentioned tickets acceptance criteria.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
