### PR TITLE
fixes selectAll of relationship items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ We will now end up with page B slug as `/peer/page` and not `/peer/peer/page` as
 Instead, makes the AposSchema for loop keys more unique using `modelValue.data._id`, 
 if document changes it re-renders schema fields.
 * Fixes `TheAposCommandMenu` modals not computing shortcuts from the current opened modal.
+* Fixes select boxes of relationships, we can now check manually published relationships, and `AposSlatList` renders properly checked relationships.
 
 ## 4.3.2 (2024-05-18)
 

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -81,7 +81,7 @@
               disableUnchecked: maxReached(),
               hideCheckboxes: !relationshipField
             }"
-            @update:checked="setCheckedByIds"
+            @update:checked="setCheckedDocs"
             @edit="updateEditing"
             @select="select"
             @select-series="selectSeries"
@@ -347,7 +347,7 @@ export default {
         return;
       }
       if (Array.isArray(imgIds) && imgIds.length) {
-        this.checked = this.checked.concat(imgIds);
+        this.concatCheckedDocs(imgIds);
 
         // If we're currently editing one, don't interrupt that by replacing it.
         if (!this.editing && imgIds.length === 1) {

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -72,7 +72,7 @@
         <template #bodyMain>
           <AposMediaManagerDisplay
             ref="display"
-            v-model:checked="checked"
+            :checked="checked"
             :accept="accept"
             :items="items"
             :module-options="moduleOptions"
@@ -81,6 +81,7 @@
               disableUnchecked: maxReached(),
               hideCheckboxes: !relationshipField
             }"
+            @update:checked="setCheckedByIds"
             @edit="updateEditing"
             @select="select"
             @select-series="selectSeries"
@@ -384,9 +385,12 @@ export default {
     // select setters
     select(id) {
       if (this.checked.includes(id)) {
-        this.checked = [];
+        this.setCheckedDocs([]);
       } else {
-        this.checked = [ id ];
+        const item = this.items.find(item => item._id === id);
+        if (item) {
+          this.setCheckedDocs([ item ]);
+        }
       }
       this.updateEditing(id);
       this.lastSelected = id;

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -393,9 +393,9 @@ export default {
     },
     selectAnother(id) {
       if (this.checked.includes(id)) {
-        this.checked = this.checked.filter(checkedId => checkedId !== id);
+        this.removeCheckedDoc(id);
       } else {
-        this.checked.push(id);
+        this.addCheckedDoc(id);
       }
 
       this.lastSelected = id;
@@ -422,7 +422,7 @@ export default {
       // always want to check, never toggle
       sliced.forEach(item => {
         if (!this.checked.includes(item._id)) {
-          this.checked.push(item._id);
+          this.addCheckedDoc(item._id);
         }
       });
 

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
@@ -111,27 +111,32 @@ export default {
           doc._fields = this.subfields[doc._id];
         }
       }
-    },
-    checked() {
-      this.updateCheckedDocs();
     }
   },
   methods: {
-    addCheckedDoc(docOdId) {
-      if (docOdId._id) {
-        this.checked.push(docOdId._id);
-        this.checkedDocs.push(docOdId);
-      } else if (typeof docOdId === 'string') {
-        const found = this.items.find(item => item._id === docOdId);
-        if (found) {
-          this.checked.push(found._id);
-          this.checkedDocs.push(found);
-        }
+    addCheckedDoc(docOrId) {
+      const [ docId, doc ] = docOrId._id
+        ? [ docOrId._id, docOrId ]
+        : [ docOrId, this.items.find(item => item._id === docOrId) ];
+
+      if (!doc) {
+        return;
       }
+
+      this.checked = [ ...this.checked, docId ];
+      this.checkedDocs = [ ...this.checkedDocs, doc ];
     },
     setCheckedDocs(docs) {
       this.checked = docs.map(item => item._id);
       this.checkedDocs = docs;
+    },
+    setCheckedByIds(ids) {
+      this.checked = ids;
+      this.checkedDocs = this.items.filter(item => ids.includes(item._id));
+    },
+    removeCheckedDoc(id) {
+      this.checked = this.checked.filter((checkedId) => checkedId !== id);
+      this.checkedDocs = this.checkedDocs.filter((doc) => doc.id !== id);
     },
     findDocById(docs, id) {
       return docs.find(p => p._id === id);
@@ -146,10 +151,6 @@ export default {
     },
     selectAll() {
       if (!this.checked.length) {
-        this.checked = this.items
-          .filter((item) => {
-            const relationshipsMaxedOrUnpublished = this.relationshipField &&
-            (this.maxReached() || !item.lastPublishedAt);
 
         this.items.forEach((item) => {
           const notPublished = this.manuallyPublished && !item.lastPublishedAt;
@@ -237,26 +238,26 @@ export default {
     // update this.checkedDocs based on this.checked. The default
     // implementation is suitable for paginated lists. Can be overridden
     // for other cases.
-    updateCheckedDocs() {
-      // Keep `checkedDocs` in sync with `checked`, first removing from
-      // `checkedDocs` if no longer in `checked`
-      this.checkedDocs = this.checkedDocs.filter(doc => {
-        return this.checked.includes(doc._id);
-      });
-      // then adding to `checkedDocs` if not there yet. These should be in
-      // `items` which is assumed to contain a flat list of items currently
-      // visible.
-      //
-      // TODO: Once we have the option to select all docs of a type even if not
-      // currently visible in the manager this will need to make calls to the
-      // database.
-      this.checked.forEach(id => {
-        if (this.checkedDocs.findIndex(doc => doc._id === id) === -1) {
-          const found = this.items.find(item => item._id === id);
-          found && this.checkedDocs.push(found);
-        }
-      });
-    },
+    /* updateCheckedDocs() { */
+    /*   // Keep `checkedDocs` in sync with `checked`, first removing from */
+    /*   // `checkedDocs` if no longer in `checked` */
+    /*   this.checkedDocs = this.checkedDocs.filter(doc => { */
+    /*     return this.checked.includes(doc._id); */
+    /*   }); */
+    /*   // then adding to `checkedDocs` if not there yet. These should be in */
+    /*   // `items` which is assumed to contain a flat list of items currently */
+    /*   // visible. */
+    /*   // */
+    /*   // TODO: Once we have the option to select all docs of a type even if not */
+    /*   // currently visible in the manager this will need to make calls to the */
+    /*   // database. */
+    /*   this.checked.forEach(id => { */
+    /*     if (this.checkedDocs.findIndex(doc => doc._id === id) === -1) { */
+    /*       const found = this.items.find(item => item._id === id); */
+    /*       found && this.checkedDocs.push(found); */
+    /*     } */
+    /*   }); */
+    /* }, */
     docsManagerAddEventHandlers() {
       apos.bus.$on('content-changed', this.docsManagerOnContentChanged);
     },

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
@@ -115,38 +115,34 @@ export default {
   },
   methods: {
     addCheckedDoc(docOrId) {
-      const items = this.moduleOptions.name === '@apostrophecms/page'
-        ? this.pagesFlat
-        : this.items;
-      const [ docId, doc ] = docOrId._id
-        ? [ docOrId._id, docOrId ]
-        : [ docOrId, items.find(item => item._id === docOrId) ];
-
-      if (!doc) {
-        return;
-      }
-
-      this.checked = [ ...this.checked, docId ];
-      this.checkedDocs = [ ...this.checkedDocs, doc ];
+      this.concatCheckedDocs([ docOrId ]);
     },
-    setCheckedDocs(docs) {
+    setCheckedDocs(docsOrIds) {
+      const docs = this.getDocs(docsOrIds);
+
       this.checked = docs.map(item => item._id);
       this.checkedDocs = docs;
     },
-    setCheckedByIds(ids) {
-      const items = this.moduleOptions.name === '@apostrophecms/page'
-        ? this.pagesFlat
-        : this.items;
+    concatCheckedDocs(docsOrIds) {
+      const docs = this.getDocs(docsOrIds);
 
-      this.checked = ids;
-      this.checkedDocs = items.filter(item => ids.includes(item._id));
+      this.checked = [ ...this.checked, ...docs.map(({ _id }) => _id) ];
+      this.checkedDocs = [ ...this.checkedDocs, ...docs ];
     },
     removeCheckedDoc(id) {
       this.checked = this.checked.filter((checkedId) => checkedId !== id);
       this.checkedDocs = this.checkedDocs.filter((doc) => doc.id !== id);
     },
-    findDocById(docs, id) {
-      return docs.find(p => p._id === id);
+    getDocs(docsOrIds) {
+      const items = this.moduleOptions.name === '@apostrophecms/page'
+        ? this.pagesFlat
+        : this.items;
+
+      return docsOrIds.map(docOrId => {
+        return docOrId._id
+          ? docOrId
+          : items.find(item => item._id === docOrId);
+      });
     },
     // It would have been nice for this to be computed, however
     // AposMediaManagerDisplay does not re-render when it is
@@ -158,7 +154,6 @@ export default {
     },
     selectAll() {
       if (!this.checked.length) {
-
         this.items.forEach((item) => {
           const notPublished = this.manuallyPublished && !item.lastPublishedAt;
           if (this.relationshipField && (this.maxReached() || notPublished)) {

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
@@ -115,9 +115,12 @@ export default {
   },
   methods: {
     addCheckedDoc(docOrId) {
+      const items = this.moduleOptions.name === '@apostrophecms/page'
+        ? this.pagesFlat
+        : this.items;
       const [ docId, doc ] = docOrId._id
         ? [ docOrId._id, docOrId ]
-        : [ docOrId, this.items.find(item => item._id === docOrId) ];
+        : [ docOrId, items.find(item => item._id === docOrId) ];
 
       if (!doc) {
         return;
@@ -131,8 +134,12 @@ export default {
       this.checkedDocs = docs;
     },
     setCheckedByIds(ids) {
+      const items = this.moduleOptions.name === '@apostrophecms/page'
+        ? this.pagesFlat
+        : this.items;
+
       this.checked = ids;
-      this.checkedDocs = this.items.filter(item => ids.includes(item._id));
+      this.checkedDocs = items.filter(item => ids.includes(item._id));
     },
     removeCheckedDoc(id) {
       this.checked = this.checked.filter((checkedId) => checkedId !== id);

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
@@ -242,29 +242,6 @@ export default {
         }
       }
     },
-    // update this.checkedDocs based on this.checked. The default
-    // implementation is suitable for paginated lists. Can be overridden
-    // for other cases.
-    /* updateCheckedDocs() { */
-    /*   // Keep `checkedDocs` in sync with `checked`, first removing from */
-    /*   // `checkedDocs` if no longer in `checked` */
-    /*   this.checkedDocs = this.checkedDocs.filter(doc => { */
-    /*     return this.checked.includes(doc._id); */
-    /*   }); */
-    /*   // then adding to `checkedDocs` if not there yet. These should be in */
-    /*   // `items` which is assumed to contain a flat list of items currently */
-    /*   // visible. */
-    /*   // */
-    /*   // TODO: Once we have the option to select all docs of a type even if not */
-    /*   // currently visible in the manager this will need to make calls to the */
-    /*   // database. */
-    /*   this.checked.forEach(id => { */
-    /*     if (this.checkedDocs.findIndex(doc => doc._id === id) === -1) { */
-    /*       const found = this.items.find(item => item._id === id); */
-    /*       found && this.checkedDocs.push(found); */
-    /*     } */
-    /*   }); */
-    /* }, */
     docsManagerAddEventHandlers() {
       apos.bus.$on('content-changed', this.docsManagerOnContentChanged);
     },

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -85,7 +85,7 @@
             :icons="icons"
             :options="treeOptions"
             :module-options="moduleOptions"
-            @update:checked="setCheckedByIds"
+            @update:checked="setCheckedDocs"
             @update="update"
           />
         </template>

--- a/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
+++ b/modules/@apostrophecms/page/ui/apos/components/AposPagesManager.vue
@@ -79,12 +79,13 @@
         </template>
         <template #bodyMain>
           <AposTree
-            v-model:checked="checked"
+            :checked="checked"
             :items="items"
             :headers="headers"
             :icons="icons"
             :options="treeOptions"
             :module-options="moduleOptions"
+            @update:checked="setCheckedByIds"
             @update="update"
           />
         </template>
@@ -102,7 +103,6 @@ export default {
   // Keep it for linting
   emits: [ 'archive', 'search', 'modal-result' ]
 };
-// TODO: check when child page is created and with what perm
 </script>
 
 <style lang="scss" scoped>

--- a/modules/@apostrophecms/page/ui/apos/logic/AposPagesManager.js
+++ b/modules/@apostrophecms/page/ui/apos/logic/AposPagesManager.js
@@ -252,9 +252,9 @@ export default {
     },
     toggleRowCheck(id) {
       if (this.checked.includes(id)) {
-        this.checked = this.checked.filter(item => item !== id);
+        this.removeCheckedDoc(id);
       } else {
-        this.checked.push(id);
+        this.addCheckedDoc(id);
       }
     },
     selectAll(event) {
@@ -287,12 +287,6 @@ export default {
         this.checkedDocs.push(doc);
         this.checked.push(doc._id);
       }
-    },
-    setCheckedDocs(checkedDocs) {
-      this.checked = checkedDocs.map(doc => doc._id);
-    },
-    updateCheckedDocs() {
-      this.checkedDocs = this.checked.map(_id => this.pagesFlat.find(page => page._id === _id));
     }
   }
 };

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
@@ -102,7 +102,7 @@
         <template #bodyMain>
           <AposDocsManagerDisplay
             v-if="items.length > 0"
-            v-model:checked="checked"
+            :checked="checked"
             :items="items"
             :headers="headers"
             :options="{
@@ -111,6 +111,7 @@
               disableUnpublished: disableUnpublished,
               manuallyPublished: manuallyPublished
             }"
+            @update:checked="setCheckedByIds"
             @open="edit"
           />
           <div v-else class="apos-pieces-manager__empty">
@@ -213,11 +214,8 @@ export default {
     },
     selectAllChoice() {
       const checkCount = this.checked.length;
-      console.log('checkCount', checkCount);
       const pageNotFullyChecked = this.items
         .some((item) => !this.checked.includes(item._id));
-
-      console.log('pageNotFullyChecked', pageNotFullyChecked);
 
       return {
         value: 'checked',
@@ -257,13 +255,6 @@ export default {
     apos.bus.$off('command-menu-manager-close', this.confirmAndCancel);
   },
   methods: {
-    setCheckedDocs(checked) {
-      console.log('=====> set checked docs <=====');
-      this.checkedDocs = checked;
-      this.checked = this.checkedDocs.map(item => {
-        return item._id;
-      });
-    },
     async create() {
       await this.edit(null);
     },

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
@@ -213,8 +213,11 @@ export default {
     },
     selectAllChoice() {
       const checkCount = this.checked.length;
+      console.log('checkCount', checkCount);
       const pageNotFullyChecked = this.items
         .some((item) => !this.checked.includes(item._id));
+
+      console.log('pageNotFullyChecked', pageNotFullyChecked);
 
       return {
         value: 'checked',
@@ -255,6 +258,7 @@ export default {
   },
   methods: {
     setCheckedDocs(checked) {
+      console.log('=====> set checked docs <=====');
       this.checkedDocs = checked;
       this.checked = this.checkedDocs.map(item => {
         return item._id;

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
@@ -111,7 +111,7 @@
               disableUnpublished: disableUnpublished,
               manuallyPublished: manuallyPublished
             }"
-            @update:checked="setCheckedByIds"
+            @update:checked="setCheckedDocs"
             @open="edit"
           />
           <div v-else class="apos-pieces-manager__empty">

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposSchema.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposSchema.js
@@ -181,7 +181,7 @@ export default {
         this.populateDocData();
       }
     },
-    generation(generated) {
+    generation() {
       // repopulate the schema.
       this.populateDocData();
     },


### PR DESCRIPTION
[PRO-6071](https://linear.app/apostrophecms/issue/PRO-6071/the-select-all-checkbox-doesnt-work-when-trying-to-give-a-user)

## Summary

Fix select all broken for all relationships + for manually published relationships.

Update code to remove the `updateCheckedDocs` watcher. When checking a box it use a proxy to properly updated `checked` and `checkedDocs` together. And we have proper methods to set, add, remove checked docs (that will updated both).
The reason behind this change is code predictability improvement, it's easier to understand what code does, also to avoid side effects which can be really hard to debug.
Watchers are great but the often can be avoided with more straightforward implementations.
Also the bug we had here was linked to the watcher not being triggered when doing a `checked.push`. We have now the right methods to use from the mixins.

See [this PR](https://github.com/apostrophecms/doc-template-library/pull/60) too (that probably had bug because using `this.checked.push` which is not watched).

## What are the specific steps to test this change?

You can now properly select relationships, docs or pages, the AposSlatList is updated and doc saved. Also it fixes relationships of non localized documents like users.

Cypress tests running [here](https://github.com/apostrophecms/testbed/actions/runs/9368290458) 🟢 

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
