### PR TITLE
Block typing slash key in slugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * When deleting a draft document, we remove related reverse IDs of documents having a relation to the deleted one.
 * Fix publishing or moving published page after a draft page on the same tree level to work as expected.
+* Block typing slash key (`/`) in slugs to prevent infinite loop (slashes are still automatically added for pages).
 
 ### Changes
 

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
@@ -18,6 +18,7 @@
           :class="classes"
           v-model="next" :type="type"
           :placeholder="$t(field.placeholder)"
+          @keydown="blockSlash"
           @keydown.enter="emitReturn"
           :disabled="field.readOnly" :required="field.required"
           :id="uid" :tabindex="tabindex"

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
@@ -276,6 +276,11 @@ export default {
     },
     emitReturn() {
       this.$emit('return');
+    },
+    blockSlash(evt) {
+      if (evt.key === '/') {
+        evt.preventDefault();
+      }
     }
   }
 };


### PR DESCRIPTION
https://linear.app/apostrophecms/issue/PRO-5490/crash-due-to-adding-a-slash-in-a-page-slug-field

Prevent infinite loop in pages if typing a slash in slug.

Standard slugs for pieces work correctly.