### PR TITLE
add "type" property in projections by default to hide permission warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* Improve the `can` method of the permission module in order to hide warnings by always providing to it the `type` property of a doc or widget and getting the appropriate manager.
+
 ## 3.57.0 2023-09-27
 
 ### Adds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* Improve the `can` method of the permission module in order to hide warnings by always providing to it the `type` property of a doc or widget and getting the appropriate manager.
+* Ensure Apostrophe can make appropriate checks by always including `type` in the projection even if it is not explicitly listed.
 
 ## 3.57.0 2023-09-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixes
 
 * Ensure Apostrophe can make appropriate checks by always including `type` in the projection even if it is not explicitly listed.
+* Never try to annotate a widget with permissions the way we annotate a document, even if the widget is simulating a document
+for purposes of calling loaders in an editing situation.
 
 ## 3.57.0 2023-09-27
 

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1615,6 +1615,7 @@ module.exports = {
           },
           finalize() {
             let projection = query.get('project') || {};
+            console.log('🚀 ~ file: index.js:1618 ~ finalize ~ projection:', projection);
             // Keys beginning with `_` are computed values
             // (exception: `_id`). They do not make sense
             // in MongoDB projections. However Apostrophe
@@ -1624,6 +1625,12 @@ module.exports = {
             // to the projection instead.
             const add = [];
             const remove = [];
+
+            // Add type in projection by default
+            if (!_.isEmpty(projection)) {
+              add.push('type');
+            }
+
             for (const [ key, val ] of Object.entries(projection)) {
               if (!val) {
                 // For a negative projection this is just
@@ -1664,6 +1671,7 @@ module.exports = {
               // contains a search or not
               delete projection.textScore;
             }
+            // console.log('projection', projection);
             query.set('project', projection);
           }
         },

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1615,7 +1615,6 @@ module.exports = {
           },
           finalize() {
             let projection = query.get('project') || {};
-            console.log('🚀 ~ file: index.js:1618 ~ finalize ~ projection:', projection);
             // Keys beginning with `_` are computed values
             // (exception: `_id`). They do not make sense
             // in MongoDB projections. However Apostrophe
@@ -1671,7 +1670,6 @@ module.exports = {
               // contains a search or not
               delete projection.textScore;
             }
-            // console.log('projection', projection);
             query.set('project', projection);
           }
         },

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -61,11 +61,7 @@ module.exports = {
         }
         const type = docOrType && (docOrType.type || docOrType);
         const doc = (docOrType && docOrType._id) ? docOrType : null;
-        let manager = type && self.apos.doc.getManager(type);
-        if (doc && !manager) {
-          // Fallback to an appropriate manager module
-          manager = self.apos.util.getManagerOf(doc);
-        }
+        const manager = type && self.apos.doc.getManager(type);
         if (type && !manager) {
           self.apos.util.warn('A permission.can() call was made with a type that has no manager:', type);
           return false;

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -61,7 +61,11 @@ module.exports = {
         }
         const type = docOrType && (docOrType.type || docOrType);
         const doc = (docOrType && docOrType._id) ? docOrType : null;
-        const manager = type && self.apos.doc.getManager(type);
+        let manager = type && self.apos.doc.getManager(type);
+        if (doc && !manager) {
+          // Fallback to an appropriate manager module
+          manager = self.apos.util.getManagerOf(doc);
+        }
         if (type && !manager) {
           self.apos.util.warn('A permission.can() call was made with a type that has no manager:', type);
           return false;

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -227,8 +227,13 @@ module.exports = {
       annotate(req, action, objects) {
         const property = `_${action}`;
         for (const object of objects) {
-          if (self.can(req, action, object)) {
-            object[property] = true;
+          // Not appropriate to annotate widgets even if they
+          // are being treated as docs to access other "after"
+          // handlers
+          if (!object._virtual) {
+            if (self.can(req, action, object)) {
+              object[property] = true;
+            }
           }
         }
       },

--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -685,7 +685,7 @@ module.exports = {
       },
       // Given a widget or doc, return the appropriate manager module.
       getManagerOf(object) {
-        if (!object.metaType || object.metaType === 'doc') {
+        if (object.metaType === 'doc') {
           return self.apos.doc.getManager(object.type);
         } else if (object.metaType === 'widget') {
           return self.apos.area.getWidgetManager(object.type);

--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -685,7 +685,7 @@ module.exports = {
       },
       // Given a widget or doc, return the appropriate manager module.
       getManagerOf(object) {
-        if (object.metaType === 'doc') {
+        if (!object.metaType || object.metaType === 'doc') {
           return self.apos.doc.getManager(object.type);
         } else if (object.metaType === 'widget') {
           return self.apos.area.getWidgetManager(object.type);

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -1000,8 +1000,9 @@ describe('Pieces', function() {
     const keys = Object.keys(response);
 
     assert(response);
-    assert(keys.length === 2);
-    assert(keys.every((key) => [ '_id', 'title' ].includes(key)));
+
+    // type is available by default
+    assert([ '_id', 'type', 'title' ].every(expectedKey => keys.includes(expectedKey)));
   });
 
   it('can GET a single article with reverse relationships', async function() {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Improve the `can` method of the permission module in order to hide warnings by always providing to it the `type` property of a doc or widget and getting the appropriate manager.

## What are the specific steps to test this change?

Log in as an editor.
Create a new page with a slug `/a`.
Create another page and type `/a` in the slug field
There should be no `type has no manager` error in the server console

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
