### PR TITLE
removes related reverse IDs when deleting a draft document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* When deleting a draft document, we remove related reverse IDs of documents having a relation to the deleted one.
+
 ## 3.62.0 (2024-01-25)
 
 ### Adds

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -381,10 +381,12 @@ module.exports = {
   methods(self) {
     return {
       async deleteRelatedReverseId(doc, deleting = false) {
-        const locales = doc.aposLocale && deleting ? [
-          doc.aposLocale.replace(':draft', ':published'),
-          doc.aposLocale.replace(':published', ':draft')
-        ] : [ doc.aposLocale ];
+        const locales = doc.aposLocale && deleting
+          ? [
+            doc.aposLocale.replace(':draft', ':published'),
+            doc.aposLocale.replace(':published', ':draft')
+          ]
+          : [ doc.aposLocale ];
         return self.apos.doc.db.updateMany({
           relatedReverseIds: { $in: [ doc.aposDocId ] },
           aposLocale: { $in: [ ...locales, null ] }

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -330,9 +330,9 @@ module.exports = {
       },
       afterDelete: {
         async deleteRelatedReverseId(req, doc) {
-          // When deleting a draft document, we remove related reverse IDs
-          // of documents having a relation to the deleted one
-          if (doc.aposMode === 'draft') {
+          // When deleting an unlocalized or draft document,
+          // we remove related reverse IDs of documents having a relation to the deleted one
+          if (!doc.aposMode || doc.aposMode === 'draft') {
             await self.deleteRelatedReverseId(doc);
           }
         }

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -328,6 +328,15 @@ module.exports = {
           }
         }
       },
+      afterDelete: {
+        async deleteRelatedReverseId(req, doc) {
+          // When deleting a draft document, we remove related reverse IDs
+          // of documents having a relation to the deleted one
+          if (doc.aposMode === 'draft') {
+            await self.deleteRelatedReverseId(doc);
+          }
+        }
+      },
       afterRescue: {
         async revertDeduplication(req, doc) {
           const $set = await self.getRevertDeduplicationSet(req, doc);
@@ -371,18 +380,21 @@ module.exports = {
 
   methods(self) {
     return {
-      async updateCacheField(req, doc) {
-        const relatedDocsIds = self.getRelatedDocsIds(req, doc);
-
-        // - Remove current doc reference from docs that include it
-        // - Update these docs' cache field
-        await self.apos.doc.db.updateMany({
+      async deleteRelatedReverseId(doc) {
+        return self.apos.doc.db.updateMany({
           relatedReverseIds: { $in: [ doc.aposDocId ] },
           aposLocale: { $in: [ doc.aposLocale, null ] }
         }, {
           $pull: { relatedReverseIds: doc.aposDocId },
           $set: { cacheInvalidatedAt: doc.updatedAt }
         });
+      },
+      async updateCacheField(req, doc) {
+        const relatedDocsIds = self.getRelatedDocsIds(req, doc);
+
+        // - Remove current doc reference from docs that include it
+        // - Update these docs' cache field
+        await this.deleteRelatedReverseId(doc);
 
         if (relatedDocsIds.length) {
           // - Add current doc reference to related docs

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -380,8 +380,8 @@ module.exports = {
 
   methods(self) {
     return {
-      async deleteRelatedReverseId(doc, del = false) {
-        const locales = doc.aposLocale && del ? [
+      async deleteRelatedReverseId(doc, deleting = false) {
+        const locales = doc.aposLocale && deleting ? [
           doc.aposLocale.replace(':draft', ':published'),
           doc.aposLocale.replace(':published', ':draft')
         ] : [ doc.aposLocale ];

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -717,7 +717,6 @@ module.exports = {
       // This operation ignores the locale and mode of `req`
       // in favor of the actual document's locale and mode.
       async delete(req, doc, options = {}) {
-        options = options || {};
         const m = self.getManager(doc.type);
         await m.emit('beforeDelete', req, doc, options);
         await self.deleteBody(req, doc, options);

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -1056,8 +1056,8 @@ module.exports = {
           ]
         };
         doc.advisoryLock = {
-          username: (req.user && req.user.username) || '',
-          title: (req.user && req.user.title) || '',
+          username: req.user && req.user.username,
+          title: req.user && req.user.title,
           _id: tabId,
           updatedAt: new Date()
         };

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -1057,17 +1057,17 @@ module.exports = {
           ]
         };
         doc.advisoryLock = {
-          username: req.user && req.user.username,
-          title: req.user && req.user.title,
+          username: (req.user && req.user.username) || '',
+          title: (req.user && req.user.title) || '',
           _id: tabId,
           updatedAt: new Date()
         };
-        const result = await self.db.updateOne(criteria, {
+        const { result } = await self.db.updateOne(criteria, {
           $set: {
             advisoryLock: doc.advisoryLock
           }
         });
-        if (!result.result.nModified) {
+        if (!result.nModified) {
           const info = await self.db.findOne({
             _id
           }, {

--- a/test/docs.js
+++ b/test/docs.js
@@ -880,10 +880,14 @@ describe('Docs', function() {
     const req = apos.task.getReq();
     await insertPeople(apos);
     const doc = await apos.doc.db.findOne({ _id: 'carl:en:published' });
+    const wait = (time) => new Promise((resolve) => setTimeout(() => {
+      resolve();
+    }, time));
 
     try {
       await apos.doc.lock(req, doc, 'abc');
       const locked = await apos.doc.db.findOne({ _id: 'carl:en:published' });
+      await wait(500);
       await apos.doc.lock(req, locked, 'abc');
     } catch (e) {
       assert(!e);


### PR DESCRIPTION
[PRO-5489](https://linear.app/apostrophecms/issue/PRO-5489/[advanced-permission-3]-deleting-draft-does-not-remove-per-doc)

## Summary

* When deleting a draft document, we remove related reverse IDs of documents having a relation to the deleted one.
* Updates docs.js tests to make them independants.
* Adding two test for the fix (one for delete draft, one for delete unlocalized docs).

## What are the specific steps to test this change?

Deleting a draft document should delete the related reverse IDs of all document having a relation to the deleted document.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
