### PR TITLE
PRO-5234: use findForEditing consistently so that doc-template-library does not cause crashes during the addition of new locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ to the page tree.
 it is missing for existing pages.
 * Fixed a bug that prevented page ranks from renumbering properly during "insert after" operations.
 * Added a one-time migration to make existing page ranks unique among peers.
-* Fix `if` and `requiredIf` fields inside array.
 * Fixes conditional fields not being properly updated when switching items in array editor.
 * The `beforeSend` event for pages and the loading of deferred widgets are now
 handled in `renderPage` with the proper timing so that areas can be annotated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.60.1 (2023-12-06)
+
+### Fixes
+
+* corrected an issue where the use of the doc template library can result in errors at startup when
+replicating certain content to new locales. This was not a bug in the doc template library.
+Apostrophe was not invoking `findForEditing` where it should have.
+
 ## 3.60.0 (2023-11-29)
 
 ### Adds

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1057,7 +1057,7 @@ module.exports = {
               let { lastTargetId, lastPosition } = await self.apos.page.inferLastTargetIdAndPosition(draft);
               let localizedTargetId = lastTargetId.replace(`:${draft.aposLocale}`, `:${toLocale}:draft`);
               const localizedTarget = await actionModule
-                .find(toReq, self.apos.page.getIdCriteria(localizedTargetId))
+                .findForEditing(toReq, self.apos.page.getIdCriteria(localizedTargetId))
                 .archived(null)
                 .areas(false)
                 .relationships(false)
@@ -1070,7 +1070,7 @@ module.exports = {
                     parentNotLocalized: true
                   });
                 } else {
-                  const originalTarget = await actionModule.find(req, self.apos.page.getIdCriteria(lastTargetId)).archived(null).areas(false).relationships(false).toObject();
+                  const originalTarget = await actionModule.findForEditing(req, self.apos.page.getIdCriteria(lastTargetId)).archived(null).areas(false).relationships(false).toObject();
                   if (!originalTarget) {
                     // Almost impossible (race conditions like someone removing it while we're in the modal)
                     throw self.apos.error('notfound');
@@ -1078,7 +1078,7 @@ module.exports = {
                   const criteria = {
                     path: self.apos.page.getParentPath(originalTarget)
                   };
-                  const localizedTarget = await actionModule.find(toReq, criteria).archived(null).areas(false).relationships(false).toObject();
+                  const localizedTarget = await actionModule.findForEditing(toReq, criteria).archived(null).areas(false).relationships(false).toObject();
                   if (!localizedTarget) {
                     throw self.apos.error('notfound', req.t('apostrophe:parentNotLocalized'), {
                       // Also provide as data for code that prefers to localize client side


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Hotfix to correct an issue where template docs were not found during localization to a new locale, resulting in crashes.

## What are the specific steps to test this change?

I tested it using mongodumps provided by a client.

Adding a new locale to a site with template pages should not crash on startup.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
