### PR TITLE
make widget modal width and origin configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Add translation keys used by the multisite assembly module.
 * Add side by side comparison support in AposSchema component.
+* Add the possibility to make widget modals wider, which can be useful for widgets that contain areas taking significant space. See the [documentation](TODO:).
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Add translation keys used by the multisite assembly module.
 * Add side by side comparison support in AposSchema component.
-* Add the possibility to make widget modals wider, which can be useful for widgets that contain areas taking significant space. See the [documentation](TODO:).
+* Add the possibility to make widget modals wider, which can be useful for widgets that contain areas taking significant space. See [documentation](https://v3.docs.apostrophecms.org/reference/modules/widget-type.html#options).
 
 ### Fixes
 

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -308,7 +308,7 @@ export default {
       top: 0;
       bottom: 0;
       transform: translateX(0);
-      width: 90%;
+      width: 100%;
       border-radius: 0;
       height: 100vh;
 
@@ -336,6 +336,12 @@ export default {
     &.apos-modal__inner--half {
       @media screen and (min-width: 800px) {
         max-width: 50%;
+      }
+    }
+
+    &.apos-modal__inner--full {
+      @media screen and (min-width: 800px) {
+        max-width: 100%;
       }
     }
 

--- a/modules/@apostrophecms/widget-type/index.js
+++ b/modules/@apostrophecms/widget-type/index.js
@@ -100,7 +100,11 @@ module.exports = {
     neverLoadSelf: true,
     initialModal: true,
     placeholder: false,
-    placeholderClass: 'apos-placeholder'
+    placeholderClass: 'apos-placeholder',
+    // two-thirds, half or full:
+    width: '',
+    // left or right:
+    origin: 'right'
   },
   init(self) {
     const badFieldName = Object.keys(self.fields).indexOf('type') !== -1;
@@ -400,7 +404,9 @@ module.exports = {
           contextual: self.options.contextual,
           placeholderClass: self.options.placeholderClass,
           className: self.options.className,
-          components: self.options.components
+          components: self.options.components,
+          width: self.options.width,
+          origin: self.options.origin
         });
         return result;
       }

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -92,6 +92,8 @@ export default {
   },
   emits: [ 'safe-close', 'modal-result' ],
   data() {
+    const moduleOptions = window.apos.modules[apos.area.widgetManagers[this.type]];
+
     return {
       id: this.value && this.value._id,
       original: null,
@@ -103,6 +105,8 @@ export default {
         title: this.editLabel,
         active: false,
         type: 'slide',
+        width: moduleOptions.width,
+        origin: moduleOptions.origin,
         showModal: false
       },
       triggerValidation: false
@@ -218,9 +222,3 @@ export default {
   }
 };
 </script>
-
-<style lang="scss" scoped>
-  .apos-widget-editor ::v-deep .apos-modal__inner {
-    max-width: 458px;
-  }
-</style>


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Add the possibility to make widget modals wider, which can be useful for widgets that contain areas taking significant space.

Default width is now `540px`.
Add new `origin` and `width` options in order to configure widget modals at module level.

## What are the specific steps to test this change?

Setting the width to `half`, the widget modal will take 50% of the screen.
Setting the width to `two-thirds`, the widget modal will take 66% of the screen.
Setting the width to `full`, the widget modal will take 100% of the screen.
Setting the origin to `left`, the widget modal will be displayed on the left hand side of the screen. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated -> https://github.com/apostrophecms/a3-vitepress-docs/pull/92
- [x] Related tests have been updated -> https://github.com/apostrophecms/testbed/pull/228

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
