### PR TITLE
fixes broken disabled style

### DIFF
--- a/modules/@apostrophecms/ui/ui/apos/scss/global/_inputs.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/_inputs.scss
@@ -238,8 +238,8 @@
   }
 
   .apos-input--choice[disabled] + & {
-    border-color: $input-color-disabled;
-    background-color: $input-color-disabled;
+    border-color: var(--a-base-7);
+    background-color: var(--a-base-7);
   }
   .apos-input--choice:checked,
   .apos-input--choice[checked] {

--- a/modules/@apostrophecms/ui/ui/apos/scss/mixins/_theme_mixins.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/mixins/_theme_mixins.scss
@@ -16,7 +16,7 @@ $spacing-quadruple: $spacing-base * 4;
 $input-padding: $spacing-base * 1.5;
 $boolean-padding: $spacing-double;
 
-$input-color-disabled: var(--a-base-7);
+$input-color-disabled: var(--a-base-4);
 
 @mixin apos-primary-mixin($color) {
   --a-primary: #{$color};


### PR DESCRIPTION
[PRO-5439](https://linear.app/apostrophecms/issue/PRO-5439/updates-to-the-disabled-checkbox-state-styles)

## Summary

Instead of updating the disabled variable value, only apply changes to checkboxes (no changes for normal inputs).
read only fields text became invisible, it's back to its initial state:
![image](https://github.com/apostrophecms/apostrophe/assets/17548370/f6ea95f3-9944-4c12-963c-a5ea5e085e00)

Checkboxes disabled  state use the right color:
![image](https://github.com/apostrophecms/apostrophe/assets/17548370/9ec397fa-c1d3-4ff3-b9a5-b7c86c4f3b1c)

## What are the specific steps to test this change?

Check that document versions read only fields are visible.
Checkboxes in disabled state must use the `--a-base-7` variable for background and border.

## What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
