### PR TITLE
Refactor `date` query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Adds
 
-
 * Add a `validate` method to the `url` field type to allow the use of the `pattern` property.
 * Add `autocomplete` attribute to schema fields that implement it (cf. [HTML attribute: autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)).
 
 
 ### Fixes
 
+* Fix `date` schema field query builder to work with arrays.
 * Fix `if` on pages. When you open the `AposDocEditor` modal on pages, you now see an up to date view of the visible fields.
 * Pass on complete annotation information for nested areas when adding or editing a nested widget using an external front, like Astro.
 * Pass on the module name and the full, namespaced template name to external front ends, e.g. Astro.

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -637,18 +637,16 @@ module.exports = (self) => {
         finalize: function () {
           if (self.queryBuilderInterested(query, field.name)) {
             const value = query.get(field.name);
-            let criteria;
+            const criteria = {};
             if (Array.isArray(value)) {
-              criteria = {};
               criteria[field.name] = {
                 $gte: value[0],
                 $lte: value[1]
               };
             } else {
-              criteria = {};
               criteria[field.name] = self.apos.launder.date(value);
-              query.and(criteria);
             }
+            query.and(criteria);
           }
         },
         launder: function (value) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
In writing the documentation for query builders added to schema fields, I found that when I queried on the date field, a single date would work, but an array containing two dates wouldn't return any documents. While looking at the array handling in the custom query builder I realized that the query was not updated with the calculated criteria. This PR fixes this. Closes PRO-5299.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?
*(Check at least one)*
1. Create a project with an 'article' piece-type and set an ApiKey
2. Add multiple articles with different publication dates throughout 2023 in the `pubDate` schema field of type `date`
3. Add a handler using the following code.
```
  handlers(self) {
    return {
      '@apostrophecms/page:beforeSend': {
        async findArticles(req, piece) {
        const articles = await self.apos.http.get('/api/v1/article', { qs: { pubDate: [ '2023-06-01', '2023-12-25'], apikey: 'key1'}});
          console.log('articles', articles);
        }
      }
    };
  },
```
4. This should return multiple documents
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
I didn't find any tests in the repo.
