### PR TITLE
Supports create and delete permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ coverage
 test/package.json
 test/public
 test/apos-build
+test/workspaces-project/node_modules
 
 # We do not commit CSS, only LESS, with the exception of a few vendor CSS files we don't have LESS for
 */public/css/*.css

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Unreleased
+
+### Adds
+
+* Adds support in can and criteria methods for `create` and `delete`.
+
 ## 3.61.0 (2023-12-21)
 
 ### Adds

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -104,7 +104,8 @@ module.exports = {
         function canView() {
           if (checkRoleConfig('viewRole')) {
             return false;
-          } else if (((typeof docOrType) === 'object') && (docOrType.visibility !== 'public')) {
+          }
+          if ((typeof docOrType === 'object') && (docOrType.visibility !== 'public')) {
             return (role === 'guest') || (role === 'contributor') || (role === 'editor');
           }
           return true;
@@ -113,7 +114,8 @@ module.exports = {
         function canEdit() {
           if (checkRoleConfig('editRole')) {
             return false;
-          } else if (mode === 'draft') {
+          }
+          if (mode === 'draft') {
             return (role === 'contributor') || (role === 'editor');
           }
           return role === 'editor';

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -82,7 +82,7 @@ module.exports = {
           return (role === 'contributor') || (role === 'editor');
         }
 
-        if (action === 'edit') {
+        if (action === 'edit' || action === 'create') {
           return canEdit();
         }
 
@@ -95,9 +95,7 @@ module.exports = {
         }
 
         if (action === 'delete') {
-          return doc && !doc.lastPublishedAt
-            ? self.can(req, 'edit', doc)
-            : self.can(req, 'publish', doc);
+          canDelete();
         }
 
         throw self.apos.error('invalid', 'That action is not implemented');
@@ -130,6 +128,14 @@ module.exports = {
             return false;
           }
           return role === 'editor';
+        }
+
+        function canDelete() {
+          if (doc && (!doc.lastPublishedAt || doc.aposMode === 'draft')) {
+            return self.can(req, 'edit', doc);
+          }
+
+          return self.can(req, 'publish', doc || type);
         }
       },
 

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -60,11 +60,6 @@ module.exports = {
           return true;
         }
 
-        // TODO: remove this
-        if (action === 'archive') {
-          action = 'edit';
-        }
-
         const type = docOrType && (docOrType.type || docOrType);
         const doc = (docOrType && docOrType._id) ? docOrType : null;
         const manager = type && self.apos.doc.getManager(type);
@@ -95,7 +90,7 @@ module.exports = {
           return (role === 'contributor') || (role === 'editor');
         }
 
-        if (action === 'delete') {
+        if ([ 'delete', 'archive' ].includes(action)) {
           return canDelete();
         }
 
@@ -132,11 +127,11 @@ module.exports = {
         }
 
         function canDelete() {
-          if (doc && (!doc.lastPublishedAt || doc.aposMode === 'draft')) {
-            return self.can(req, 'edit', doc);
+          if (doc && (!doc.lastPublishedAt)) {
+            return self.can(req, 'edit', doc, mode);
           }
 
-          return self.can(req, 'publish', docOrType);
+          return self.can(req, 'publish', docOrType, mode);
         }
       },
 

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -127,7 +127,7 @@ module.exports = {
         }
 
         function canDelete() {
-          if (doc && (!doc.lastPublishedAt)) {
+          if (doc && (!doc.lastPublishedAt || doc.aposMode === 'draft')) {
             return self.can(req, 'edit', doc, mode);
           }
 

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -210,7 +210,7 @@ module.exports = {
 
             return query;
           }
-        } else if (action === 'edit') {
+        } else if ([ 'edit', 'create', 'delete' ].includes(action)) {
           if (role === 'contributor') {
             return {
               aposMode: {

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -144,10 +144,6 @@ module.exports = {
           return {};
         }
 
-        if (action === 'create' || action === 'archive') {
-          action = 'edit';
-        }
-
         const restrictedViewTypes = Object.keys(self.apos.doc.managers).filter(name => ranks[self.apos.doc.getManager(name).options.viewRole] > ranks[role]);
         const restrictedEditTypes = Object.keys(self.apos.doc.managers).filter(name => ranks[self.apos.doc.getManager(name).options.editRole] > ranks[role]);
         const restrictedPublishTypes = Object.keys(self.apos.doc.managers).filter(name => ranks[self.apos.doc.getManager(name).options.publishRole] > ranks[role]);

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -82,7 +82,7 @@ module.exports = {
           return (role === 'contributor') || (role === 'editor');
         }
 
-        if (action === 'edit' || action === 'create') {
+        if ([ 'edit', 'create' ].includes(action)) {
           return canEdit();
         }
 
@@ -95,7 +95,7 @@ module.exports = {
         }
 
         if (action === 'delete') {
-          canDelete();
+          return canDelete();
         }
 
         throw self.apos.error('invalid', 'That action is not implemented');

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -60,7 +60,8 @@ module.exports = {
           return true;
         }
 
-        if (action === 'create' || action === 'archive') {
+        // TODO: remove this
+        if (action === 'archive') {
           action = 'edit';
         }
 
@@ -135,7 +136,7 @@ module.exports = {
             return self.can(req, 'edit', doc);
           }
 
-          return self.can(req, 'publish', doc || type);
+          return self.can(req, 'publish', docOrType);
         }
       },
 


### PR DESCRIPTION
[PRO-4792](https://linear.app/apostrophecms/issue/PRO-4792/in-core-queries-for-create-and-delete-permission-must-be-handled)

## Summary

See ticket.

## What are the specific steps to test this change?

Tests added must cover new actions added:
In can method:
* `create` action should be treated like `edit`
* `delete` should be handled appropriately following ticket instructions.

In criteria method:
* `create` and `delete` actions return the same criterias than `edit`.

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [X] Related tests have been updated
