### PR TITLE
PRO-5473: media manager compatible with per doc edit permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 * Add testing for the `float` schema field query builder.
 * Add testing for the `integer` schema field query builder.
 * Add support for link HTML attributes in the rich text widget via configurable fields `linkFields`, extendable on a project level (same as it's done for `fields`). Add an `htmlAttribute` property to the standard fields that map directly to an HTML attribute, except `href` (see special case below), and set it accordingly, even if it is the same as the field name. Setting `htmlAttribute: 'href'` is not allowed and will throw a schema validation exception (on application boot).
-* Adds support in can and criteria methods for `create` and `delete`.
+* Adds support in `can` and `criteria` methods for `create` and `delete`.
 * Changes support for image upload from `canEdit` to `canCreate`.
+* The media manager is compatible with per-doc permissions granted via the `@apostrophecms-pro/advanced-permission` module.
 
 ### Fixes
 

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -105,7 +105,6 @@
           />
           <AposMediaManagerSelections
             :items="selected"
-            :can-edit="moduleOptions.canEdit"
             @clear="clearSelected" @edit="updateEditing"
             v-show="!editing"
           />
@@ -247,7 +246,8 @@ export default {
     async getMedia (options) {
       const qs = {
         ...this.filterValues,
-        page: this.currentPage
+        page: this.currentPage,
+        viewContext: this.relationshipField ? 'relationship' : 'manage'
       };
       const filtered = !!Object.keys(this.filterValues).length;
       if (this.moduleOptions && Array.isArray(this.moduleOptions.filters)) {
@@ -353,9 +353,7 @@ export default {
       this.editing = undefined;
     },
     async updateEditing(id) {
-      if (!this.moduleOptions.canEdit) {
-        return;
-      }
+      const item = this.items.find(item => item._id === id);
       // We only care about the current doc for this prompt,
       // we are not in danger of discarding a selection when
       // we switch images
@@ -370,7 +368,11 @@ export default {
           return false;
         }
       }
-      this.editing = this.items.find(item => item._id === id);
+      if (!item?._edit) {
+        this.editing = null;
+        return true;
+      }
+      this.editing = item;
       return true;
     },
     // select setters

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -155,13 +155,10 @@ export default {
   },
   computed: {
     moduleOptions() {
-      if (!this.activeMedia) {
-        console.trace();
-      }
       return window.apos.modules[this.activeMedia.type] || {};
     },
     canLocalize() {
-      return this.activeMedia?._id && this.moduleOptions.canLocalize;
+      return this.moduleOptions.canLocalize && this.activeMedia._id;
     },
     moreMenu() {
       const menu = [ {
@@ -174,7 +171,7 @@ export default {
           action: 'localize'
         });
       }
-      if (this.activeMedia?._id && !this.restoreOnly) {
+      if (this.activeMedia._id && !this.restoreOnly) {
         menu.push({
           label: 'apostrophe:archiveImage',
           action: 'archive',
@@ -218,9 +215,6 @@ export default {
   watch: {
     'docFields.data': {
       handler(newData, oldData) {
-        newData = newData || {};
-        oldData = oldData || {};
-        const activeMedia = this.activeMedia || {};
         this.$nextTick(() => {
           // If either old or new state are an empty object, it's not "modified."
           if (!(Object.keys(oldData).length > 0 && Object.keys(newData).length > 0)) {
@@ -230,12 +224,12 @@ export default {
           }
         });
 
-        if ((activeMedia.attachment && !newData.attachment)) {
+        if ((this.activeMedia.attachment && !newData.attachment)) {
           this.updateActiveAttachment({});
         } else if (
-          (newData.attachment && !activeMedia.attachment) ||
-          (activeMedia.attachment && !newData.attachment) ||
-          !isEqual(newData.attachment, activeMedia.attachment)
+          (newData.attachment && !this.activeMedia.attachment) ||
+          (this.activeMedia.attachment && !newData.attachment) ||
+          !isEqual(newData.attachment, this.activeMedia.attachment)
         ) {
           this.updateActiveAttachment(newData.attachment);
         }
@@ -256,13 +250,13 @@ export default {
     async updateActiveDoc(newMedia) {
       this.showReplace = false;
       this.activeMedia = klona(newMedia);
-      this.restoreOnly = !!this.activeMedia?.archived;
+      this.restoreOnly = !!this.activeMedia.archived;
       this.original = klona(newMedia);
       this.docFields.data = klona(newMedia);
       this.generateLipKey();
       await this.unlock();
       // Distinguish between an actual doc and an empty placeholder
-      if (newMedia?._id) {
+      if (newMedia._id) {
         if (!await this.lock(`${this.moduleOptions.action}/${newMedia._id}`)) {
           this.lockNotAvailable();
         }

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -171,7 +171,7 @@ export default {
           action: 'localize'
         });
       }
-      if (this.activeMedia._id && !this.restoreOnly) {
+      if (this.activeMedia._id && this.activeMedia._delete && !this.restoreOnly) {
         menu.push({
           label: 'apostrophe:archiveImage',
           action: 'archive',

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerSelections.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerSelections.vue
@@ -30,7 +30,7 @@
               {{ item.title }}
             </div>
             <AposButton
-              v-if="canEdit"
+              v-if="item._edit"
               label="apostrophe:edit"
               type="quiet"
               :modifiers="['no-motion']"
@@ -49,10 +49,6 @@
 <script>
 export default {
   props: {
-    canEdit: {
-      type: Boolean,
-      default: false
-    },
     items: {
       type: Array,
       required: true


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

See title

## What are the specific steps to test this change?

* Give a group "create" permission for images
* Create a user and put them in that group
* Experiment with uploading images and then editing their metadata
* You can do so
* But you don't see anyone else's media in the media library, unless you are using it as a chooser for a relationship

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
