### PR TITLE
Remove blocking page slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 * Copy requires create and edit permission.
 * Display a more informative error message when publishing a page because the parent page is not published and the current user has no permission to publish the parent page (while having permission to publish the current one).
 * The `content-changed` event for the submit draft action now uses a complete document.
-* Block typing slash key (`/`) in slugs to prevent infinite loop (slashes are still automatically added for pages).
 
 ### Changes
 

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
@@ -18,7 +18,6 @@
           :class="classes"
           v-model="next" :type="type"
           :placeholder="$t(field.placeholder)"
-          @keydown="blockSlash"
           @keydown.enter="emitReturn"
           :disabled="field.readOnly" :required="field.required"
           :id="uid" :tabindex="tabindex"

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
@@ -277,10 +277,5 @@ export default {
     emitReturn() {
       this.$emit('return');
     },
-    blockSlash(evt) {
-      if (evt.key === '/') {
-        evt.preventDefault();
-      }
-    }
   }
 };

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
@@ -276,6 +276,6 @@ export default {
     },
     emitReturn() {
       this.$emit('return');
-    },
+    }
   }
 };


### PR DESCRIPTION
https://linear.app/apostrophecms/issue/PRO-5490/crash-due-to-adding-a-slash-in-a-page-slug-field

Tested in dev and prod modes, works correctly: slashes can be added in a slug without problem.