### PR TITLE
Get rid of the double modals stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### Adds
+
+* Adds pinia and a store to handle modals logic. Methods from the store are registered on `apos.modal` instead of component methods.
+
 ### Changes
 
 * Improves widget tabs for the hidden entries, improves UX when validation errors are present in non-focused tabs.

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaExpandedMenu.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaExpandedMenu.vue
@@ -6,7 +6,6 @@
     @inactive="modal.active = false"
     @show-modal="modal.showModal = true"
     @esc="close"
-    @no-modal="$emit('safe-close')"
   >
     <template #main>
       <AposModalBody>
@@ -77,7 +76,7 @@ export default {
       default: 0
     }
   },
-  emits: [ 'expanded-menu-close', 'safe-close', 'modal-result' ],
+  emits: [ 'expanded-menu-close', 'modal-result' ],
   data() {
     return {
       modal: {

--- a/modules/@apostrophecms/command-menu/ui/apos/components/AposCommandMenuShortcut.vue
+++ b/modules/@apostrophecms/command-menu/ui/apos/components/AposCommandMenuShortcut.vue
@@ -3,7 +3,6 @@
     :modal="modal"
     class="apos-command-menu-shortcut"
     @esc="close"
-    @no-modal="$emit('safe-close')"
     @inactive="modal.active = false"
     @show-modal="modal.showModal = true"
   >

--- a/modules/@apostrophecms/command-menu/ui/apos/components/TheAposCommandMenu.vue
+++ b/modules/@apostrophecms/command-menu/ui/apos/components/TheAposCommandMenu.vue
@@ -105,11 +105,8 @@ export default {
       return this.modal;
     },
     getFirstNonShortcutModal(index = -1) {
-      console.log('index', index);
       const modal = this.getAt(index);
-      console.log('modal', modal);
       const properties = this.getProperties(modal.id);
-      console.log('properties', properties);
 
       return properties.itemName === '@apostrophecms/command-menu:shortcut'
         ? this.getFirstNonShortcutModal(index + -1)
@@ -121,6 +118,3 @@ export default {
   }
 };
 </script>
-
-<style lang="scss" scoped>
-</style>

--- a/modules/@apostrophecms/command-menu/ui/apos/components/TheAposCommandMenu.vue
+++ b/modules/@apostrophecms/command-menu/ui/apos/components/TheAposCommandMenu.vue
@@ -8,7 +8,10 @@
 </template>
 
 <script>
+import { mapActions } from 'pinia';
 import AposThemeMixin from 'Modules/@apostrophecms/ui/mixins/AposThemeMixin';
+import { useModalStore } from 'Modules/@apostrophecms/ui/stores/modal';
+
 export default {
   name: 'TheAposCommandMenu',
   mixins: [ AposThemeMixin ],
@@ -92,6 +95,7 @@ export default {
     apos.bus.$off('modal-resolved', this.updateModal);
   },
   methods: {
+    ...mapActions(useModalStore, [ 'getAt', 'getProperties' ]),
     delay(resolve, ms) {
       return new Promise(() => {
         setTimeout(resolve, ms);
@@ -101,8 +105,11 @@ export default {
       return this.modal;
     },
     getFirstNonShortcutModal(index = -1) {
-      const modal = apos.modal.getAt(index);
-      const properties = apos.modal.getProperties(modal.id);
+      console.log('index', index);
+      const modal = this.getAt(index);
+      console.log('modal', modal);
+      const properties = this.getProperties(modal.id);
+      console.log('properties', properties);
 
       return properties.itemName === '@apostrophecms/command-menu:shortcut'
         ? this.getFirstNonShortcutModal(index + -1)

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -6,7 +6,6 @@
     @inactive="modal.active = false"
     @show-modal="modal.showModal = true"
     @esc="confirmAndCancel"
-    @no-modal="$emit('safe-close')"
   >
     <template #secondaryControls>
       <AposButton
@@ -159,7 +158,7 @@ export default {
       default: null
     }
   },
-  emits: [ 'modal-result', 'safe-close' ],
+  emits: [ 'modal-result' ],
   data() {
     return {
       docType: this.moduleName,

--- a/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
+++ b/modules/@apostrophecms/i18n/ui/apos/components/AposI18nLocalize.vue
@@ -6,7 +6,6 @@
     @esc="close"
     @inactive="modal.active = false"
     @show-modal="modal.showModal = true"
-    @no-modal="$emit('safe-close')"
   >
     <template #leftRail>
       <AposModalBody class="apos-wizard__navigation">
@@ -303,7 +302,7 @@ export default {
       default: null
     }
   },
-  emits: [ 'safe-close', 'modal-result' ],
+  emits: [ 'modal-result' ],
   data() {
     return {
       modal: {

--- a/modules/@apostrophecms/image/ui/apos/components/AposImageRelationshipEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposImageRelationshipEditor.vue
@@ -6,7 +6,6 @@
     @inactive="modal.active = false"
     @show-modal="modal.showModal = true"
     @esc="confirmAndCancel"
-    @no-modal="$emit('safe-close')"
   >
     <template #secondaryControls>
       <AposButton
@@ -135,7 +134,7 @@ export default {
       default: () => ({})
     }
   },
-  emits: [ 'modal-result', 'safe-close' ],
+  emits: [ 'modal-result' ],
   data() {
     const { aspectRatio, disableAspectRatio } = this.getAspectRatioFromConfig();
     const minSize = this.getMinSize();

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -12,7 +12,6 @@
     @inactive="modal.active = false"
     @show-modal="modal.showModal = true"
     @esc="confirmAndCancel"
-    @no-modal="$emit('safe-close')"
   >
     <template v-if="relationshipField" #secondaryControls>
       <AposButton
@@ -134,7 +133,7 @@ export default {
       required: true
     }
   },
-  emits: [ 'safe-close', 'archive', 'save', 'search', 'piece-relationship-query' ],
+  emits: [ 'archive', 'save', 'search', 'piece-relationship-query' ],
   data() {
     return {
       items: [],

--- a/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
+++ b/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
@@ -15,6 +15,7 @@ export default function() {
   const modalStore = useModalStore();
 
   apos.modal.execute = modalStore.execute;
+  apos.modal.get = modalStore.get;
   apos.modal.getAt = modalStore.getAt;
   apos.modal.getProperties = modalStore.getProperties;
   apos.modal.onTopOf = modalStore.onTopOf;

--- a/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
+++ b/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
@@ -14,7 +14,6 @@ export default function() {
 
   const modalStore = useModalStore();
 
-  apos.modal.stack = modalStore.stack;
   apos.modal.execute = modalStore.execute;
   apos.modal.getAt = modalStore.getAt;
   apos.modal.getProperties = modalStore.getProperties;

--- a/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
+++ b/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
@@ -10,7 +10,7 @@ export default function() {
   const app = createApp(component, {
     modals: apos.modal.modals
   });
-  const theAposModals = app.mount(el);
+  app.mount(el);
 
   const modalStore = useModalStore();
 

--- a/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
+++ b/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
@@ -1,4 +1,5 @@
 import createApp from 'Modules/@apostrophecms/ui/lib/vue';
+import { useModalStore } from 'Modules/@apostrophecms/ui/stores/modal';
 
 export default function() {
   const component = apos.vueComponents.TheAposModals;
@@ -11,9 +12,11 @@ export default function() {
   });
   const theAposModals = app.mount(el);
 
-  apos.modal.execute = theAposModals.execute;
-  apos.modal.getAt = theAposModals.getAt;
-  apos.modal.getProperties = theAposModals.getProperties;
+  const modalStore = useModalStore();
+
+  apos.modal.execute = modalStore.execute;
+  apos.modal.getAt = modalStore.getAt;
+  apos.modal.getProperties = modalStore.getProperties;
   apos.modal.onTopOf = onTopOf;
   apos.modal.stack = [];
   apos.confirm = theAposModals.confirm;

--- a/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
+++ b/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
@@ -14,60 +14,11 @@ export default function() {
 
   const modalStore = useModalStore();
 
+  apos.modal.stack = modalStore.stack;
   apos.modal.execute = modalStore.execute;
   apos.modal.getAt = modalStore.getAt;
   apos.modal.getProperties = modalStore.getProperties;
-  apos.modal.onTopOf = onTopOf;
-  apos.modal.stack = [];
-  apos.confirm = theAposModals.confirm;
-  apos.alert = theAposModals.alert;
-}
-
-// Returns true if el1 is "on top of" el2 in the
-// modal stack, as viewed by the user. If el1 is a
-// modal that appears later in the stack than el2
-// (visually stacked on top), this method returns true.
-// If el2 is `document` and el1 is a modal, this
-// method returns true. For convenenience, if el1
-// or el2 is not a modal, it is treated as its DOM
-// parent modal, or as `document`. If el1 has no
-// parent modal this method always returns false.
-//
-// If el1 is no longer connected to the DOM then it
-// is also considered to be "on top" e.g. not something
-// that should concern `v-click-outside-element` and
-// similar functionality. This is necessary because
-// sometimes Vue removes elements from the DOM before
-// we can examine their relationships.
-function onTopOf(el1, el2) {
-  if (el2.matches('[data-apos-menu]')) {
-    return false;
-  }
-  if (!el1.isConnected) {
-    // If el1 is no longer in the DOM we can't make a proper determination,
-    // returning true prevents unwanted things like click-outside-element
-    // events from firing
-    return true;
-  }
-  if (!el1.matches('[data-apos-modal]')) {
-    el1 = el1.closest('[data-apos-modal]') || document;
-  }
-  if (!el2.matches('[data-apos-modal]')) {
-    el2 = el2.closest('[data-apos-modal]') || document;
-  }
-  if (el1 === document) {
-    return false;
-  }
-  if (el2 === document) {
-    return true;
-  }
-  const index1 = apos.modal.stack.findIndex(modal => modal.modalEl === el1);
-  const index2 = apos.modal.stack.findIndex(modal => modal.modalEl === el2);
-  if (index1 === -1) {
-    throw new Error('apos.modal.onTopOf: el1 is not in the modal stack');
-  }
-  if (index2 === -1) {
-    throw new Error('apos.modal.onTopOf: el2 is not in the modal stack');
-  }
-  return index1 > index2;
+  apos.modal.onTopOf = modalStore.onTopOf;
+  apos.confirm = modalStore.confirm;
+  apos.alert = modalStore.alert;
 }

--- a/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
+++ b/modules/@apostrophecms/modal/ui/apos/apps/AposModals.js
@@ -7,9 +7,7 @@ export default function() {
   if (!el) {
     return;
   }
-  const app = createApp(component, {
-    modals: apos.modal.modals
-  });
+  const app = createApp(component);
   app.mount(el);
 
   const modalStore = useModalStore();

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -210,9 +210,10 @@ watch(triggerFocusRefresh, (newVal) => {
   }
 });
 
-onMounted(() => {
+onMounted(async () => {
+  await nextTick();
   if (shouldTrapFocus.value) {
-    nextTick(trapFocus);
+    trapFocus();
   }
   store.updateModalData(props.modalId, { modalEl: modalEl.value });
 });

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -21,7 +21,7 @@
         <div
           v-if="modal.showModal"
           class="apos-modal__overlay"
-          @click="close"
+          @click="emit('esc')"
         />
       </transition>
       <transition :name="transitionType" @after-leave="$emit('inactive')">

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -14,7 +14,8 @@
       :aria-labelledby="props.modalId"
       data-apos-modal
       @focus.capture="storeFocusedElement"
-      @keydown="onKeydown"
+      @keydown.esc="close"
+      @keydown.tab="onTab"
     >
       <transition :name="transitionType">
         <div
@@ -218,12 +219,7 @@ onMounted(async () => {
   store.updateModalData(props.modalId, { modalEl: modalEl.value });
 });
 
-function onKeydown(e) {
-  const hasPressedEsc = e.keyCode === 27;
-  if (hasPressedEsc) {
-    close(e);
-  }
-
+function onTab(e) {
   const currentModal = store.get(props.modalId);
   cycleElementsToFocus(e, currentModal.elementsToFocus);
 }

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -127,7 +127,7 @@ const props = defineProps({
 const store = useModalStore();
 
 const slots = useSlots();
-const emit = defineEmits([ 'inactive', 'esc', 'show-modal', 'no-modal', 'ready' ]);
+const emit = defineEmits([ 'inactive', 'esc', 'show-modal', 'safe-close', 'ready' ]);
 const modalEl = ref(null);
 
 const transitionType = computed(() => {
@@ -236,7 +236,8 @@ async function onEnter() {
 }
 
 function onLeave() {
-  emit('no-modal');
+  emit('safe-close');
+  store.remove(props.modalId);
   focusLastModalFocusedElement();
 }
 

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -127,7 +127,7 @@ const props = defineProps({
 const store = useModalStore();
 
 const slots = useSlots();
-const emit = defineEmits([ 'inactive', 'esc', 'show-modal', 'safe-close', 'ready' ]);
+const emit = defineEmits([ 'inactive', 'esc', 'show-modal', 'safe-close', 'no-modal', 'ready' ]);
 const modalEl = ref(null);
 
 const transitionType = computed(() => {
@@ -239,6 +239,7 @@ function onLeave() {
   emit('safe-close');
   store.remove(props.modalId);
   focusLastModalFocusedElement();
+  emit('no-modal');
 }
 
 function trapFocus() {

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -14,7 +14,7 @@
       :aria-labelledby="props.modalId"
       data-apos-modal
       @focus.capture="storeFocusedElement"
-      @keydown.esc="close"
+      @esc="close"
       @keydown.tab="onTab"
     >
       <transition :name="transitionType">
@@ -97,7 +97,7 @@
 // transition.
 
 import {
-  ref, onMounted, computed, watch, nextTick, useSlots
+  ref, onMounted, onUnmounted, computed, watch, nextTick, useSlots
 } from 'vue';
 import { useAposFocus } from 'Modules/@apostrophecms/modal/composables/AposFocus';
 import { useModalStore } from 'Modules/@apostrophecms/ui/stores/modal';
@@ -217,7 +217,19 @@ onMounted(async () => {
     trapFocus();
   }
   store.updateModalData(props.modalId, { modalEl: modalEl.value });
+  window.addEventListener('keydown', onKeydown);
 });
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', onKeydown);
+});
+
+function onKeydown(e) {
+  const hasPressedEsc = e.keyCode === 27;
+  if (hasPressedEsc) {
+    close(e);
+  }
+}
 
 function onTab(e) {
   const currentModal = store.get(props.modalId);
@@ -266,7 +278,10 @@ function trapFocus() {
 }
 
 function close() {
-  emit('esc');
+  const activeModalId = store.activeModal?.id;
+  if (activeModalId === props.modalId) {
+    emit('esc');
+  }
 }
 </script>
 

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -128,7 +128,7 @@ const props = defineProps({
 const store = useModalStore();
 
 const slots = useSlots();
-const emit = defineEmits([ 'inactive', 'esc', 'show-modal', 'safe-close', 'no-modal', 'ready' ]);
+const emit = defineEmits([ 'inactive', 'esc', 'show-modal', 'no-modal', 'ready' ]);
 const modalEl = ref(null);
 
 const transitionType = computed(() => {
@@ -244,7 +244,6 @@ async function onEnter() {
 }
 
 function onLeave() {
-  emit('safe-close');
   store.remove(props.modalId);
   focusLastModalFocusedElement();
   emit('no-modal');

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -96,11 +96,10 @@
 // transition.
 
 import {
-  ref, reactive, onMounted, computed, watch, nextTick, useSlots
+  ref, onMounted, computed, watch, nextTick, useSlots
 } from 'vue';
 import { useAposFocus } from 'Modules/@apostrophecms/modal/composables/AposFocus';
 import { useModalStore } from 'Modules/@apostrophecms/ui/stores/modal';
-import cuid from 'cuid';
 
 const {
   cycleElementsToFocus,

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalConfirm.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalConfirm.vue
@@ -3,7 +3,6 @@
     :modal="modal"
     class="apos-confirm"
     v-on="mode !== 'alert' ? { esc: cancel } : null"
-    @no-modal="$emit('safe-close')"
     @inactive="modal.active = false"
     @show-modal="modal.showModal = true"
     @ready="ready"
@@ -87,7 +86,7 @@ export default {
       }
     }
   },
-  emits: [ 'safe-close', 'confirm-response', 'modal-result' ],
+  emits: [ 'confirm-response', 'modal-result' ],
   data() {
     return {
       modal: {

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalShareDraft.vue
@@ -4,7 +4,6 @@
     class="apos-share-draft"
     data-apos-test="share-draft-modal"
     v-on="{ esc: close }"
-    @no-modal="$emit('safe-close')"
     @inactive="modal.active = false"
     @show-modal="modal.showModal = true"
   >
@@ -88,7 +87,6 @@ export default {
       required: true
     }
   },
-  emits: [ 'safe-close' ],
   data() {
     return {
       modal: {

--- a/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
@@ -19,20 +19,10 @@
 import { onMounted } from 'vue';
 import { useAposTheme } from 'Modules/@apostrophecms/ui/composables/AposTheme';
 import { useModalStore } from 'Modules/@apostrophecms/ui/stores/modal';
-import { mapStores } from 'pinia';
-
-const props = {
-  modals: {
-    type: Array,
-    required: true
-  }
-};
 
 const { themeClass } = useAposTheme();
 
 const store = useModalStore();
-
-const currentModal = store;
 
 onMounted(() => {
   // Open one of the server-side configured top level admin bar menus by name.

--- a/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
@@ -74,20 +74,4 @@ function getModuleName(itemName) {
   }
   return (itemName.indexOf(':') > -1) ? itemName.split(':')[0] : itemName;
 }
-
-async function confirm(content, options = {}) {
-  return store.execute(apos.modal.components.confirm, {
-    content,
-    mode: 'confirm',
-    options
-  });
-}
-
-async function alert(alertContent, options = {}) {
-  return store.execute(apos.modal.components.confirm, {
-    content: alertContent,
-    mode: 'alert',
-    options
-  });
-}
 </script>

--- a/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
@@ -17,6 +17,10 @@
 <script>
 import cuid from 'cuid';
 import AposThemeMixin from 'Modules/@apostrophecms/ui/mixins/AposThemeMixin';
+import { useModalStore } from 'Modules/@apostrophecms/ui/stores/modal';
+import { mapStores } from 'pinia';
+
+console.log('useModalStore', useModalStore);
 export default {
   name: 'TheAposModals',
   mixins: [ AposThemeMixin ],
@@ -31,7 +35,11 @@ export default {
       stack: []
     };
   },
+  computed: {
+    ...mapStores(useModalStore)
+  },
   mounted() {
+    console.log('this.modalStore', this.modalStore);
     // Open one of the server-side configured top level admin bar menus by name.
     // To allow for injecting additional props dynamically, if itemName is an
     // object, it must have an itemName property and a props property. The props
@@ -74,11 +82,13 @@ export default {
           props: props || {}
         };
 
+        console.log('item', item);
         this.stack.push(item);
         apos.bus.$emit('modal-launched', item);
       });
     },
     resolve(modal) {
+      console.log('modal', modal);
       this.stack = this.stack.filter(_modal => modal.id !== _modal.id);
       modal.resolve(modal.result);
       apos.bus.$emit('modal-resolved', modal);

--- a/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    id="apos-modals"
-    :class="themeClass"
-  >
+  <div :class="themeClass">
     <component
       v-bind="modal.props"
       :is="modal.componentName"
@@ -21,7 +18,6 @@ import { useAposTheme } from 'Modules/@apostrophecms/ui/composables/AposTheme';
 import { useModalStore } from 'Modules/@apostrophecms/ui/stores/modal';
 
 const { themeClass } = useAposTheme();
-
 const store = useModalStore();
 
 onMounted(() => {

--- a/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
@@ -7,7 +7,6 @@
       :key="modal.id"
       :modal-id="modal.id"
       @modal-result="store.setModalResult(modal.id, $event)"
-      @safe-close="store.resolve(modal)"
     />
   </div>
 </template>

--- a/modules/@apostrophecms/modal/ui/apos/composables/AposFocus.js
+++ b/modules/@apostrophecms/modal/ui/apos/composables/AposFocus.js
@@ -1,8 +1,11 @@
 import { ref } from 'vue';
+import { useModalStore } from 'Modules/@apostrophecms/ui/stores/modal';
 
 export function useAposFocus() {
   const elementsToFocus = ref([]);
   const focusedElement = ref(null);
+
+  const modalStore = useModalStore();
 
   return {
     elementsToFocus,
@@ -22,8 +25,9 @@ export function useAposFocus() {
   // `cycleElementsToFocus` listeners relies on this dynamic list which has the advantage of
   // taking new or less elements to focus, after an update has happened inside a modal,
   // like an XHR call to get the pieces list in the AposDocsManager modal, for instance.
-  function cycleElementsToFocus(e) {
-    if (!elementsToFocus.value.length) {
+  function cycleElementsToFocus(e, elements) {
+    const elems = elements || elementsToFocus.value;
+    if (!elems.length) {
       return;
     }
 
@@ -32,8 +36,8 @@ export function useAposFocus() {
       return;
     }
 
-    const firstElementToFocus = elementsToFocus.value.at(0);
-    const lastElementToFocus = elementsToFocus.value.at(-1);
+    const firstElementToFocus = elems.at(0);
+    const lastElementToFocus = elems.at(-1);
 
     // If shift key pressed for shift + tab combination
     if (e.shiftKey) {
@@ -57,8 +61,7 @@ export function useAposFocus() {
   // If it is not focusable (not visible/not in the DOM),
   // fallbacks to the first focusable element from the last modal.
   function focusLastModalFocusedElement() {
-    const lastModal = apos.modal.stack.at(-1);
-
+    const lastModal = modalStore.activeModal;
     if (!lastModal) {
       return;
     }

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -3,7 +3,6 @@
     :modal="modal"
     modal-title="apostrophe:managePages"
     @esc="confirmAndCancel"
-    @no-modal="$emit('safe-close')"
     @inactive="modal.active = false"
     @show-modal="modal.showModal = true"
   >
@@ -101,7 +100,7 @@ export default {
   name: 'AposPagesManager',
   mixins: [ AposPagesManagerLogic ],
   // Keep it for linting
-  emits: [ 'archive', 'search', 'safe-close', 'modal-result' ]
+  emits: [ 'archive', 'search', 'modal-result' ]
 };
 // TODO: check when child page is created and with what perm
 </script>

--- a/modules/@apostrophecms/page/ui/apos/logic/AposPagesManager.js
+++ b/modules/@apostrophecms/page/ui/apos/logic/AposPagesManager.js
@@ -9,7 +9,7 @@ import { klona } from 'klona';
 export default {
   name: 'AposPagesManager',
   mixins: [ AposModifiedMixin, AposDocsManagerMixin, AposArchiveMixin, AposPublishMixin ],
-  emits: [ 'archive', 'search', 'safe-close', 'modal-result' ],
+  emits: [ 'archive', 'search', 'modal-result' ],
   data() {
 
     return {

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
@@ -4,7 +4,6 @@
     :modal="modal"
     :modal-title="modalTitle"
     @esc="confirmAndCancel"
-    @no-modal="$emit('safe-close')"
     @inactive="modal.active = false"
     @show-modal="modal.showModal = true"
   >
@@ -142,7 +141,7 @@ export default {
       required: true
     }
   },
-  emits: [ 'archive', 'safe-close' ],
+  emits: [ 'archive' ],
   data() {
     return {
       modal: {

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
@@ -124,9 +124,11 @@
 </template>
 
 <script>
+import { mapState } from 'pinia';
 import AposDocsManagerMixin from 'Modules/@apostrophecms/modal/mixins/AposDocsManagerMixin';
 import AposModifiedMixin from 'Modules/@apostrophecms/ui/mixins/AposModifiedMixin';
 import AposPublishMixin from 'Modules/@apostrophecms/ui/mixins/AposPublishMixin';
+import { useModalStore } from 'Modules/@apostrophecms/ui/stores/modal';
 import { debounce } from 'Modules/@apostrophecms/ui/utils';
 
 export default {
@@ -167,6 +169,7 @@ export default {
     };
   },
   computed: {
+    ...mapState(useModalStore, [ 'activeModal' ]),
     moduleOptions() {
       return window.apos.modules[this.moduleName];
     },
@@ -405,11 +408,11 @@ export default {
     },
     shortcutNew(event) {
       const interesting = event.keyCode === 78; // N(ew)
-      const topModalId = apos.modal.stack.at(-1)?.id;
+      console.log('this.activeModal', this.activeModal);
       if (
         interesting &&
         document.activeElement.tagName !== 'INPUT' &&
-        this.$refs.modal.id === topModalId
+        this.$refs.modal.id === this.activeModal?.id
       ) {
         this.create();
       }

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
@@ -407,7 +407,6 @@ export default {
     },
     shortcutNew(event) {
       const interesting = event.keyCode === 78; // N(ew)
-      console.log('this.activeModal', this.activeModal);
       if (
         interesting &&
         document.activeElement.tagName !== 'INPUT' &&

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposRelationshipEditor.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposRelationshipEditor.vue
@@ -6,7 +6,6 @@
     @inactive="modal.active = false"
     @show-modal="modal.showModal = true"
     @esc="confirmAndCancel"
-    @no-modal="$emit('safe-close')"
   >
     <template #secondaryControls>
       <AposButton
@@ -93,7 +92,7 @@ export default {
       required: true
     }
   },
-  emits: [ 'modal-result', 'safe-close' ],
+  emits: [ 'modal-result' ],
   data() {
     return {
       docReady: false,

--- a/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
@@ -6,7 +6,6 @@
     @inactive="modal.active = false"
     @show-modal="modal.showModal = true"
     @esc="confirmAndCancel"
-    @no-modal="emitSafeClose"
   >
     <template #secondaryControls>
       <AposButton
@@ -94,8 +93,7 @@ import AposArrayEditorLogic from '../logic/AposArrayEditor';
 
 export default {
   name: 'AposArrayEditor',
-  mixins: [ AposArrayEditorLogic ],
-  emits: [ 'safe-close' ]
+  mixins: [ AposArrayEditorLogic ]
 };
 </script>
 

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposArrayEditor.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposArrayEditor.js
@@ -37,7 +37,7 @@ export default {
       default: null
     }
   },
-  emits: [ 'modal-result', 'safe-close' ],
+  emits: [ 'modal-result' ],
   data() {
     // Automatically add `_id` to default items
     const items = this.items.map(item => ({
@@ -367,9 +367,6 @@ export default {
         }
       }
       return choices;
-    },
-    emitSafeClose() {
-      this.$emit('safe-close');
     }
   }
 };

--- a/modules/@apostrophecms/settings/ui/apos/components/AposSettingsManager.vue
+++ b/modules/@apostrophecms/settings/ui/apos/components/AposSettingsManager.vue
@@ -6,7 +6,6 @@
     @esc="close"
     @inactive="modal.active = false"
     @show-modal="modal.showModal = true"
-    @no-modal="$emit('safe-close')"
   >
     <template #secondaryControls>
       <AposButton
@@ -86,7 +85,7 @@ import AposSettingsManagerLogic from 'Modules/@apostrophecms/settings/logic/Apos
 export default {
   name: 'AposSettingsManager',
   mixins: [ AposSettingsManagerLogic ],
-  emits: [ 'safe-close', 'modal-result' ]
+  emits: [ 'modal-result' ]
 };
 </script>
 

--- a/modules/@apostrophecms/settings/ui/apos/logic/AposSettingsManager.js
+++ b/modules/@apostrophecms/settings/ui/apos/logic/AposSettingsManager.js
@@ -1,6 +1,5 @@
 export default {
   name: 'AposSettingsManager',
-  emits: [ 'safe-close' ],
   props: {
     restore: {
       type: String,

--- a/modules/@apostrophecms/ui/ui/apos/lib/vue.js
+++ b/modules/@apostrophecms/ui/ui/apos/lib/vue.js
@@ -1,7 +1,10 @@
 import { createApp } from 'vue';
+import { createPinia } from 'pinia';
 import ClickOutsideElement from './click-outside-element';
 import Tooltip from './tooltip';
 import VueAposI18Next from './i18next';
+
+const pinia = createPinia();
 
 export default (appConfig, props = {}) => {
   const app = createApp(appConfig, props);
@@ -12,6 +15,7 @@ export default (appConfig, props = {}) => {
   });
   app.use(Tooltip);
   app.use(ClickOutsideElement);
+  app.use(pinia);
 
   const sources = [ window.apos.vueComponents, window.apos.iconComponents ];
   for (const source of sources) {

--- a/modules/@apostrophecms/ui/ui/apos/stores/modal.js
+++ b/modules/@apostrophecms/ui/ui/apos/stores/modal.js
@@ -1,0 +1,29 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+export const useModalStore = defineStore('modal', () => {
+  const stack = ref([]);
+
+  function add(modal) {
+    stack.value.push(modal);
+  }
+
+  function getAt(index) {
+    const last = stack.value.length - 1;
+    const target = index < 0
+      ? last + 1 + index
+      : index > stack.value.length
+        ? last
+        : index;
+
+    const modal = stack.value[target] || {};
+
+    return modal;
+  }
+
+  return {
+    stack,
+    add,
+    getAt
+  };
+});

--- a/modules/@apostrophecms/ui/ui/apos/stores/modal.js
+++ b/modules/@apostrophecms/ui/ui/apos/stores/modal.js
@@ -1,9 +1,14 @@
 import { defineStore } from 'pinia';
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import cuid from 'cuid';
 
 export const useModalStore = defineStore('modal', () => {
   const stack = ref([]);
+  const activeId = ref(null);
+
+  const activeModal = computed(() => {
+    return stack.value.find(modal => activeId.value === modal.id);
+  });
 
   function add(modal) {
     stack.value.push(modal);
@@ -21,9 +26,8 @@ export const useModalStore = defineStore('modal', () => {
         ? last
         : index;
 
-    const modal = stack.value[target] || {};
-
-    return modal;
+    console.log('target', target);
+    return stack.value[target] || {};
   }
 
   function getProperties(id) {
@@ -47,11 +51,12 @@ export const useModalStore = defineStore('modal', () => {
         id: `modal:${cuid()}`,
         componentName,
         resolve,
-        props: props || {}
-        /* elementsToFocus: [], */
-        /* focusedElement: null */
+        props: props || {},
+        elementsToFocus: [],
+        focusedElement: null
       };
 
+      activeId.value = item.id;
       stack.value.push(item);
       apos.bus.$emit('modal-launched', item);
     });
@@ -67,8 +72,6 @@ export const useModalStore = defineStore('modal', () => {
   }
 
   function setModalResult(modalId, result) {
-    console.log('modalId', modalId);
-    console.log('result', result);
     stack.value = stack.value.map((modal) => {
       return modal.id === modalId
         ? {
@@ -81,14 +84,81 @@ export const useModalStore = defineStore('modal', () => {
 
   function resolve(modal) {
     stack.value = stack.value.filter(_modal => modal.id !== _modal.id);
-
-    console.log('modal.result', modal.result);
+    const current = getAt(-1);
+    activeId.value = current.id || null;
     modal.resolve(modal.result);
     apos.bus.$emit('modal-resolved', modal);
   }
 
+  async function confirm(content, options = {}) {
+    return execute(apos.modal.components.confirm, {
+      content,
+      mode: 'confirm',
+      options
+    });
+  }
+
+  async function alert(alertContent, options = {}) {
+    return execute(apos.modal.components.confirm, {
+      content: alertContent,
+      mode: 'alert',
+      options
+    });
+  }
+
+  // Returns true if el1 is "on top of" el2 in the
+  // modal stack, as viewed by the user. If el1 is a
+  // modal that appears later in the stack than el2
+  // (visually stacked on top), this method returns true.
+  // If el2 is `document` and el1 is a modal, this
+  // method returns true. For convenenience, if el1
+  // or el2 is not a modal, it is treated as its DOM
+  // parent modal, or as `document`. If el1 has no
+  // parent modal this method always returns false.
+  //
+  // If el1 is no longer connected to the DOM then it
+  // is also considered to be "on top" e.g. not something
+  // that should concern `v-click-outside-element` and
+  // similar functionality. This is necessary because
+  // sometimes Vue removes elements from the DOM before
+  // we can examine their relationships.
+  function onTopOf(el1, el2) {
+    if (el2.matches('[data-apos-menu]')) {
+      return false;
+    }
+    if (!el1.isConnected) {
+    // If el1 is no longer in the DOM we can't make a proper determination,
+    // returning true prevents unwanted things like click-outside-element
+    // events from firing
+      return true;
+    }
+    if (!el1.matches('[data-apos-modal]')) {
+      el1 = el1.closest('[data-apos-modal]') || document;
+    }
+    if (!el2.matches('[data-apos-modal]')) {
+      el2 = el2.closest('[data-apos-modal]') || document;
+    }
+    if (el1 === document) {
+      return false;
+    }
+    if (el2 === document) {
+      return true;
+    }
+    const index1 = stack.value.findIndex(modal => modal.modalEl === el1);
+    const index2 = stack.value.findIndex(modal => modal.modalEl === el2);
+    if (index1 === -1) {
+      throw new Error('apos.modal.onTopOf: el1 is not in the modal stack');
+    }
+    if (index2 === -1) {
+      throw new Error('apos.modal.onTopOf: el2 is not in the modal stack');
+    }
+    return index1 > index2;
+  }
+
   return {
     stack,
+    activeId,
+    activeModal,
     add,
     get,
     getAt,
@@ -96,6 +166,9 @@ export const useModalStore = defineStore('modal', () => {
     execute,
     updateModalData,
     setModalResult,
-    resolve
+    resolve,
+    confirm,
+    alert,
+    onTopOf
   };
 });

--- a/modules/@apostrophecms/ui/ui/apos/stores/modal.js
+++ b/modules/@apostrophecms/ui/ui/apos/stores/modal.js
@@ -14,6 +14,12 @@ export const useModalStore = defineStore('modal', () => {
     stack.value.push(modal);
   }
 
+  function remove(id) {
+    stack.value = stack.value.filter(modal => id !== modal.id);
+    const current = getAt(-1);
+    activeId.value = current.id || null;
+  }
+
   function get(id) {
     return id
       ? stack.value.find(modal => id === modal.id)
@@ -84,9 +90,6 @@ export const useModalStore = defineStore('modal', () => {
   }
 
   function resolve(modal) {
-    stack.value = stack.value.filter(_modal => modal.id !== _modal.id);
-    const current = getAt(-1);
-    activeId.value = current.id || null;
     modal.resolve(modal.result);
     apos.bus.$emit('modal-resolved', modal);
   }
@@ -161,6 +164,7 @@ export const useModalStore = defineStore('modal', () => {
     activeId,
     activeModal,
     add,
+    remove,
     get,
     getAt,
     getProperties,

--- a/modules/@apostrophecms/ui/ui/apos/stores/modal.js
+++ b/modules/@apostrophecms/ui/ui/apos/stores/modal.js
@@ -15,6 +15,13 @@ export const useModalStore = defineStore('modal', () => {
   }
 
   function remove(id) {
+    const modal = get(id);
+    if (!modal) {
+      return;
+    }
+
+    modal.resolve(modal.result);
+    apos.bus.$emit('modal-resolved', modal);
     stack.value = stack.value.filter(modal => id !== modal.id);
     const current = getAt(-1);
     activeId.value = current.id || null;
@@ -87,11 +94,6 @@ export const useModalStore = defineStore('modal', () => {
         }
         : modal;
     });
-  }
-
-  function resolve(modal) {
-    modal.resolve(modal.result);
-    apos.bus.$emit('modal-resolved', modal);
   }
 
   async function confirm(content, options = {}) {
@@ -171,7 +173,6 @@ export const useModalStore = defineStore('modal', () => {
     execute,
     updateModalData,
     setModalResult,
-    resolve,
     confirm,
     alert,
     onTopOf

--- a/modules/@apostrophecms/ui/ui/apos/stores/modal.js
+++ b/modules/@apostrophecms/ui/ui/apos/stores/modal.js
@@ -1,11 +1,16 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
+import cuid from 'cuid';
 
 export const useModalStore = defineStore('modal', () => {
   const stack = ref([]);
 
   function add(modal) {
     stack.value.push(modal);
+  }
+
+  function get(id) {
+    return stack.value.find(modal => id === modal.id);
   }
 
   function getAt(index) {
@@ -21,9 +26,76 @@ export const useModalStore = defineStore('modal', () => {
     return modal;
   }
 
+  function getProperties(id) {
+    const stackModal = stack.value.find(modal => id === modal.id);
+    if (!stackModal || !apos.modal.modals) {
+      return {};
+    }
+
+    const properties = {
+      ...apos.modal.modals
+        .find(modal => modal.componentName === stackModal.componentName &&
+          modal.props.moduleName === stackModal.props.moduleName)
+    };
+
+    return properties;
+  }
+
+  async function execute(componentName, props) {
+    return new Promise((resolve) => {
+      const item = {
+        id: `modal:${cuid()}`,
+        componentName,
+        resolve,
+        props: props || {}
+        /* elementsToFocus: [], */
+        /* focusedElement: null */
+      };
+
+      stack.value.push(item);
+      apos.bus.$emit('modal-launched', item);
+    });
+  }
+
+  function updateModalData(id, data) {
+    stack.value = stack.value.map((modal) => {
+      return modal.id === id ? {
+        ...modal,
+        ...data
+      } : modal;
+    });
+  }
+
+  function setModalResult(modalId, result) {
+    console.log('modalId', modalId);
+    console.log('result', result);
+    stack.value = stack.value.map((modal) => {
+      return modal.id === modalId
+        ? {
+          ...modal,
+          result
+        }
+        : modal;
+    });
+  }
+
+  function resolve(modal) {
+    stack.value = stack.value.filter(_modal => modal.id !== _modal.id);
+
+    console.log('modal.result', modal.result);
+    modal.resolve(modal.result);
+    apos.bus.$emit('modal-resolved', modal);
+  }
+
   return {
     stack,
     add,
-    getAt
+    get,
+    getAt,
+    getProperties,
+    execute,
+    updateModalData,
+    setModalResult,
+    resolve
   };
 });

--- a/modules/@apostrophecms/ui/ui/apos/stores/modal.js
+++ b/modules/@apostrophecms/ui/ui/apos/stores/modal.js
@@ -15,7 +15,9 @@ export const useModalStore = defineStore('modal', () => {
   }
 
   function get(id) {
-    return stack.value.find(modal => id === modal.id);
+    return id
+      ? stack.value.find(modal => id === modal.id)
+      : stack.value;
   }
 
   function getAt(index) {

--- a/modules/@apostrophecms/ui/ui/apos/stores/modal.js
+++ b/modules/@apostrophecms/ui/ui/apos/stores/modal.js
@@ -26,7 +26,6 @@ export const useModalStore = defineStore('modal', () => {
         ? last
         : index;
 
-    console.log('target', target);
     return stack.value[target] || {};
   }
 

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -6,7 +6,6 @@
     @inactive="modal.active = false"
     @show-modal="modal.showModal = true"
     @esc="confirmAndCancel"
-    @no-modal="$emit('safe-close')"
   >
     <template #breadcrumbs>
       <AposModalBreadcrumbs v-if="breadcrumbs && breadcrumbs.length" :items="breadcrumbs" />
@@ -109,7 +108,7 @@ export default {
       default: null
     }
   },
-  emits: [ 'safe-close', 'modal-result' ],
+  emits: [ 'modal-result' ],
   data() {
     const moduleOptions = window.apos.modules[apos.area.widgetManagers[this.type]];
 

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "passport-local": "^1.0.0",
     "path-to-regexp": "^1.8.0",
     "performance-now": "^2.1.0",
+    "pinia": "^2.1.7",
     "postcss-html": "^1.3.0",
     "postcss-loader": "^5.0.0",
     "postcss-scss": "^4.0.3",


### PR DESCRIPTION
[PRO-5818](https://linear.app/apostrophecms/issue/PRO-5818/get-rid-of-double-modals-stack-array)

## Summary

* Adds pinia
* Stores modals and modals logic in a pinia store. Methods are attached to `apos.modal` accessible in and out of vue components.
* Only BC is that `apos.modal.stack` isn't existing anymore, a method called `apos.modal.get()` allows to get all modals or one by ID. Not sure users needed to call this `apos.modal.stack` before.
* Fixes the `esc` that close modals that wasn't working like before.

[PR in Cypress-tools](https://github.com/apostrophecms/cypress-tools/pull/43):
* `hasModalCount` method has been updated to use `apos.modal.get()` instead of `apos.modal.stack`.

[PR in document-versions](https://github.com/apostrophecms/document-versions/pull/58):
* Use the store to get the `stack`. It'll need to be updated with core. If needed we can tweak `document-versions` to support both?

Tests are green:
https://github.com/apostrophecms/testbed/actions/runs/9176562447

## What are the specific steps to test this change?

Everything works as expected. There is just one fix to make for shortcuts that'll come in another PR.

## What kind of change does this PR introduce?

- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [X] Related tests have been updated

