### PR TITLE
adds schema getChanges method, updates isEqual method to accept getCh…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Add translation keys used by the multisite assembly module.
 * Add side by side comparison support in AposSchema component.
+* Add new `getChanges` method to the schema module to get an array of document changed field names instead of just a boolean like does the `isEqual` method. 
 
 ### Fixes
 

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -859,7 +859,7 @@ module.exports = (self) => {
       if (one[field.name].length !== two[field.name].length) {
         return false;
       }
-      for (let i = 0; (i < one.length); i++) {
+      for (let i = 0; (i < one[field.name].length); i++) {
         if (!self.isEqual(req, field.schema, one[field.name][i], two[field.name][i])) {
           return false;
         }

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -288,6 +288,44 @@ describe('Schemas', function() {
               }
             };
           }
+        },
+        article: {
+          extend: '@apostrophecms/piece-type',
+          options: {
+            alias: 'article'
+          },
+          fields(self) {
+            return {
+              add: {
+                title: {
+                  label: '',
+                  type: 'string',
+                  required: true
+                },
+                area: {
+                  label: 'Area',
+                  type: 'area',
+                  options: {
+                    widgets: {
+                      '@apostrophecms/rich-text': {}
+                    }
+                  }
+                },
+                array: {
+                  label: 'Array',
+                  type: 'array',
+                  fields: {
+                    add: {
+                      arrayTitle: {
+                        label: 'Array Title',
+                        type: 'string'
+                      }
+                    }
+                  }
+                }
+              }
+            };
+          }
         }
       }
     });
@@ -2255,6 +2293,106 @@ describe('Schemas', function() {
 
     assert(output.emptyValue === null);
     assert(output.goodValue === '2022-05-09T22:36:00.000Z');
+  });
+
+  it('should compare two document properly with the method getChanges', async function() {
+    const req = apos.task.getReq();
+    const instance = apos.article.newInstance();
+    const article1 = {
+      ...instance,
+      title: 'article 1',
+      area: {
+        _id: 'clrth36680007mnmd3jj7cta0',
+        items: [
+          {
+            _id: 'clt79l48g001h2061j5ihxjkv',
+            metaType: 'widget',
+            type: '@apostrophecms/rich-text',
+            aposPlaceholder: false,
+            content: '<p>Some text here.</p>',
+            permalinkIds: [],
+            imageIds: []
+          }
+        ],
+        metaType: 'area'
+      },
+      array: [
+        {
+          _id: 'clt79llm800242061v4dx9kv5',
+          metaType: 'arrayItem',
+          scopedArrayName: 'doc.article.array',
+          arrayTitle: 'array title 1'
+        },
+        {
+          _id: 'clt79llm800242061v4d47364',
+          metaType: 'arrayItem',
+          scopedArrayName: 'doc.article.array',
+          arrayTitle: 'array title 2'
+        }
+      ]
+    };
+    const article2 = {
+      ...article1,
+      title: 'article 2'
+    };
+    const article3 = {
+      ...instance,
+      title: 'article 3',
+
+      area: {
+        _id: 'clrth36680007mnmd3jj7cta0',
+        items: [
+          {
+            _id: 'clt79l48g001h2061j5ihxjkv',
+            metaType: 'widget',
+            type: '@apostrophecms/rich-text',
+            aposPlaceholder: false,
+            content: '<p>Some text here changed.</p>',
+            permalinkIds: [],
+            imageIds: []
+          }
+        ],
+        metaType: 'area'
+      },
+      array: [
+        {
+          _id: 'clt79llm800242061v4dx9kv5',
+          metaType: 'arrayItem',
+          scopedArrayName: 'doc.article.array',
+          arrayTitle: 'array title 1 changed'
+        },
+        {
+          _id: 'clt79llm800242061v4d47364',
+          metaType: 'arrayItem',
+          scopedArrayName: 'doc.article.array',
+          arrayTitle: 'array title 2'
+        }
+      ]
+    };
+
+    await apos.article.insert(req, article1);
+    await apos.article.insert(req, article2);
+    await apos.article.insert(req, article3);
+
+    const art1 = await apos.doc.db.findOne({ title: 'article 1' });
+    const art2 = await apos.doc.db.findOne({ title: 'article 2' });
+    const art3 = await apos.doc.db.findOne({ title: 'article 3' });
+
+    const changes11 = apos.schema.getChanges(req, apos.article.schema, art1, art1);
+    const changes12 = apos.schema.getChanges(req, apos.article.schema, art1, art2);
+    const changes23 = apos.schema.getChanges(req, apos.article.schema, art2, art3);
+    const actual = {
+      changes11,
+      changes12,
+      changes23
+    };
+    const expected = {
+      changes11: [],
+      changes12: [ 'title', 'slug' ],
+      changes23: [ 'title', 'slug', 'area', 'array' ]
+    };
+
+    assert.deepEqual(actual, expected);
   });
 
   describe('field editPermission|viewPermission', function() {


### PR DESCRIPTION
[PRO-5613](https://linear.app/apostrophecms/issue/PRO-5613/as-an-editor-i-can-see-how-many-changes-were-made-in-each-published)

## Summary

Adds a `getChanges` method in the `schema` module.
A wrapper calling `isEqual` with the option `getChanges`.
Instead of returning true or false, it returns an array of changed field names.

Fixes `array` field type `isEqual` method.

Adds test for new `getChanges` method.

## What are the specific steps to test this change?

Tests should pass

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [X] Related tests have been updated
