### PR TITLE
Async REST API permission check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNPUBLISHED
 
+### Adds
+
+* Add `publicApiCheckAsync` wrapper method (and use it internally) to allow for async permission checks of REST APIs. This feature doesn't introduce any breaking changes.
+
 ### Fixes
 
 * Infer parent ID mode from the request when retrieving the parent (target) page to avoid `notfound`.


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

- Introduce `publicApiCheckAsync` wrapper for `publicApiCheck` and use it internally.
- Introduce `omitPermissionCheck` flag on `getRestQuery` for extending purposes. Add a fair warning comment. 

As a part of HOL-2124. 

## What are the specific steps to test this change?

- Projects can extend/override `async publicApiCheckAsync(req)` when custom async permission check is needed.
- No breaking changes related with the above - `publicApiCheck` still works as expected.
- Projects can extend `getRestQuery` and disable the internal permission check and `publicApiProjection` feature:
```js
extendMethods(self) {
  return {
    getRestQuery(_super, req) {
      // The `true` flag will avoid permission checks starting from v3.55.0
      const query = _super(req, true);
      // ...extend the query
      return query;
    }
  };
}
```
THE ABOVE SHOULD NOT be used without a good reason. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

