### PR TITLE
update permissions matrix, remove unnecessary step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,3 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Tests
 
 # Controls when the action will run.
@@ -20,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16, 18]
+        node-version: [18, 20]
         mongodb-version: [4.4, 5.0, 6.0, 7.0]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -37,9 +35,6 @@ jobs:
         uses: supercharge/mongodb-github-action@1.3.0
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
-
-      # Exit status must be succesful in the end
-      - run:  ( ( node --version | grep v14 ) && npm install -g npm@8 ) || echo "npm OK"
 
       - run: npm install
 


### PR DESCRIPTION
* Node versions 18 and 20 are current.
* We don't need to force an npm upgrade for node 14 anymore because it is no longer in the matrix.