### PR TITLE
correct metadata for nested areas when working with an external front

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* Pass on complete annotation information for nested areas when adding or editing a nested widget using an external front, like Astro.
+
 ## 3.60.1 (2023-12-06)
 
 ### Fixes

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -69,6 +69,28 @@ module.exports = {
           }
           async function render() {
             if (req.aposExternalFront) {
+              // Simulate an area and annotate it so that the
+              // widget's sub-areas wind up with the right metadata
+              const area = {
+                metaType: 'area',
+                items: [ widget ],
+                _docId
+              };
+              self.apos.template.annotateAreaForExternalFront(field, area);
+              // Annotate sub-areas. It's like annotating a doc, but not quite,
+              // so this logic is reproduced partially
+              self.apos.doc.walk(area, (o, k, v) => {
+                if (v && v.metaType === 'area') {
+                  const manager = self.apos.util.getManagerOf(o);
+                  if (!manager) {
+                    self.apos.util.warnDevOnce('noManagerForDocInExternalFront', `No manager for: ${o.metaType} ${o.type || ''}`);
+                    return;
+                  }
+                  const field = manager.schema.find(f => f.name === k);
+                  v._docId = _docId;
+                  self.apos.template.annotateAreaForExternalFront(field, v);
+                }
+              });
               const result = {
                 ...req.data,
                 options,


### PR DESCRIPTION
... So that nested widgets work as expected when first added to the page

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

See changelog

## What are the specific steps to test this change?

The `pro-5248` branch of `astro-demo`, used together with the `pro-5248` branch of `starter-kit-essentials`, produces an astro experience in which a "two-column" widget can be added successfully to the home page, with both sub-areas immediately editable.

Everything depends on pro-5248 branches of everything else so you shouldn't have to link anything, just npm install from scratch.

I'm only ready for review on the `apostrophe` module (the others need unrelated cleanup).

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
