### PR TITLE
PRO-4773 PRO-4997

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ an empty `items` array. While the area may not initially satisfy its `min` or `r
 that will be enforced on save. The purpose of a fallback default is to ensure a call to `newInstance`
 for a page or piece produces a sensible data structure. This is not retroactive e.g. it is not a migration.
 It simplifies certain issues going forward in new projects.
+* `newInstance` always returns a reasonable non-null empty value for area and
+object fields in case the document is inserted without being passed through
+the editor, e.g. in a parked page like the home page. This simplifies
+the new external front feature.
 
 ### Adds
 
@@ -29,10 +33,9 @@ frameworks such as Astro, may now be implemented more easily. Apostrophe recogni
 If both are present and `apos-external-front-key` matches the `APOS_EXTERNAL_FRONT_KEY`
 environment variable, then Apostrophe returns JSON in place of a normal page response.
 This mechanism is also available for the `render-widget` route.
-* Schema field types may now set `def` to a function. If `def` is a function then
-it is invoked with no arguments and its return value is used directly, without cloning.
-Note this is only permitted for the fallback `def` of the field type itself. It is *not*
-permitted for an individual field.
+* Like `type`, `metaType` is always included in projections. This helps
+ensure that `apos.util.getManagerOf()` can be used on any object returned
+by the Apostrophe APIs.
 
 ## 3.58.1 (2023-10-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,6 @@ when you have chosen to do this via `extendMethods`, so that you can call `_supe
 receiving this warning. The default implementation still just returns the first page found, but always following the
 `_super()` pattern here opens the door to npm modules that `improve` `@apostrophecms/piece-page` to do something more
 sophisticated by default.
-* `area` fields now have a sensible default value, e.g. an object with an `_id`, a `metaType` and
-an empty `items` array. While the area may not initially satisfy its `min` or `required` setting,
-that will be enforced on save. The purpose of a fallback default is to ensure a call to `newInstance`
-for a page or piece produces a sensible data structure. This is not retroactive e.g. it is not a migration.
-It simplifies certain issues going forward in new projects.
 * `newInstance` always returns a reasonable non-null empty value for area and
 object fields in case the document is inserted without being passed through
 the editor, e.g. in a parked page like the home page. This simplifies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ when you have chosen to do this via `extendMethods`, so that you can call `_supe
 receiving this warning. The default implementation still just returns the first page found, but always following the
 `_super()` pattern here opens the door to npm modules that `improve` `@apostrophecms/piece-page` to do something more
 sophisticated by default.
+* `area` fields now have a sensible default value, e.g. an object with an `_id`, a `metaType` and
+an empty `items` array. While the area may not initially satisfy its `min` or `required` setting,
+that will be enforced on save. The purpose of a fallback default is to ensure a call to `newInstance`
+for a page or piece produces a sensible data structure. This is not retroactive e.g. it is not a migration.
+It simplifies certain issues going forward in new projects.
+
+### Adds
+
+* An adapter for Astro is under development with support from Michelin.
+Starting with this release, adapters for external fronts, i.e. "back for front"
+frameworks such as Astro, may now be implemented more easily. Apostrophe recognizes the
+`x-requested-with: AposExternalFront` header and the `apos-external-front-key` header.
+If both are present and `apos-external-front-key` matches the `APOS_EXTERNAL_FRONT_KEY`
+environment variable, then Apostrophe returns JSON in place of a normal page response.
+This mechanism is also available for the `render-widget` route.
+* Schema field types may now set `def` to a function. If `def` is a function then
+it is invoked with no arguments and its return value is used directly, without cloning.
+Note this is only permitted for the fallback `def` of the field type itself. It is *not*
+permitted for an individual field.
 
 ## 3.58.1 (2023-10-18)
 

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -68,6 +68,13 @@ module.exports = {
             return manager.loadIfSuitable(req, [ widget ]);
           }
           async function render() {
+            if (req.aposExternalFront) {
+              const result = {
+                ...req.data,
+                widget
+              };
+              return result;
+            }
             return self.renderWidget(req, type, widget, options);
           }
         }

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1629,6 +1629,7 @@ module.exports = {
             const hasExclusion = Object.values(projection).some(value => !value);
             if (!_.isEmpty(projection) && !hasExclusion) {
               add.push('type');
+              add.push('metaType');
             }
 
             for (const [ key, val ] of Object.entries(projection)) {

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -423,7 +423,74 @@ module.exports = {
       // for this part of the behavior of sendPage.
 
       async renderPage(req, template, data) {
+        if (req.aposExternalFront) {
+          await self.annotateDataForExternalFront(req, template, data);
+          self.pruneDataForExternalFront(req, template, data);
+          // Reply with JSON
+          return data;
+        }
         return self.apos.template.renderPageForModule(req, template, data, self);
+      },
+
+      async annotateDataForExternalFront(req, template, data) {
+        const docs = self.getDocsForExternalFront(req, template, data);
+        for (const doc of docs) {
+          self.annotateDocForExternalFront(doc);
+        }
+        data.aposBodyData = await self.apos.template.getBodyData(req);
+        return data;
+      },
+
+      pruneDataForExternalFront(req, data, template) {
+        return data;
+      },
+
+      getDocsForExternalFront(req, template, data) {
+        return [ data.page, data.piece, ...(data.pieces || []) ].filter(doc => !!doc);
+      },
+
+      annotateDocForExternalFront(doc) {
+        self.apos.doc.walk(doc, (o, k, v) => {
+          if (v && v.metaType === 'area') {
+            const manager = self.apos.util.getManagerOf(o);
+            if (!manager) {
+              self.apos.util.warnDevOnce('noManagerForDocInExternalFront', `No manager for: ${o.metaType} ${o.type || ''}`);
+              return;
+            }
+            const field = manager.schema.find(f => f.name === k);
+            if (!field) {
+              self.apos.util.warnDevOnce('noSchemaFieldForAreaInExternalFront', `Area ${k} has no matching schema field in ${o.metaType} ${o.type || ''}`);
+              return;
+            }
+            return self.annotateAreaForExternalFront(field, v);
+          }
+        });
+      },
+
+      // Annotate an area for easy rendering by an external front end
+      // such as Astro. This includes adding the `field`, `options`, `widgets`
+      // and `choices` properties, and guaranteeing that `items` exists,
+      // at least as an empty array.
+
+      annotateAreaForExternalFront(field, area) {
+        area.field = field;
+        area.options = field.options;
+        // Really widget configurations, but the method name is already set in stone
+        const widgets = self.apos.area.getWidgets(area.options);
+        area.choices = Object.entries(widgets).map(([ name, options ]) => {
+          const manager = self.apos.area.widgetManagers[name];
+          return manager && {
+            name,
+            icon: manager.options.icon,
+            label: options.addLabel || manager.label || `No label for ${name}`
+          };
+        }).filter(choice => !!choice);
+        area.items ||= [];
+        if (area._docId) {
+          for (const item of area.items) {
+            item._docId = area._docId;
+          }
+        }
       },
 
       // This method generates and sends a complete HTML page to the browser.

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -369,7 +369,11 @@ module.exports = {
         const instance = {};
         for (const field of schema) {
           if (field.def !== undefined) {
-            instance[field.name] = klona(field.def);
+            if ((typeof field.def) === 'function') {
+              instance[field.name] = field.def();
+            } else {
+              instance[field.name] = klona(field.def);
+            }
           } else {
             // All fields should have an initial value in the database
             instance[field.name] = null;

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -390,7 +390,7 @@ module.exports = {
           // A workaround specifically for objects. These too need
           // to have reasonable values in parked pages and any other
           // situation where the data never passes through the UI
-          if ((field.type === 'object') && (!instance[field.name])) {
+          if ((field.type === 'object') && ((!instance[field.name]) || _.isEmpty(instance[field.name]))) {
             instance[field.name] = self.newInstance(field.schema);
           }
         }

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -369,14 +369,29 @@ module.exports = {
         const instance = {};
         for (const field of schema) {
           if (field.def !== undefined) {
-            if ((typeof field.def) === 'function') {
-              instance[field.name] = field.def();
-            } else {
-              instance[field.name] = klona(field.def);
-            }
+            instance[field.name] = klona(field.def);
           } else {
             // All fields should have an initial value in the database
             instance[field.name] = null;
+          }
+          // A workaround specifically for areas. They must have a
+          // unique `_id` which makes `klona` a poor way to establish
+          // a default, and we don't pass functions in schema
+          // definitions, but top-level areas should always exist
+          // for reasonable results if the output of `newInstance`
+          // is saved without further editing on the front end
+          if ((field.type === 'area') && (!instance[field.name])) {
+            instance[field.name] = {
+              metaType: 'area',
+              items: [],
+              _id: self.apos.util.generateId()
+            };
+          }
+          // A workaround specifically for objects. These too need
+          // to have reasonable values in parked pages and any other
+          // situation where the data never passes through the UI
+          if ((field.type === 'object') && (!instance[field.name])) {
+            instance[field.name] = self.newInstance(field.schema);
           }
         }
         return instance;

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -90,6 +90,13 @@ module.exports = (self) => {
           manager.addSearchTexts(item, texts);
         }
       }
+    },
+    def() {
+      return {
+        _id: self.apos.util.generateId(),
+        metaType: 'area',
+        items: []
+      }
     }
   });
 

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -90,13 +90,6 @@ module.exports = (self) => {
           manager.addSearchTexts(item, texts);
         }
       }
-    },
-    def() {
-      return {
-        _id: self.apos.util.generateId(),
-        metaType: 'area',
-        items: []
-      }
     }
   });
 

--- a/modules/@apostrophecms/template/index.js
+++ b/modules/@apostrophecms/template/index.js
@@ -884,7 +884,6 @@ module.exports = {
       },
 
       async annotateDataForExternalFront(req, template, data) {
-        console.log('AD');
         const docs = self.getDocsForExternalFront(req, template, data);
         for (const doc of docs) {
           self.annotateDocForExternalFront(doc);

--- a/modules/@apostrophecms/template/index.js
+++ b/modules/@apostrophecms/template/index.js
@@ -881,6 +881,68 @@ module.exports = {
         const key = end + '-' + location;
         self.insertions[key] = self.insertions[key] || [];
         self.insertions[key].push(componentName);
+      },
+
+      async annotateDataForExternalFront(req, template, data) {
+        console.log('AD');
+        const docs = self.getDocsForExternalFront(req, template, data);
+        for (const doc of docs) {
+          self.annotateDocForExternalFront(doc);
+        }
+        data.aposBodyData = await self.getBodyData(req);
+        return data;
+      },
+
+      pruneDataForExternalFront(req, data, template) {
+        return data;
+      },
+
+      getDocsForExternalFront(req, template, data) {
+        return [ data.page, data.piece, ...(data.pieces || []) ].filter(doc => !!doc);
+      },
+
+      annotateDocForExternalFront(doc) {
+        self.apos.doc.walk(doc, (o, k, v) => {
+          if (v && v.metaType === 'area') {
+            const manager = self.apos.util.getManagerOf(o);
+            if (!manager) {
+              self.apos.util.warnDevOnce('noManagerForDocInExternalFront', `No manager for: ${o.metaType} ${o.type || ''}`);
+              return;
+            }
+            const field = manager.schema.find(f => f.name === k);
+            if (!field) {
+              self.apos.util.warnDevOnce('noSchemaFieldForAreaInExternalFront', `Area ${k} has no matching schema field in ${o.metaType} ${o.type || ''}`);
+              return;
+            }
+            return self.annotateAreaForExternalFront(field, v);
+          }
+        });
+      },
+
+      // Annotate an area for easy rendering by an external front end
+      // such as Astro. This includes adding the `field`, `options`, `widgets`
+      // and `choices` properties, and guaranteeing that `items` exists,
+      // at least as an empty array.
+
+      annotateAreaForExternalFront(field, area) {
+        area.field = field;
+        area.options = field.options;
+        // Really widget configurations, but the method name is already set in stone
+        const widgets = self.apos.area.getWidgets(area.options);
+        area.choices = Object.entries(widgets).map(([ name, options ]) => {
+          const manager = self.apos.area.widgetManagers[name];
+          return manager && {
+            name,
+            icon: manager.options.icon,
+            label: options.addLabel || manager.label || `No label for ${name}`
+          };
+        }).filter(choice => !!choice);
+        area.items ||= [];
+        if (area._docId) {
+          for (const item of area.items) {
+            item._docId = area._docId;
+          }
+        }
       }
     };
   }

--- a/modules/@apostrophecms/template/index.js
+++ b/modules/@apostrophecms/template/index.js
@@ -639,36 +639,11 @@ module.exports = {
             [SemanticAttributes.CODE_FUNCTION]: 'renderPageForModule',
             [SemanticAttributes.CODE_NAMESPACE]: self.__meta.name
           });
-
-          let scene = req.user ? 'apos' : 'public';
-          if (req.scene) {
-            scene = req.scene;
-          } else {
-            req.scene = scene;
-          }
-          span.setAttribute(telemetry.Attributes.SCENE, scene);
           span.setAttribute(telemetry.Attributes.TEMPLATE, template);
 
-          const aposBodyData = {
-            modules: {},
-            prefix: req.prefix,
-            sitePrefix: self.apos.prefix,
-            shortName: self.apos.shortName,
-            locale: req.locale,
-            csrfCookieName: self.apos.csrfCookieName,
-            tabId: self.apos.util.generateId(),
-            uploadsUrl: self.apos.attachment.uploadfs.getUrl(),
-            assetBaseUrl: self.apos.asset.getAssetBaseUrl(),
-            scene
-          };
-          if (req.user) {
-            aposBodyData.user = {
-              title: req.user.title,
-              _id: req.user._id,
-              username: req.user.username
-            };
-          }
-          await self.emit('addBodyData', req, aposBodyData);
+          const aposBodyData = await self.getBodyData(req);
+          span.setAttribute(telemetry.Attributes.SCENE, aposBodyData.scene);
+
           self.addBodyDataAttribute(req, { apos: JSON.stringify(aposBodyData) });
 
           // Always the last call; signifies we're done initializing the
@@ -693,7 +668,7 @@ module.exports = {
           const args = {
             outerLayout: decorate ? '@apostrophecms/template:outerLayout.html' : '@apostrophecms/template:refreshLayout.html',
             permissions: req.user && (req.user._permissions || {}),
-            scene,
+            scene: aposBodyData.scene,
             refreshing: !decorate,
             // Make the query available to templates for easy access to
             // filter settings etc.
@@ -715,7 +690,7 @@ module.exports = {
             const content = await telemetry.startActiveSpan(spanRenderName, async (spanRender) => {
               spanRender.setAttribute(SemanticAttributes.CODE_FUNCTION, 'render');
               spanRender.setAttribute(SemanticAttributes.CODE_NAMESPACE, module.__meta.name);
-              spanRender.setAttribute(telemetry.Attributes.SCENE, scene);
+              spanRender.setAttribute(telemetry.Attributes.SCENE, aposBodyData.scene);
               spanRender.setAttribute(telemetry.Attributes.TEMPLATE, template);
 
               try {
@@ -723,7 +698,7 @@ module.exports = {
                 spanRender.setStatus({ code: telemetry.api.SpanStatusCode.OK });
                 const filledContent = self.insertBundlesMarkup({
                   page: req.data.bestPage,
-                  scene,
+                  scene: aposBodyData.scene,
                   template,
                   content,
                   scriptsPlaceholder: req.scriptsPlaceholder,
@@ -772,6 +747,38 @@ module.exports = {
             return url.replace('&aposRefresh=1', '');
           }
         }
+      },
+
+      async getBodyData(req) {
+        let scene = req.user ? 'apos' : 'public';
+        if (req.scene) {
+          scene = req.scene;
+        } else {
+          req.scene = scene;
+        }
+
+        const aposBodyData = {
+          modules: {},
+          prefix: req.prefix,
+          sitePrefix: self.apos.prefix,
+          shortName: self.apos.shortName,
+          locale: req.locale,
+          csrfCookieName: self.apos.csrfCookieName,
+          tabId: self.apos.util.generateId(),
+          uploadsUrl: self.apos.attachment.uploadfs.getUrl(),
+          assetBaseUrl: self.apos.asset.getAssetBaseUrl(),
+          scene
+        };
+        if (req.user) {
+          aposBodyData.user = {
+            title: req.user.title,
+            _id: req.user._id,
+            username: req.user.username
+          };
+        }
+        await self.emit('addBodyData', req, aposBodyData);
+
+        return aposBodyData;
       },
 
       // Log the given template error with timestamp and user information


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Initial support for external front end rendering, e.g. adapters for Astro etc.

## What are the specific steps to test this change?

* Use this branch of apostrophe with the `astro-demo-core` branch of `a3-boilerplate` as the Apostrophe side, and the `apostrophecms/astro-demo` project as the astro side
* Be sure to do a fresh `npm install` on the astro side
* Everything still works
* Re PRO-4773, I tested that object fields do get populated by newInstance and wind up in the database with valid area objects for any area fields, even if just a part of a parked page and not mentioned in the parked properties

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [X] New feature
- [X] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
