### PR TITLE
when pasting content into RT don't force fit a valid class

### DIFF
--- a/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Classes.js
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/tiptap-extensions/Classes.js
@@ -64,6 +64,7 @@ export default (options) => {
                   });
                 }
               } else {
+                console.log('toggleMark');
                 commands.toggleMark('textStyle', { class: options.class });
               }
             }
@@ -93,16 +94,10 @@ export default (options) => {
                   .filter(c => allow[tag].includes(c));
 
                 // If we have valid classes, join and return them.
-                // If no valid classes for this parse, default to the
-                // the first setting for this tag (including null for tags defined without classes).
                 // else, remove classes.
-                const defaultOrNull =
-                  options.nodes.find(s => s.tag === tag)?.class ||
-                  options.marks.find(s => s.tag === tag)?.class ||
-                  null;
                 return classes.length
                   ? classes.join(' ')
-                  : defaultOrNull;
+                  : null;
               }
             }
           }


### PR DESCRIPTION
## Summary

An alternate fix to PRO-5922

In our current provision for ensuring only configured classes remain in tact when pasting content into a RT editor we convert a valid tag with an invalid class to the valid tag with the first-found valid class of its tag type. This is causing unexpected styling, often with spans, where any span pasted is now converted to (what we encourage people to configure) is a stylized mark. 

This change removes that first-found default class behavior and allows the tag to be returned **without** any class, which I think is the more correct behavior (now). This gets us a similar effect to #4537 but more broadly across tags and without adding hacky hidden elements to our rich text config.

@ETLaurent 

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
