### PR TITLE
Fixed the <pre> tags in the rich text widget so now line breaks inside <pre> tags will work

### DIFF
--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -335,8 +335,11 @@ module.exports = {
       optionsToSanitizeHtml(options) {
         return {
           ...sanitizeHtml.defaults,
-          allowedTags: self.toolbarToAllowedTags(options),
-          allowedAttributes: self.toolbarToAllowedAttributes(options),
+          allowedTags: [...self.toolbarToAllowedTags(options), 'pre'],
+          allowedAttributes: {
+            ...self.toolbarToAllowedAttributes(options),
+            'pre': ['*']
+          },
           allowedClasses: self.toolbarToAllowedClasses(options),
           allowedStyles: self.toolbarToAllowedStyles(options)
         };


### PR DESCRIPTION
Issue #4288 which is "Line breaks don't work inside <pre> tags in rich text widget" is now resolved