### PR TITLE
I18n fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Italian translation i18n file created for the Apostrophe Admin-UI. Thanks to [Antonello Zanini](https://github.com/Tonel) for this contribution.
 
+### Fixes
+
+* The `118n` module now ignores non-JSON files within the i18n folder of any module and does not crash the build process.
+
 ## 3.56.0 (2023-09-13)
 
 ### Adds

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -524,12 +524,12 @@ module.exports = {
                 (metadata[ns] && metadata[ns].browser);
               const namespaceDir = path.join(localizationsDir, ns);
               if (!fs.statSync(namespaceDir).isDirectory()) {
-                // Handle files in the namespace that aren't JSON files
+                // Skip non-directory items, such as hidden files
                 continue;
               }
               for (const localizationFile of fs.readdirSync(namespaceDir)) {
                 if (!localizationFile.endsWith('.json')) {
-                  // A JSON file for the default namespace, already handled
+                  // Exclude parsing of non-JSON files, like hidden files, in the namespace directory
                   continue;
                 }
                 const fullLocalizationFile = path.join(namespaceDir, localizationFile);

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -523,7 +523,15 @@ module.exports = {
               self.namespaces[ns].browser = self.namespaces[ns].browser ||
                 (metadata[ns] && metadata[ns].browser);
               const namespaceDir = path.join(localizationsDir, ns);
+              if (!fs.statSync(namespaceDir).isDirectory()) {
+                // Handle files in the namespace that aren't JSON files
+                continue;
+              }
               for (const localizationFile of fs.readdirSync(namespaceDir)) {
+                if (!localizationFile.endsWith('.json')) {
+                  // A JSON file for the default namespace, already handled
+                  continue;
+                }
                 const fullLocalizationFile = path.join(namespaceDir, localizationFile);
                 const data = JSON.parse(fs.readFileSync(fullLocalizationFile));
                 const locale = localizationFile.replace('.json', '');


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
Currently, if an i18n folder has any files inside besides JSON translation string files, it will break the build process. For example, this can occur if a user creates a new JSON file using the Mac OS finder. The finder will leave behind a `.DS_Store` file. This PR fixes this issue and closes PRO-4701. 

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly
1. In testbed (or any project) create two files - `modules/<some-module>/i18n/test.txt` and `modules/<some-module>/i18n/testNs/test.txt`. The first will test without namespace, the second with. Testbed already has the structure in place for the `topic` module.
2. Project build should succeed with `npm run dev`

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
