### PR TITLE
Infer parent ID mode from the request when creating a page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNPUBLISHED
+
+### Fixes
+
+* Infer parent ID mode from the request when retrieving the parent (target) page to avoid `notfound`.
+
 ## 3.54.0 (2023-08-16)
 
 ### Adds

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -1226,7 +1226,7 @@ database.`);
       // value. `position` is used to prevent attempts to move after the archive
       // "page."
       async getTarget(req, targetId, position) {
-        const criteria = self.getIdCriteria(targetId);
+        const criteria = self.getIdCriteria(self.inferIdLocaleAndMode(req, targetId));
         // Use findForEditing to ensure we get improvements to that method from
         // npm modules that make the query more inclusive. Then explicitly shut off
         // things we know we don't want to be blocked by

--- a/test/pages.js
+++ b/test/pages.js
@@ -335,6 +335,27 @@ describe('Pages', function() {
     assert(subPage.level === 3);
   });
 
+  it('is able to insert a draft subpage from published parent id', async function() {
+
+    const subPageInfo = {
+      slug: '/parent/sub-draft-page',
+      visibility: 'public',
+      type: 'test-page',
+      title: 'Sub Draft Page'
+    };
+    console.log('PARENT PAGE', newPage);
+
+    const subPage = await apos.page.insert(
+      apos.task.getReq({ mode: 'draft' }),
+      // ensure it ends with ":published"
+      newPage._id.replace(':draft', ':published'),
+      'lastChild',
+      subPageInfo
+    );
+    // Should not throw 'notfound'.
+    assert(subPage);
+  });
+
   // MOVING
 
   it('is able to move root/parent/sibling/cousin after root/parent', async function() {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

When invoking `self.apos.page.insert(req, parentId, position, page);` and `parentId` is a published page (ends with `:published`) and `req.mode === 'draft'` the operation results in `notfound` error. The reason is `apos.page.getTarget(req, parentId)` is not inferring the mode from the request. This PR fixes that.

Closes PRO-4696.

## What are the specific steps to test this change?

Tests should pass.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
