### PR TITLE
Show widget icons in the editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Display a more informative error message when publishing a page because the parent page is not published and the current user has no permission to publish the parent page (while having permission to publish the current one).
 * The `content-changed` event for the submit draft action now uses a complete document.
 * Fix the context bar overlap on palette for non-admin users that have the permission to modify it.
+* Show widget icons in the editor area context menu.
 
 ### Changes
 

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposInputArea.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposInputArea.js
@@ -43,7 +43,8 @@ export default {
       for (const [ name, options ] of Object.entries(widgets)) {
         result.push({
           name,
-          label: options.addLabel || apos.modules[`${name}-widget`].label
+          label: options.addLabel || apos.modules[`${name}-widget`].label,
+          icon: apos.modules[`${name}-widget`].icon
         });
       }
       return result;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

As part of HOL-2522. 
Widget icons are not shown in the are context menu when in an modal Editor. This change fixes that.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
