### PR TITLE
PRO-5272: Astro needs to know the full template name, which also includes the module name, and for convenience the module name alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixes
 
 * Pass on complete annotation information for nested areas when adding or editing a nested widget using an external front, like Astro.
+* Pass on the module name and the full, namespaced template name to external front ends, e.g. Astro.
+Also make this information available to other related methods for future and project-level use.
 
 ## 3.60.1 (2023-12-06)
 

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -432,8 +432,8 @@ module.exports = {
         await self.apos.area.loadDeferredWidgets(req);
         if (req.aposExternalFront) {
           data = self.apos.template.getRenderDataArgs(req, data, self);
-          await self.apos.template.annotateDataForExternalFront(req, template, data);
-          self.apos.template.pruneDataForExternalFront(req, template, data);
+          await self.apos.template.annotateDataForExternalFront(req, template, data, self.__meta.name);
+          self.apos.template.pruneDataForExternalFront(req, template, data, self.__meta.name);
           // Reply with JSON
           return data;
         }

--- a/modules/@apostrophecms/template/index.js
+++ b/modules/@apostrophecms/template/index.js
@@ -890,20 +890,24 @@ module.exports = {
         self.insertions[key].push(componentName);
       },
 
-      async annotateDataForExternalFront(req, template, data) {
-        const docs = self.getDocsForExternalFront(req, template, data);
+      async annotateDataForExternalFront(req, template, data, moduleName) {
+        const docs = self.getDocsForExternalFront(req, template, data, moduleName);
         for (const doc of docs) {
           self.annotateDocForExternalFront(doc);
         }
         data.aposBodyData = await self.getBodyData(req);
+        // Already contains module name too
+        data.template = template;
+        // For simple cases (not piece pages and the like)
+        data.module = moduleName;
         return data;
       },
 
-      pruneDataForExternalFront(req, data, template) {
+      pruneDataForExternalFront(req, template, data, moduleName) {
         return data;
       },
 
-      getDocsForExternalFront(req, template, data) {
+      getDocsForExternalFront(req, template, data, moduleName) {
         return [ data.home, ...(data.page?._ancestors || []), ...(data.page?._children || []), data.page, data.piece, ...(data.pieces || []) ].filter(doc => !!doc);
       },
 


### PR DESCRIPTION
…

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

See above.

Without this information, piece-pages cannot be handled by Astro because it cannot distinguish the "index page" from the "show page."

Also this allows a more idiomatic pattern for "page not found" templates and others with no `data.page`. They have their standard full names from Apostrophe (module-name:templateName) and these can be mapped in Astro (see corresponding PR in astro-integration).

## What are the specific steps to test this change?

See the `pro-5272` branches of `starter-kit-essentials` and `astro-demo`.

Adding a blog page works.

Populating a blog post works and then you can see it on the index page and click through to the show page.

Simple pagination works (I did not go full crazy mode here or build in the other blog filters, but I did provide a simple way to manipulate query parameters so developers can contemplate doing so).

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
