### PR TITLE
DO NOT MERGE - proof of concept PR for aria-label custom HTML attribute in links

### DIFF
--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -404,7 +404,8 @@ module.exports = {
               'href',
               'id',
               'name',
-              'target'
+              'target',
+              'aria-label'
             ]
           },
           alignLeft: {

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
@@ -90,6 +90,7 @@ export default {
     return {
       generation: 1,
       href: null,
+      'aria-label': null,
       target: null,
       active: false,
       hasLinkOnOpen: false,
@@ -152,6 +153,12 @@ export default {
           if: {
             linkTo: '_url'
           }
+        },
+        {
+          name: 'aria-label',
+          label: 'Aria Label',
+          type: 'string',
+          required: false
         },
         {
           name: 'target',
@@ -251,7 +258,8 @@ export default {
         }
         this.editor.commands.setLink({
           target: this.docFields.data.target[0],
-          href: this.docFields.data.href
+          href: this.docFields.data.href,
+          'aria-label': this.docFields.data['aria-label']
         });
         this.close();
       });

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
@@ -12,20 +12,8 @@ export default (options) => {
       return {
         'aria-label': {
           default: null
-        },
-        href: {
-          default: null,
-        },
-        target: {
-          default: this.options.HTMLAttributes.target
-        },
-        rel: {
-          default: this.options.HTMLAttributes.rel
-        },
-        class: {
-          default: this.options.HTMLAttributes.class
-        },
-      }
+        }
+      };
     },
   
   });

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
@@ -5,19 +5,13 @@ export default (options) => {
       return {
         ...this.parent?.(),
         openOnClick: false,
-        linkOnPaste: true,
-        HTMLAttributes: {
-          target: '_blank',
-          rel: 'noopener noreferrer nofollow',
-          class: null,
-          'aria-label': null
-        }
+        linkOnPaste: true
       };
     },
     addAttributes() {
       return {
         'aria-label': {
-          default: this.options.HTMLAttributes['aria-label']
+          default: null
         },
         href: {
           default: null,

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
@@ -5,7 +5,8 @@ export default (options) => {
       return {
         ...this.parent?.(),
         openOnClick: false,
-        linkOnPaste: true
+        linkOnPaste: true,
+        HTMLAttributes: {}
       };
     },
     addAttributes() {

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
@@ -6,8 +6,33 @@ export default (options) => {
         ...this.parent?.(),
         openOnClick: false,
         linkOnPaste: true,
-        HTMLAttributes: {}
+        HTMLAttributes: {
+          target: '_blank',
+          rel: 'noopener noreferrer nofollow',
+          class: null,
+          'aria-label': null
+        }
       };
-    }
+    },
+    addAttributes() {
+      return {
+        'aria-label': {
+          default: this.options.HTMLAttributes['aria-label']
+        },
+        href: {
+          default: null,
+        },
+        target: {
+          default: this.options.HTMLAttributes.target
+        },
+        rel: {
+          default: this.options.HTMLAttributes.rel
+        },
+        class: {
+          default: this.options.HTMLAttributes.class
+        },
+      }
+    },
+  
   });
 };

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
@@ -8,14 +8,6 @@ export default (options) => {
         linkOnPaste: true,
         HTMLAttributes: {}
       };
-    },
-    addAttributes() {
-      return {
-        'aria-label': {
-          default: null
-        }
-      };
-    },
-  
+    }
   });
 };

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
@@ -6,7 +6,18 @@ export default (options) => {
         ...this.parent?.(),
         openOnClick: false,
         linkOnPaste: true,
+        // Intentional, the default-defaults are poorly suited
+        // to CMS work e.g. nofollow
         HTMLAttributes: {}
+      };
+    },
+    addAttributes() {
+      return {
+        // Necessary to not break href, etc.
+        ...this.parent?.(),
+        'aria-label': {
+          default: null
+        }
       };
     }
   });


### PR DESCRIPTION
This PR demonstrates how to add extra attributes to the link control in our rich text widget, so far as tiptap is concerned.

However see tech design as we want to do this via an extensible schema, not one-off hacks. So the kind of code seen here would be applied iteratively in a loop based on a schema, etc.