### PR TITLE
poc of live access on demand (not reactive, but up to date on demand)

### DIFF
--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -137,7 +137,8 @@ export default {
   ],
   provide () {
     return {
-      originalDoc: this.originalDoc
+      originalDoc: this.originalDoc,
+      liveOriginalDoc: this.docFields
     };
   },
   props: {

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -26,6 +26,7 @@ export default {
       default: null
     }
   },
+
   data() {
     return {
       docFields: {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputSlug.vue
@@ -36,6 +36,7 @@
           :size="iconSize"
           class="apos-input-icon"
         />
+        <button @click="summarizeLiveDoc">Summarize Live Doc</button>
       </div>
     </template>
   </AposInputWrapper>

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
@@ -17,6 +17,7 @@ export default {
       originalSlugPartsLength: null
     };
   },
+  inject: [ 'liveOriginalDoc' ],
   computed: {
     tabindex () {
       return this.field.disableFocus ? '-1' : '0';
@@ -98,6 +99,9 @@ export default {
     this.originalSlugPartsLength = this.next.split('/').length;
   },
   methods: {
+    summarizeLiveDoc() {
+      console.log(`The title is: ${this.liveOriginalDoc.data.title}`);
+    },
     async watchNext() {
       this.next = this.slugify(this.next);
       this.validateAndEmit();


### PR DESCRIPTION
This works great from a top level field, and seo fields are top level fields. Any changes in the fields are available immediately when the button is clicked.

What's left from here is figuring out the best place to put the buttons themselves in the code. I haven't seen the design for this. We could certainly make them custom fields and it would definitely work that way.

![Screenshot from 2024-04-19 10-32-25](https://github.com/apostrophecms/apostrophe/assets/32125/8839d9f9-98d1-4da7-a713-356e7423e7b9)
