### PR TITLE
fix the areas query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Ensure Apostrophe can make appropriate checks by always including `type` in the projection even if it is not explicitly listed.
 * Never try to annotate a widget with permissions the way we annotate a document, even if the widget is simulating a document.
+* The `areas` query builder now works properly when an array of area names has been specified.
 
 ### Adds
 

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -2234,7 +2234,7 @@ module.exports = {
                   const dotPath = info.dotPath;
                   if (setting && Array.isArray(setting)) {
                     if (!_.includes(setting, dotPath)) {
-                      return;
+                      continue;
                     }
                   }
                   if (doc._edit) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Tiny fix see changelog

## What are the specific steps to test this change?

In the pro-4972 branch of `a3-demo`, linked to this branch of apostrophe, you can try editing an article to include an image in both the main content area and the `featuredImage` content area (it's in the misc tab at the end), and then visiting:

http://localhost:3000/api/v1/article/fetch

Prettyprint the JSON and you'll find that the actual image piece is only fetched for the `featuredImage` content area (you can see why in `article/index.js`, I'm passing `areas: [ 'featuredImage' ]`. You'll see other properties of other areas, that's normal, the difference is that loaders aren't called so their image relationships are not populated fully.

I've done this test myself, of course.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
