### PR TITLE
Pro 4998 recaptcha token on submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### Adds
+
+* Add `uponSubmit` requirement in the `@apostrophecms/login` module. `uponSubmit` requirements are checked each time the user submit the login form. See the documentation for more information.
+
 ### Fixes
 
 * We can now close the image modal in rich-text widgets when we click outside of the modal.

--- a/modules/@apostrophecms/login/ui/apos/components/AposLoginForm.vue
+++ b/modules/@apostrophecms/login/ui/apos/components/AposLoginForm.vue
@@ -30,6 +30,16 @@
           @done="requirementDone(requirement, $event)"
           @block="requirementBlock(requirement)"
         />
+        <template v-if="phase === 'uponSubmit'">
+          <Component
+            v-for="requirement in uponSubmitRequirements"
+            :key="requirement.name"
+            :is="requirement.component"
+            v-bind="getRequirementProps(requirement.name)"
+            @done="requirementDone(requirement, $event)"
+            @block="requirementBlock(requirement)"
+          />
+        </template>
         <AposButton
           data-apos-test="loginSubmit"
           :busy="busy"

--- a/modules/@apostrophecms/login/ui/apos/components/AposLoginForm.vue
+++ b/modules/@apostrophecms/login/ui/apos/components/AposLoginForm.vue
@@ -2,7 +2,7 @@
   <div
     key="1"
     class="apos-login-form"
-    v-if="phase === 'beforeSubmit'"
+    v-if="phase === 'beforeSubmit' || phase === 'uponSubmit'"
   >
     <TheAposLoginHeader
       :env="context.env"

--- a/modules/@apostrophecms/login/ui/apos/logic/AposLoginForm.js
+++ b/modules/@apostrophecms/login/ui/apos/logic/AposLoginForm.js
@@ -90,7 +90,6 @@ export default {
     uponSubmitRequirements: {
       deep: true,
       async handler(newVal) {
-        console.log(newVal);
         if (this.phase !== 'uponSubmit') {
           return;
         }

--- a/modules/@apostrophecms/login/ui/apos/logic/AposLoginForm.js
+++ b/modules/@apostrophecms/login/ui/apos/logic/AposLoginForm.js
@@ -41,6 +41,9 @@ export default {
     beforeSubmitRequirements() {
       return this.requirements.filter(requirement => requirement.phase === 'beforeSubmit');
     },
+    uponSubmitRequirements() {
+      return this.requirements.filter(requirement => requirement.phase === 'uponSubmit');
+    },
     // The currently active requirement expecting a solo presentation.
     // Currently it only concerns `afterPasswordVerified` requirements.
     // beforeSubmit requirements are not presented solo.
@@ -95,6 +98,10 @@ export default {
       }
       this.busy = true;
       this.error = '';
+      // apos.bus.$emit('@apostrophecms/login:before-submit');
+      this.uponSubmitRequirements.forEach(async requirement => {
+        this.doc.data = await requirement.callback(this.doc.data);
+      });
 
       await this.invokeInitialLoginApi();
     },
@@ -234,6 +241,7 @@ function getRequirements() {
   });
   return [
     ...requirements.filter(r => r.phase === 'beforeSubmit'),
+    ...requirements.filter(r => r.phase === 'uponSubmit'),
     ...requirements.filter(r => r.phase === 'afterPasswordVerified')
   ];
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Add support for `uponSubmit` requirements in login phases

## What are the specific steps to test this change?

Each steps below requires on valid login attempt upon page load and one invalid then valid login attempt to validate that we can recover the login process after a failed attempt.

1. Try to login without any login requirements
2. Try to login with login-recaptcha enabled (you will need https://github.com/apostrophecms/login-recaptcha/pull/10)
3. Try to login with login-totp enabled
4. Try to login with login-hcaptcha enabled
5. Try to login with both login-recaptcha and login-totp enabled (you will need https://github.com/apostrophecms/login-recaptcha/pull/10)

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
