### PR TITLE
Allow widgets and custom widget previews to follow parent schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Adds
 
 * Widget schema can now follow the parent schema via the similar to introduced in the `array` field type syntax (`<` prefix). In order a parent followed field to be available to the widget schema, the area field should follow it. For example, if area follows the root schema `title` field via `following: ['title']`, any field from a widget schema inside that area can do `following: ['<title']`.
-* Followed by an area values are now available in custom widget preview Vue components (registered with widget option `options.widget = 'MyComponentPreview'`). Those components will also receive additional `area-field` prop (the parent area field definition object).
+* Followed by an area values are now available in custom widget preview Vue components (registered with widget option `options.widget = 'MyComponentPreview'`). Those components will also receive additional `area-field` and `widget` props (the parent area and widget field definition objects respectively).
 
 ## 3.57.0 2023-09-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Adds
 
-* Widgets schema can now use follow the parent schema via the similar to introduced in the `array` field type syntax (`<` prefix). In order a parent followed field to be available to the widget schema, the area field should follow it. For example, if area follows the root schema `title` field via `following: ['title']`, any field from a widget schema inside that area can do `following: ['<title']`.
+* Widget schema can now follow the parent schema via the similar to introduced in the `array` field type syntax (`<` prefix). In order a parent followed field to be available to the widget schema, the area field should follow it. For example, if area follows the root schema `title` field via `following: ['title']`, any field from a widget schema inside that area can do `following: ['<title']`.
 * Followed by an area values are now available in custom widget preview Vue components (registered with widget option `options.widget = 'MyComponentPreview'`). Those components will also receive additional `area-field` prop (the parent area field definition object).
 
 ## 3.57.0 2023-09-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## UNRELEASED
+
+### Adds
+
+* Widgets schema can now use follow the parent schema via the similar to introduced in the `array` field type syntax (`<` prefix). In order a parent followed field to be available to the widget schema, the area field should follow it. For example, if area follows the root schema `title` field via `following: ['title']`, any field from a widget schema inside that area can do `following: ['<title']`.
+* Followed by an area values are now available in custom widget preview Vue components (registered with widget option `options.widget = 'MyComponentPreview'`). Those components will also receive additional `area-field` prop (the parent area field definition object).
+
 ## 3.57.0 2023-09-27
 
 ### Adds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Adds
 
 * Widget schema can now follow the parent schema via the similar to introduced in the `array` field type syntax (`<` prefix). In order a parent followed field to be available to the widget schema, the area field should follow it. For example, if area follows the root schema `title` field via `following: ['title']`, any field from a widget schema inside that area can do `following: ['<title']`.
-* Followed by an area values are now available in custom widget preview Vue components (registered with widget option `options.widget = 'MyComponentPreview'`). Those components will also receive additional `area-field` and `widget` props (the parent area and widget field definition objects respectively).
+* The values of fields followed by an `area` field are now available in custom widget preview Vue components (registered with widget option `options.widget = 'MyComponentPreview'`). Those components will also receive additional `area-field` prop (the parent area field definition object).
 
 ## 3.57.0 2023-09-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Adds
 
 * Widget schema can now follow the parent schema via the similar to introduced in the `array` field type syntax (`<` prefix). In order a parent followed field to be available to the widget schema, the area field should follow it. For example, if area follows the root schema `title` field via `following: ['title']`, any field from a widget schema inside that area can do `following: ['<title']`.
-* The values of fields followed by an `area` field are now available in custom widget preview Vue components (registered with widget option `options.widget = 'MyComponentPreview'`). Those components will also receive additional `area-field` prop (the parent area field definition object).
+* The values of fields followed by an `area` field are now available in custom widget preview Vue components (registered with widget option `options.widget = 'MyComponentPreview'`). Those components will also receive additional `areaField` prop (the parent area field definition object).
 
 ## 3.57.0 2023-09-27
 

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -43,9 +43,11 @@
         :i="i"
         :options="options"
         :next="next"
+        :following-values="followingValues"
         :doc-id="docId"
         :context-menu-options="contextMenuOptions"
         :field-id="fieldId"
+        :field="field"
         :disabled="field && field.readOnly"
         :widget-hovered="hoveredWidget"
         :non-foreign-widget-hovered="hoveredNonForeignWidget"
@@ -107,6 +109,12 @@ export default {
       type: Array,
       default() {
         return [];
+      }
+    },
+    followingValues: {
+      type: Object,
+      default() {
+        return {};
       }
     },
     choices: {
@@ -370,7 +378,8 @@ export default {
           value: widget,
           options: this.widgetOptionsByType(widget.type),
           type: widget.type,
-          docId: this.docId
+          docId: this.docId,
+          parentFollowingValues: this.followingValues
         });
         apos.area.activeEditor = null;
         apos.bus.$off('apos-refreshing', cancelRefresh);
@@ -467,7 +476,8 @@ export default {
           value: null,
           options: this.widgetOptionsByType(name),
           type: name,
-          docId: this.docId
+          docId: this.docId,
+          parentFollowingValues: this.followingValues
         });
         apos.area.activeEditor = null;
         if (widget) {

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -120,14 +120,13 @@
         :id="widget._id"
         :area-field-id="fieldId"
         :area-field="field"
-        :widget="widget"
         :following-values="followingValuesWithParent"
         :value="widget"
         :foreign="foreign"
         @edit="$emit('edit', i);"
         :doc-id="docId"
         :rendering="rendering"
-        :key="`${generation}-preveiw`"
+        :key="`${generation}-preview`"
       />
       <div
         class="apos-area-widget-controls apos-area-widget-controls--add apos-area-widget-controls--add--bottom"

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -120,6 +120,7 @@
         :id="widget._id"
         :area-field-id="fieldId"
         :area-field="field"
+        :widget="widget"
         :following-values="followingValuesWithParent"
         :value="widget"
         :foreign="foreign"

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -119,12 +119,14 @@
         :type="widget.type"
         :id="widget._id"
         :area-field-id="fieldId"
+        :area-field="field"
+        :following-values="followingValuesWithParent"
         :value="widget"
         :foreign="foreign"
         @edit="$emit('edit', i);"
         :doc-id="docId"
         :rendering="rendering"
-        :key="generation"
+        :key="`${generation}-preveiw`"
       />
       <div
         class="apos-area-widget-controls apos-area-widget-controls--add apos-area-widget-controls--add--bottom"
@@ -190,8 +192,18 @@ export default {
         return {};
       }
     },
+    followingValues: {
+      type: Object,
+      default() {
+        return {};
+      }
+    },
     next: {
       type: Array,
+      required: true
+    },
+    field: {
+      type: Object,
       required: true
     },
     fieldId: {
@@ -266,6 +278,14 @@ export default {
     };
   },
   computed: {
+    // Passed only to the preview layer (custom preview components).
+    followingValuesWithParent() {
+      return Object.entries(this.followingValues || {})
+        .reduce((acc, [ key, value ]) => {
+          acc[`<${key}`] = value;
+          return acc;
+        }, {});
+    },
     bottomContextMenuOptions() {
       return {
         ...this.contextMenuOptions,

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArea.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArea.vue
@@ -22,6 +22,7 @@
           :id="next._id"
           :field-id="field._id"
           :field="field"
+          :following-values="followingValues"
           :generation="generation"
           @changed="changed"
         />

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -77,6 +77,10 @@ export default {
     focused: {
       type: Boolean,
       default: false
+    },
+    parentFollowingValues: {
+      type: Object,
+      default: null
     }
   },
   emits: [ 'safe-close', 'modal-result' ],

--- a/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
+++ b/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
@@ -6,6 +6,11 @@ export default {
     type: String,
     areaFieldId: String,
     value: Object,
+    // Ignored for server side rendering
+    areaField: Object,
+    followingValues: Object,
+    // Fix missing prop rendered as `[object Object]` attribute in the DOM
+    options: Object,
     rendering: {
       type: Object,
       default() {

--- a/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
+++ b/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
@@ -8,7 +8,6 @@ export default {
     areaFieldId: String,
     value: Object,
     // Ignored for server side rendering
-    widget: Object,
     areaField: Object,
     followingValues: Object,
     // Fix missing prop rendered as `[object Object]` attribute in the DOM

--- a/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
+++ b/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
@@ -2,11 +2,13 @@ import { isEqual } from 'lodash';
 
 export default {
   props: {
+    // NOTE: docId is always null, investigate if needed
     docId: String,
     type: String,
     areaFieldId: String,
     value: Object,
     // Ignored for server side rendering
+    widget: Object,
     areaField: Object,
     followingValues: Object,
     // Fix missing prop rendered as `[object Object]` attribute in the DOM


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Given the following setup:
```js
// modules/some-page/index.js

module.exports = {
  extend: '@apostrophecms/page-type',
  fields: {
      contentCard: {
        type: 'area',
        following: [ 'title' ],
        options: {
          widgets: {
            'app-content-card': {}
          }
        }
      },
      // ....
  }
```
```js
// modules/app-content-card-widget/index.js

module.exports = {
  extend: '@apostrophecms/widget-type',
  options: {
    label: 'Content Card',
    icon: 'category',
    components: {
      widget: 'AppCardWidgetPreview'
    }
  },
  fields: {
      add: {
        templateTitle: {
          type: 'text',
          label: 'Card Title',
          following: [ '<title' ]
        },
        // ...
      }
  }
}
```

The following happens:
- `templateTitle` from the widgets schema can follow the page value of `title`
- `AppCardWidgetPreview.vue` will receive now `followingValues`, that will also include root schema values prefixed with `<`. 
- `AppCardWidgetPreview.vue` now receives `areaFeld` prop - the parent area field definition.
- The above works for nested areas.

Related to HOL-2129, HOL-2130.

## What are the specific steps to test this change?

The described above setup should work.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

