### PR TITLE
PRO-6049: Fix widget validation, improve tabs annotation and UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## UNRELEASED
 
+### Changes
+
+* Improves widget tabs for the hidden entries, improves UX when validation errors are present in non-focused tabs.
+
 ### Fixes
 
-* Rich Text editor properly unsets marks on heading close 
+* Rich Text editor properly unsets marks on heading close.
+* Widget client side schema validation.
 
 ## 4.3.1 (2024-05-17)
 

--- a/modules/@apostrophecms/modal/ui/apos/components/AposWidgetModalTabs.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposWidgetModalTabs.vue
@@ -1,22 +1,25 @@
 <template>
   <div class="apos-modal-tabs" :class="{ 'apos-modal-tabs--horizontal': orientation === 'horizontal' }">
-    <ul class="apos-modal-tabs__tabs">
+    <ul class="apos-modal-tabs__tabs" data-apos-test="widget-tabs">
       <li
         v-for="tab in visibleTabs"
         v-show="tab.isVisible !== false"
         :key="tab.name"
         class="apos-modal-tabs__tab"
+        data-apos-test="widget-tabs-item"
       >
         <button
           :id="tab.name"
           class="apos-modal-tabs__btn"
           :aria-selected="tab.name === current ? true : false"
+          data-apos-test="widget-tabs-button"
           @click="selectTab"
         >
           {{ $t(tab.label) }}
           <span
             v-if="tabErrors[tab.name] && tabErrors[tab.name].length"
             class="apos-modal-tabs__label apos-modal-tabs__label--error"
+            data-apos-test="widget-tabs-error"
           >
             {{ tabErrors[tab.name].length }}&nbsp;{{ generateErrorLabel(tabErrors[tab.name].length) }}
           </span>

--- a/modules/@apostrophecms/modal/ui/apos/components/AposWidgetModalTabs.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposWidgetModalTabs.vue
@@ -18,21 +18,22 @@
             v-if="tabErrors[tab.name] && tabErrors[tab.name].length"
             class="apos-modal-tabs__label apos-modal-tabs__label--error"
           >
-            {{ tabErrors[tab.name].length }} {{ generateErrorLabel(tabErrors[tab.name].length) }}
+            {{ tabErrors[tab.name].length }}&nbsp;{{ generateErrorLabel(tabErrors[tab.name].length) }}
           </span>
         </button>
       </li>
       <li
-        v-if="hiddenTabs.length"
+        v-if="menuTabs.length"
         key="placeholder-for-hidden-tabs"
         class="apos-modal-tabs__tab apos-modal-tabs__tab--small"
       />
     </ul>
     <AposContextMenu
-      v-if="hiddenTabs.length"
-      :menu="hiddenTabs"
+      v-if="menuTabs.length"
+      :menu="menuTabs"
       menu-placement="bottom-end"
       :button="moreMenuButton"
+      data-apos-test="context-menu-tabs"
       @item-clicked="moreMenuHandler($event)"
     />
   </div>
@@ -64,7 +65,6 @@ export default {
   emits: [ 'select-tab' ],
   data() {
     const visibleTabs = [];
-    const hiddenTabs = [];
 
     for (let i = 0; i < this.tabs.length; i++) {
       // Shallow clone is sufficient to make mutating
@@ -73,14 +73,11 @@ export default {
       tab.action = tab.name;
       if (i < 5) {
         visibleTabs.push(tab);
-      } else {
-        hiddenTabs.push(tab);
       }
     }
 
     return {
       visibleTabs,
-      hiddenTabs,
       moreMenuButton: {
         icon: 'dots-vertical-icon',
         iconOnly: true,
@@ -100,6 +97,25 @@ export default {
         }
       }
       return errors;
+    },
+    menuTabs() {
+      return this.tabs.map((tab) => {
+        const modifiers = [];
+        if (tab.name === this.current) {
+          modifiers.push('selected');
+          if (!this.tabErrors[tab.name] || !this.tabErrors[tab.name].length) {
+            modifiers.push('primary');
+          }
+        }
+        if (this.tabErrors[tab.name] && this.tabErrors[tab.name].length) {
+          modifiers.push('danger');
+        }
+        return {
+          ...tab,
+          action: tab.name,
+          modifiers
+        };
+      });
     }
   },
   methods: {
@@ -116,12 +132,6 @@ export default {
       this.$emit('select-tab', id);
     },
     moreMenuHandler(item) {
-      const lastVisibleTab = this.visibleTabs[this.visibleTabs.length - 1];
-      const selectedItem = this.hiddenTabs.find((tab) => tab.name === item);
-
-      this.hiddenTabs.splice(this.hiddenTabs.indexOf(selectedItem), 1, lastVisibleTab);
-      this.visibleTabs.splice(this.visibleTabs.length - 1, 1, selectedItem);
-
       this.$emit('select-tab', item);
     }
   }
@@ -219,6 +229,7 @@ export default {
 
 .apos-modal-tabs__label--error {
   border: 1px solid var(--a-danger);
+  margin-left: 5px;
 }
 
 .apos-modal-tabs__btn {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuItem.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuItem.vue
@@ -5,6 +5,9 @@
       :class="modifiers"
       :tabindex="tabindex"
       data-apos-test="context-menu-item"
+      :data-apos-test-selected="selected"
+      :data-apos-test-danger="danger"
+      :data-apos-test-disabled="disabled"
       @click="click"
     >
       {{ $t(label) }}
@@ -27,6 +30,15 @@ export default {
     tabindex() {
       return this.open ? '0' : '-1';
     },
+    selected() {
+      return this.menuItem.modifiers?.includes('selected');
+    },
+    danger() {
+      return this.menuItem.modifiers?.includes('danger');
+    },
+    disabled() {
+      return this.menuItem.modifiers?.includes('disabled');
+    },
     modifiers() {
       const classes = [];
       if (this.menuItem.modifiers) {
@@ -38,7 +50,7 @@ export default {
     },
     label() {
       let label = this.menuItem.label;
-      if (this.menuItem.modifiers && this.menuItem.modifiers.includes('selected')) {
+      if (this.selected) {
         label = {
           key: 'apostrophe:selectedMenuItem',
           label: this.$t(this.menuItem.label)

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuItem.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuItem.vue
@@ -4,6 +4,7 @@
       class="apos-context-menu__button"
       :class="modifiers"
       :tabindex="tabindex"
+      data-apos-test="context-menu-item"
       @click="click"
     >
       {{ $t(label) }}
@@ -88,6 +89,15 @@ export default {
       }
       &:focus, &:active {
         color: var(--a-danger-button-active);
+      }
+    }
+
+    &--primary {
+      color: var(--a-primary);
+      &:hover,
+      &:focus,
+      &:active {
+        color: var(--a-primary);
       }
     }
 

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -29,6 +29,7 @@
               v-show="tab.name === currentTab"
               :key="tab.name"
               :ref="tab.name"
+              :data-apos-test="`schema:${tab.name}`"
               :trigger-validation="triggerValidation"
               :current-fields="groups[tab.name].fields"
               :schema="groups[tab.name].schema"

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -52,7 +52,7 @@
       <AposButton
         type="primary"
         :label="saveLabel"
-        :disabled="docFields.hasErrors"
+        :disabled="errorCount > 0"
         @click="save"
       />
     </template>
@@ -62,6 +62,7 @@
 <script>
 import AposModifiedMixin from 'Modules/@apostrophecms/ui/mixins/AposModifiedMixin';
 import AposEditorMixin from 'Modules/@apostrophecms/modal/mixins/AposEditorMixin';
+import AposDocErrorsMixin from 'Modules/@apostrophecms/modal/mixins/AposDocErrorsMixin';
 import AposModalTabsMixin from 'Modules/@apostrophecms/modal/mixins/AposModalTabsMixin';
 import { detectDocChange } from 'Modules/@apostrophecms/schema/lib/detectChange';
 import cuid from 'cuid';
@@ -69,7 +70,7 @@ import { klona } from 'klona';
 
 export default {
   name: 'AposWidgetEditor',
-  mixins: [ AposModifiedMixin, AposEditorMixin, AposModalTabsMixin ],
+  mixins: [ AposModifiedMixin, AposEditorMixin, AposDocErrorsMixin, AposModalTabsMixin ],
   props: {
     type: {
       required: true,
@@ -193,6 +194,7 @@ export default {
   },
   methods: {
     updateDocFields(value) {
+      this.updateFieldErrors(value.fieldState);
       this.docFields.data = {
         ...this.docFields.data,
         ...value.data
@@ -203,8 +205,14 @@ export default {
       this.triggerValidation = true;
       this.$nextTick(async () => {
         const widget = klona(this.docFields.data);
-        if (this.docFields.hasErrors) {
+        if (this.errorCount > 0) {
           this.triggerValidation = false;
+          await apos.notify('apostrophe:resolveErrorsBeforeSaving', {
+            type: 'warning',
+            icon: 'alert-circle-icon',
+            dismiss: true
+          });
+          this.focusNextError();
           return;
         }
         try {
@@ -239,6 +247,9 @@ export default {
           : null;
       });
       return widget;
+    },
+    getAposSchema(field) {
+      return this.$refs[field.group.name][0];
     }
   }
 };


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

- When I select a tab that isn't displayed in the navigation tabs, then the navigation does not change but the selected item has a check next to it. 
- The active element has a check mark next to its label no matter where it is.
- The UI validation now works properly for multiple schema instances.

## What are the specific steps to test this change?

The described above behavior works as expected. Widgets are validating their groups schema and mark them:
- Visible tabs are annotated similar to Document Editor tabs
- The context menu tabs that contain non-valid data are marked in red.

The active tab is always marked in the context menu tabs. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
