### PR TITLE
Pro 5252 add url validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### Adds
+
+* Add a `validate` method to the `url` field type to allow the use of the `pattern` property.
+
 ### Fixes
 
 * Pass on complete annotation information for nested areas when adding or editing a nested widget using an external front, like Astro.

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -553,6 +553,18 @@ module.exports = (self) => {
       // always return a valid string
       return '';
     },
+    validate(field, options, warn, fail) {
+      if (!field.pattern) {
+        return;
+      }
+
+      const isRegexInstance = field.pattern instanceof RegExp;
+      if (!isRegexInstance && typeof field.pattern !== 'string') {
+        fail('The pattern property must be a RegExp or a String');
+      }
+
+      field.pattern = isRegexInstance ? field.pattern.source : field.pattern;
+    },
     addQueryBuilder(field, query) {
       query.addBuilder(field.name, {
         finalize: function () {

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -544,6 +544,18 @@ module.exports = (self) => {
     vueComponent: 'AposInputString',
     async convert(req, field, data, destination) {
       destination[field.name] = self.apos.launder.url(data[field.name], field.def, true);
+
+      if (field.required && (_.isUndefined(data[field.name]) || !data[field.name].toString().length)) {
+        throw self.apos.error('required');
+      }
+
+      if (field.pattern) {
+        const regex = new RegExp(field.pattern);
+
+        if (!regex.test(destination[field.name])) {
+          throw self.apos.error('invalid');
+        }
+      }
     },
     diffable: function (value) {
       // URLs are fine to diff and display

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -545,7 +545,7 @@ module.exports = (self) => {
     async convert(req, field, data, destination) {
       destination[field.name] = self.apos.launder.url(data[field.name], field.def, true);
 
-      if (field.required && (_.isUndefined(data[field.name]) || !data[field.name].toString().length)) {
+      if (field.required && data[field.name] == null) {
         throw self.apos.error('required');
       }
 

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -545,7 +545,7 @@ module.exports = (self) => {
     async convert(req, field, data, destination) {
       destination[field.name] = self.apos.launder.url(data[field.name], field.def, true);
 
-      if (field.required && data[field.name] == null) {
+      if (field.required && (data[field.name] == null || !data[field.name].toString().length)) {
         throw self.apos.error('required');
       }
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
This PR adds the `validate` method from the `string` schema field to the `url` field definition. This allows for the safe use of the `pattern` property in a `url` schema field type. Closes PRO-5252.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly
1. Add a `url` schema field with a disallowed `pattern` property, such as `pattern: 123`
2. Try to bring the site up and you should have an error appear in the console
## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
