### PR TITLE
Display the "Browse" button in a relationship inside an inline array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * A user who has permission to `publish` a particular page should always be allowed to insert it into the
 published version of the site even if they could not otherwise insert a child of the published
 parent.
+* Display the "Browse" button in a relationship inside an inline array.
 
 ## 3.61.1 (2023-01-08)
 

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
@@ -171,12 +171,6 @@ export default {
     }
   }
   ::v-deep .apos-input-relationship {
-    .apos-button__wrapper {
-      display: none;
-    }
-    .apos-input {
-      width: auto;
-    }
     .apos-slat__main {
       min-width: 130px;
     }


### PR DESCRIPTION
https://linear.app/apostrophecms/issue/PRO-5511/investigate-1nces-reported-piece-editor-interface-bug

Display the "Browse" button in a relationship inside an inline array

Get this
![image](https://github.com/apostrophecms/apostrophe/assets/11479686/364f3f79-ee44-49a1-9983-616a6f85b755)

instead of this
![image](https://github.com/apostrophecms/apostrophe/assets/11479686/c5edd9b0-1c00-4754-be6e-2495e996fcb6)


