### PR TITLE
pass on widget options in render-widget route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Setting the `apos-notification--hidden` class will hide the notification, which 
 * Give the possibility to add horizontal rules from the insert menu of the rich text editor with the following widget option: `insert: [ 'horizontalRule' ]`.  
 Improve also the UX to focus back the editor after inserting a horizontal rule or a table.
 
+### Fixes
+
+* The `render-widget` route now provides an `options` property on the widget, so that
+schema-level options of the widget are available to the external front end when
+rendering a newly added or edited widget in the editor. Note that when rendering a full page,
+this information is already available on the parent area: `area.options.widgets[widget.type]`
+
 ## 3.59.0 (2023-11-03)
 
 ### Changes

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -71,6 +71,7 @@ module.exports = {
             if (req.aposExternalFront) {
               const result = {
                 ...req.data,
+                options,
                 widget
               };
               return result;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Clément at Michelin pointed out he didn't have access to schema level options when rendering widgets. For full page renders the issue was in the astro-integration module, however for the render-widget route used when re-rendering a single widget during contextual editing, there was a missing property on our side.

## What are the specific steps to test this change?

See the PR on astro-integration for details on testing.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
