### PR TITLE
only include type to projection if there are no exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* Include `type` in the projection only if there are no exclusions in the projection. Needed to prevent `Cannot do
+exclusion on field in inclusion projection` error.
+
 ## 3.58.0 (2023-10-12)
 
 ### Fixes

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1626,8 +1626,8 @@ module.exports = {
             const remove = [];
 
             // Add type in projection by default
-            const values = Object.values(projection);
-            if (!_.isEmpty(projection) && (values.includes(false) || values.includes(0)) === false) {
+            const hasExclusion = Object.values(projection).some(value => !value);
+            if (!_.isEmpty(projection) && !hasExclusion) {
               add.push('type');
             }
 

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1626,7 +1626,8 @@ module.exports = {
             const remove = [];
 
             // Add type in projection by default
-            if (!_.isEmpty(projection)) {
+            const values = Object.values(projection);
+            if (!_.isEmpty(projection) && (values.includes(false) || values.includes(0)) === false) {
               add.push('type');
             }
 

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -1005,6 +1005,21 @@ describe('Pieces', function() {
     assert([ '_id', 'type', 'title' ].every(expectedKey => keys.includes(expectedKey)));
   });
 
+  it('can GET a single product using projections with fields omission', async function() {
+    const response = await apos.http.get(`/api/v1/product/${relatedProductId}`, {
+      qs: {
+        project: {
+          highSearchText: 0,
+          highSearchWords: 0,
+          lowSearchText: 0,
+          searchSummary: 0
+        }
+      }
+    });
+
+    assert(response);
+  });
+
   it('can GET a single article with reverse relationships', async function() {
     const response = await apos.http.get(`/api/v1/article/${relatedArticleId}`);
     assert(response);


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Only add `type` to projection if there are no exclusions in the projection

## What are the specific steps to test this change?

1. `npm test` are green
2. Update `const values = Object.values(projection);` with `const values = [];` in `modules/@apostrophecms/doc-type/index.js`
3. Re-run `'can GET a single product using projections with fields omission'` in `test/pieces.js`, it should fail with `Cannot do exclusion on field in inclusion projection` 

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
