### PR TITLE
update options to allow drag/drop betweeen parents and children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Allows to disable page refresh on content changed for page types.
 
+### Fixes
+
+* Fixes drag and drop regression in the page tree where pages were not able to be moved between parent and child.
+
 ## 4.2.0 (2024-04-18)
 
 * Typing a `/` in the title field of a page no longer confuses the slug field. Thanks to [Gauav Kumar](https://github.com/gkumar9891).

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -1,10 +1,10 @@
 <template>
   <draggable
-    v-bind="dragOptions"
     item-key="_id"
     class="apos-tree__list"
     tag="ol"
     :list="rows"
+    :options="dragOptions"
     @start="startDrag"
     @end="endDrag"
   >
@@ -208,7 +208,9 @@ export default {
     },
     dragOptions() {
       return {
-        group: { name: this.treeId },
+        group: this.treeId,
+        fallbackOnBody: true,
+        swapThreshold: 0.65,
         dataListId: this.listId,
         disabled: !this.options.draggable,
         handle: '.apos-tree__row__icon--handle',


### PR DESCRIPTION
## Summary

Fixes a bug where pages were not able to be dragged between different levels of hierarchy.

## What are the specific steps to test this change?

1. `npm run dev`
1. Use the Page manager to create Pages, navigate to a Page and create a Child Page.
1. Edit the Page Tree by dragging Pages. You should be able to move Pages between different levels of heirarchy.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

