### PR TITLE
PRO-5529: same fix as for pages

### DIFF
--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -670,6 +670,11 @@ module.exports = {
       },
       // Similar to insertDraftOf, invoked on first publication.
       insertPublishedOf(req, doc, published, options) {
+        // Check publish permission up front because we won't check it
+        // in insert
+        if (!self.apos.permission.can(req, 'publish', doc)) {
+          throw self.apos.error('forbidden');
+        }
         return self.insert(
           req.clone({ mode: 'published' }),
           published,

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -673,7 +673,10 @@ module.exports = {
         return self.insert(
           req.clone({ mode: 'published' }),
           published,
-          options
+          {
+            ...options,
+            permissions: false
+          }
         );
       },
       // Returns one editable piece matching the criteria, throws `notfound`


### PR DESCRIPTION
`insertPublishedOf` now does the same permissions bypass for pieces that I already added for pages, after first confirming publish permission.