### PR TITLE
PRO-5234: still need findForEditing for inclusiveness, but then allow view permissions to get us through so we can create a child of a parent we cannot edit

### DIFF
--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1028,9 +1028,16 @@ module.exports = {
         });
         const toId = draft._id.replace(`:${draft.aposLocale}`, `:${toLocale}:draft`);
         const actionModule = self.apos.page.isPage(draft) ? self.apos.page : self;
+        // Use findForEditing so that we are successful even for edge cases
+        // like doc templates that don't appear in public renderings, but
+        // also use permission('view') so that we are not actually restricted
+        // to what we can edit, avoiding any confusion about whether there
+        // is really an existing localized doc or not and preventing the
+        // possibility of inserting an unwanted duplicate. The update() call will
+        // still stop us if edit permissions are an issue
         const existing = await actionModule.findForEditing(toReq, {
           _id: toId
-        }).toObject();
+        }).permission('view').toObject();
         // We only want to copy schema properties, leave non-schema
         // properties of the source document alone
         const data = Object.fromEntries(Object.entries(draft).filter(([ key, value ]) => self.schema.find(field => field.name === key)));
@@ -1056,8 +1063,15 @@ module.exports = {
               // A page that is not the home page, being replicated for the first time
               let { lastTargetId, lastPosition } = await self.apos.page.inferLastTargetIdAndPosition(draft);
               let localizedTargetId = lastTargetId.replace(`:${draft.aposLocale}`, `:${toLocale}:draft`);
+              // When fetching the target (parent or peer), always use findForEditing
+              // so we don't miss doc templates and other edge cases, but also use
+              // .permission('view') because we are not actually editing the target
+              // and should not be blocked over edit permissions. Later change this check
+              // to 'create' ("can create a child of this doc"), but not until we're ready
+              // to do it for all creation attempts
               const localizedTarget = await actionModule
                 .findForEditing(toReq, self.apos.page.getIdCriteria(localizedTargetId))
+                .permission('view')
                 .archived(null)
                 .areas(false)
                 .relationships(false)
@@ -1070,7 +1084,13 @@ module.exports = {
                     parentNotLocalized: true
                   });
                 } else {
-                  const originalTarget = await actionModule.findForEditing(req, self.apos.page.getIdCriteria(lastTargetId)).archived(null).areas(false).relationships(false).toObject();
+                  const originalTarget = await actionModule
+                    .findForEditing(req, self.apos.page.getIdCriteria(lastTargetId))
+                    .permission('view')
+                    .archived(null)
+                    .areas(false)
+                    .relationships(false)
+                    .toObject();
                   if (!originalTarget) {
                     // Almost impossible (race conditions like someone removing it while we're in the modal)
                     throw self.apos.error('notfound');
@@ -1078,7 +1098,13 @@ module.exports = {
                   const criteria = {
                     path: self.apos.page.getParentPath(originalTarget)
                   };
-                  const localizedTarget = await actionModule.findForEditing(toReq, criteria).archived(null).areas(false).relationships(false).toObject();
+                  const localizedTarget = await actionModule
+                    .findForEditing(toReq, criteria)
+                    .permission('view')
+                    .archived(null)
+                    .areas(false)
+                    .relationships(false)
+                    .toObject();
                   if (!localizedTarget) {
                     throw self.apos.error('notfound', req.t('apostrophe:parentNotLocalized'), {
                       // Also provide as data for code that prefers to localize client side


### PR DESCRIPTION
…

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Still need findForEditing for inclusiveness, but then allow view permissions to get us through so we can create a child of a parent we cannot edit.

No further changes to the changelog because it's still the same unreleased bug fix, just better.

## What are the specific steps to test this change?

As before. I have tested this against the client's database. The regression tests will tell us if I fixed my oversight in the scenario described in the summary above.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
