### PR TITLE
added date verification for null date and no default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Adds
 
 * Italian translation i18n file created for the Apostrophe Admin-UI. Thanks to [Antonello Zanini](https://github.com/Tonel) for this contribution.
+* Fixed date in piece type being displayed as current date in column when set as undefined and without default value.
 
 ## 3.56.0 (2023-09-13)
 

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -584,9 +584,9 @@ module.exports = (self) => {
         destination[field.name] = null;
         return;
       }
-      if (!newDateVal && !field.def){
+      if (!newDateVal && !field.def) {
         // If no inputted date or default date, leave as empty
-        destination[field.name] = null
+        destination[field.name] = null;
         return;
       }
       if (field.min && newDateVal && (newDateVal < field.min)) {

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -584,17 +584,17 @@ module.exports = (self) => {
         destination[field.name] = null;
         return;
       }
+      if (!newDateVal && !field.def){
+        // If no inputted date or default date, leave as empty
+        destination[field.name] = null
+        return;
+      }
       if (field.min && newDateVal && (newDateVal < field.min)) {
         // If the min requirement isn't met, leave as-is.
         return;
       }
       if (field.max && newDateVal && (newDateVal > field.max)) {
         // If the max requirement isn't met, leave as-is.
-        return;
-      }
-      if (!newDateVal && !field.def){
-        // If no inputted date or default date, leave as empty
-        destination[field.name] = ''
         return;
       }
 

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -592,6 +592,11 @@ module.exports = (self) => {
         // If the max requirement isn't met, leave as-is.
         return;
       }
+      if (!newDateVal && !field.def){
+        // If no inputted date or default date, leave as empty
+        destination[field.name] = ''
+        return;
+      }
 
       destination[field.name] = self.apos.launder.date(newDateVal, field.def);
     },

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellDate.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellDate.vue
@@ -18,7 +18,7 @@ export default {
   computed: {
     formattedDate () {
       const value = this.get(this.header.name);
-      return value ? this.formatDateColumn(value) : "";
+      return value ? this.formatDateColumn(value) : '';
     }
   },
   methods: {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellDate.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellDate.vue
@@ -18,7 +18,7 @@ export default {
   computed: {
     formattedDate () {
       const value = this.get(this.header.name);
-      return this.formatDateColumn(value);
+      return value ? this.formatDateColumn(value) : "";
     }
   },
   methods: {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*

Closes Issue number #4291. Empty dates for piece types are no longer filled with the current date after submitting nothing. 
## What are the specific steps to test this change?

1. create a default apos app. 
2. create a piece type: 
```module.exports = {
  extend: '@apostrophecms/piece-type',
  options: {
    label: 'Testing Piece',
  },
  fields: {
    add: {
      date: {
        label: 'Date?',
        type: 'date'
      },
    },
    group: {
      basics: {
        label: 'Basics',
        fields: [ 'date']
      }
    }
  },
  columns: {
    add: {
      date: { label: 'Confirmed On', component: 'AposCellDate' }
    }
  }
};
```
3. create the new piece type and set date as empty
4. the date should remain as an empty string

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
