### PR TITLE
Pro 5643 manager indicator

### DIFF
--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -48,6 +48,7 @@
   "automaticTranslationErrorNoProvider": "Translation provider not found. Page \"{{ title }}\" was not translated.",
   "automaticTranslationLngCheckNoProvider": "Translation provider not found.",
   "automaticTranslationCheckbox": "Translate text content",
+  "automaticTranslationPending": "Pending Translations",
   "automaticTranslationSettings": "Automatic translation settings",
   "automaticTranslationSourceErrMsg": "The current locale <strong>{{ source }}</strong> is not suitable for translation. Translation will be skipped.",
   "automaticTranslationTargetErrMsg": "Could not find a suitable language for the locale <strong>{{ targets }}</strong>. Translation will be skipped for this locale.",

--- a/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
+++ b/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
@@ -495,7 +495,6 @@ export default {
     },
     async 'wizard.values.translateContent.data'(value) {
       await this.checkAvailableTranslations(value);
-      console.log('this.wizard.values.translateTargets', this.wizard.values.translateTargets.data);
     },
     selectedLocales() {
       this.updateRelatedDocs();

--- a/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
+++ b/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
@@ -218,7 +218,7 @@
               </div>
               <div v-if="translationEnabled" class="apos-wizard__translation">
                 <p class="apos-wizard__translation-title">
-                  <AposTranslationChip />
+                  <AposTranslationIndicator :size="18" />
                   <span class="apos-wizard__translation-title-text">
                     {{ $t('apostrophe:automaticTranslationSettings') }}
                   </span>

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -29,6 +29,7 @@ module.exports = {
     self.arrayManagers = {};
     self.objectManagers = {};
     self.fieldMetadataComponents = [];
+    self.uiManagerIndicators = [];
 
     self.enableBrowserData();
 
@@ -1706,6 +1707,10 @@ module.exports = {
           options.allow = '/';
         }
         return options;
+      },
+
+      addManagerIndicator(componentInfo) {
+        self.uiManagerIndicators.push(componentInfo);
       }
     };
   },
@@ -1771,6 +1776,7 @@ module.exports = {
         browserOptions.action = self.action;
         browserOptions.components = { fields: fields };
         browserOptions.fieldMetadataComponents = self.fieldMetadataComponents;
+        browserOptions.customCellIndicators = self.uiManagerIndicators;
         return browserOptions;
       }
     };

--- a/modules/@apostrophecms/translation/index.js
+++ b/modules/@apostrophecms/translation/index.js
@@ -8,7 +8,6 @@ module.exports = {
     self.providers = [];
 
     self.enableBrowserData();
-    self.addTranslationIndicator();
   },
   handlers(self) {
     return {
@@ -188,14 +187,6 @@ module.exports = {
             label
           }))
         };
-      },
-      addTranslationIndicator() {
-        self.apos.schema.addManagerIndicator({
-          component: 'AposTranslationIndicator',
-          props: {
-            label: 'apostrophe:automaticTranslationPending'
-          }
-        });
       }
     };
   }

--- a/modules/@apostrophecms/translation/index.js
+++ b/modules/@apostrophecms/translation/index.js
@@ -8,6 +8,7 @@ module.exports = {
     self.providers = [];
 
     self.enableBrowserData();
+    self.addTranslationIndicator();
   },
   handlers(self) {
     return {
@@ -187,6 +188,14 @@ module.exports = {
             label
           }))
         };
+      },
+      addTranslationIndicator() {
+        self.apos.schema.addManagerIndicator({
+          component: 'AposTranslationIndicator',
+          props: {
+            label: 'apostrophe:automaticTranslationPending'
+          }
+        });
       }
     };
   }

--- a/modules/@apostrophecms/translation/index.js
+++ b/modules/@apostrophecms/translation/index.js
@@ -181,6 +181,7 @@ module.exports = {
       },
       getBrowserData(req) {
         return {
+          action: self.action,
           enabled: options.enabled && Boolean(self.providers.length),
           providers: self.providers.map(({ name, label }) => ({
             name,

--- a/modules/@apostrophecms/translation/index.js
+++ b/modules/@apostrophecms/translation/index.js
@@ -14,16 +14,24 @@ module.exports = {
       '@apostrophecms/doc-type:beforeLocalize': {
         // Translate the document using the first available provider.
         async translate(req, doc, source, target, options) {
-          if (!req.query.aposTranslateTargets?.includes(target)) {
+          const targets = req.body.aposTranslateTargets || [];
+          const translationProvider = self.apos.launder.string(req.body.aposTranslateProvider);
+
+          if (!Array.isArray(targets)) {
+            throw self.apos.error('invalid', 'Badly formatted translation targets');
+          }
+
+          if (!targets.includes(target)) {
             return;
           }
+
           // We don't support multiple providers yet, so just use the first one
           // when no provider is specified.
-          const name = self.getProvider(req.query.aposTranslateProvider)?.name;
+          const providerName = self.getProvider(translationProvider)?.name;
           const module = self.getProviderModule(name);
-          if (!name || !module) {
-            const name = req.query.aposTranslateProvider ||
-              'apostrophe:notAvailable';
+
+          if (!providerName || !module) {
+            const name = translationProvider || 'apostrophe:notAvailable';
 
             self.logError('before-localize-translate', 'Provider not found.', {
               _id: doc._id,
@@ -46,7 +54,7 @@ module.exports = {
             );
           }
 
-          return module.translate(req, name, doc, source, target, options);
+          return module.translate(req, providerName, doc, source, target, options);
         }
       }
     };

--- a/modules/@apostrophecms/translation/ui/apos/components/AposTranslationIndicator.vue
+++ b/modules/@apostrophecms/translation/ui/apos/components/AposTranslationIndicator.vue
@@ -23,7 +23,7 @@
       />
     </svg>
     <p v-if="label" class="apos-translation-chip__text">
-      {{ label }}
+      {{ $t(label) }}
     </p>
   </span>
 </template>
@@ -38,7 +38,7 @@ export default {
     },
     size: {
       type: Number,
-      default: 18
+      default: 16
     }
   }
 };
@@ -65,6 +65,7 @@ $background: #F7FEF4;
 
   margin: 0 0 0 4px;
   color: $color;
+  font-size: var(--a-type-tiny);
 }
 
 #svg-path {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellLabels.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellLabels.vue
@@ -30,6 +30,16 @@
         :modifiers="[ 'apos-is-filled', 'apos-is-danger' ]"
       />
     </span>
+    <span
+      v-for="({component, props}, index) in customCellIndicators"
+      :key="index"
+    >
+      <component
+        :is="component"
+        class="apos-table__cell-field__label"
+        v-bind="props"
+      />
+    </span>
   </div>
 </template>
 
@@ -38,7 +48,12 @@ import AposCellMixin from 'Modules/@apostrophecms/ui/mixins/AposCellMixin';
 
 export default {
   name: 'AposCellLabels',
-  mixins: [ AposCellMixin ]
+  mixins: [ AposCellMixin ],
+  data() {
+    return {
+      customCellIndicators: apos.schema.customCellIndicators
+    };
+  }
 };
 </script>
 

--- a/modules/@apostrophecms/ui/ui/apos/components/AposCellLabels.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposCellLabels.vue
@@ -31,11 +31,12 @@
       />
     </span>
     <span
-      v-for="({component, props}, index) in customCellIndicators"
+      v-for="({component, props, if: conditions}, index) in customCellIndicators"
       :key="index"
     >
       <component
         :is="component"
+        v-if="evaluateConditions(conditions)"
         class="apos-table__cell-field__label"
         v-bind="props"
       />
@@ -53,6 +54,27 @@ export default {
     return {
       customCellIndicators: apos.schema.customCellIndicators
     };
+  },
+  methods: {
+    evaluateConditions(conditions = {}) {
+      try {
+        return Object.entries(conditions).every(([ property, expected ]) => {
+          const properties = property.split('.');
+
+          const draftProp = properties.reduce((acc, cur) => {
+            if (Object.hasOwn(acc, cur)) {
+              return acc[cur];
+            }
+
+            throw new Error(`Property not found in draft document: ${property}`);
+          }, this.draft);
+
+          return draftProp === expected;
+        });
+      } catch (err) {
+        return false;
+      }
+    }
   }
 };
 </script>


### PR DESCRIPTION
[PRO-5643](https://linear.app/apostrophecms/issue/PRO-5643/ui-manager-indicators)

## Summary

Handles the new  `Pending Translations` on pieces and pages managers.

⚠️ Must be tested with [this PR](https://github.com/apostrophecms/automatic-translation/pull/1) in `automatic-translation`.

## What are the specific steps to test this change?

Since the conditions about the meta isn't existing for now you won't see the new indicator.
You can change the condition in `automatic-translation` to see the indicator being showed or you can create a new one.

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
