### PR TITLE
use autocomplete="new-password" to get the right effect in modern browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.227.6 (2024-04-29)
+
+### Changes
+
+* Replace `autocomplete="off"`, which modern browsers ignore, with `autocomplete="new-password"`
+so that (1) admin user's password is not stuffed into password fields when editing an entirely
+different user and (2) the admin user's username is not stuffed into the text field preceding
+it. Browser autocomplete is quite aggressive in 2024.
+
 ## 2.227.5 (2024-04-18)
 
 ### Changes

--- a/lib/modules/apostrophe-schemas/views/macros.html
+++ b/lib/modules/apostrophe-schemas/views/macros.html
@@ -87,7 +87,7 @@
 {%- endmacro -%}
 
 {%- macro passwordBody(field, options) -%}
-  <input id="{{ options.id }}" class="apos-field-input apos-field-input-text{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}" name="{{ field.name }}" autocomplete="off" type="password"{% if field.readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
+  <input id="{{ options.id }}" class="apos-field-input apos-field-input-text{% if options.fieldClasses %} {{ options.fieldClasses }}{% endif %}" name="{{ field.name }}" autocomplete="new-password" type="password"{% if field.readOnly %} disabled{% endif %}{% if options.fieldAttributes %} {{ options.fieldAttributes }}{% endif %}>
 {%- endmacro -%}
 
 {%- macro tags(field) -%}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "2.227.5",
+  "version": "2.227.6",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Simple change, tested in kimpton dashboard. Chrome still tries to helpfully suggest you might want to autofill your password, but it doesn't silently auto-stuff it anymore!

I also verified that the actual login page has its own custom, non-schema driven markup so this won't disable autocomplete there.