### PR TITLE
PRO-5822: documents autocrop on image replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Allows to disable page refresh on content changed for page types.
 
+### Fixes
+
+* Autocrop image attachments for referenced documents when replacing an image in the Media Manager.
+
 ## 4.2.0 (2024-04-18)
 
 * Typing a `/` in the title field of a page no longer confuses the slug field. Thanks to [Gauav Kumar](https://github.com/gkumar9891).

--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -205,6 +205,8 @@
   "hideInNavigation": "Hide in Navigation",
   "home": "Home",
   "image": "Image",
+  "imageOnReplaceAutocropMessage": "The replaced image has been autocropped for \"{{ title }}\".",
+  "imageOnReplaceAutocropError": "An error occurred while autocropping the replaced image for {{ title }}",
   "imageDescription": "Add an inline image",
   "imageFile": "Image File",
   "imagePlaceholder": "Image placeholder",

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -2301,7 +2301,7 @@ database.`);
       // Apostrophe queries used to fetch Apostrophe pages
       // consult this method.
       getBaseUrl(req) {
-        const hostname = self.apos.i18n.locales[req.locale].hostname;
+        const hostname = self.apos.i18n.locales[req.locale]?.hostname;
 
         return hostname
           ? `${req.protocol}://${hostname}`

--- a/test/images.js
+++ b/test/images.js
@@ -1,8 +1,10 @@
 const t = require('../test-lib/test.js');
-const assert = require('assert');
-const fs = require('fs');
+const assert = require('assert/strict');
+const fs = require('fs-extra');
 const path = require('path');
 const FormData = require('form-data');
+
+const publicFolderPath = path.join(process.cwd(), 'test/public');
 
 describe('Images', function() {
 
@@ -73,7 +75,8 @@ describe('Images', function() {
   // Test pieces.list()
   it('should clean up any existing images for testing', async function() {
     try {
-      const response = await apos.doc.db.deleteMany({ type: '@apostrophecms/image' }
+      const response = await apos.doc.db.deleteMany(
+        { type: '@apostrophecms/image' }
       );
       assert(response.result.ok === 1);
     } catch (e) {
@@ -261,6 +264,133 @@ describe('Images', function() {
     assert.strictEqual(fields.left, 0);
     assert.strictEqual(fields.width, 450);
     assert.strictEqual(fields.height, 225);
+  });
+
+  it('should update crop fields when replacing an image attachment', async function () {
+    await t.destroy(apos);
+    await fs.remove(publicFolderPath + '/uploads');
+    apos = await t.create({
+      root: module,
+      modules: {
+        'test-piece': {
+          extend: '@apostrophecms/piece-type',
+          fields: {
+            add: {
+              main: {
+                type: 'area',
+                options: {
+                  widgets: {
+                    '@apostrophecms/image': {
+                      aspectRatio: [ 3, 2 ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+    await insertUser({
+      title: 'admin',
+      username: 'admin',
+      password: 'admin',
+      email: 'ad@min.com',
+      role: 'admin'
+    });
+
+    // Upload an image (landscape), crop it, insert a piece with the cropped image
+    jar = await login('admin');
+    const formData = new FormData();
+    const stream = fs.createReadStream(
+      path.join(apos.rootDir, '/public/test-image-landscape.jpg')
+    );
+    formData.append('file', stream);
+    const attachment = await apos.http.post('/api/v1/@apostrophecms/attachment/upload', {
+      body: formData,
+      jar
+    });
+    stream.close();
+    image = await apos.http.post('/api/v1/@apostrophecms/image', {
+      body: {
+        title: 'Test Image Landscape',
+        attachment
+      },
+      jar
+    });
+    assert.equal(image._prevAttachmentId, attachment._id);
+    const crop = await apos.http.post('/api/v1/@apostrophecms/image/autocrop', {
+      body: {
+        relationship: [ image ],
+        widgetOptions: {
+          aspectRatio: [ 3, 2 ]
+        }
+      },
+      jar
+    });
+    let piece = await apos.http.post('/api/v1/test-piece', {
+      jar,
+      body: {
+        title: 'Test Piece',
+        slug: 'test-piece',
+        type: 'test-piece',
+        main: {
+          metaType: 'area',
+          items: [
+            {
+              type: '@apostrophecms/image',
+              metaType: 'widget',
+              imageIds: [ image.aposDocId ],
+              imageFields: {
+                [image.aposDocId]: crop.relationship[0]._fields
+              },
+              _image: [ crop.relationship[0] ]
+            }
+          ]
+        }
+      }
+    });
+
+    let imageFields = piece.main.items[0].imageFields[image.aposDocId];
+    assert(imageFields, 'imageFields should be present when creating the piece');
+    assert.equal(imageFields.width / imageFields.height, 3 / 2, 'aspect ratio should be 3:2');
+    await fs.access(path.join(
+      publicFolderPath,
+      attachment._urls.original.replace(
+        '.jpg',
+        `.${imageFields.left}.${imageFields.top}.${imageFields.width}.${imageFields.height}.jpg`
+      )
+    ));
+
+    // Replace the image with portrait orientation, verify that the aspect ratio is preserved
+    const formDataPortrait = new FormData();
+    const streamPortrait = fs.createReadStream(path.join(apos.rootDir, '/public/test-image.jpg'));
+    formDataPortrait.append('file', streamPortrait);
+    const attachmentPortrait = await apos.http.post('/api/v1/@apostrophecms/attachment/upload', {
+      body: formDataPortrait,
+      jar
+    });
+    image = await apos.http.put(`/api/v1/@apostrophecms/image/${image._id}`, {
+      body: {
+        title: 'Test Image Portrait',
+        attachment: attachmentPortrait
+      },
+      jar
+    });
+    streamPortrait.close();
+    piece = await apos.http.get(`/api/v1/test-piece/${piece._id}`, {
+      jar
+    });
+    imageFields = piece.main.items[0].imageFields[image.aposDocId];
+    assert(imageFields, 'imageFields should be present after replacing the image attachment');
+    assert.equal(imageFields.width / imageFields.height, 3 / 2, 'aspect ratio should be 3:2');
+    await fs.access(path.join(
+      publicFolderPath,
+      attachmentPortrait._urls.original.replace(
+        '.jpg',
+        `.${imageFields.left}.${imageFields.top}.${imageFields.width}.${imageFields.height}.jpg`
+      )
+    ));
   });
 
   async function insertUser(info) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Fixes broken, previously cropped, images, when an attachment is `replaced` in the Media Manager. The change ensures that the replaced image will be autocropped in all relations that it's used (when appropriate). 

## What are the specific steps to test this change?

Replace an image in Media Manager. Ensure that widgets using that image and having configured aspect ratio will be re-cropped and not broken on the page view. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
