### PR TITLE
Pro 4962 required if field

### DIFF
--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -696,20 +696,6 @@ module.exports = {
               continue;
             }
 
-            if (val.min || val.max) {
-              if (val.min) {
-                if (object[key] < val.min) {
-                  result = false;
-                }
-              }
-              if (val.max) {
-                if (object[key] > val.max) {
-                  result = false;
-                }
-              }
-              break;
-            }
-
             if (conditionalFields[key] === false) {
               result = false;
               break;

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -511,7 +511,7 @@ module.exports = {
 
           if (convert) {
             try {
-              const isRequired = self.isFieldRequired({
+              const isRequired = await self.isFieldRequired({
                 req,
                 field,
                 destination
@@ -631,9 +631,8 @@ module.exports = {
         destination,
         conditionalFields
       }) {
-        const {
-          if: clause, name: fieldName, moduleName: fieldModuleName
-        } = field;
+        const { name: fieldName, moduleName: fieldModuleName } = field;
+        const clause = field.if || field.requiredIf;
         let result = true;
         for (const [ key, val ] of Object.entries(clause)) {
           if (key === '$or') {
@@ -686,11 +685,20 @@ module.exports = {
             continue;
           }
 
-          if (conditionalFields[key] === false) {
+          if (field.requiredIf) {
+            if (typeof val === 'boolean' && !destination[key]) {
+              result = false;
+            }
+            if ((typeof val === 'string' || typeof val === 'number') && destination[key] != val) {
+              result = false;
+            }
+          }
+
+          if (conditionalFields?.[key] === false) {
             result = false;
             break;
           }
-          if (val !== destination[key]) {
+          if (val !== destination[key] && !field.requiredIf) {
             result = false;
             break;
           }

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -658,7 +658,6 @@ module.exports = {
         } else {
           return true;
         }
-
         async function evaluate(clause, fieldName, fieldModuleName) {
           let result = true;
           for (const [ key, val ] of Object.entries(clause)) {

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -467,17 +467,17 @@ module.exports = {
 
       async isFieldRequired(field, data, destination) {
         return field.requiredIf
-          ? await evaluate(field.requiredIf, destination)
+          ? evaluate(field.requiredIf, destination)
           : field.required;
 
-        async function evaluate(clause, destination) {
+        function evaluate(clause, destination) {
           let result = true;
 
           for (const [ key, val ] of Object.entries(clause)) {
             const destinationKey = _.get(destination, key);
 
             if (key === '$or') {
-              const results = await Promise.all(val.map(clause => evaluate(clause, destination)));
+              const results = val.map(clause => evaluate(clause, destination));
               if (!results.some((value) => value)) {
                 result = false;
                 break;
@@ -491,9 +491,21 @@ module.exports = {
               }
             }
 
+            if (val.min) {
+              if (destinationKey < val.min) {
+                result = false;
+              }
+            }
+            if (val.max) {
+              if (destinationKey > val.max) {
+                result = false;
+              }
+            }
+
             if (typeof val === 'boolean' && !destinationKey) {
               result = false;
             }
+
             // eslint-disable-next-line eqeqeq
             if ((typeof val === 'string' || typeof val === 'number') && destinationKey != val) {
               result = false;

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -465,7 +465,7 @@ module.exports = {
         });
       },
 
-      async isFieldRequired(field, data, destination) {
+      async isFieldRequired(field, destination) {
         return field.requiredIf
           ? evaluate(field.requiredIf, destination)
           : field.required;
@@ -555,7 +555,7 @@ module.exports = {
 
           if (convert) {
             try {
-              const isRequired = await self.isFieldRequired(field, data, destination);
+              const isRequired = await self.isFieldRequired(field, destination);
               await convert(
                 req,
                 {

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -696,6 +696,20 @@ module.exports = {
               continue;
             }
 
+            if (val.min || val.max) {
+              if (val.min) {
+                if (object[key] < val.min) {
+                  result = false;
+                }
+              }
+              if (val.max) {
+                if (object[key] > val.max) {
+                  result = false;
+                }
+              }
+              break;
+            }
+
             if (conditionalFields[key] === false) {
               result = false;
               break;

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -237,7 +237,7 @@ const hasAreaWithoutWidgets = {
 
 const warnMessages = [];
 
-describe.only('Schemas', function() {
+describe('Schemas', function() {
 
   this.timeout(t.timeout);
 
@@ -2382,7 +2382,7 @@ describe.only('Schemas', function() {
       assert.deepEqual(actual, expected);
     });
 
-    it.only('should enforce required property with ifRequired boolean', async function() {
+    it('should enforce required property with ifRequired boolean', async function() {
       const req = apos.task.getReq();
       const schema = apos.schema.compose({
         addFields: [
@@ -2408,7 +2408,7 @@ describe.only('Schemas', function() {
       assert(output.shoeSize === null);
     });
 
-    it.only('should error required property with ifRequired boolean', async function() {
+    it('should error required property with ifRequired boolean', async function() {
       const schema = apos.schema.compose({
         addFields: [
           {
@@ -2431,7 +2431,7 @@ describe.only('Schemas', function() {
       }, 'shoeSize', 'required');
     });
 
-    it.only('should enforce required property with ifRequired string', async function() {
+    it('should enforce required property with ifRequired string', async function() {
       const req = apos.task.getReq();
       const schema = apos.schema.compose({
         addFields: [
@@ -2457,7 +2457,7 @@ describe.only('Schemas', function() {
       assert(output.shoeSize === null);
     });
 
-    it.only('should error required property with ifRequired string', async function() {
+    it('should error required property with ifRequired string', async function() {
       const schema = apos.schema.compose({
         addFields: [
           {
@@ -2480,7 +2480,7 @@ describe.only('Schemas', function() {
       }, 'shoeSize', 'required');
     });
 
-    it.only('should enforce required property with ifRequired number', async function() {
+    it('should enforce required property with ifRequired number', async function() {
       const req = apos.task.getReq();
       const schema = apos.schema.compose({
         addFields: [
@@ -2506,7 +2506,7 @@ describe.only('Schemas', function() {
       assert(output.shoeSize === null);
     });
 
-    it.only('should error required property with ifRequired number', async function() {
+    it('should error required property with ifRequired number', async function() {
       const schema = apos.schema.compose({
         addFields: [
           {
@@ -2529,7 +2529,126 @@ describe.only('Schemas', function() {
       }, 'shoeSize', 'required');
     });
 
-    it.only('should enforce required property with ifRequired logical AND', async function() {
+    it('should enforce required property with ifRequired number min', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'age',
+            type: 'integer',
+            required: false
+          },
+          {
+            name: 'shoeSize',
+            type: 'integer',
+            requiredIf: {
+              age: {
+                min: 18
+              }
+            }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        shoeSize: '',
+        age: 17
+      }, output);
+      assert(output.shoeSize === null);
+    });
+
+    it('should error required property with ifRequired number min', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'age',
+            type: 'integer',
+            required: false
+          },
+          {
+            name: 'prop2',
+            type: 'boolean',
+            required: false
+          },
+          {
+            name: 'shoeSize',
+            type: 'integer',
+            requiredIf: {
+              age: {
+                min: 18
+              }
+            }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        shoeSize: '',
+        age: 19,
+        prop2: false
+      }, 'shoeSize', 'required');
+    });
+
+    it('should enforce required property with ifRequired number max', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'age',
+            type: 'integer',
+            required: false
+          },
+          {
+            name: 'shoeSize',
+            type: 'integer',
+            requiredIf: {
+              age: {
+                min: 18,
+                max: 36
+              }
+            }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        shoeSize: '',
+        age: 37
+      }, output);
+      assert(output.shoeSize === null);
+    });
+
+    it('should error required property with ifRequired number max', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'age',
+            type: 'integer',
+            required: false
+          },
+          {
+            name: 'prop2',
+            type: 'boolean',
+            required: false
+          },
+          {
+            name: 'shoeSize',
+            type: 'integer',
+            requiredIf: {
+              age: {
+                min: 18,
+                max: 36
+              }
+            }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        shoeSize: '',
+        age: 36
+      }, 'shoeSize', 'required');
+    });
+
+    it('should enforce required property with ifRequired logical AND', async function() {
       const req = apos.task.getReq();
       const schema = apos.schema.compose({
         addFields: [
@@ -2562,7 +2681,7 @@ describe.only('Schemas', function() {
       assert(output.requiredIfProp === null);
     });
 
-    it.only('should error required property with ifRequired logical AND', async function() {
+    it('should error required property with ifRequired logical AND', async function() {
       const schema = apos.schema.compose({
         addFields: [
           {
@@ -2592,7 +2711,7 @@ describe.only('Schemas', function() {
       }, 'requiredIfProp', 'required');
     });
 
-    it.only('should enforce required property with ifRequired logical OR', async function() {
+    it('should enforce required property with ifRequired logical OR', async function() {
       const req = apos.task.getReq();
       const schema = apos.schema.compose({
         addFields: [
@@ -2627,7 +2746,7 @@ describe.only('Schemas', function() {
       assert(output.requiredIfProp === null);
     });
 
-    it.only('should error required property with ifRequired logical OR', async function() {
+    it('should error required property with ifRequired logical OR', async function() {
       const schema = apos.schema.compose({
         addFields: [
           {
@@ -2659,7 +2778,7 @@ describe.only('Schemas', function() {
       }, 'requiredIfProp', 'required');
     });
 
-    it.only('should enforce required property with ifRequired not equal match', async function() {
+    it('should enforce required property with ifRequired not equal match', async function() {
       const req = apos.task.getReq();
       const schema = apos.schema.compose({
         addFields: [
@@ -2688,7 +2807,7 @@ describe.only('Schemas', function() {
       assert(output.requiredIfProp === null);
     });
 
-    it.only('should error required property with ifRequired not equal match', async function() {
+    it('should error required property with ifRequired not equal match', async function() {
       const schema = apos.schema.compose({
         addFields: [
           {
@@ -2714,7 +2833,7 @@ describe.only('Schemas', function() {
       }, 'requiredIfProp', 'required');
     });
 
-    it.only('should enforce required property with ifRequired nested boolean', async function() {
+    it('should enforce required property with ifRequired nested boolean', async function() {
       const req = apos.task.getReq();
       const schema = apos.schema.compose({
         addFields: [
@@ -2755,7 +2874,7 @@ describe.only('Schemas', function() {
       assert(output.requiredIfProp === null);
     });
 
-    it.only('should error required property with ifRequired nested boolean', async function() {
+    it('should error required property with ifRequired nested boolean', async function() {
       const schema = apos.schema.compose({
         addFields: [
           {
@@ -2793,7 +2912,7 @@ describe.only('Schemas', function() {
       }, 'requiredIfProp', 'required');
     });
 
-    it.only('should enforce required property with ifRequired nested string', async function() {
+    it('should enforce required property with ifRequired nested string', async function() {
       const req = apos.task.getReq();
       const schema = apos.schema.compose({
         addFields: [
@@ -2834,7 +2953,7 @@ describe.only('Schemas', function() {
       assert(output.requiredIfProp === null);
     });
 
-    it.only('should error required property with ifRequired nested string', async function() {
+    it('should error required property with ifRequired nested string', async function() {
       const schema = apos.schema.compose({
         addFields: [
           {
@@ -2872,7 +2991,7 @@ describe.only('Schemas', function() {
       }, 'requiredIfProp', 'required');
     });
 
-    it.only('should enforce required property with ifRequired nested number', async function() {
+    it('should enforce required property with ifRequired nested number', async function() {
       const req = apos.task.getReq();
       const schema = apos.schema.compose({
         addFields: [
@@ -2913,7 +3032,7 @@ describe.only('Schemas', function() {
       assert(output.requiredIfProp === null);
     });
 
-    it.only('should error required property with ifRequired nested number', async function() {
+    it('should error required property with ifRequired nested number', async function() {
       const schema = apos.schema.compose({
         addFields: [
           {
@@ -2951,7 +3070,7 @@ describe.only('Schemas', function() {
       }, 'requiredIfProp', 'required');
     });
 
-    it.only('should enforce required property with ifRequired nested logical AND', async function() {
+    it('should enforce required property with ifRequired nested logical AND', async function() {
       const req = apos.task.getReq();
       const schema = apos.schema.compose({
         addFields: [
@@ -2999,7 +3118,7 @@ describe.only('Schemas', function() {
       assert(output.requiredIfProp === null);
     });
 
-    it.only('should error required property with ifRequired nested logical AND', async function() {
+    it('should error required property with ifRequired nested logical AND', async function() {
       const schema = apos.schema.compose({
         addFields: [
           {
@@ -3044,7 +3163,7 @@ describe.only('Schemas', function() {
       }, 'requiredIfProp', 'required');
     });
 
-    it.only('should enforce required property with ifRequired nested logical OR', async function() {
+    it('should enforce required property with ifRequired nested logical OR', async function() {
       const req = apos.task.getReq();
       const schema = apos.schema.compose({
         addFields: [
@@ -3094,7 +3213,7 @@ describe.only('Schemas', function() {
       assert(output.requiredIfProp === null);
     });
 
-    it.only('should error required property with ifRequired nested logical OR', async function() {
+    it('should error required property with ifRequired nested logical OR', async function() {
       const schema = apos.schema.compose({
         addFields: [
           {
@@ -3141,7 +3260,7 @@ describe.only('Schemas', function() {
       }, 'requiredIfProp', 'required');
     });
 
-    it.only('should enforce required property with ifRequired nested not equal match', async function() {
+    it('should enforce required property with ifRequired nested not equal match', async function() {
       const req = apos.task.getReq();
       const schema = apos.schema.compose({
         addFields: [
@@ -3182,7 +3301,7 @@ describe.only('Schemas', function() {
       assert(output.requiredIfProp === null);
     });
 
-    it.only('should error required property with ifRequired nested not equal match', async function() {
+    it('should error required property with ifRequired nested not equal match', async function() {
       const schema = apos.schema.compose({
         addFields: [
           {

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -2529,7 +2529,7 @@ describe.only('Schemas', function() {
       }, 'shoeSize', 'required');
     });
 
-    it.only('should enforce required property with ifRequired default AND', async function() {
+    it.only('should enforce required property with ifRequired logical AND', async function() {
       const req = apos.task.getReq();
       const schema = apos.schema.compose({
         addFields: [
@@ -2562,7 +2562,7 @@ describe.only('Schemas', function() {
       assert(output.requiredIfProp === null);
     });
 
-    it.only('should error required property with ifRequired default AND', async function() {
+    it.only('should error required property with ifRequired logical AND', async function() {
       const schema = apos.schema.compose({
         addFields: [
           {
@@ -2725,6 +2725,85 @@ describe.only('Schemas', function() {
             fields: {
               add: {
                 subfield: {
+                  type: 'boolean'
+                }
+              }
+            },
+            schema: [
+              {
+                name: 'subfield',
+                type: 'boolean'
+              }
+            ]
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              'prop1.subfield': true
+            }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        requiredIfProp: null,
+        prop1: {
+          subfield: false
+        }
+      }, output);
+      assert(output.requiredIfProp === null);
+    });
+
+    it.only('should error required property with ifRequired nested boolean', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'object',
+            required: false,
+            fields: {
+              add: {
+                subfield: {
+                  type: 'boolean'
+                }
+              }
+            },
+            schema: [
+              {
+                name: 'subfield',
+                type: 'boolean'
+              }
+            ]
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              'prop1.subfield': true
+            }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        requiredIfProp: null,
+        prop1: {
+          subfield: true
+        }
+      }, 'requiredIfProp', 'required');
+    });
+
+    it.only('should enforce required property with ifRequired nested string', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'object',
+            required: false,
+            fields: {
+              add: {
+                subfield: {
                   type: 'string'
                 }
               }
@@ -2755,7 +2834,7 @@ describe.only('Schemas', function() {
       assert(output.requiredIfProp === null);
     });
 
-    it.only('should error required property with ifRequired nested boolean', async function() {
+    it.only('should error required property with ifRequired nested string', async function() {
       const schema = apos.schema.compose({
         addFields: [
           {
@@ -2789,6 +2868,354 @@ describe.only('Schemas', function() {
         requiredIfProp: null,
         prop1: {
           subfield: 'test'
+        }
+      }, 'requiredIfProp', 'required');
+    });
+
+    it.only('should enforce required property with ifRequired nested number', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'object',
+            required: false,
+            fields: {
+              add: {
+                subfield: {
+                  type: 'integer'
+                }
+              }
+            },
+            schema: [
+              {
+                name: 'subfield',
+                type: 'integer'
+              }
+            ]
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              'prop1.subfield': 1
+            }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        requiredIfProp: null,
+        prop1: {
+          subfield: 2
+        }
+      }, output);
+      assert(output.requiredIfProp === null);
+    });
+
+    it.only('should error required property with ifRequired nested number', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'object',
+            required: false,
+            fields: {
+              add: {
+                subfield: {
+                  type: 'integer'
+                }
+              }
+            },
+            schema: [
+              {
+                name: 'subfield',
+                type: 'integer'
+              }
+            ]
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              'prop1.subfield': 1
+            }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        requiredIfProp: null,
+        prop1: {
+          subfield: 1
+        }
+      }, 'requiredIfProp', 'required');
+    });
+
+    it.only('should enforce required property with ifRequired nested logical AND', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'object',
+            required: false,
+            fields: {
+              add: {
+                subfield: {
+                  type: 'integer'
+                }
+              }
+            },
+            schema: [
+              {
+                name: 'subfield',
+                type: 'integer'
+              }
+            ]
+          },
+          {
+            name: 'prop2',
+            type: 'boolean',
+            required: false
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              'prop1.subfield': 1,
+              prop2: true
+            }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        requiredIfProp: null,
+        prop1: {
+          subfield: 1
+        },
+        prop2: false
+      }, output);
+      assert(output.requiredIfProp === null);
+    });
+
+    it.only('should error required property with ifRequired nested logical AND', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'object',
+            required: false,
+            fields: {
+              add: {
+                subfield: {
+                  type: 'integer'
+                }
+              }
+            },
+            schema: [
+              {
+                name: 'subfield',
+                type: 'integer'
+              }
+            ]
+          },
+          {
+            name: 'prop2',
+            type: 'boolean',
+            required: false
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              'prop1.subfield': 1,
+              prop2: true
+            }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        requiredIfProp: null,
+        prop1: {
+          subfield: 1
+        },
+        prop2: true
+      }, 'requiredIfProp', 'required');
+    });
+
+    it.only('should enforce required property with ifRequired nested logical OR', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'object',
+            required: false,
+            fields: {
+              add: {
+                subfield: {
+                  type: 'integer'
+                }
+              }
+            },
+            schema: [
+              {
+                name: 'subfield',
+                type: 'integer'
+              }
+            ]
+          },
+          {
+            name: 'prop2',
+            type: 'boolean',
+            required: false
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              $or: [
+                { 'prop1.subfield': 1 },
+                { prop2: true }
+              ]
+            }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        requiredIfProp: null,
+        prop1: {
+          subfield: 2
+        },
+        prop2: false
+      }, output);
+      assert(output.requiredIfProp === null);
+    });
+
+    it.only('should error required property with ifRequired nested logical OR', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'object',
+            required: false,
+            fields: {
+              add: {
+                subfield: {
+                  type: 'integer'
+                }
+              }
+            },
+            schema: [
+              {
+                name: 'subfield',
+                type: 'integer'
+              }
+            ]
+          },
+          {
+            name: 'prop2',
+            type: 'boolean',
+            required: false
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              $or: [
+                { 'prop1.subfield': 1 },
+                { prop2: true }
+              ]
+            }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        requiredIfProp: null,
+        prop1: {
+          subfield: 1
+        },
+        prop2: false
+      }, 'requiredIfProp', 'required');
+    });
+
+    it.only('should enforce required property with ifRequired nested not equal match', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'object',
+            required: false,
+            fields: {
+              add: {
+                subfield: {
+                  type: 'string'
+                }
+              }
+            },
+            schema: [
+              {
+                name: 'subfield',
+                type: 'string'
+              }
+            ]
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              'prop1.subfield': { $ne: 'test' }
+            }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        requiredIfProp: null,
+        prop1: {
+          subfield: 'test'
+        }
+      }, output);
+      assert(output.requiredIfProp === null);
+    });
+
+    it.only('should error required property with ifRequired nested not equal match', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'object',
+            required: false,
+            fields: {
+              add: {
+                subfield: {
+                  type: 'string'
+                }
+              }
+            },
+            schema: [
+              {
+                name: 'subfield',
+                type: 'string'
+              }
+            ]
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              'prop1.subfield': { $ne: 'test' }
+            }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        requiredIfProp: null,
+        prop1: {
+          subfield: 'test2'
         }
       }, 'requiredIfProp', 'required');
     });

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -2711,6 +2711,69 @@ describe('Schemas', function() {
       }, 'requiredIfProp', 'required');
     });
 
+    it('should enforce required property with ifRequired logical AND with inverted props', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'string',
+            required: false
+          },
+          {
+            name: 'prop2',
+            type: 'boolean',
+            required: false
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              prop2: true,
+              prop1: 'test'
+            }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        requiredIfProp: null,
+        prop1: 'test',
+        prop2: false
+      }, output);
+      assert(output.requiredIfProp === null);
+    });
+
+    it('should error required property with ifRequired logical AND  with inverted props', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'string',
+            required: false
+          },
+          {
+            name: 'prop2',
+            type: 'boolean',
+            required: false
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              prop2: true,
+              prop1: 'test'
+            }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        requiredIfProp: null,
+        prop1: 'test',
+        prop2: true
+      }, 'requiredIfProp', 'required');
+    });
+
     it('should enforce required property with ifRequired logical OR', async function() {
       const req = apos.task.getReq();
       const schema = apos.schema.compose({
@@ -2766,6 +2829,73 @@ describe('Schemas', function() {
               $or: [
                 { prop1: 'test' },
                 { prop2: true }
+              ]
+            }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        requiredIfProp: null,
+        prop1: 'test2',
+        prop2: true
+      }, 'requiredIfProp', 'required');
+    });
+
+    it('should enforce required property with ifRequired logical OR with inverted props', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'string',
+            required: false
+          },
+          {
+            name: 'prop2',
+            type: 'boolean',
+            required: false
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              $or: [
+                { prop2: true },
+                { prop1: 'test' }
+              ]
+            }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        requiredIfProp: null,
+        prop1: 'test2',
+        prop2: false
+      }, output);
+      assert(output.requiredIfProp === null);
+    });
+
+    it('should error required property with ifRequired logical OR with inverted props', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'string',
+            required: false
+          },
+          {
+            name: 'prop2',
+            type: 'boolean',
+            required: false
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              $or: [
+                { prop2: true },
+                { prop1: 'test' }
               ]
             }
           }

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -237,7 +237,7 @@ const hasAreaWithoutWidgets = {
 
 const warnMessages = [];
 
-describe('Schemas', function() {
+describe.only('Schemas', function() {
 
   this.timeout(t.timeout);
 
@@ -2380,6 +2380,216 @@ describe('Schemas', function() {
       ];
 
       assert.deepEqual(actual, expected);
+    });
+
+    it.only('should enforce required property with ifRequired boolean', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'age',
+            type: 'integer',
+            required: false
+          },
+          {
+            name: 'shoeSize',
+            type: 'integer',
+            requiredIf: {
+              age: true
+            }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        shoeSize: '6',
+        age: '18'
+      }, output);
+      assert(output.shoeSize === 6);
+    });
+
+    it.only('should error required property with ifRequired', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'age',
+            type: 'integer',
+            required: false
+          },
+          {
+            name: 'shoeSize',
+            type: 'integer',
+            requiredIf: {
+              age: true
+            }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        shoeSize: '',
+        age: '18'
+      }, 'shoeSize', 'required');
+    });
+
+    it.only('should enforce required property with ifRequired string', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'age',
+            type: 'integer',
+            required: false
+          },
+          {
+            name: 'shoeSize',
+            type: 'integer',
+            requiredIf: {
+              age: '18'
+            }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        shoeSize: '',
+        age: '17'
+      }, output);
+      assert(output.shoeSize === null);
+    });
+
+    it.only('should error required property with ifRequired string', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'age',
+            type: 'integer',
+            required: false
+          },
+          {
+            name: 'shoeSize',
+            type: 'integer',
+            requiredIf: {
+              age: '18'
+            }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        shoeSize: '',
+        age: '18'
+      }, 'shoeSize', 'required');
+    });
+
+    it.only('should enforce required property with ifRequired number', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'age',
+            type: 'integer',
+            required: false
+          },
+          {
+            name: 'shoeSize',
+            type: 'integer',
+            requiredIf: {
+              age: 18
+            }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        shoeSize: '',
+        age: 17
+      }, output);
+      assert(output.shoeSize === null);
+    });
+
+    it.only('should error required property with ifRequired number', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'age',
+            type: 'integer',
+            required: false
+          },
+          {
+            name: 'shoeSize',
+            type: 'integer',
+            requiredIf: {
+              age: 18
+            }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        shoeSize: '',
+        age: 18
+      }, 'shoeSize', 'required');
+    });
+
+    it.only('should enforce required property with ifRequired default AND', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'string',
+            required: false
+          },
+          {
+            name: 'prop2',
+            type: 'boolean',
+            required: false
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              prop1: 'test',
+              prop2: true
+            }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        requiredIfProp: null,
+        prop1: 'test',
+        prop2: false
+      }, output);
+      assert(output.requiredIfProp === null);
+    });
+
+    it.only('should error required property with ifRequired default AND', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'string',
+            required: false
+          },
+          {
+            name: 'prop2',
+            type: 'boolean',
+            required: false
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              prop1: 'test',
+              prop2: true
+            }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        requiredIfProp: null,
+        prop1: 'test',
+        prop2: true
+      }, 'requiredIfProp', 'required');
     });
   });
 });

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -2402,13 +2402,13 @@ describe.only('Schemas', function() {
       });
       const output = {};
       await apos.schema.convert(req, schema, {
-        shoeSize: '6',
-        age: '18'
+        shoeSize: '',
+        age: ''
       }, output);
-      assert(output.shoeSize === 6);
+      assert(output.shoeSize === null);
     });
 
-    it.only('should error required property with ifRequired', async function() {
+    it.only('should error required property with ifRequired boolean', async function() {
       const schema = apos.schema.compose({
         addFields: [
           {
@@ -2589,6 +2589,128 @@ describe.only('Schemas', function() {
         requiredIfProp: null,
         prop1: 'test',
         prop2: true
+      }, 'requiredIfProp', 'required');
+    });
+
+    it.only('should enforce required property with ifRequired logical OR', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'string',
+            required: false
+          },
+          {
+            name: 'prop2',
+            type: 'boolean',
+            required: false
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              $or: [
+                { prop1: 'test' },
+                { prop2: true }
+              ]
+            }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        requiredIfProp: null,
+        prop1: 'test2',
+        prop2: false
+      }, output);
+      assert(output.requiredIfProp === null);
+    });
+
+    it.only('should error required property with ifRequired logical OR', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'string',
+            required: false
+          },
+          {
+            name: 'prop2',
+            type: 'boolean',
+            required: false
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              $or: [
+                { prop1: 'test' },
+                { prop2: true }
+              ]
+            }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        requiredIfProp: null,
+        prop1: 'test2',
+        prop2: true
+      }, 'requiredIfProp', 'required');
+    });
+
+    it.only('should enforce required property with ifRequired not equal match', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'string',
+            required: false
+          },
+          {
+            name: 'prop2',
+            type: 'boolean',
+            required: false
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: { prop1: { $ne: 'test' } }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        requiredIfProp: null,
+        prop1: 'test'
+      }, output);
+      assert(output.requiredIfProp === null);
+    });
+
+    it.only('should error required property with ifRequired not equal match', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'string',
+            required: false
+          },
+          {
+            name: 'prop2',
+            type: 'boolean',
+            required: false
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: { prop1: { $ne: 'test' } }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        requiredIfProp: null,
+        prop1: 'test2'
       }, 'requiredIfProp', 'required');
     });
   });

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -2713,6 +2713,85 @@ describe.only('Schemas', function() {
         prop1: 'test2'
       }, 'requiredIfProp', 'required');
     });
+
+    it.only('should enforce required property with ifRequired nested boolean', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'object',
+            required: false,
+            fields: {
+              add: {
+                subfield: {
+                  type: 'string'
+                }
+              }
+            },
+            schema: [
+              {
+                name: 'subfield',
+                type: 'string'
+              }
+            ]
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              'prop1.subfield': 'test'
+            }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        requiredIfProp: null,
+        prop1: {
+          subfield: ''
+        }
+      }, output);
+      assert(output.requiredIfProp === null);
+    });
+
+    it.only('should error required property with ifRequired nested boolean', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'object',
+            required: false,
+            fields: {
+              add: {
+                subfield: {
+                  type: 'string'
+                }
+              }
+            },
+            schema: [
+              {
+                name: 'subfield',
+                type: 'string'
+              }
+            ]
+          },
+          {
+            name: 'requiredIfProp',
+            type: 'integer',
+            requiredIf: {
+              'prop1.subfield': 'test'
+            }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        requiredIfProp: null,
+        prop1: {
+          subfield: 'test'
+        }
+      }, 'requiredIfProp', 'required');
+    });
   });
 });
 


### PR DESCRIPTION
# As a developer, I want to be able to make a required field optional based on a user's selection in another field.

https://linear.app/apostrophecms/issue/PRO-4962/as-a-developer-i-want-to-be-able-to-make-a-required-field-optional

## Syntax 

- exact match on a value (boolean, string, number)
- logical AND by default
- logical OR
- not equal with exact match
- all the above with nested properties

```js
requiredIf: {
  fieldA: true,
  fieldB: 'active',
  $or: [
    { fieldC: 10 },
    { fieldD: 20 }
  ],
  fieldF: { $ne: 'default' },
  'fieldE.subFieldA': 'AAA'
}
```


## Acceptance criteria

- we have conditionally required fields on the backend
- it accepts the same syntax as if
- integration test