### PR TITLE
Pro 6200 broken array modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ We will now end up with page B slug as `/peer/page` and not `/peer/peer/page` as
 * Allow `G,Shift+I` shortcut style.
 * Detect shortcut conflicts when using multiple shortcuts.
 * Fixes stylelint config file, uses config from our shared configuration, fixes all lint errors. 
+* Removes `$nextTick` use to re render schema in `AposArrayEditor` because it was triggering weird vue error in production.
+Instead, makes the AposSchema for loop keys more unique using `modelValue.data._id`, 
+if document changes it re-renders schema fields.
 
 
 ## 4.3.2 (2024-05-18)

--- a/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
@@ -32,7 +32,7 @@
     <component
       :is="fieldStyle === 'table' ? 'td' : 'div'"
       v-for="field in schema"
-      :key="field.name.concat(field._id ?? '')"
+      :key="generateItemUniqueKey(field)"
       :data-apos-field="field.name"
       :style="(fieldStyle === 'table' && field.columnStyle) || {}"
       :class="{'apos-field--hidden': !displayComponent(field)}"

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposArrayEditor.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposArrayEditor.js
@@ -149,7 +149,7 @@ export default {
       const [ _id, name ] = first.path.split('.');
       await this.select(_id);
       const aposSchema = this.$refs.schema;
-      await this.nextTick();
+      await this.$nextTick();
       aposSchema.scrollFieldIntoView(name);
     }
     this.titleFieldChoices = await this.getTitleFieldChoices();
@@ -160,11 +160,7 @@ export default {
         return;
       }
       if (await this.validate(true, false)) {
-        // Force the array editor to totally reset to avoid in-schema
-        // animations when switching (e.g., the relationship input).
         this.currentDocToCurrentItem();
-        this.currentId = null;
-        await this.nextTick();
         this.currentId = _id;
         this.currentDoc = {
           hasErrors: false,
@@ -261,7 +257,7 @@ export default {
       if (validateItem) {
         this.triggerValidation = true;
       }
-      await this.nextTick();
+      await this.$nextTick();
       if (validateLength) {
         this.updateMinMax();
       }
@@ -278,14 +274,6 @@ export default {
       } else {
         return true;
       }
-    },
-    // Awaitable nextTick
-    nextTick() {
-      return new Promise((resolve, reject) => {
-        this.$nextTick(() => {
-          return resolve();
-        });
-      });
     },
     newInstance() {
       const instance = {};

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposSchema.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposSchema.js
@@ -181,7 +181,7 @@ export default {
         this.populateDocData();
       }
     },
-    generation() {
+    generation(generated) {
       // repopulate the schema.
       this.populateDocData();
     },
@@ -331,6 +331,10 @@ export default {
     },
     highlight(fieldName) {
       return this.meta[fieldName]?.['@apostrophecms/schema:highlight'];
+    },
+    generateItemUniqueKey(field) {
+      return `${field.name}:${field._id ?? ''}:${this.modelValue?.data?._id ?? ''}`;
+
     }
   }
 };


### PR DESCRIPTION
[PRO-6200](https://linear.app/apostrophecms/issue/PRO-6200/issues-adding-to-array-field-on-staging-site)

## Summary

Fixes bug by removing the excess of `nextTick` use and making the `AposSchema` reload fields when they are from another document (by using `v-for` keys), which is a more idiomatic way to.

## What are the specific steps to test this change?

See ticket, you can create a random array field, with some required fields, when you add an item and make it show the required field message, fix it and try to create another item, it breaks.

In prod, when having an array field, 

Cypress tests running [here](https://github.com/apostrophecms/testbed/actions/runs/9350527931). 🟢 


## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
