### PR TITLE
Implement publicBundle option for assets builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Allows to disable page refresh on content changed for page types.
 * Adds prop to `AposInputMixin` to disable blur emit.
 * Adds `throttle` function in ui module utils.
+* Adds a `publicBundle` option to `@apostrophecms/asset` - when set to `false`, it will prevent from rebuilding asset bundles unless `APOS_DEV` env variable is set or when there is no bundle already built - to be used when using Apostrophe with an External Front End
 
 ### Changes
 

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -42,7 +42,10 @@ module.exports = {
     watchDebounceMs: 1000,
     // Object containing instructions for remapping existing bundles.
     // See the modulre reference documentation for more information.
-    rebundleModules: undefined
+    rebundleModules: undefined,
+    // In case of external front end like Astro, this option allows to
+    // disable the build of the public UI assets.
+    publicBundle: true
   },
 
   async init(self) {
@@ -170,7 +173,9 @@ module.exports = {
           // to the same relative path `/public/apos-frontend/namespace/modules/modulename`.
           // Inherited files are also copied, with the deepest subclass overriding in the
           // event of a conflict
-          await moduleOverrides(`${bundleDir}/modules`, 'public');
+          if (self.options.publicBundle) {
+            await moduleOverrides(`${bundleDir}/modules`, 'public');
+          }
 
           for (const [ name, options ] of Object.entries(self.builds)) {
             // If the option is not present always rebuild everything...
@@ -181,11 +186,12 @@ module.exports = {
             } else if (!rebuild) {
               let checkTimestamp = false;
 
-              // Only builds contributing to the apos admin UI (currently just "apos")
+              // If options.publicBundle, only builds contributing to the apos admin UI (currently just "apos")
               // are candidates to skip the build simply because package-lock.json is
               // older than the bundle. All other builds frequently contain
               // project level code
-              if (options.apos) {
+              // Else we can skip also for the src bundle
+              if (options.apos || !self.options.publicBundle) {
                 const bundleExists = await fs.pathExists(bundleDir);
 
                 if (!bundleExists) {
@@ -439,7 +445,7 @@ module.exports = {
                   modulesPrefix: `${self.getAssetBaseUrl()}/modules`
                 }));
               }
-              if (options.apos) {
+              if (options.apos || !self.options.publicBundle) {
                 const now = Date.now().toString();
                 fs.writeFileSync(`${bundleDir}/${name}-build-timestamp.txt`, now);
               }
@@ -1309,7 +1315,7 @@ module.exports = {
         `;
         self.builds = {
           src: {
-            scenes: [ 'public', 'apos' ],
+            scenes: [ 'apos' ],
             webpack: true,
             outputs: [ 'css', 'js' ],
             label: 'apostrophe:modernBuild',
@@ -1318,13 +1324,6 @@ module.exports = {
             // Load only in browsers that support ES6 modules
             condition: 'module',
             prologue: self.srcPrologue
-          },
-          public: {
-            scenes: [ 'public', 'apos' ],
-            outputs: [ 'css', 'js' ],
-            label: 'apostrophe:rawCssAndJs',
-            // Just concatenates
-            webpack: false
           },
           apos: {
             scenes: [ 'apos' ],
@@ -1350,6 +1349,16 @@ module.exports = {
           // We could add an apos-ie11 bundle that just pushes a "sorry charlie" prologue,
           // if we chose
         };
+        if (self.options.publicBundle) {
+          self.builds.public = {
+            scenes: [ 'public', 'apos' ],
+            outputs: [ 'css', 'js' ],
+            label: 'apostrophe:rawCssAndJs',
+            // Just concatenates
+            webpack: false
+          };
+          self.builds.src.scenes.push('public');
+        }
       },
       // Filter the given css performing any necessary transformations,
       // such as support for the /modules path regardless of where


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Adds a `publicBundle` option to `@apostrophecms/asset` - when set to `false`, it will prevent from rebuilding asset bundles unless `APOS_DEV` env variable is set or when there is no bundle already built - to be used when using Apostrophe with an External Front End

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
