### PR TITLE
Restore widget copy button

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -35,12 +35,15 @@
         }"
         :modifiers="[ 'inline' ]"
       />
-      <!-- <AposButton
+      <AposButton
         v-bind="copyButton"
         v-if="!foreign"
         @click="$emit('copy')"
-        tooltip="Copy"
-      /> -->
+        :tooltip="{
+          content: 'apostrophe:copy',
+          placement: 'left'
+        }"
+      />
       <AposButton
         v-if="!foreign"
         :disabled="disabled || maxReached"


### PR DESCRIPTION
## Summary

- Restores the 'copy' button on in-context widget controls
- update the tooltip object

## What are the specific steps to test this change?

1. link a demo and run
2. get to an area
3. use the 'copy' button (pictured below)
4. be able to paste the widget in an area
5. clipboard is cleared
6. saving works, etc

<img width="609" alt="image" src="https://github.com/apostrophecms/apostrophe/assets/1889830/755a931e-2fe9-4126-a1a2-4e8bf5179016">


## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
