### PR TITLE
fix modal ref in onTopOf

### DIFF
--- a/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
+++ b/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
@@ -58,8 +58,8 @@ function onTopOf(el1, el2) {
   if (el2 === document) {
     return true;
   }
-  const index1 = apos.modal.stack.findIndex(modal => modal.$el === el1);
-  const index2 = apos.modal.stack.findIndex(modal => modal.$el === el2);
+  const index1 = apos.modal.stack.findIndex(modal => modal.modalEl === el1);
+  const index2 = apos.modal.stack.findIndex(modal => modal.modalEl === el2);
   if (index1 === -1) {
     throw new Error('apos.modal.onTopOf: el1 is not in the modal stack');
   }


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/apostrophecms/apostrophe/pull/4482.

Before, components were entirely stored in the modal stack.
In https://github.com/apostrophecms/apostrophe/pull/4482, the logic has been changed to store the modal element inside a reactive object, under `modalEl`.

So now, we need to use `modalEl` and not `$el` anymore.