### PR TITLE
make type larger, make toggle input hitbox larger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * When deleting a draft document, we remove related reverse IDs of documents having a relation to the deleted one.
 * Fix publishing or moving published page after a draft page on the same tree level to work as expected.
 
+### Changes
+
+* Share Drafts modal styles made larger and it's toggle input has a larger hitbox.
+
 ## 3.62.0 (2024-01-25)
 
 ### Adds

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
@@ -30,7 +30,7 @@
                 class="apos-share-draft__toggle"
                 @toggle="toggle"
               />
-              <p class="apos-share-draft__toggle-label">
+              <p @click="toggle" class="apos-share-draft__toggle-label">
                 {{ $t('apostrophe:shareDraftEnable') }}
               </p>
             </div>
@@ -266,6 +266,7 @@ export default {
 .apos-share-draft__toggle-wrapper {
   display: flex;
   align-items: center;
+  margin-bottom: $spacing-base;
 }
 
 .apos-share-draft__toggle {
@@ -273,14 +274,18 @@ export default {
 }
 
 .apos-share-draft__toggle-label {
-  @include type-base;
+  @include type-large;
+  flex-grow: 1;
   max-width: 370px;
   line-height: var(--a-line-tallest);
   margin: 0;
+  &:hover {
+    cursor: pointer;
+  }
 }
 
 .apos-share-draft__description {
-  @include type-small;
+  @include type-base;
   line-height: var(--a-line-tall);
   max-width: 355px;
   color: var(--a-base-2);


### PR DESCRIPTION
## Summary

* Share Drafts modal styles made larger and it's toggle input has a larger hitbox.

## What are the specific steps to test this change?

*For example:*
1. npm run dev
2. Share Draft
3. see a larger description text
4. see a larger input label
5. click a large toggle hitbox

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
