### PR TITLE
PRO-5793 hotfix for rich text styles option bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 4.1.1 (2024-03-21)
+
+### Fixes
+
+* Hotfix for a bug that broke the rich text editor when the rich text widget has
+a `styles` property. The bug was introduced in 4.0.0 as an indirect side effect of deeper
+watching behavior by Vue 3.
+
 ## 4.1.0 (2024-03-20)
 
 ### Fixes

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -140,6 +140,8 @@ import TableHeader from '@tiptap/extension-table-header';
 import TableRow from '@tiptap/extension-table-row';
 import Placeholder from '@tiptap/extension-placeholder';
 
+import { klona } from 'klona';
+
 export default {
   name: 'AposRichTextWidgetEditor',
   components: {
@@ -209,7 +211,10 @@ export default {
       return this.moduleOptions.defaultOptions;
     },
     editorOptions() {
-      const activeOptions = Object.assign({}, this.options);
+      // Deep clone to prevent runaway recursive rendering
+      // as the subproperties are mutated in several places
+      // by this code and its dependencies (TODO: find them all)
+      const activeOptions = klona(this.options);
 
       activeOptions.styles = this.enhanceStyles(
         activeOptions.styles?.length
@@ -491,6 +496,7 @@ export default {
     },
     // Enhances the dev-defined styles list with tiptap
     // commands and parameters used internally.
+    // WARNING: mutates its argument
     enhanceStyles(styles) {
       const self = this;
       (styles || []).forEach(style => {
@@ -544,8 +550,6 @@ export default {
       return styles;
     },
     localizeStyle(style) {
-      style.label = this.$t(style.label);
-
       return {
         ...style,
         label: this.$t(style.label)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
TL;DR: mutating things, even subproperties of things, causes Vue 3 to consider them to have changed and can lead to unexpected behavior. Methods that return a result usually don't alter their arguments. This is a safe workaround for now