### PR TITLE
fixed slug creation issue for '/'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+* fixed slug creation issue if we get some value in title like 'new page /'
+
 ### Changes
 
 * Rich text styles are now split into Nodes and Marks, with independent toolbar controls for a better UX when applying text styles.

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
@@ -67,7 +67,10 @@ export default {
         delete oldClone.archived;
 
         oldValue = Object.values(oldClone).join(' ');
+        oldValue = oldValue.replace(/\//g, ' ');
+
         newValue = Object.values(newClone).join(' ');
+        newValue = newValue.replace(/\//g, ' ');
 
         if (this.compatible(oldValue, this.next) && !newValue.archived) {
           // If this is a page slug, we only replace the last section of the slug.


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*The page editor stops generating slug if a '/' appears in the page title. "Closes #4086"*

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Click on pages button placed on top left.
> 3. click on new page button top right.
> 4. Add string like "new pages / new page" in title field.
> 5. You will observe slug field include value like "/new pages / new page".

##  kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
