### PR TITLE
Pro 5441

### DIFF
--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArea.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArea.vue
@@ -3,7 +3,7 @@
     :field="field"
     :error="effectiveError" :uid="uid"
     :display-options="displayOptions"
-    :modifiers="modifiers"
+    :modifiers="[...modifiers, 'full-width']"
   >
     <template #body>
       <!-- data-apos-schema-area lets all the child areas know that this area is in a schema (which is in a modal)

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
@@ -5,6 +5,9 @@
     :uid="uid"
     :items="next"
     :display-options="displayOptions"
+    :modifiers="[
+      ...field.style === 'table' ? ['full-width'] : []
+    ]"
   >
     <template #additional>
       <AposMinMaxCount

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputWrapper.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputWrapper.vue
@@ -3,7 +3,7 @@
     class="apos-field__wrapper"
     :class="{
       [`apos-field__wrapper--${field.type}`]: true,
-      'apos-field__wrapper--full-width': field.type === 'array' && field.style === 'table'
+      'apos-field__wrapper--full-width': modifiers.includes('full-width')
     }"
   >
     <component :is="wrapEl" :class="classList">
@@ -74,6 +74,7 @@ export default {
 .apos-field__wrapper {
   position: relative;
 }
+
 .apos-field__wrapper.apos-field__wrapper--full-width {
   max-width: 100%;
 }

--- a/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
@@ -69,12 +69,9 @@ export default {
   .apos-schema ::v-deep .apos-field__wrapper {
     max-width: $input-max-width;
   }
+
   .apos-schema ::v-deep .apos-field__wrapper.apos-field__wrapper--full-width {
     max-width: inherit;
-  }
-
-  .apos-schema ::v-deep .apos-field__wrapper--area {
-    max-width: 100%;
   }
 
   .apos-schema ::v-deep img {


### PR DESCRIPTION
[PRO-5441](https://linear.app/apostrophecms/issue/PRO-5441/the-group-permissions-table-field-ui-should-be-full-width-in-the)

## Summary

Handle fields full-width with modifiers.
used in [this PR](https://github.com/apostrophecms/advanced-permission/pull/103) for advanced permission.

## What are the specific steps to test this change?

Full width still works for areas and array with table style.