### PR TITLE
prepareForStorage now accepts permissions: false to disable permissio…

### DIFF
--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -225,8 +225,8 @@ module.exports = {
   handlers(self) {
     return {
       beforeSave: {
-        prepareForStorage(req, doc) {
-          self.apos.schema.prepareForStorage(req, doc);
+        prepareForStorage(req, doc, options) {
+          self.apos.schema.prepareForStorage(req, doc, options);
         },
         async updateCacheField(req, doc) {
           await self.updateCacheField(req, doc);

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -999,9 +999,10 @@ module.exports = {
       //
       // Currently `req` does not impact this, but that may change.
 
-      prepareForStorage(req, doc) {
+      prepareForStorage(req, doc, options = {}) {
         const can = (field) => {
-          return (!field.withType && !field.editPermission && !field.viewPermission) ||
+          return options.permissions === false ||
+            (!field.withType && !field.editPermission && !field.viewPermission) ||
             (field.withType && self.apos.permission.can(req, 'view', field.withType)) ||
             (field.editPermission && self.apos.permission.can(req, field.editPermission.action, field.editPermission.type)) ||
             (field.viewPermission && self.apos.permission.can(req, field.viewPermission.action, field.viewPermission.type)) ||


### PR DESCRIPTION
…n checks

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

[PRO-4794](https://linear.app/apostrophecms/issue/PRO-4794/as-a-user-who-creates-a-document-i-should-be-granted-permission-to)

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
