### PR TITLE
Fix conditional fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Adds
 
-* Add the possibility to add custom classes to notifications.  
+* Add the possibility to add custom classes to notifications.
 Setting the `apos-notification--hidden` class will hide the notification, which can be useful when we only care about the event carried by it.
-* Give the possibility to add horizontal rules from the insert menu of the rich text editor with the following widget option: `insert: [ 'horizontalRule' ]`.  
+* Give the possibility to add horizontal rules from the insert menu of the rich text editor with the following widget option: `insert: [ 'horizontalRule' ]`.
 Improve also the UX to focus back the editor after inserting a horizontal rule or a table.
 
 ### Fixes
@@ -18,6 +18,7 @@ to the page tree.
 it is missing for existing pages.
 * Fixed a bug that prevented page ranks from renumbering properly during "insert after" operations.
 * Added a one-time migration to make existing page ranks unique among peers.
+* Fix `if` and `requiredIf` fields inside array.
 
 ## 3.59.0 (2023-11-03)
 

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -498,10 +498,10 @@ module.exports = {
             }
             continue;
           } else if (val.$ne) {
-            // eslint-disable-next-line eqeqeq
-            if (val.$ne == destinationKey) {
+            if (val.$ne === destinationKey) {
               return false;
             }
+            continue;
           }
 
           // Handle external conditions:
@@ -526,23 +526,21 @@ module.exports = {
             continue;
           }
 
-          if (val.min && destinationKey < val.min) {
-            return false;
-          }
-          if (val.max && destinationKey > val.max) {
-            return false;
+          if (val.min || val.max) {
+            if (destinationKey < val.min) {
+              return false;
+            }
+            if (destinationKey > val.max) {
+              return false;
+            }
+            continue;
           }
 
           if (conditionalFields?.[key] === false) {
             return false;
           }
 
-          if (typeof val === 'boolean' && !destinationKey) {
-            return false;
-          }
-
-          // eslint-disable-next-line eqeqeq
-          if ((typeof val === 'string' || typeof val === 'number') && destinationKey != val) {
+          if (destinationKey !== val) {
             return false;
           }
         }

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -526,7 +526,11 @@ module.exports = {
             continue;
           }
 
-          if (val.min || val.max) {
+          // test with Object.prototype for the case val.min === 0
+          if (
+            Object.prototype.hasOwnProperty.call(val, 'min') ||
+            Object.prototype.hasOwnProperty.call(val, 'max')
+          ) {
             if (destinationKey < val.min) {
               return false;
             }

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -527,10 +527,7 @@ module.exports = {
           }
 
           // test with Object.prototype for the case val.min === 0
-          if (
-            Object.hasOwn(val, 'min') ||
-            Object.hasOwn(val, 'max')
-          ) {
+          if (Object.hasOwn(val, 'min') || Object.hasOwn(val, 'max')) {
             if (destinationKey < val.min) {
               return false;
             }

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -528,8 +528,8 @@ module.exports = {
 
           // test with Object.prototype for the case val.min === 0
           if (
-            Object.prototype.hasOwnProperty.call(val, 'min') ||
-            Object.prototype.hasOwnProperty.call(val, 'max')
+            Object.hasOwn(val, 'min') ||
+            Object.hasOwn(val, 'max')
           ) {
             if (destinationKey < val.min) {
               return false;

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -2675,6 +2675,120 @@ describe('Schemas', function() {
       }, 'requiredProp', 'required');
     });
 
+    it('should enforce required property number min', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'integer',
+            required: false
+          },
+          {
+            name: 'prop2',
+            type: 'string',
+            required: true,
+            if: {
+              prop1: {
+                min: 0,
+                max: 10
+              }
+            }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        prop1: -1,
+        prop2: ''
+      }, output);
+      assert(output.prop2 === '');
+    });
+
+    it('should error required property number min', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'integer',
+            required: false
+          },
+          {
+            name: 'prop2',
+            type: 'string',
+            required: true,
+            if: {
+              prop1: {
+                min: 0,
+                max: 10
+              }
+            }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        prop1: 0,
+        prop2: ''
+      }, 'prop2', 'required');
+    });
+
+    it('should enforce required property number max', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'integer',
+            required: false
+          },
+          {
+            name: 'prop2',
+            type: 'string',
+            required: true,
+            if: {
+              prop1: {
+                min: -10,
+                max: 0
+              }
+            }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        prop1: 1,
+        prop2: ''
+      }, output);
+      assert(output.prop2 === '');
+    });
+
+    it('should error required property number max', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'integer',
+            required: false
+          },
+          {
+            name: 'prop2',
+            type: 'string',
+            required: true,
+            if: {
+              prop1: {
+                min: -10,
+                max: 0
+              }
+            }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        prop1: 0,
+        prop2: ''
+      }, 'prop2', 'required');
+    });
+
     it('should enforce required property nested logical AND', async function() {
       const req = apos.task.getReq();
       const schema = apos.schema.compose({
@@ -3135,11 +3249,6 @@ describe('Schemas', function() {
             required: false
           },
           {
-            name: 'prop2',
-            type: 'boolean',
-            required: false
-          },
-          {
             name: 'shoeSize',
             type: 'integer',
             requiredIf: {
@@ -3152,8 +3261,60 @@ describe('Schemas', function() {
       });
       await testSchemaError(schema, {
         shoeSize: '',
-        age: 19,
-        prop2: false
+        age: 19
+      }, 'shoeSize', 'required');
+    });
+
+    it('should enforce required property with ifRequired number min 0', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'age',
+            type: 'integer',
+            required: false
+          },
+          {
+            name: 'shoeSize',
+            type: 'integer',
+            requiredIf: {
+              age: {
+                min: 1
+              }
+            }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        shoeSize: '',
+        age: 0
+      }, output);
+      assert(output.shoeSize === null);
+    });
+
+    it('should error required property with ifRequired number min 0', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'age',
+            type: 'integer',
+            required: false
+          },
+          {
+            name: 'shoeSize',
+            type: 'integer',
+            requiredIf: {
+              age: {
+                min: 0
+              }
+            }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        shoeSize: '',
+        age: 0
       }, 'shoeSize', 'required');
     });
 
@@ -3195,11 +3356,6 @@ describe('Schemas', function() {
             required: false
           },
           {
-            name: 'prop2',
-            type: 'boolean',
-            required: false
-          },
-          {
             name: 'shoeSize',
             type: 'integer',
             requiredIf: {
@@ -3215,6 +3371,61 @@ describe('Schemas', function() {
         shoeSize: '',
         age: 36
       }, 'shoeSize', 'required');
+    });
+
+    it('should enforce required property with ifRequired number max 0', async function() {
+      const req = apos.task.getReq();
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'integer',
+            required: false
+          },
+          {
+            name: 'prop2',
+            type: 'string',
+            requiredIf: {
+              prop1: {
+                min: -10,
+                max: 0
+              }
+            }
+          }
+        ]
+      });
+      const output = {};
+      await apos.schema.convert(req, schema, {
+        prop1: 1,
+        prop2: ''
+      }, output);
+      assert(output.prop2 === '');
+    });
+
+    it('should error required property with ifRequired number max 0', async function() {
+      const schema = apos.schema.compose({
+        addFields: [
+          {
+            name: 'prop1',
+            type: 'integer',
+            required: false
+          },
+          {
+            name: 'prop2',
+            type: 'string',
+            requiredIf: {
+              prop1: {
+                min: -10,
+                max: 0
+              }
+            }
+          }
+        ]
+      });
+      await testSchemaError(schema, {
+        prop1: 0,
+        prop2: ''
+      }, 'prop2', 'required');
     });
 
     it('should enforce required property with ifRequired logical AND', async function() {

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -2381,7 +2381,9 @@ describe('Schemas', function() {
 
       assert.deepEqual(actual, expected);
     });
+  });
 
+  describe('field if|ifRequired', function () {
     it('should enforce required property not equal match', async function() {
       const req = apos.task.getReq();
       const schema = apos.schema.compose({
@@ -2468,10 +2470,7 @@ describe('Schemas', function() {
           subfield: false
         }
       }, output);
-      console.log('output', require('util').inspect(output, {
-        colors: true,
-        depth: 1
-      }));
+
       assert(!output.requiredProp);
     });
 
@@ -2956,48 +2955,49 @@ describe('Schemas', function() {
       const schema = apos.schema.compose({
         addFields: [
           {
-            name: 'age',
-            type: 'integer',
+            name: 'prop1',
+            type: 'boolean',
             required: false
           },
           {
-            name: 'shoeSize',
-            type: 'integer',
+            name: 'prop2',
+            type: 'string',
             requiredIf: {
-              age: true
+              prop1: true
             }
           }
         ]
       });
       const output = {};
       await apos.schema.convert(req, schema, {
-        shoeSize: '',
-        age: ''
+        prop1: false,
+        prop2: ''
       }, output);
-      assert(output.shoeSize === null);
+
+      assert(output.prop2 === '');
     });
 
     it('should error required property with ifRequired boolean', async function() {
       const schema = apos.schema.compose({
         addFields: [
           {
-            name: 'age',
-            type: 'integer',
+            name: 'prop1',
+            type: 'boolean',
             required: false
           },
           {
-            name: 'shoeSize',
-            type: 'integer',
+            name: 'prop2',
+            type: 'string',
             requiredIf: {
-              age: true
+              prop1: true
             }
           }
         ]
       });
       await testSchemaError(schema, {
-        shoeSize: '',
-        age: '18'
-      }, 'shoeSize', 'required');
+        prop1: true,
+        prop2: ''
+      }, 'prop2', 'required');
     });
 
     it('should enforce required property with ifRequired string', async function() {
@@ -3006,7 +3006,7 @@ describe('Schemas', function() {
         addFields: [
           {
             name: 'age',
-            type: 'integer',
+            type: 'string',
             required: false
           },
           {
@@ -3031,7 +3031,7 @@ describe('Schemas', function() {
         addFields: [
           {
             name: 'age',
-            type: 'integer',
+            type: 'string',
             required: false
           },
           {
@@ -4080,7 +4080,6 @@ describe('Schemas', function() {
 
       await testSchemaError(schema, {}, 'age', 'required');
     });
-
   });
 });
 


### PR DESCRIPTION
# Fix required fields not enforced when the field is not visible in Apostrophe 3.59.0

https://linear.app/apostrophecms/issue/PRO-5117/[regression]-a-required-field-is-still-enforced-when-the-field-is-not

## Summary

Fix `if` and `requiredIf` fields inside array.

## What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated
