### PR TITLE
Pro 4801 is indeterminate

### DIFF
--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1870,6 +1870,7 @@ module.exports = {
           after(results) {
             // In all cases we mark the docs with ._edit and ._publish if
             // the req is permitted to do those things
+            self.apos.permission.annotate(query.req, 'create', results);
             self.apos.permission.annotate(query.req, 'edit', results);
             self.apos.permission.annotate(query.req, 'publish', results);
             self.apos.permission.annotate(query.req, 'delete', results);

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1870,7 +1870,6 @@ module.exports = {
           after(results) {
             // In all cases we mark the docs with ._edit and ._publish if
             // the req is permitted to do those things
-            self.apos.permission.annotate(query.req, 'create', results);
             self.apos.permission.annotate(query.req, 'edit', results);
             self.apos.permission.annotate(query.req, 'publish', results);
             self.apos.permission.annotate(query.req, 'archive', results);

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -906,7 +906,7 @@ database.`);
           if ((position === 'before') || (position === 'after')) {
             parent = await self.findForEditing(req, {
               path: self.getParentPath(target)
-            }).children({
+            }, { permission: 'create' }).children({
               depth: 1,
               archived: null,
               orphan: null,
@@ -922,7 +922,7 @@ database.`);
             throw self.apos.error('notfound');
           }
           if (options.permissions !== false) {
-            if (!parent._edit) {
+            if (!parent._create) {
               throw self.apos.error('forbidden');
             }
           }

--- a/modules/@apostrophecms/page/ui/apos/logic/AposPagesManager.js
+++ b/modules/@apostrophecms/page/ui/apos/logic/AposPagesManager.js
@@ -130,6 +130,10 @@ export default {
       return this.pageSetMenuSelection === 'live';
     },
     canCreate() {
+      const page = this.pagesFlat.find(page => page.aposDocId === this.moduleOptions.page.aposDocId);
+      if (page) {
+        return page._create;
+      }
       return this.moduleOptions.canCreate;
     }
   },

--- a/modules/@apostrophecms/page/ui/apos/logic/AposPagesManager.js
+++ b/modules/@apostrophecms/page/ui/apos/logic/AposPagesManager.js
@@ -130,11 +130,7 @@ export default {
       return this.pageSetMenuSelection === 'live';
     },
     canCreate() {
-      const page = this.pagesFlat.find(page => page.aposDocId === this.moduleOptions.page.aposDocId);
-      if (page) {
-        return page._create;
-      }
-      return false;
+      return this.moduleOptions.canCreate;
     }
   },
   watch: {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCheckbox.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCheckbox.vue
@@ -11,6 +11,7 @@
       :name="field.name"
       :id="id" :aria-label="choice.label || field.label"
       :tabindex="tabindex" :disabled="field.readOnly || choice.readOnly"
+      :is-indeterminate="choice.indeterminate === true ? 'true' : 'false'"
       @change="update"
     >
     <span class="apos-input-indicator" aria-hidden="true">


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Remove annotate permission with `create`. If it's a new document, it will not be present in the DB and the annotate `create` won't be available.

Is indeterminate on checkboxes is needed to be able to tell is all checkboxes on the row are checked.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
