### PR TITLE
unset marks on heading return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNREALEASED
+
+### Fixes
+
+* Rich Text editor properly unsets marks on heading close 
+
 ## 4.3.0 (2024-05-15)
 
 ### Adds

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Heading.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Heading.js
@@ -1,4 +1,5 @@
 // Lock Heading levels down to just those provided via configuration
+// import { mergeAttributes } from '@tiptap/core';
 import Heading from '@tiptap/extension-heading';
 
 export default (options) => {
@@ -22,6 +23,16 @@ export default (options) => {
           rendered: false
         }
       };
+    },
+    addKeyboardShortcuts() {
+      const marks = Object.keys(this.editor.schema.marks);
+      return this.options.levels.reduce((items, level) => ({
+        ...items,
+        ...{
+          [`Mod-Alt-${level}`]: () => this.editor.commands.toggleHeading({ level }),
+          Enter: () => marks.forEach(mark => this.editor.commands.unsetMark(mark))
+        }
+      }), {});
     }
   });
 };

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Heading.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Heading.js
@@ -1,5 +1,4 @@
 // Lock Heading levels down to just those provided via configuration
-// import { mergeAttributes } from '@tiptap/core';
 import Heading from '@tiptap/extension-heading';
 
 export default (options) => {


### PR DESCRIPTION
## Summary

- Unsets marks on heading close, as reported in #4538
- Soft returns remain in tact

## What are the specific steps to test this change?

1. Configure a RT widget with inline styles and headings
2. Add a heading, style it with a mark
3. Smash return, the next line should return to the default style.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated