### PR TITLE
Implement publicBundle option for assets builds (A3 backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixes
 * Autocrop image attachments for referenced documents when replacing an image in the Media Manager.
 
+### Adds
+* Adds a `publicBundle` option to `@apostrophecms/asset` - when set to `false`, it will prevent from rebuilding asset bundles unless `APOS_DEV` env variable is set or when there is no bundle already built - to be used when using Apostrophe with an External Front End
+
 ## 3.64.0 (2024-04-18)
 
 ### Adds


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Adds a publicBundle option to `@apostrophecms/asset` - when set to `false`, it will prevent from rebuilding asset bundles unless `APOS_DEV` env variable is set or when there is no bundle already built - to be used when using Apostrophe with an External Front End

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
