### PR TITLE
PRO-5362 fix the toolbar bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.61.1 (2023-01-08)
+
+### Fixes
+
+* Pinned Vue dependency to 2.7.15. Released on December 24th, Vue 2.7.16 broke the rich text toolbar
+in Apostrophe.
+
 ## 3.61.0 (2023-12-21)
 
 ### Adds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Fixes
 
-* Pinned Vue dependency to 2.7.15. Released on December 24th, Vue 2.7.16 broke the rich text toolbar
-in Apostrophe.
+* Pinned Vue dependency to 2.7.15. Released on December 24th, Vue 2.7.16 broke the rich text toolbar in Apostrophe.
 
 ## 3.61.0 (2023-12-21)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "3.61.0",
+  "version": "3.61.1",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {
@@ -132,7 +132,7 @@
     "underscore.string": "^3.3.4",
     "uploadfs": "^1.22.3",
     "v-tooltip": "^2.0.3",
-    "vue": "^2.6.14",
+    "vue": "2.6.15",
     "vue-advanced-cropper": "^1.10.1",
     "vue-loader": "^15.10.0",
     "vue-material-design-icons": "~4.12.1",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "underscore.string": "^3.3.4",
     "uploadfs": "^1.22.3",
     "v-tooltip": "^2.0.3",
-    "vue": "2.6.15",
+    "vue": "2.7.15",
     "vue-advanced-cropper": "^1.10.1",
     "vue-loader": "^15.10.0",
     "vue-material-design-icons": "~4.12.1",


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Just pin it

## What are the specific steps to test this change?

To reproduce the bug:

```
cd a3-demo
git pull
export APOS_DEV=1
rm -rf node_modules && rm package-lock.json && npm install
npm run dev
```

Try to open the rich text toolbar. You can't.

To reproduce the fix:

* Change your apostrophe dependency in a3-demo's `package.json` to this branch, `hotfix-3.61.1`
* `export APOS_DEV=1`
* `rm package-lock.json && rm -rf node_modules/ && npm install && npm run dev`

I will PR the basis branch back to main after release of the hotfix.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
