### PR TITLE
Rt render span classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+* Adds `textStyle` to Tiptap types so that spans are rendered on RT initialization
 * `field.help` and `field.htmlHelp` are now correctly translated when displayed in a tooltip.
 
 ## 3.63.1 (2024-02-22)

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -331,6 +331,7 @@ module.exports = {
       blockquote: [ 'blockquote' ],
       superscript: [ 'sup' ],
       subscript: [ 'sub' ],
+      textStyle: [ 'span' ],
       // Generic div type, usually used with classes,
       // and for A2 content migration. Intentionally not
       // given a nicer-sounding name


### PR DESCRIPTION
## Summary

- Register spans as a `textStyle` and pass them into the RT configuration so they can be rendered

## What are the specific steps to test this change?

1. link to a demo, like a3-demo
2. make a RT widg, set some text to a span with a class
3. refresh the page, see that the RT editor renders the span + class

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
