### PR TITLE
ignores non localized related docs

### DIFF
--- a/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
+++ b/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
@@ -223,12 +223,12 @@
                   </span>
                 </p>
                 <AposCheckbox
+                  v-model="wizard.values.translateContent.data"
                   :field="{ name: 'translate' }"
                   :choice="{
                     value: wizard.values.translateContent.data,
                     label: $t('apostrophe:automaticTranslationCheckbox')
                   }"
-                  v-model="wizard.values.translateContent.data"
                   data-apos-test="localizationTranslationCheck"
                 />
 
@@ -236,8 +236,8 @@
                   <!-- eslint-disable vue/no-v-html -->
                   <p
                     class="apos-wizard__translation-error"
-                    v-html="translationErrMsg"
                     data-apos-test="localizationTranslationErr"
+                    v-html="translationErrMsg"
                   />
                   <!-- eslint-disable vue/no-v-html -->
                   <AposButton
@@ -858,7 +858,11 @@ export default {
         // never be considered "related" to other pages simply because
         // of navigation links, the feature is meant for pieces that feel more like
         // part of the document being localized)
-        return related.filter(doc => apos.modules[doc.type].relatedDocument !== false);
+        // We also remove non localized content like users
+        return related.filter(doc => {
+          return apos.modules[doc.type].relatedDocument !== false &&
+            apos.modules[doc.type].localized !== false;
+        });
       }
     },
     async updateRelatedDocs() {


### PR DESCRIPTION
[PRO-5699](https://linear.app/apostrophecms/issue/PRO-5699/localization-wizard-should-not-ask-to-localize-non-localized-content)

## Summary

Ignores non localized related docs when localizind, like users.
You should never see this:

![image](https://github.com/apostrophecms/apostrophe/assets/17548370/07faae09-edb8-47bc-bd0a-bfeb58178d2b)


## What are the specific steps to test this change?

Check that documents from module having `localized: false` never appears in the related docs list.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
