### PR TITLE
Archive images: remove menu for users without permission `archive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 * Fix the `launder` and `finalize` methods of the `float` schema field query builder.
 * Fix the `launder` and `finalize` methods of the `integer` schema field query builder.
-
+* Archive images: remove menu for users without permission `archive` on images
 
 ## 3.61.1 (2023-01-08)
 

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -160,6 +160,9 @@ export default {
     canLocalize() {
       return this.moduleOptions.canLocalize && this.activeMedia._id;
     },
+    canArchive() {
+      return this.moduleOptions.canArchive && this.activeMedia._id && !this.restoreOnly;
+    },
     moreMenu() {
       const menu = [ {
         label: 'apostrophe:discardChanges',
@@ -171,7 +174,7 @@ export default {
           action: 'localize'
         });
       }
-      if (this.activeMedia._id && !this.restoreOnly) {
+      if (this.canArchive) {
         menu.push({
           label: 'apostrophe:archiveImage',
           action: 'archive',


### PR DESCRIPTION
https://linear.app/apostrophecms/issue/PRO-5418/user-can-archive-images-without-having-delete-permissions-for-images

Needs to be fixed, as delete is supposed to be required to archive anything, it sounds like something isn’t checking for delete permission.

Might be same logic as hiding input when you can create, just passing the right permissions info to the modal in order to show the right data.