### PR TITLE
PRO-5341: Link HTML attributes for rich text widget 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ npm-debug.log
 coverage
 /node_modules
 /test/node_modules
+/test/workspaces-project/node_modules
 test/package.json
 test/public
 test/apos-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Adds support for `type` query parameter for page autocomplete. This allows to filter the results by page type. Example: `/api/v1/@apostrophecms/page?autocomplete=something&type=my-page-type`.
 * Add testing for the `float` schema field query builder.
 * Add testing for the `integer` schema field query builder.
+* Add support for link HTML attributes in the rich text widget via configurable fields `linkFields`, extendable on a project level (same as it's done for `fields`). A property `htmlAttribute: true` should be set on every attribute field in order to be used as a link HTML attribute.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Adds support for `type` query parameter for page autocomplete. This allows to filter the results by page type. Example: `/api/v1/@apostrophecms/page?autocomplete=something&type=my-page-type`.
 * Add testing for the `float` schema field query builder.
 * Add testing for the `integer` schema field query builder.
-* Add support for link HTML attributes in the rich text widget via configurable fields `linkFields`, extendable on a project level (same as it's done for `fields`). A property `htmlAttribute: true` should be set on every attribute field in order to be used as a link HTML attribute.
+* Add support for link HTML attributes in the rich text widget via configurable fields `linkFields`, extendable on a project level (same as it's done for `fields`). Add an `htmlAttribute` property to the standard fields that map directly to an HTML attribute, except `href` (see special case below), and set it accordingly, even if it is the same as the field name. Setting `htmlAttribute: 'href'` is not allowed and will throw a schema validation exception (on application boot).
 
 ### Fixes
 

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -73,23 +73,12 @@ module.exports = {
         target: {
           label: 'apostrophe:linkTarget',
           type: 'checkboxes',
-          htmlAttribute: true,
+          htmlAttribute: 'target',
           choices: [
             {
               label: 'apostrophe:openLinkInNewTab',
               value: '_blank'
             }
-          ]
-        }
-      },
-      group: {
-        link: {
-          fields: [
-            'linkTo',
-            ...linkWithType.map(type => `_${type}`),
-            'updateTitle',
-            'href',
-            'target'
           ]
         }
       }
@@ -507,7 +496,7 @@ module.exports = {
               'name',
               ...self.linkSchema
                 .filter(field => field.htmlAttribute)
-                .map(field => field.name)
+                .map(field => field.htmlAttribute)
             ]
           },
           alignLeft: {
@@ -814,23 +803,17 @@ module.exports = {
           addFields: self.apos.schema.fieldsToArray(`Links ${self.__meta.name}`, self.linkFields),
           arrangeFields: self.apos.schema.groupsToArray(self.linkFieldsGroups)
         }, self);
-        const forbiddenFields = [
-          '_id'
-        ];
-        self.linkSchema.forEach((field) => {
-          if (forbiddenFields.includes(field.name)) {
-            throw new Error('Doc type ' + self.name + ': the field name ' + field.name + ' is forbidden');
-          }
-        });
+
         self.apos.schema.validate(self.linkSchema, {
-          type: 'doc type',
+          type: 'link',
           subtype: self.__meta.name
         });
-        // Don't allow htmlAttribute on href, it's a special case.
-        if (self.linkSchema.find(field => field.name === 'href')?.htmlAttribute) {
-          throw new Error('The link field "href" can not have "htmlAttribute: true"');
+
+        // Don't allow htmlAttribute `href`, it's a special case.
+        const hrefField = self.linkSchema.find(field => field.htmlAttribute === 'href');
+        if (hrefField) {
+          throw new Error(`Field "${hrefField.name}" validation error: "htmlAttribute: href" is not allowed.`);
         }
-        self.apos.schema.register('widget', self.__meta.name, self.linkSchema);
       }
     };
   },

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -83,7 +83,7 @@ module.exports = {
         }
       },
       group: {
-        basic: {
+        link: {
           fields: [
             'linkTo',
             ...linkWithType.map(type => `_${type}`),

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -6,6 +6,95 @@ const cheerio = require('cheerio');
 
 module.exports = {
   extend: '@apostrophecms/widget-type',
+  cascades: [ 'linkFields' ],
+  linkFields(self, options) {
+    const linkWithType = (Array.isArray(options.linkWithType)
+      ? options.linkWithType
+      : [ options.linkWithType ]);
+
+    // Labels are not available at the time the schema is built,
+    // they are added on modulesRegistered.
+    const linkWithTypeChoices = linkWithType
+      .map(type => ({
+        label: type,
+        value: type
+      }))
+      .concat([
+        {
+          label: 'apostrophe:url',
+          value: '_url'
+        }
+      ]);
+
+    const linkWithTypeFields = linkWithType.reduce((fields, type) => {
+      const name = `_${type}`;
+      fields[name] = {
+        type: 'relationship',
+        label: type,
+        withType: type,
+        required: true,
+        max: 1,
+        browse: true,
+        if: {
+          linkTo: type
+        }
+      };
+      return fields;
+    }, {});
+    linkWithTypeFields.updateTitle = {
+      label: 'apostrophe:updateTitle',
+      type: 'boolean',
+      def: true,
+      if: {
+        $or: linkWithType.map(type => ({
+          linkTo: type
+        }))
+      }
+    };
+
+    return {
+      add: {
+        linkTo: {
+          label: 'apostrophe:linkTo',
+          type: 'select',
+          choices: linkWithTypeChoices,
+          required: true,
+          def: linkWithTypeChoices[0].value
+        },
+        ...linkWithTypeFields,
+        href: {
+          label: 'apostrophe:url',
+          type: 'string',
+          required: true,
+          if: {
+            linkTo: '_url'
+          }
+        },
+        target: {
+          label: 'apostrophe:linkTarget',
+          type: 'checkboxes',
+          htmlAttribute: true,
+          choices: [
+            {
+              label: 'apostrophe:openLinkInNewTab',
+              value: '_blank'
+            }
+          ]
+        }
+      },
+      group: {
+        basic: {
+          fields: [
+            'linkTo',
+            ...linkWithType.map(type => `_${type}`),
+            'updateTitle',
+            'href',
+            'target'
+          ]
+        }
+      }
+    };
+  },
   options: {
     icon: 'format-text-icon',
     label: 'apostrophe:richText',
@@ -270,6 +359,18 @@ module.exports = {
     'format-color-highlight-icon': 'FormatColorHighlight',
     'table-icon': 'Table'
   },
+  handlers(self) {
+    return {
+      'apostrophe:modulesRegistered': {
+        validateAndFixLinkWithTypes() {
+          self.validateAndFixLinkWithTypes();
+        },
+        composeLinkSchema() {
+          self.composeLinkSchema();
+        }
+      }
+    };
+  },
   methods(self) {
     return {
       // Return just the rich text of the widget, which may be undefined or null if it has not yet been edited
@@ -404,7 +505,9 @@ module.exports = {
               'href',
               'id',
               'name',
-              'target'
+              ...self.linkSchema
+                .filter(field => field.htmlAttribute)
+                .map(field => field.name)
             ]
           },
           alignLeft: {
@@ -675,6 +778,59 @@ module.exports = {
           }
         }
         return content;
+      },
+      // Validate the types provided for links, update labels derived from
+      // corresponding modules, as they are not available at the time
+      // the schema is generated.
+      validateAndFixLinkWithTypes() {
+        const linkWithType = (Array.isArray(self.options.linkWithType)
+          ? self.options.linkWithType
+          : [ self.options.linkWithType ]);
+
+        for (const type of linkWithType) {
+          if (!self.apos.modules[type]) {
+            throw new Error(
+              `The linkWithType option of rich text widget "${type}" must be a valid module type`
+            );
+          }
+
+          self.linkFields[`_${type}`].label = getLabel(type);
+          const choice = self.linkFields.linkTo.choices
+            .find(choice => choice.value === type);
+
+          choice.label = getLabel(type);
+        }
+
+        function getLabel(type) {
+          if ([ '@apostrophecms/any-page-type', '@apostrophecms/page' ].includes(type)) {
+            return 'apostrophe:page';
+          }
+          return self.apos.modules[type].options?.label ?? type;
+        }
+      },
+      // Compose and register the link schema.
+      composeLinkSchema() {
+        self.linkSchema = self.apos.schema.compose({
+          addFields: self.apos.schema.fieldsToArray(`Links ${self.__meta.name}`, self.linkFields),
+          arrangeFields: self.apos.schema.groupsToArray(self.linkFieldsGroups)
+        }, self);
+        const forbiddenFields = [
+          '_id'
+        ];
+        self.linkSchema.forEach((field) => {
+          if (forbiddenFields.includes(field.name)) {
+            throw new Error('Doc type ' + self.name + ': the field name ' + field.name + ' is forbidden');
+          }
+        });
+        self.apos.schema.validate(self.linkSchema, {
+          type: 'doc type',
+          subtype: self.__meta.name
+        });
+        // Don't allow htmlAttribute on href, it's a special case.
+        if (self.linkSchema.find(field => field.name === 'href')?.htmlAttribute) {
+          throw new Error('The link field "href" can not have "htmlAttribute: true"');
+        }
+        self.apos.schema.register('widget', self.__meta.name, self.linkSchema);
       }
     };
   },
@@ -739,6 +895,7 @@ module.exports = {
           // Not optional in presence of an insert menu, it's not acceptable UX without it
           placeholderTextWithInsertMenu: self.options.placeholderTextWithInsertMenu,
           linkWithType: Array.isArray(self.options.linkWithType) ? self.options.linkWithType : [ self.options.linkWithType ],
+          linkSchema: self.linkSchema,
           imageStyles: self.options.imageStyles
         };
         return finalData;

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
@@ -122,7 +122,7 @@ export default {
       return this.originalSchema;
     },
     schemaHtmlAttributes() {
-      return this.schema.filter(item => (item.htmlAttribute ?? false));
+      return this.schema.filter(item => !!item.htmlAttribute);
     }
   },
   watch: {
@@ -193,10 +193,10 @@ export default {
             return acc;
           }
           if (field.type === 'boolean') {
-            acc[field.name] = value === true ? '' : null;
+            acc[field.htmlAttribute] = value === true ? '' : null;
             return acc;
           }
-          acc[field.name] = Array.isArray(value) ? value[0] : value;
+          acc[field.htmlAttribute] = Array.isArray(value) ? value[0] : value;
           return acc;
         }, {});
         attrs.href = this.docFields.data.href;
@@ -225,13 +225,17 @@ export default {
         this.docFields.data = {};
         this.schema.forEach((item) => {
           if (item.htmlAttribute && item.type === 'checkboxes') {
-            this.docFields.data[item.name] = attrs[item.name] ? [ attrs[item.name] ] : [];
+            this.docFields.data[item.name] = attrs[item.htmlAttribute] ? [ attrs[item.htmlAttribute] ] : [];
             return;
           }
           if (item.htmlAttribute && item.type === 'boolean') {
-            this.docFields.data[item.name] = attrs[item.name] === null
+            this.docFields.data[item.name] = attrs[item.htmlAttribute] === null
               ? null
-              : (attrs[item.name] === '');
+              : (attrs[item.htmlAttribute] === '');
+            return;
+          }
+          if (item.htmlAttribute) {
+            this.docFields.data[item.name] = attrs[item.htmlAttribute] || '';
             return;
           }
           this.docFields.data[item.name] = attrs[item.name] || '';

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
@@ -86,11 +86,19 @@ export default {
     }
   },
   data() {
-    const linkWithType = getOptions().linkWithType;
+    // const linkWithType = getOptions().linkWithType;
+    const attrs = getOptions().linkSchema
+      .filter(field => field.htmlAttribute)
+      .reduce((obj, field) => {
+        obj[field.name] = null;
+        return obj;
+      }, {});
+
     return {
+      ...attrs,
       generation: 1,
       href: null,
-      target: null,
+      // target: null,
       active: false,
       hasLinkOnOpen: false,
       triggerValidation: false,
@@ -98,73 +106,74 @@ export default {
         data: {}
       },
       formModifiers: [ 'small', 'margin-micro' ],
-      originalSchema: [
-        {
-          name: 'linkTo',
-          label: this.$t('apostrophe:linkTo'),
-          type: 'select',
-          def: linkWithType[0],
-          required: true,
-          choices: [
-            ...(linkWithType.map(type => {
-              return {
-                // Should already be localized server side
-                label: apos.modules[type].label,
-                value: type
-              };
-            })),
-            {
-              // TODO this needs i18n
-              label: this.$t('apostrophe:url'),
-              // Value that will never be a doc type
-              value: '_url'
-            }
-          ]
-        },
-        ...getOptions().linkWithType.map(type => ({
-          name: `_${type}`,
-          type: 'relationship',
-          label: apos.modules[type].label,
-          withType: type,
-          required: true,
-          max: 1,
-          browse: true,
-          if: {
-            linkTo: type
-          }
-        })),
-        {
-          name: 'updateTitle',
-          label: this.$t('apostrophe:updateTitle'),
-          type: 'boolean',
-          def: true,
-          if: {
-            $or: linkWithType.map(type => ({
-              linkTo: type
-            }))
-          }
-        },
-        {
-          name: 'href',
-          label: this.$t('apostrophe:url'),
-          type: 'string',
-          required: true,
-          if: {
-            linkTo: '_url'
-          }
-        },
-        {
-          name: 'target',
-          label: this.$t('apostrophe:linkTarget'),
-          type: 'checkboxes',
-          choices: [
-            {
-              label: this.$t('apostrophe:openLinkInNewTab'),
-              value: '_blank'
-            }
-          ]
-        }
-      ]
+      originalSchema: getOptions().linkSchema
+      // originalSchema: [
+      //   {
+      //     name: 'linkTo',
+      //     label: this.$t('apostrophe:linkTo'),
+      //     type: 'select',
+      //     def: linkWithType[0],
+      //     required: true,
+      //     choices: [
+      //       ...(linkWithType.map(type => {
+      //         return {
+      //           // Should already be localized server side
+      //           label: apos.modules[type].label,
+      //           value: type
+      //         };
+      //       })),
+      //       {
+      //         // TODO this needs i18n
+      //         label: this.$t('apostrophe:url'),
+      //         // Value that will never be a doc type
+      //         value: '_url'
+      //       }
+      //     ]
+      //   },
+      //   ...getOptions().linkWithType.map(type => ({
+      //     name: `_${type}`,
+      //     type: 'relationship',
+      //     label: apos.modules[type].label,
+      //     withType: type,
+      //     required: true,
+      //     max: 1,
+      //     browse: true,
+      //     if: {
+      //       linkTo: type
+      //     }
+      //   })),
+      //   {
+      //     name: 'updateTitle',
+      //     label: this.$t('apostrophe:updateTitle'),
+      //     type: 'boolean',
+      //     def: true,
+      //     if: {
+      //       $or: linkWithType.map(type => ({
+      //         linkTo: type
+      //       }))
+      //     }
+      //   },
+      //   {
+      //     name: 'href',
+      //     label: this.$t('apostrophe:url'),
+      //     type: 'string',
+      //     required: true,
+      //     if: {
+      //       linkTo: '_url'
+      //     }
+      //   },
+      //   {
+      //     name: 'target',
+      //     label: this.$t('apostrophe:linkTarget'),
+      //     type: 'checkboxes',
+      //     choices: [
+      //       {
+      //         label: this.$t('apostrophe:openLinkInNewTab'),
+      //         value: '_blank'
+      //       }
+      //     ]
+      //   }
+      // ]
     };
   },
   computed: {
@@ -186,6 +195,9 @@ export default {
     },
     schema() {
       return this.originalSchema;
+    },
+    schemaHtmlAttributes() {
+      return this.schema.filter(item => (item.htmlAttribute ?? false));
     }
   },
   watch: {
@@ -249,10 +261,21 @@ export default {
         if (this.docFields.data.target && !this.docFields.data.href) {
           delete this.docFields.data.target;
         }
-        this.editor.commands.setLink({
-          target: this.docFields.data.target[0],
-          href: this.docFields.data.href
-        });
+
+        const attrs = this.schemaHtmlAttributes.reduce((attrs, field) => {
+          const value = this.docFields.data[field.name];
+          if (field.type === 'checkboxes' && !value?.[0]) {
+            return attrs;
+          }
+          if (field.type === 'boolean' && value === false) {
+            return attrs;
+          }
+          attrs[field.name] = Array.isArray(value) ? value[0] : value;
+          return attrs;
+        }, {});
+        attrs.href = this.docFields.data.href;
+        this.editor.commands.setLink(attrs);
+
         this.close();
       });
     },
@@ -272,13 +295,17 @@ export default {
     },
     async populateFields() {
       try {
-        const attrs = this.attributes;
-        if (attrs.target) {
-          // checkboxes field expects an array
-          attrs.target = [ attrs.target ];
-        }
+        const attrs = { ...this.attributes };
         this.docFields.data = {};
         this.schema.forEach((item) => {
+          if (item.htmlAttribute && item.type === 'checkboxes') {
+            this.docFields.data[item.name] = attrs[item.name] ? [ attrs[item.name] ] : [];
+            return;
+          }
+          if (item.htmlAttribute && item.type === 'boolean') {
+            this.docFields.data[item.name] = !!attrs[item.name];
+            return;
+          }
           this.docFields.data[item.name] = attrs[item.name] || '';
         });
         const matches = this.docFields.data.href.match(/^#apostrophe-permalink-(.*)\?updateTitle=(\d)$/);

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
@@ -1,20 +1,23 @@
 import Link from '@tiptap/extension-link';
 export default (options) => {
-  const attrs = apos.modules['@apostrophecms/rich-text-widget'].linkSchema
-    .filter(field => field.htmlAttribute)
-    .reduce((obj, field) => {
-      obj[field.name] = { default: null };
-      return obj;
-    }, {});
-
   return Link.extend({
     addOptions() {
       return {
         ...this.parent?.(),
-        ...attrs,
         openOnClick: false,
         linkOnPaste: true,
         HTMLAttributes: {}
+      };
+    },
+    addAttributes() {
+      return {
+        ...this.parent?.(),
+        ...apos.modules['@apostrophecms/rich-text-widget'].linkSchema
+          .filter(field => field.htmlAttribute)
+          .reduce((obj, field) => {
+            obj[field.name] = { default: null };
+            return obj;
+          }, {})
       };
     }
   });

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
@@ -15,7 +15,7 @@ export default (options) => {
         ...apos.modules['@apostrophecms/rich-text-widget'].linkSchema
           .filter(field => field.htmlAttribute)
           .reduce((obj, field) => {
-            obj[field.name] = { default: null };
+            obj[field.name] = { default: field.def ?? null };
             return obj;
           }, {})
       };

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
@@ -1,9 +1,17 @@
 import Link from '@tiptap/extension-link';
 export default (options) => {
+  const attrs = apos.modules['@apostrophecms/rich-text-widget'].linkSchema
+    .filter(field => field.htmlAttribute)
+    .reduce((obj, field) => {
+      obj[field.name] = { default: null };
+      return obj;
+    }, {});
+
   return Link.extend({
     addOptions() {
       return {
         ...this.parent?.(),
+        ...attrs,
         openOnClick: false,
         linkOnPaste: true,
         HTMLAttributes: {}

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Link.js
@@ -13,9 +13,9 @@ export default (options) => {
       return {
         ...this.parent?.(),
         ...apos.modules['@apostrophecms/rich-text-widget'].linkSchema
-          .filter(field => field.htmlAttribute)
+          .filter(field => !!field.htmlAttribute)
           .reduce((obj, field) => {
-            obj[field.name] = { default: field.def ?? null };
+            obj[field.htmlAttribute] = { default: field.def ?? null };
             return obj;
           }, {})
       };

--- a/test/rich-text-widget.js
+++ b/test/rich-text-widget.js
@@ -1,7 +1,7 @@
 const assert = require('assert/strict');
 const t = require('../test-lib/test.js');
 
-describe.only('Rich Text Widget', function () {
+describe('Rich Text Widget', function () {
   let apos;
   this.timeout(t.timeout);
 

--- a/test/rich-text-widget.js
+++ b/test/rich-text-widget.js
@@ -29,7 +29,7 @@ describe.only('Rich Text Widget', function () {
       value: '_url'
     });
     assert.deepEqual(richText.linkFieldsGroups, {
-      basic: {
+      link: {
         fields: [
           'linkTo',
           '_@apostrophecms/any-page-type',
@@ -79,7 +79,7 @@ describe.only('Rich Text Widget', function () {
       value: '_url'
     });
     assert.deepEqual(richText.linkFieldsGroups, {
-      basic: {
+      link: {
         fields: [
           'linkTo',
           '_@apostrophecms/any-page-type',
@@ -156,7 +156,7 @@ describe.only('Rich Text Widget', function () {
             },
             remove: [ 'target' ],
             group: {
-              basic: {
+              link: {
                 fields: [
                   'not-attribute',
                   'data-foo',

--- a/test/rich-text-widget.js
+++ b/test/rich-text-widget.js
@@ -28,17 +28,6 @@ describe('Rich Text Widget', function () {
       label: 'apostrophe:url',
       value: '_url'
     });
-    assert.deepEqual(richText.linkFieldsGroups, {
-      link: {
-        fields: [
-          'linkTo',
-          '_@apostrophecms/any-page-type',
-          'updateTitle',
-          'href',
-          'target'
-        ]
-      }
-    });
   });
 
   it('should support custom rich text link types', async function () {
@@ -78,31 +67,11 @@ describe('Rich Text Widget', function () {
       label: 'apostrophe:url',
       value: '_url'
     });
-    assert.deepEqual(richText.linkFieldsGroups, {
-      link: {
-        fields: [
-          'linkTo',
-          '_@apostrophecms/any-page-type',
-          '_article',
-          'updateTitle',
-          'href',
-          'target'
-        ]
-      }
-    });
     // Shouls allow the HTML attributes in the schema
     const attributes = richText
       .toolbarToAllowedAttributes(richText.options.defaultOptions);
 
     assert(attributes.a.includes('target'));
-
-    // Should find field by ID (and thus support remote methods)
-    assert(richText.linkSchema.length > 0);
-    const target = richText.linkSchema.find(field => field.name === 'target');
-    assert(target);
-    assert(target._id);
-    const found = apos.schema.getFieldById(target._id);
-    assert.deepEqual(found, target);
   });
 
   it('should support link schema management and html attributes', async function () {
@@ -113,19 +82,19 @@ describe('Rich Text Widget', function () {
         '@apostrophecms/rich-text-widget': {
           linkFields: {
             add: {
-              'not-attribute': {
-                label: 'Not Attribute',
+              notAnAttribute: {
+                label: 'Not An Attribute',
                 type: 'string'
               },
-              'aria-label': {
+              ariaLabel: {
                 label: 'Aria Label',
                 type: 'string',
-                htmlAttribute: true
+                htmlAttribute: 'aria-label'
               },
-              'data-foo': {
+              dataFoo: {
                 label: 'Data Foo',
                 type: 'select',
-                htmlAttribute: true,
+                htmlAttribute: 'data-foo',
                 choices: [
                   {
                     label: 'Foo',
@@ -137,15 +106,15 @@ describe('Rich Text Widget', function () {
                   }
                 ]
               },
-              'data-bool': {
+              dataBool: {
                 label: 'Data Bar',
                 type: 'boolean',
-                htmlAttribute: true
+                htmlAttribute: 'data-bool'
               },
-              'data-single-choice': {
+              dataSingleChoice: {
                 label: 'Data Choice',
                 type: 'checkboxes',
-                htmlAttribute: true,
+                htmlAttribute: 'data-single-choice',
                 choices: [
                   {
                     label: 'Foo',
@@ -154,18 +123,7 @@ describe('Rich Text Widget', function () {
                 ]
               }
             },
-            remove: [ 'target' ],
-            group: {
-              link: {
-                fields: [
-                  'not-attribute',
-                  'data-foo',
-                  'data-bool',
-                  'data-single-choice',
-                  'aria-label'
-                ]
-              }
-            }
+            remove: [ 'target' ]
           }
         }
       }
@@ -173,36 +131,25 @@ describe('Rich Text Widget', function () {
 
     const richText = apos.modules['@apostrophecms/rich-text-widget'];
     assert(richText.linkFields);
-    assert(richText.linkFields['aria-label']);
-    assert(richText.linkFields['data-foo']);
-    assert(richText.linkFields['data-bool']);
-    assert(richText.linkFields['data-single-choice']);
+    assert(richText.linkFields.ariaLabel);
+    assert(richText.linkFields.dataFoo);
+    assert(richText.linkFields.dataBool);
+    assert(richText.linkFields.dataSingleChoice);
     assert(richText.linkSchema.length > 0);
 
-    const ariaLabel = richText.linkSchema.find(field => field.name === 'aria-label');
-    const dataFoo = richText.linkSchema.find(field => field.name === 'data-foo');
-    const dataBool = richText.linkSchema.find(field => field.name === 'data-bool');
-    const dataSingleChoice = richText.linkSchema.find(field => field.name === 'data-single-choice');
-    const target = richText.linkSchema.find(field => field.name === 'target');
-    const notAttribute = richText.linkSchema.find(field => field.name === 'not-attribute');
+    const ariaLabel = richText.linkSchema.find(field => field.htmlAttribute === 'aria-label');
+    const dataFoo = richText.linkSchema.find(field => field.htmlAttribute === 'data-foo');
+    const dataBool = richText.linkSchema.find(field => field.htmlAttribute === 'data-bool');
+    const dataSingleChoice = richText.linkSchema.find(field => field.htmlAttribute === 'data-single-choice');
+    const target = richText.linkSchema.find(field => field.htmlAttribute === 'target');
+    const notAttribute = richText.linkSchema.find(field => field.htmlAttribute === 'not-attribute');
 
     assert(ariaLabel);
-    assert(ariaLabel.htmlAttribute);
     assert(dataFoo);
-    assert(dataFoo.htmlAttribute);
     assert(dataBool);
-    assert(dataBool.htmlAttribute);
     assert(dataSingleChoice);
-    assert(dataSingleChoice.htmlAttribute);
-    assert(notAttribute);
-    assert(!notAttribute.htmlAttribute);
+    assert.equal(typeof notAttribute, 'undefined');
     assert.equal(typeof target, 'undefined');
-
-    // Groups are respected
-    assert.equal(
-      richText.linkSchema[richText.linkSchema.length - 1].name,
-      'aria-label'
-    );
 
     // Allows the HTML attributes in the schema
     const attributes = richText

--- a/test/rich-text-widget.js
+++ b/test/rich-text-widget.js
@@ -1,0 +1,217 @@
+const assert = require('assert/strict');
+const t = require('../test-lib/test.js');
+
+describe.only('Rich Text Widget', function () {
+  let apos;
+  this.timeout(t.timeout);
+
+  after(function() {
+    return t.destroy(apos);
+  });
+
+  it('should have rich text link types by default', async function () {
+    apos = await t.create({
+      root: module,
+      modules: {}
+    });
+
+    const richText = apos.modules['@apostrophecms/rich-text-widget'];
+
+    assert(richText.linkFields);
+    assert(richText.linkFields.linkTo);
+    assert.equal(richText.linkFields.linkTo.choices.length, 2);
+    assert.deepEqual(richText.linkFields.linkTo.choices[0], {
+      label: 'apostrophe:page',
+      value: '@apostrophecms/any-page-type'
+    });
+    assert.deepEqual(richText.linkFields.linkTo.choices[1], {
+      label: 'apostrophe:url',
+      value: '_url'
+    });
+    assert.deepEqual(richText.linkFieldsGroups, {
+      basic: {
+        fields: [
+          'linkTo',
+          '_@apostrophecms/any-page-type',
+          'updateTitle',
+          'href',
+          'target'
+        ]
+      }
+    });
+  });
+
+  it('should support custom rich text link types', async function () {
+    await t.destroy(apos);
+    apos = await t.create({
+      root: module,
+      modules: {
+        article: {
+          extend: '@apostrophecms/piece-type',
+          options: {
+            label: 'Article'
+          }
+        },
+        '@apostrophecms/rich-text-widget': {
+          options: {
+            linkWithType: [ '@apostrophecms/any-page-type', 'article' ]
+          }
+        }
+      }
+    });
+
+    const richText = apos.modules['@apostrophecms/rich-text-widget'];
+
+    assert(apos.modules.article);
+    assert(richText.linkFields);
+    assert(richText.linkFields.linkTo);
+    assert.equal(richText.linkFields.linkTo.choices.length, 3);
+    assert.deepEqual(richText.linkFields.linkTo.choices[0], {
+      label: 'apostrophe:page',
+      value: '@apostrophecms/any-page-type'
+    });
+    assert.deepEqual(richText.linkFields.linkTo.choices[1], {
+      label: 'Article',
+      value: 'article'
+    });
+    assert.deepEqual(richText.linkFields.linkTo.choices[2], {
+      label: 'apostrophe:url',
+      value: '_url'
+    });
+    assert.deepEqual(richText.linkFieldsGroups, {
+      basic: {
+        fields: [
+          'linkTo',
+          '_@apostrophecms/any-page-type',
+          '_article',
+          'updateTitle',
+          'href',
+          'target'
+        ]
+      }
+    });
+    // Shouls allow the HTML attributes in the schema
+    const attributes = richText
+      .toolbarToAllowedAttributes(richText.options.defaultOptions);
+
+    assert(attributes.a.includes('target'));
+
+    // Should find field by ID (and thus support remote methods)
+    assert(richText.linkSchema.length > 0);
+    const target = richText.linkSchema.find(field => field.name === 'target');
+    assert(target);
+    assert(target._id);
+    const found = apos.schema.getFieldById(target._id);
+    assert.deepEqual(found, target);
+  });
+
+  it('should support link schema management and html attributes', async function () {
+    await t.destroy(apos);
+    apos = await t.create({
+      root: module,
+      modules: {
+        '@apostrophecms/rich-text-widget': {
+          linkFields: {
+            add: {
+              'not-attribute': {
+                label: 'Not Attribute',
+                type: 'string'
+              },
+              'aria-label': {
+                label: 'Aria Label',
+                type: 'string',
+                htmlAttribute: true
+              },
+              'data-foo': {
+                label: 'Data Foo',
+                type: 'select',
+                htmlAttribute: true,
+                choices: [
+                  {
+                    label: 'Foo',
+                    value: 'foo'
+                  },
+                  {
+                    label: 'Bar',
+                    value: 'bar'
+                  }
+                ]
+              },
+              'data-bool': {
+                label: 'Data Bar',
+                type: 'boolean',
+                htmlAttribute: true
+              },
+              'data-single-choice': {
+                label: 'Data Choice',
+                type: 'checkboxes',
+                htmlAttribute: true,
+                choices: [
+                  {
+                    label: 'Foo',
+                    value: 'foo'
+                  }
+                ]
+              }
+            },
+            remove: [ 'target' ],
+            group: {
+              basic: {
+                fields: [
+                  'not-attribute',
+                  'data-foo',
+                  'data-bool',
+                  'data-single-choice',
+                  'aria-label'
+                ]
+              }
+            }
+          }
+        }
+      }
+    });
+
+    const richText = apos.modules['@apostrophecms/rich-text-widget'];
+    assert(richText.linkFields);
+    assert(richText.linkFields['aria-label']);
+    assert(richText.linkFields['data-foo']);
+    assert(richText.linkFields['data-bool']);
+    assert(richText.linkFields['data-single-choice']);
+    assert(richText.linkSchema.length > 0);
+
+    const ariaLabel = richText.linkSchema.find(field => field.name === 'aria-label');
+    const dataFoo = richText.linkSchema.find(field => field.name === 'data-foo');
+    const dataBool = richText.linkSchema.find(field => field.name === 'data-bool');
+    const dataSingleChoice = richText.linkSchema.find(field => field.name === 'data-single-choice');
+    const target = richText.linkSchema.find(field => field.name === 'target');
+    const notAttribute = richText.linkSchema.find(field => field.name === 'not-attribute');
+
+    assert(ariaLabel);
+    assert(ariaLabel.htmlAttribute);
+    assert(dataFoo);
+    assert(dataFoo.htmlAttribute);
+    assert(dataBool);
+    assert(dataBool.htmlAttribute);
+    assert(dataSingleChoice);
+    assert(dataSingleChoice.htmlAttribute);
+    assert(notAttribute);
+    assert(!notAttribute.htmlAttribute);
+    assert.equal(typeof target, 'undefined');
+
+    // Groups are respected
+    assert.equal(
+      richText.linkSchema[richText.linkSchema.length - 1].name,
+      'aria-label'
+    );
+
+    // Allows the HTML attributes in the schema
+    const attributes = richText
+      .toolbarToAllowedAttributes(richText.options.defaultOptions);
+
+    assert.equal(attributes.a.includes('target'), false);
+    assert.equal(attributes.a.includes('aria-label'), true);
+    assert.equal(attributes.a.includes('data-foo'), true);
+    assert.equal(attributes.a.includes('data-bool'), true);
+    assert.equal(attributes.a.includes('data-single-choice'), true);
+  });
+});


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

- `linkFields` top configuration property (cascade) can be configured on a project level to add additional schema for rich text Link extension.
- `htmlAttribute: 'attribute-name'` should be set on every link attribute field in order to be functional
- There are no constraints on the types, but some types won't make sense (object, array, etc). The functionality is tested against `string`, `select`, `choices` (with one only option), `boolean`. 
- ~~Schema order and overall all standard schema features are supported, including remote choices.~~ Schema order and dynamic choices are not supported.

## What are the specific steps to test this change?

Extend `@apostrophecms/rich-text-widget`:
```js
module.exports = {
  linkFields: {
    add: {
      ariaLabel: {
        type: 'string',
        label: 'Aria Label',
        htmlAttribute: 'aria-label'
      }
    }
  }
};
```
~~The field order can be controlled via group `link` - in this case `aria-label` will be shown before the existing `target` field.~~
The "Aria Label" field should be shown in the link management modal. Saving it will result in a link having `aria-label="value"`. The value is preserved after saving and editable on consequent link management.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
