### PR TITLE
PRO-5513: Fix publish after draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* Fix publishing or moving published page after a draft page on the same tree level to work as expected.
+
 ## 3.62.0 (2024-01-25)
 
 ### Adds

--- a/modules/@apostrophecms/page-type/index.js
+++ b/modules/@apostrophecms/page-type/index.js
@@ -162,7 +162,7 @@ module.exports = {
               title: 1,
               type: 1
             }).toArray();
-            throw self.apos.error('invalid', {
+            throw self.apos.error('invalid', 'Publish the parent page(s) first.', {
               unpublishedAncestors: draftAncestors.filter(draftAncestor => {
                 return !publishedAncestors.find(publishedAncestor => {
                   return draftAncestor.aposDocId === publishedAncestor.aposDocId;
@@ -365,7 +365,9 @@ module.exports = {
           // Replay the high level positioning used to place it in the draft locale
           return self.apos.page.insert(
             _req,
-            lastTargetId.replace(':draft', ':published'),
+            // do not force published doc as it might not exist, lastTargetId
+            // existance is granted (see `inferLastTargetIdAndPosition`).
+            lastTargetId,
             lastPosition,
             published,
             {

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -988,6 +988,15 @@ database.`);
           page.path = self.apos.util.addSlashIfNeeded(parent.path) + page.aposDocId;
           page.level = parent.level + 1;
           await self.apos.doc.insert(req, page, options);
+          // Prevent a published page from being inserted as a child of a draft page.
+          // In effect when this method is called again from the `afterInsert` event
+          // of the `doc` module. This can happen when we are inserting a page
+          // in req.mode == 'published', which results in insertDrafOf being called
+          // (`page-type` module).
+          if (page.lastPublishedAt && !parent.lastPublishedAt) {
+            await self.unpublish(req, page);
+            throw self.apos.error('forbidden', 'Publish the parent page first.');
+          }
           return page;
         });
       },
@@ -1077,8 +1086,8 @@ database.`);
       },
       // Move a page already in the page tree to another location.
       //
-      // `movedId` is the id of the page being moved. ``targetId` must be an existing page
-      // id, and `position` may be `before`, `inside` or `after`. Alternatively
+      // `movedId` is the id of the page being moved. `targetId` must be an existing page
+      // id, and `position` may be `before`, `firstChild`, `lastChild` or `after`. Alternatively
       // `position` may be a zero-based offset for the new child
       // of `targetId` (note that the `rank` property of sibling pages
       // is not strictly ascending, so use an array index into `_children` to
@@ -1108,7 +1117,22 @@ database.`);
           let originalSlug;
           const moved = await getMoved();
           const oldParent = moved._ancestors[0];
-          const target = await self.getTarget(req, targetId, position);
+          let target;
+          try {
+            target = await self.getTarget(req, targetId, position);
+          } catch (e) {
+            // Try again with the draft version of the target, only when
+            // moving before/after and the target is published page.
+            if (e.name === 'notfound' && targetId.endsWith(':published') && [ 'before', 'after' ].includes(position)) {
+              target = await self.getTarget(
+                req.clone({ mode: 'draft' }),
+                targetId.replace(':published', ':draft'),
+                position
+              );
+            } else {
+              throw e;
+            }
+          }
           const manager = self.apos.doc.getManager(moved.type);
           await manager.emit('beforeMove', req, moved, target, position);
           determineRankAndNewParent();
@@ -1252,23 +1276,32 @@ database.`);
       // value. `position` is used to prevent attempts to move after the archive
       // "page."
       async getTarget(req, targetId, position) {
-        const criteria = self.getIdCriteria(self.inferIdLocaleAndMode(req, targetId));
+        // self.inferIdLocaleAndMode (see i18n module)
+        // is mutating the req object. This leads to various issues. This
+        // handler is shared among different routines (publish, insert, etc)
+        // and should NOT alter the request state.
+        const _req = req.clone({});
+        const criteria = self.getIdCriteria(self.inferIdLocaleAndMode(_req, targetId));
         // Use findForEditing to ensure we get improvements to that method from
         // npm modules that make the query more inclusive. Then explicitly shut off
         // things we know we don't want to be blocked by
-        const target = await self.findForEditing(req, criteria).permission(false).archived(null).areas(false).ancestors({
-          depth: 1,
-          archived: null,
-          orphan: null,
-          areas: false,
-          permission: false
-        }).children({
-          depth: 1,
-          archived: null,
-          orphan: null,
-          areas: false,
-          permission: false
-        }).toObject();
+        const target = await self.findForEditing(_req, criteria)
+          .permission(false)
+          .archived(null)
+          .areas(false)
+          .ancestors({
+            depth: 1,
+            archived: null,
+            orphan: null,
+            areas: false,
+            permission: false
+          }).children({
+            depth: 1,
+            archived: null,
+            orphan: null,
+            areas: false,
+            permission: false
+          }).toObject();
         if (!target) {
           throw self.apos.error('notfound');
         }

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapImage.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapImage.vue
@@ -42,13 +42,6 @@ export default {
       active: false
     };
   },
-  watch: {
-    hasSelection(newVal, oldVal) {
-      if (!newVal) {
-        this.close();
-      }
-    }
-  },
   computed: {
     attributes() {
       return this.editor.getAttributes('image');
@@ -69,6 +62,13 @@ export default {
       const [ { type } = {} ] = content;
 
       return text !== '' || type?.name === 'image';
+    }
+  },
+  watch: {
+    hasSelection(newVal, oldVal) {
+      if (!newVal) {
+        this.close();
+      }
     }
   },
   methods: {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Also closes PRO-5151

Publish and move published page just after a (same level, sibling) draft page works as expected. 
> It also fixes eslint warning that annoys me from some time!

## What are the specific steps to test this change?

Create 3 draft pages on a same tree level. Publish the last one (no errors). Moved it after the 1st one (no errors). Should work for any tree level (all pages above should be the same level).

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
