### PR TITLE
Turn off webpack size warnings during build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Changes
+
+* Webpack warnings about package size during the build process have been turned off by default.
+
 ## 3.58.1 (2023-10-18)
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-* Webpack warnings about package size during the build process have been turned off by default.
+* Webpack warnings about package size during the admin UI build process have been turned off by default. Warnings are still enabled for the public build, where a large bundle can be problematic for SEO.
 
 ## 3.58.1 (2023-10-18)
 

--- a/modules/@apostrophecms/asset/lib/webpack/apos/webpack.config.js
+++ b/modules/@apostrophecms/asset/lib/webpack/apos/webpack.config.js
@@ -24,6 +24,9 @@ module.exports = ({
 
   const pnpmModulePath = apos.isPnpm ? [ path.join(apos.selfDir, '../') ] : [];
   const config = {
+    performance: {
+      hints: false
+    },
     entry: importFile,
     // Ensure that the correct version of vue-loader is found
     context: __dirname,

--- a/modules/@apostrophecms/asset/lib/webpack/src/webpack.config.js
+++ b/modules/@apostrophecms/asset/lib/webpack/src/webpack.config.js
@@ -31,9 +31,6 @@ module.exports = ({
   const moduleName = es5 ? 'nomodule' : 'module';
   const pnpmModulePath = apos.isPnpm ? [ path.join(apos.selfDir, '../') ] : [];
   const config = {
-    performance: {
-      hints: false
-    },
     entry: {
       [mainBundleName]: importFile,
       ...bundles

--- a/modules/@apostrophecms/asset/lib/webpack/src/webpack.config.js
+++ b/modules/@apostrophecms/asset/lib/webpack/src/webpack.config.js
@@ -31,6 +31,9 @@ module.exports = ({
   const moduleName = es5 ? 'nomodule' : 'module';
   const pnpmModulePath = apos.isPnpm ? [ path.join(apos.selfDir, '../') ] : [];
   const config = {
+    performance: {
+      hints: false
+    },
     entry: {
       [mainBundleName]: importFile,
       ...bundles


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
This PR alters the webpack configuration to turn off warnings about package size limits during the build process. Closes PRO-4955.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly
1) Run `APOS_RELEASE_ID=1 npm run build.
2) Check output for a lack of size warnings.
## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [X] Build-related changes
- [X] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
