### PR TITLE
fix a tiptap bug when a pasted text takes the style of the first configured text style element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ except as part of the admin UI bundle which depends on it. For use with external
 Thanks to Michelin for contributing this feature.
 
 ### Fixes
+
 * Do not show widget editor tabs when the developer hasn't created any groups.
 * Fix a bug in the Rich Text Editor widget when a pasted text took the style of the first configured text style element
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Thanks to Michelin for contributing this feature.
 
 ### Fixes
 * Do not show widget editor tabs when the developer hasn't created any groups.
+* Fix a bug in the Rich Text Editor widget when a pasted text took the style of the first configured text style element
 
 ### Changes
 

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -874,6 +874,23 @@ module.exports = {
           ...widget,
           content
         };
+
+        // If a RT configuration has spans,
+        // ensure an unclassed span is added to the configuration. - PRO-5922
+        const hasSpanStyle = options.styles
+          ?.some(style => style.tag === 'span' && style.label !== 'default_hidden_span_style');
+        const hasEmptySpanStyle = options.styles
+          ?.some(style => style.tag === 'span' && style.label === 'default_hidden_span_style');
+
+        if (hasSpanStyle && !hasEmptySpanStyle) {
+          const firstSpanStyleIndex = options.styles.findIndex(style => style.tag === 'span');
+          const emptySpanStyle = {
+            tag: 'span',
+            label: 'default_hidden_span_style'
+          };
+          options.styles.splice(firstSpanStyleIndex, 0, emptySpanStyle);
+        }
+
         return _super(req, _widget, options, _with);
       },
       // Add on the core default options to use, if needed.

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapMarks.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapMarks.vue
@@ -27,7 +27,7 @@
         <div class="apos-marks-control__content-wrapper">
           <ul class="apos-marks-control__items">
             <li
-              v-for="mark in options.marks"
+              v-for="mark in marks"
               :key="mark.class"
               class="apos-marks-control__item"
               :class="{ 'apos-marks-control__item--is-active': activeClasses.includes(mark.class) }"
@@ -75,10 +75,16 @@ export default {
     return {
       active: false,
       open: false,
-      classes: this.options.marks.map(m => m.class)
+      classes: this.options.marks
+        .map(m => m.class)
+        .filter(Boolean)
     };
   },
   computed: {
+    marks() {
+      // Filter out the default_hidden_span_style mark - PRO-5922
+      return this.options.marks.filter(mark => mark.label !== 'default_hidden_span_style');
+    },
     activeClasses() {
       let activeClasses = [];
       const { selection } = this.editor.state;


### PR DESCRIPTION
## Summary

> When pasting content from your clipboard to our rich text editor, tiptap goes through the process of forcing your paste into appropriate markup based on your RT config. This often ends with wrapping something in a span. If the RT config has a span without a class defined this will appear as expected, but if the config does not have a plain span the span will get converted to the first available span configuration, which can be an unexpected stylization.

**Acceptance criteria**

- If a RT configuration has spans, ensure an unclassed span is added to the configuration.
- Do not add this unclassed span style to the Inline Styles menu
- Highlighting the unclassed span will not show classed spans as the active style. It will accurately reflect that the user has made no selection from the inline style menu.

## What are the specific steps to test this change?

See ticket 5922

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
