### PR TITLE
Hotfix 4.3.1: fix migration bug that impacted our client demo, could impact other projects with stray documents corresponding to no module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.3.1 (2024-05-17)
+
+### Fixes
+
+* Databases containing documents that no longer correspond to any module no longer cause the migration that adds missing mode properties
+to fail (an issue introduced in version 4.2.0). Databases with no such "orphaned" documents were not affected.
+
 ## 4.3.0 (2024-05-15)
 
 ### Adds

--- a/modules/@apostrophecms/doc/lib/migrations.js
+++ b/modules/@apostrophecms/doc/lib/migrations.js
@@ -27,7 +27,7 @@ module.exports = (self) => {
       self.apos.migration.add('set-document-modes', async () => {
         return self.apos.migration.eachDoc({}, 5, async (doc) => {
           const manager = self.getManager(doc.type);
-          if (!manager.isLocalized()) {
+          if (!manager?.isLocalized()) {
             return;
           }
           const idMode = doc._id.split(':').pop(); ;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Simple hotfix for missing manager scenario. Unfortunately migrations have to be just as smart about these as the rest of Apostrophe.