### PR TITLE
Send the original error message to the logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * Infer parent ID mode from the request when retrieving the parent (target) page to avoid `notfound`.
+* Log the actual REST API error message and not the one meant for the user. 
 
 ## 3.54.0 (2023-08-16)
 

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -250,8 +250,12 @@ module.exports = {
         });
         function logError(req, response, error) {
           const typeTrail = response.code === 500 ? '' : `-${response.name}`;
+          // Log the actual error, not the message meant for the browser.
+          const msg = response.message !== err.message
+            ? err.message
+            : response.message;
           try {
-            self.logError(req, `api-error${typeTrail}`, response.message, {
+            self.logError(req, `api-error${typeTrail}`, msg, {
               name: response.name,
               status: response.code,
               stack: error.stack.split('\n').slice(1).map(line => line.trim()),

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -251,7 +251,7 @@ module.exports = {
         function logError(req, response, error) {
           const typeTrail = response.code === 500 ? '' : `-${response.name}`;
           // Log the actual error, not the message meant for the browser.
-          const msg = response.message !== err.message
+          const msg = response.code === 500
             ? err.message
             : response.message;
           try {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Set the original error message when compiling the REST API error log and not the message meant for the browser `An error occurred`.

## What are the specific steps to test this change?

When there is an actual unhandled error, the original message should be logged in the CLI instead `An error occurred`. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

