### PR TITLE
Updates edit method to take modified copyOf value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changes
 
 * Improves `debounce` function to handle async properly (waiting for previous async call to finish before to trigger new one).
+* Allows passing of the `_id` to the `edit()` method `copyOf` argument while still allowing the entire `copyOf` object for BC
 
 ### Fixes
 

--- a/modules/@apostrophecms/doc/ui/apos/apps/AposDoc.js
+++ b/modules/@apostrophecms/doc/ui/apos/apps/AposDoc.js
@@ -29,10 +29,17 @@ export default () => {
     if (!modal) {
       throw new Error(`${type} is not a valid piece or page type, or cannot be edited`);
     }
+
+    const copyOfId = typeof copyOf === 'string' ? copyOf : copyOf?._id;
+
+    if (copyOf && !copyOfId) {
+      throw new Error('copyOf must be either a string or an object with a _id property');
+    }
+
     return apos.modal.execute(modal, {
       moduleName: type,
       docId: _id,
-      copyOf
+      copyOfId
     });
   };
   // If you don't care about the returned value, you can emit an


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
In documenting `apos.doc.edit()` I was unable to get the `copyOf` parameter to trigger the duplication of an existing document. This may have been due to user error. However, we are eliminating the use of `copyOf` in favor of `copyOfId`. This PR modifies the `apos.doc.edit()` method to accept either the `_id` as a string or the `copyOf` object containing an `_id` property. Closes PRO-5967.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly
1. Create a new piece type called 'test'.
2. Create at least one piece and note the generated `_id`
3. Create a piece-page-type for the 'test' piece.
4. Alter the index.html page to have a button with an id of 'edit-test-button'
5. Create a `modules/test-page/ui/src/index.js` file
6. Add the following code:
```
export default () => {
  document.addEventListener('DOMContentLoaded', function () {
    const button = document.getElementById('edit-test-button');
    copyOfObject = await self.findOneForCopying(req, { _id: <piece _id>});
    button.addEventListener('click', async function () {
      const editedDocument = await apos.doc.edit({
        type: 'test',
        copyOf: < piece _id or copyOfObject>
      });
      if (editedDocument) {
        console.log('Doc was edited', editedDocument);
      }
    });
  });
};
```
7. Check that the button opens a modal with a duplicate of the created piece with either the object or the `_id` as string.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [X] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
