### PR TITLE
Modifies conditional return to maintain query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ There is no change in how the `styles` option is configured.
 * Addresses a console error observed when opening and closing the `@apostrophecms-pro/palette` module across various projects.
 * Fixes the color picker field in `@apostrophecms-pro/palette` module.
 * Ensures that the `data-apos-test` attribute in the admin bar's tray item buttons is set by passing the `action` prop to `AposButton`.
+* Prevents stripping of query parameters from the URL when the page is either switched to edit mode or reloaded while in edit mode.
 
 ### Adds
 

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
@@ -549,6 +549,7 @@ export default {
 
       if (this.urlDiffers(doc._url)) {
         // Slug changed, change browser URL to reflect the actual url of the doc
+        doc._url = doc._url + (window.location.search || '');
         history.replaceState(null, '', doc._url);
       }
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
This PR modifies the logic in the `TheAposContextBar.vue` component to not strip query parameters when in edit mode. This prevents developers from testing page additions that depend on these parameters.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

1. Create a new page
2. While editing in context, add query parameters to the URL and hit return.
3. The page should reload and maintain the same query parameters in the URL.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
