### PR TITLE
Inline array: change trash icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Adds support in `can` and `criteria` methods for `create` and `delete`.
 * Changes support for image upload from `canEdit` to `canCreate`.
 * The media manager is compatible with per-doc permissions granted via the `@apostrophecms-pro/advanced-permission` module.
+* In inline arrays, the trash icon has been replaced by a close icon.
 
 ### Fixes
 

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputArray.vue
@@ -114,9 +114,9 @@
                 >
                   <AposButton
                     label="apostrophe:removeItem"
-                    icon="trash-can-outline-icon"
+                    icon="close-icon"
                     type="subtle"
-                    :modifiers="['inline', 'danger', 'no-motion']"
+                    :modifiers="['inline','no-motion']"
                     :icon-only="true"
                     @click="remove(item._id)"
                   />


### PR DESCRIPTION
https://linear.app/apostrophecms/issue/PRO-5444/the-remove-userorgroup-ui-should-be-an-x-situated-in-the-first-column

Clicking on it still works as expected. Also tested drag-n-drop as Val requested.

Old icon:
<img width="1056" alt="image" src="https://github.com/apostrophecms/apostrophe/assets/11479686/e77bfedf-8beb-4753-85c3-0614d4c211a8">


New icon:
<img width="1064" alt="image" src="https://github.com/apostrophecms/apostrophe/assets/11479686/a47ba4b2-3bf1-4e7d-908f-09424ddbe74e">
