### PR TITLE
PRO-5330: Add type support for page autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Adds
+
+* Adds support for `type` query parameter for page autocomplete. This allows to filter the results by page type. Example: `/api/v1/@apostrophecms/page?autocomplete=something&type=my-page-type`.
+
 ## 3.61.0 (2023-12-21)
 
 ### Adds

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposInputRelationship.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposInputRelationship.js
@@ -147,6 +147,10 @@ export default {
       this.next = items;
     },
     async search(qs) {
+      const action = apos.modules[this.field.withType].action;
+      const isPage = apos.modules['@apostrophecms/page'].validPageTypes
+        .includes(this.field.withType);
+
       if (this.field.suggestionLimit) {
         qs.perPage = this.field.suggestionLimit;
       }
@@ -156,16 +160,16 @@ export default {
       if (this.field.withType === '@apostrophecms/image') {
         apos.bus.$emit('piece-relationship-query', qs);
       }
+      if (isPage) {
+        qs.type = this.field.withType;
+      }
 
       this.searching = true;
-      const list = await apos.http.get(
-        apos.modules[this.field.withType].action,
-        {
-          busy: false,
-          draft: true,
-          qs
-        }
-      );
+      const list = await apos.http.get(action, {
+        busy: false,
+        draft: true,
+        qs
+      });
 
       const removeSelectedItem = item => !this.next.map(i => i._id).includes(item._id);
       const formatItems = item => ({

--- a/test/pages-autocomplete.js
+++ b/test/pages-autocomplete.js
@@ -1,0 +1,203 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert/strict');
+
+describe('Pages Autocomplete', function() {
+  let apos;
+  let jar;
+
+  this.timeout(t.timeout);
+
+  before(async function () {
+    apos = await t.create({
+      root: module,
+      modules: {
+        '@apostrophecms/page': {
+          options: {
+            park: [],
+            types: [
+              {
+                name: '@apostrophecms/home-page',
+                label: 'Home'
+              },
+              {
+                name: 'test-page',
+                label: 'Test Page'
+              },
+              {
+                name: 'complex-page',
+                label: 'Complex Page'
+              }
+            ]
+          }
+        },
+        'test-page': {
+          extend: '@apostrophecms/page-type',
+          options: {
+            alias: 'testPage',
+            label: 'Test Page'
+          }
+        },
+        // Pretend we have page relationships here
+        'complex-page': {
+          extend: '@apostrophecms/page-type',
+          options: {
+            alias: 'complexPage',
+            label: 'Complex Page'
+          }
+        }
+      }
+    });
+
+    await t.createAdmin(apos, {
+      username: 'admin',
+      password: 'admin',
+      title: 'admin',
+      email: 'admin@example.com'
+    });
+
+    jar = await login(apos);
+    await createTestPages(apos, jar);
+  });
+
+  after(async function () {
+    return t.destroy(apos);
+  });
+
+  it('should suggest all types', async function () {
+    {
+      const suggestions = await apos.http.get('/api/v1/@apostrophecms/page', {
+        jar,
+        qs: {
+          autocomplete: 'home'
+        }
+      });
+      assert.equal(suggestions.results.length, 1, 'home page not found');
+      assert.equal(suggestions.results[0].slug, '/', 'home page slug not found');
+    }
+
+    {
+      const suggestions = await apos.http.get('/api/v1/@apostrophecms/page', {
+        jar,
+        qs: {
+          autocomplete: 'test'
+        }
+      });
+      assert.equal(suggestions.results.length, 1, 'test page not found');
+      assert.equal(suggestions.results[0].slug, '/test-page', 'test page slug not found');
+    }
+
+    {
+      const suggestions = await apos.http.get('/api/v1/@apostrophecms/page', {
+        jar,
+        qs: {
+          autocomplete: 'complex'
+        }
+      });
+      assert.equal(suggestions.results.length, 1, 'complex page not found');
+      assert.equal(suggestions.results[0].slug, '/complex-page', 'complex page slug not found');
+    }
+
+    {
+      const suggestions = await apos.http.get('/api/v1/@apostrophecms/page', {
+        jar,
+        qs: {
+          autocomplete: 'page'
+        }
+      });
+      assert.equal(suggestions.results.length, 3, 'all pages does not match');
+    }
+  });
+
+  it('should suggest by type', async function () {
+    {
+      const suggestions = await apos.http.get('/api/v1/@apostrophecms/page', {
+        jar,
+        qs: {
+          autocomplete: 'page',
+          type: '@apostrophecms/home-page'
+        }
+      });
+      assert.equal(suggestions.results.length, 1, 'home page not found');
+      assert.equal(suggestions.results[0].slug, '/', 'home page slug not found');
+    }
+
+    {
+      const suggestions = await apos.http.get('/api/v1/@apostrophecms/page', {
+        jar,
+        qs: {
+          autocomplete: 'page',
+          type: 'test-page'
+        }
+      });
+      assert.equal(suggestions.results.length, 1, 'test page not found');
+      assert.equal(suggestions.results[0].slug, '/test-page', 'test page slug not found');
+    }
+
+    {
+      const suggestions = await apos.http.get('/api/v1/@apostrophecms/page', {
+        jar,
+        qs: {
+          autocomplete: 'page',
+          type: 'complex-page'
+        }
+      });
+      assert.equal(suggestions.results.length, 1, 'complex page not found');
+      assert.equal(suggestions.results[0].slug, '/complex-page', 'complex page slug not found');
+    }
+  });
+
+  it('should ignore type when no autocomplete', async function () {
+    const result = await apos.http.get('/api/v1/@apostrophecms/page', {
+      jar,
+      qs: {
+        type: 'test-page'
+      }
+    });
+    assert.equal(result.slug, '/', 'home page not found');
+    assert.equal(result._children.length, 2, 'children result does not match');
+  });
+});
+
+async function login(apos) {
+  const jar = await t.loginAs(apos, 'admin');
+  const page = await apos.http.get('/', {
+    jar
+  });
+  assert(page.match(/logged in/));
+  return jar;
+}
+
+async function createTestPages(apos, jar) {
+  const req = apos.task.getReq();
+
+  const home = await apos.page.find(req, { slug: '/' }).toObject();
+
+  const testPage = await apos.page.insert(req, home._id, 'lastChild', {
+    title: 'Test Page',
+    slug: '/test-page',
+    type: 'test-page'
+  });
+  assert(testPage);
+  assert(testPage.slug === '/test-page');
+
+  const complexPage = await apos.page.insert(req, home._id, 'lastChild', {
+    title: 'Complex Page',
+    slug: '/complex-page',
+    type: 'complex-page',
+    pageIds: [ testPage.aposDocId ],
+    basePageIds: [ home.aposDocId ]
+  });
+  assert(complexPage);
+  assert(complexPage.slug === '/complex-page');
+
+  // Validate test data
+  const tree = await apos.http.get('/api/v1/@apostrophecms/page', {
+    jar
+  });
+  assert.equal(tree.slug, '/');
+  // Important when validating suggestions.
+  assert.equal(tree.highSearchText.includes('page'), true, 'home page does not include page in highSearchText');
+  assert.equal(tree._children.length, 2);
+  assert(tree._children.some(page => page.slug === '/test-page'), 'test page missing');
+  assert(tree._children.some(page => page.slug === '/complex-page'), 'complex page missing');
+}


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Add support for `type` query parameter in page `autocomplete` mode.

## What are the specific steps to test this change?

Pages will be suggested based on the type provided and if provided. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
