### PR TITLE
Safe test check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -536,6 +536,7 @@ those writing mocha tests of Apostrophe modules.
 * Hide the suggestion help from the relationship input list when the user starts typing a search term.
 * Hide the suggestion hint from the relationship input list when the user starts typing a search term except when there are no matches to display.
 * Disable context menu for related items when their `relationship` field has no sub-[`fields`](https://v3.docs.apostrophecms.org/guide/relationships.html#providing-context-with-fields) configured.
+* Logic for checking whether we are running a unit test of an external module under mocha now uses `includes` for a simpler, safer test that should be more cross-platform.
 
 ## 3.42.0 (2023-03-16)
 

--- a/index.js
+++ b/index.js
@@ -525,12 +525,12 @@ async function apostrophe(options, telemetry, rootSpan) {
     // and throws an exception if we don't
     function findTestModule() {
       let m = module;
-      const nodeModuleRegex = new RegExp(`node_modules${path.sep}mocha`);
-      if (!require.main.filename.match(nodeModuleRegex)) {
+      const testFor = `node_modules${path.sep}mocha`;
+      if (!require.main.filename.includes(testFor)) {
         throw new Error('mocha does not seem to be running, is this really a test?');
       }
       while (m) {
-        if (m.parent && m.parent.filename.match(nodeModuleRegex)) {
+        if (m.parent && m.parent.filename.incluces(testFor)) {
           return m;
         } else if (!m.parent) {
           // Mocha v10 doesn't inject mocha paths inside `module`, therefore, we only detect the parent until the last parent. But we can get Mocha running using `require.main` - Amin

--- a/index.js
+++ b/index.js
@@ -530,7 +530,7 @@ async function apostrophe(options, telemetry, rootSpan) {
         throw new Error('mocha does not seem to be running, is this really a test?');
       }
       while (m) {
-        if (m.parent && m.parent.filename.incluces(testFor)) {
+        if (m.parent && m.parent.filename.includes(testFor)) {
           return m;
         } else if (!m.parent) {
           // Mocha v10 doesn't inject mocha paths inside `module`, therefore, we only detect the parent until the last parent. But we can get Mocha running using `require.main` - Amin


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

See:

https://github.com/apostrophecms/apostrophe/commit/19115b62fecc67f7494889cd31e61cee7073d155#commitcomment-135083415

That's 2.x, but the issue also exists in 3.x.

## What are the specific steps to test this change?

`@apostrophecms/advanced-permission` module tests still pass while this branch of apostrophe is npm linked in. e.g. I didn't make anything worse!

Here's the minimal version (one test is sufficient):

```
npx mocha test/group.js
```

I did this and it passed.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
