### PR TITLE
Hot Fix Holon appBuilder bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ to override that prop given to the modal, then it is recommended to pass
 it as a `moduleName` property of the object, not as a separate argument.
 For backwards compatibility the two-argument syntax is still permitted.
 
+## Fixes
+* Fixes a downstream bug in the `getFieldsByCategory` method in the `AposEditorMixin.js` by checking for a property before accessing it.
+
 ## 3.53.0 (2023-08-03)
 
 ### Adds

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -108,7 +108,7 @@ export default {
     // 'utility' or 'other', or the entire schema if followedByCategory
     // is falsy
     getFieldsByCategory(followedByCategory) {
-      if (followedByCategory) {
+      if (followedByCategory && this.utilityFields) {
         return (followedByCategory === 'other')
           ? this.schema.filter(field => !this.utilityFields.includes(field.name))
           : this.schema.filter(field => this.utilityFields.includes(field.name));


### PR DESCRIPTION
## Summary
Fix a downstream bug in the Holon appBuilder when trying to access a property that might not exist [PRO-4674](https://linear.app/apostrophecms/issue/PRO-4674/update-holon-to-latest-version-of-apostrophe)

## What are the specific steps to test this change?
1. link this pull in Holon
2. in holon `npm run dev`
3. Navigate to a site
4. Click appBuilder in nav bar > Add category
5. The modal loads with content and without errors in the console

## What kind of change does this PR introduce?
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:
- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated