### PR TITLE
renames archive in delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 
 * Fix the `launder` and `finalize` methods of the `float` schema field query builder.
 * Fix the `launder` and `finalize` methods of the `integer` schema field query builder.
-* Rollbacks modifications that changed the delete `permission` name in `archive`.
 
 
 ## 3.61.1 (2023-01-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * Fix the `launder` and `finalize` methods of the `float` schema field query builder.
 * Fix the `launder` and `finalize` methods of the `integer` schema field query builder.
+* Rollbacks modifications that changed the delete `permission` name in `archive`.
 
 
 ## 3.61.1 (2023-01-08)

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1502,7 +1502,7 @@ module.exports = {
           canCreate: self.apos.permission.can(req, 'create', self.name, 'draft'),
           canEdit: self.apos.permission.can(req, 'edit', self.name, 'draft'),
           canPublish: self.apos.permission.can(req, 'publish', self.name),
-          canArchive: self.apos.permission.can(req, 'archive', self.name)
+          canArchive: self.apos.permission.can(req, 'delete', self.name)
         };
         browserOptions.canLocalize = browserOptions.canEdit &&
           self.options.localized &&
@@ -1873,7 +1873,7 @@ module.exports = {
             self.apos.permission.annotate(query.req, 'create', results);
             self.apos.permission.annotate(query.req, 'edit', results);
             self.apos.permission.annotate(query.req, 'publish', results);
-            self.apos.permission.annotate(query.req, 'archive', results);
+            self.apos.permission.annotate(query.req, 'delete', results);
           }
         },
 

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -195,9 +195,14 @@ export default {
 
       return this.moduleOptions.canPublish;
     },
+    canCreate() {
+      return this.original &&
+        !this.original._id &&
+        this.moduleOptions.canCreate;
+    },
     saveDisabled() {
-      if (!this.canEdit) {
-        return true;
+      if (!this.canCreate && !this.canEdit) {
+        return false;
       }
       if (this.restoreOnly) {
         // Can always restore if it's a read-only view of the archive

--- a/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
+++ b/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
@@ -262,7 +262,7 @@ export default {
     },
     canArchive() {
       return (
-        this.context._archive &&
+        this.context._delete &&
         this.context._id &&
         !this.moduleOptions.singleton &&
         !this.context.archived &&

--- a/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
+++ b/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
@@ -245,6 +245,7 @@ export default {
       if (!this.context._id) {
         return false;
       }
+      // TODO: Should we remove this check since done backend?
       if (!this.canEdit) {
         return false;
       }

--- a/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
+++ b/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
@@ -245,10 +245,6 @@ export default {
       if (!this.context._id) {
         return false;
       }
-      // TODO: Should we remove this check since done backend?
-      if (!this.canEdit) {
-        return false;
-      }
       return (
         (!this.context.lastPublishedAt) &&
         !this.moduleOptions.singleton

--- a/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
+++ b/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
@@ -264,7 +264,7 @@ export default {
         !this.moduleOptions.singleton &&
         !this.context.archived &&
         !this.context.parked &&
-        ((this.moduleOptions.canPublish && this.context.lastPublishedAt) || !this.manuallyPublished)
+        ((this.canPublish && this.context.lastPublishedAt) || !this.manuallyPublished)
       );
     },
     canUnpublish() {

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -408,6 +408,10 @@ module.exports = {
         const page = await self.findOneForEditing(req, {
           _id
         });
+
+        if (!page) {
+          throw self.apos.error('notfound');
+        }
         return self.delete(req, page);
       },
       // Patch some properties of the page.

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -853,16 +853,13 @@ database.`);
         // not a menu of choices for creating a page manually
         browserOptions.validPageTypes = self.apos.instancesOf('@apostrophecms/page-type').map(module => module.__meta.name);
         browserOptions.canEdit = self.apos.permission.can(req, 'edit', '@apostrophecms/any-page-type', 'draft');
-        // TODO: check why not checked in frontend
-        /* browserOptions.showDiscardDraft = self.apos.permission.can(req, 'delete', { */
-        /*   _id: 'any', */
-        /*   type: '@apostrophecms/any-page-type' */
-        /* }, 'draft'); */
         browserOptions.canLocalize = browserOptions.canEdit &&
           browserOptions.localized &&
           Object.keys(self.apos.i18n.locales).length > 1 &&
           Object.values(self.apos.i18n.locales).some(locale => locale._edit);
         browserOptions.utilityOperations = self.utilityOperations;
+        browserOptions.showDiscardDraft = self.apos.permission.can(req, 'delete', '@apostrophecms/any-page-type', 'draft');
+
         return browserOptions;
       },
       // Returns a query that finds pages the current user can edit

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -853,6 +853,11 @@ database.`);
         // not a menu of choices for creating a page manually
         browserOptions.validPageTypes = self.apos.instancesOf('@apostrophecms/page-type').map(module => module.__meta.name);
         browserOptions.canEdit = self.apos.permission.can(req, 'edit', '@apostrophecms/any-page-type', 'draft');
+        // TODO: check why not checked in frontend
+        /* browserOptions.showDiscardDraft = self.apos.permission.can(req, 'delete', { */
+        /*   _id: 'any', */
+        /*   type: '@apostrophecms/any-page-type' */
+        /* }, 'draft'); */
         browserOptions.canLocalize = browserOptions.canEdit &&
           browserOptions.localized &&
           Object.keys(self.apos.i18n.locales).length > 1 &&

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -81,6 +81,7 @@
             :icons="icons"
             v-model="checked"
             :options="treeOptions"
+            :module-options="moduleOptions"
             @update="update"
           />
         </template>

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -90,7 +90,7 @@ module.exports = {
           return (role === 'contributor') || (role === 'editor');
         }
 
-        if ([ 'delete', 'archive' ].includes(action)) {
+        if (action === 'delete') {
           return canDelete();
         }
 

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -1158,11 +1158,8 @@ module.exports = {
         browserOptions.showCreate = !self.options.singleton && self.options.showCreate;
         browserOptions.showDismissSubmission = self.options.showDismissSubmission;
         browserOptions.showArchive = self.options.showArchive;
-        // We pass a fake object to the can method because we don't want to check for the publish permission here
-        browserOptions.showDiscardDraft = self.options.showDiscardDraft && self.apos.permission.can(req, 'delete', {
-          _id: 'any',
-          type: self.name
-        });
+        browserOptions.showDiscardDraft = self.options.showDiscardDraft !== false &&
+          self.apos.permission.can(req, 'delete', self.name, 'draft');
         browserOptions.canPublish = self.apos.permission.can(req, 'edit', self.name, 'publish');
 
         _.defaults(browserOptions, {

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -156,7 +156,7 @@ module.exports = {
           description: 'apostrophe:publishingBatchConfirmation',
           confirmationButton: 'apostrophe:publishingBatchConfirmationButton'
         },
-        permission: 'edit'
+        permission: 'publish'
       },
       archive: {
         label: 'apostrophe:archive',
@@ -173,7 +173,7 @@ module.exports = {
           description: 'apostrophe:archivingBatchConfirmation',
           confirmationButton: 'apostrophe:archivingBatchConfirmationButton'
         },
-        permission: 'edit'
+        permission: 'delete'
       },
       restore: {
         label: 'apostrophe:restore',
@@ -1153,14 +1153,18 @@ module.exports = {
         browserOptions.batchOperations = self.checkBatchOperationsPermissions(req);
         browserOptions.utilityOperations = self.utilityOperations;
         browserOptions.insertViaUpload = self.options.insertViaUpload;
-        browserOptions.quickCreate = !self.options.singleton && self.options.quickCreate && self.apos.permission.can(req, 'create', self.name, 'draft');
+        browserOptions.quickCreate = !self.options.singleton && self.options.quickCreate && browserOptions.canCreate;
         browserOptions.singleton = self.options.singleton;
         browserOptions.showCreate = !self.options.singleton && self.options.showCreate;
         browserOptions.showDismissSubmission = self.options.showDismissSubmission;
         browserOptions.showArchive = self.options.showArchive;
-        browserOptions.showDiscardDraft = self.options.showDiscardDraft;
-        browserOptions.canEdit = self.apos.permission.can(req, 'edit', self.name, 'draft');
+        // We pass a fake object to the can method because we don't want to check for the publish permission here
+        browserOptions.showDiscardDraft = self.options.showDiscardDraft && self.apos.permission.can(req, 'delete', {
+          _id: 'any',
+          type: self.name
+        });
         browserOptions.canPublish = self.apos.permission.can(req, 'edit', self.name, 'publish');
+
         _.defaults(browserOptions, {
           components: {}
         });

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
@@ -29,8 +29,9 @@
         :disabled="!!relationshipErrors"
         @click="saveRelationship"
       />
+      <!-- Currently we cannot create a document if we can't edit them -->
       <AposButton
-        v-else-if="moduleOptions.canEdit && moduleOptions.showCreate"
+        v-else-if="moduleOptions.canCreate && moduleOptions.canEdit && moduleOptions.showCreate"
         :label="{
           key: 'apostrophe:newDocType',
           type: $t(moduleOptions.label)

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
@@ -29,9 +29,8 @@
         :disabled="!!relationshipErrors"
         @click="saveRelationship"
       />
-      <!-- Currently we cannot create a document if we can't edit them -->
       <AposButton
-        v-else-if="moduleOptions.canCreate && moduleOptions.canEdit && moduleOptions.showCreate"
+        v-else-if="moduleOptions.canCreate && moduleOptions.showCreate"
         :label="{
           key: 'apostrophe:newDocType',
           type: $t(moduleOptions.label)

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
@@ -22,6 +22,7 @@
       list-id="root"
       :options="options"
       :tree-id="treeId"
+      :module-options="moduleOptions"
     />
   </div>
 </template>
@@ -68,6 +69,12 @@ export default {
     options: {
       type: Object,
       default () {
+        return {};
+      }
+    },
+    moduleOptions: {
+      type: Object,
+      default() {
         return {};
       }
     }

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -43,6 +43,7 @@
           :disabled="getCellDisabled(col, row)"
           :data-col="col.property"
           :style="getCellStyles(col.property, index)"
+          :options="moduleOptions"
           @click="((getEffectiveType(col, row) === 'button') && col.action) ? $emit(col.action, row._id) : null"
         >
           <AposIndicator
@@ -108,6 +109,7 @@
         :style="{
           'max-height': options.startCollapsed ? '0' : null
         }"
+        :module-options="moduleOptions"
         @update="$emit('update', $event)"
         v-model="checkedProxy"
       />
@@ -179,6 +181,12 @@ export default {
     treeId: {
       type: String,
       required: true
+    },
+    moduleOptions: {
+      type: Object,
+      default() {
+        return {};
+      }
     }
   },
   emits: [ 'update', 'change' ],
@@ -210,6 +218,7 @@ export default {
     }
   },
   mounted() {
+    console.log('this.moduleOptions', this.moduleOptions);
     // Use $nextTick to make sure attributes like `clientHeight` are settled.
     this.$nextTick(() => {
       if (!this.$refs['tree-branches']) {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -218,7 +218,6 @@ export default {
     }
   },
   mounted() {
-    console.log('this.moduleOptions', this.moduleOptions);
     // Use $nextTick to make sure attributes like `clientHeight` are settled.
     this.$nextTick(() => {
       if (!this.$refs['tree-branches']) {


### PR DESCRIPTION
[PRO-5388](https://linear.app/apostrophecms/issue/PRO-5388/were-using-archive-and-delete-interchangeably-in-advanced-permissions)

## Summary

See ticket
Also handle `discard draft` for pieces and pages:
* If user can archive but not publish, he can delete draft.
* If user cannot archive he cannot delete draft.
* If user can archive and publish he can delete draft and archive
* If user cannot edit but can archive he can delete draft (doesn't work rn because `findForEditing` checks for `edit` permission).

I also updated the frontend for the pages because we never passed the moduleOptions to the page item context menus where we need to check if we show discard draft etc..

## What are the specific steps to test this change?


## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

