### PR TITLE
fix apos tree checkboxes

### DIFF
--- a/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
@@ -13,7 +13,7 @@
       :hidden="options.hideHeader"
     />
     <AposTreeRows
-      v-model="checkedProxy"
+      v-model:checked="checkedProxy"
       list-id="root"
       :rows="myItems"
       :headers="headers"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -98,7 +98,7 @@
         </div>
         <AposTreeRows
           :ref="(el) => treeBranches.push(el)"
-          v-model="checkedProxy"
+          v-model:checked="checkedProxy"
           data-apos-branch-height
           :data-list-row="row._id"
           :rows="row._children"
@@ -190,7 +190,7 @@ export default {
       }
     }
   },
-  emits: [ 'update', 'change' ],
+  emits: [ 'update', 'update:checked' ],
   data() {
     return {
       treeBranches: []
@@ -203,7 +203,7 @@ export default {
         return this.checked;
       },
       set(val) {
-        this.$emit('change', val);
+        this.$emit('update:checked', val);
       }
     },
     dragOptions() {


### PR DESCRIPTION
[PRO-5744](https://linear.app/apostrophecms/issue/PRO-5744/redirect-module-vue3-adding-a-new-redirect-with-an-internal-page-link)

## Summary

Fix the checkboxes in the apos pages tree.

## What are the specific steps to test this change?

You should be able to select pages properly in pages relationships, like in redirects.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
