### PR TITLE
fix button data-test attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ There is no change in how the `styles` option is configured.
 * Fix a crash in `notification` when `req.body` was not present. Thanks to Michelin for contributing this fix.
 * Addresses a console error observed when opening and closing the `@apostrophecms-pro/palette` module across various projects.
 * Fixes the color picker field in `@apostrophecms-pro/palette` module.
+* Ensures that the `data-apos-test` attribute in the admin bar's tray item buttons is set by passing the `action` prop to `AposButton`.
 
 ## 4.1.1 (2024-03-21)
 

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarMenu.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarMenu.vue
@@ -70,6 +70,7 @@
           :icon="item.options.icon"
           :icon-only="true"
           :label="item.label"
+          :action="item.action"
           :state="trayItemState[item.name] ? [ 'active' ] : []"
           @click="emitEvent(item.action)"
         />


### PR DESCRIPTION
needed for https://github.com/apostrophecms/testbed/pull/236

passes `item.action` in order to fill the Button data-test attribute.