### PR TITLE
Changes support for image upload from `canEdit` to `canCreate`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add testing for the `integer` schema field query builder.
 * Add support for link HTML attributes in the rich text widget via configurable fields `linkFields`, extendable on a project level (same as it's done for `fields`). Add an `htmlAttribute` property to the standard fields that map directly to an HTML attribute, except `href` (see special case below), and set it accordingly, even if it is the same as the field name. Setting `htmlAttribute: 'href'` is not allowed and will throw a schema validation exception (on application boot).
 * Adds support in can and criteria methods for `create` and `delete`.
+* Changes support for image upload from `canEdit` to `canCreate`.
 
 ### Fixes
 

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -71,7 +71,6 @@
             :accept="accept"
             :items="items"
             :module-options="moduleOptions"
-            :can-edit="moduleOptions.canEdit"
             @edit="updateEditing"
             v-model="checked"
             @select="select"

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
@@ -2,7 +2,7 @@
   <div class="apos-media-manager-display">
     <div class="apos-media-manager-display__grid">
       <AposMediaUploader
-        v-if="canEdit"
+        v-if="moduleOptions.canCreate"
         :disabled="maxReached"
         :action="moduleOptions.action"
         :accept="accept"
@@ -83,10 +83,6 @@ export default {
     event: 'change'
   },
   props: {
-    canEdit: {
-      type: Boolean,
-      default: false
-    },
     maxReached: {
       type: Boolean,
       default: false

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaUploader.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaUploader.vue
@@ -141,9 +141,11 @@ export default {
         for (const file of files) {
           try {
             const img = await this.insertImage(file, emptyDoc);
-            imageIds.push(img._id);
+            if (img?._id) {
+              imageIds.push(img._id);
+            }
           } catch (e) {
-            const msg = e.body && e.body.message ? e.body.message : this.$t('Upload error');
+            const msg = e.body && e.body.message ? e.body.message : this.$t('apostrophe:uploadError');
             await apos.notify(msg, {
               type: 'danger',
               icon: 'alert-circle-icon',


### PR DESCRIPTION
https://linear.app/apostrophecms/issue/PRO-5419/upload-input-still-displayed-when-you-cant-create

This is in the Manage view of images -- only in the manage view, because when you edit an image you can also upload an image to change it and this one is not part of the issue.