### PR TITLE
PRO-6127: Add field access to the reactive document value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Improves widget tabs for the hidden entries, improves UX when validation errors are present in non-focused tabs.
 
+### Adds
+
+* Adds field components access to the reactive document value.
+
 ### Fixes
 
 * Rich Text editor properly unsets marks on heading close.

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -137,7 +137,8 @@ export default {
   ],
   provide () {
     return {
-      originalDoc: this.originalDoc
+      originalDoc: this.originalDoc,
+      liveOriginalDoc: this.docFields
     };
   },
   props: {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Field components can access the "live" document value now. 

## What are the specific steps to test this change?

A field component (or any other component below the `AposDocEditor`) can now do `inject: [ 'liveOriginalDoc' ]` in order to get access to the reactive document value.  

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
