### PR TITLE
fix admin bar spacer height when context bar is conditionally displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 * Copy requires create and edit permission.
 * Display a more informative error message when publishing a page because the parent page is not published and the current user has no permission to publish the parent page (while having permission to publish the current one).
 * The `content-changed` event for the submit draft action now uses a complete document.
-* Fix the context bar overlap on palette for non-admin users that have the "Modify" permission on palette.
+* Fix the context bar overlap on palette for non-admin users that have the permission to modify it.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Copy requires create and edit permission.
 * Display a more informative error message when publishing a page because the parent page is not published and the current user has no permission to publish the parent page (while having permission to publish the current one).
 * The `content-changed` event for the submit draft action now uses a complete document.
+* Fix the context bar overlap on palette for non-admin users that have the "Modify" permission on palette.
 
 ### Changes
 

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -16,7 +16,7 @@
           :items="userItems"
         />
       </div>
-      <TheAposContextBar @mounted="setSpacer" />
+      <TheAposContextBar @visibility-changed="setSpacer" />
       <component
         v-for="bar in bars"
         v-bind="bar.props || {}"

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
@@ -42,7 +42,7 @@ import AposAdvisoryLockMixin from 'Modules/@apostrophecms/ui/mixins/AposAdvisory
 export default {
   name: 'TheAposContextBar',
   mixins: [ AposPublishMixin, AposAdvisoryLockMixin ],
-  emits: [ 'mounted' ],
+  emits: [ 'visibility-changed' ],
   data() {
     const query = apos.http.parseQuery(location.search);
     // If the URL references a draft, go into draft mode but then clean up the URL
@@ -137,6 +137,11 @@ export default {
   watch: {
     editMode(newVal) {
       window.apos.adminBar.editMode = newVal;
+    },
+    contextBarActive() {
+      this.$nextTick(() => {
+        this.$emit('visibility-changed');
+      });
     }
   },
   async mounted() {
@@ -173,9 +178,6 @@ export default {
     await this.updateDraftIsEditable();
     this.rememberLastBaseContext();
     this.published = await this.getPublished();
-    this.$nextTick(() => {
-      this.$emit('mounted');
-    });
 
     apos.util.onReadyAndRefresh(() => {
       if (window.apos.adminBar.scrollPosition) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

The height of the admin bar spacer was not updated when the context was conditionnally displayed, when opening palette for instance.
In `TheAposContextBar.vue`, an event was emitted to update the height of the spacer, but only from the `mounted()` method.

To fix that, the event is now emitted when the `contextBarActive` computed changes in order to update the spacer height every time the context bar is displayed or hidden.

## What are the specific steps to test this change?

1. Run a project with advanced permission 2:

`APOS_ADVANCED_PERMISSION=2 npm run dev` for instance.

2. Create a user that has at least the `Modify` right on palette:

![image](https://github.com/apostrophecms/apostrophe/assets/8301962/b9452c5a-dbd4-48dc-aa81-204224f238de)

3. Log-in with that user
4. Open palette
5. The context bar should not overlap the top palette drop-down

| before | after |
|--------|--------|
| ![image](https://github.com/apostrophecms/apostrophe/assets/8301962/c5293e36-af49-4766-8704-38e684b9b4eb) | ![image](https://github.com/apostrophecms/apostrophe/assets/8301962/9ce06998-0828-4e15-9d6f-095b84e697eb) | 

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
