### PR TITLE
Pro 6137 shortcuts modals bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ We will now end up with page B slug as `/peer/page` and not `/peer/peer/page` as
 * Removes `$nextTick` use to re render schema in `AposArrayEditor` because it was triggering weird vue error in production.
 Instead, makes the AposSchema for loop keys more unique using `modelValue.data._id`, 
 if document changes it re-renders schema fields.
+* Fixes `TheAposCommandMenu` modals not computing shortcuts from the current opened modal.
 
 
 ## 4.3.2 (2024-05-18)

--- a/modules/@apostrophecms/command-menu/index.js
+++ b/modules/@apostrophecms/command-menu/index.js
@@ -12,7 +12,7 @@ module.exports = {
           type: 'item',
           label: 'apostrophe:commandMenuShowShortcutList',
           action: {
-            type: 'open-modal',
+            type: '@apostrophecms/command-menu:open-modal',
             payload: {
               name: 'AposCommandMenuShortcut',
               props: { moduleName: '@apostrophecms/command-menu' }

--- a/modules/@apostrophecms/command-menu/ui/apos/components/TheAposCommandMenu.vue
+++ b/modules/@apostrophecms/command-menu/ui/apos/components/TheAposCommandMenu.vue
@@ -54,7 +54,7 @@ export default {
     }
   },
   mounted() {
-    apos.bus.$on('open-modal', async state => {
+    apos.bus.$on('@apostrophecms/command-menu:open-modal', async state => {
       await apos.modal.execute(state.name, state.props);
     });
 

--- a/modules/@apostrophecms/command-menu/ui/apos/components/TheAposCommandMenu.vue
+++ b/modules/@apostrophecms/command-menu/ui/apos/components/TheAposCommandMenu.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script>
-import { mapActions } from 'pinia';
+import { mapActions, mapState } from 'pinia';
 import AposThemeMixin from 'Modules/@apostrophecms/ui/mixins/AposThemeMixin';
 import { useModalStore } from 'Modules/@apostrophecms/ui/stores/modal';
 
@@ -26,11 +26,11 @@ export default {
   data() {
     return {
       previousKey: '',
-      modal: 'default',
-      keyboardShortcutListener() {}
+      modal: 'default'
     };
   },
   computed: {
+    ...mapState(useModalStore, [ 'stack' ]),
     shortcuts() {
       const modals = Object.values(this.modals[this.modal] || {});
 
@@ -48,12 +48,40 @@ export default {
       );
     }
   },
+  watch: {
+    stack(newStack) {
+      this.modal = this.getFirstNonShortcutModal();
+    }
+  },
   mounted() {
     apos.bus.$on('open-modal', async state => {
       await apos.modal.execute(state.name, state.props);
     });
 
-    this.keyboardShortcutListener = (event) => {
+    document.addEventListener('keydown', this.keyboardShortcutListener.bind(this));
+  },
+  beforeUnmount() {
+    document.removeEventListener('keydown', this.keyboardShortcutListener);
+  },
+  methods: {
+    ...mapActions(useModalStore, [ 'getAt', 'getProperties' ]),
+    delay(resolve, ms) {
+      return new Promise(() => {
+        setTimeout(resolve, ms);
+      });
+    },
+    getModal() {
+      return this.modal;
+    },
+    getFirstNonShortcutModal(index = -1) {
+      const modal = this.getAt(index);
+      const properties = this.getProperties(modal.id);
+
+      return properties.itemName === '@apostrophecms/command-menu:shortcut'
+        ? this.getFirstNonShortcutModal(index + -1)
+        : properties.itemName || 'default';
+    },
+    keyboardShortcutListener(event) {
       if (event.target.nodeName !== 'INPUT' && event.target.nodeName !== 'TEXTAREA' && document.activeElement.contentEditable !== 'true') {
         const key = [
           [ 'ALT', event.altKey ],
@@ -87,39 +115,6 @@ export default {
           }, 1000);
         }
       }
-    };
-
-    document.addEventListener('keydown', this.keyboardShortcutListener.bind(this));
-
-    apos.bus.$on('modal-launched', this.updateModal);
-    apos.bus.$on('modal-resolved', this.updateModal);
-  },
-  beforeUnmount() {
-    document.removeEventListener('keydown', this.keyboardShortcutListener);
-
-    apos.bus.$off('modal-launched', this.updateModal);
-    apos.bus.$off('modal-resolved', this.updateModal);
-  },
-  methods: {
-    ...mapActions(useModalStore, [ 'getAt', 'getProperties' ]),
-    delay(resolve, ms) {
-      return new Promise(() => {
-        setTimeout(resolve, ms);
-      });
-    },
-    getModal() {
-      return this.modal;
-    },
-    getFirstNonShortcutModal(index = -1) {
-      const modal = this.getAt(index);
-      const properties = this.getProperties(modal.id);
-
-      return properties.itemName === '@apostrophecms/command-menu:shortcut'
-        ? this.getFirstNonShortcutModal(index + -1)
-        : properties.itemName || 'default';
-    },
-    updateModal() {
-      this.modal = this.getFirstNonShortcutModal();
     }
   }
 };

--- a/modules/@apostrophecms/settings/index.js
+++ b/modules/@apostrophecms/settings/index.js
@@ -106,7 +106,7 @@ module.exports = {
           type: 'item',
           label: 'apostrophe:settings',
           action: {
-            type: 'open-modal',
+            type: '@apostrophecms/command-menu:open-modal',
             payload: {
               name: 'AposSettingsManager',
               props: { moduleName: '@apostrophecms/settings' }

--- a/modules/@apostrophecms/ui/ui/apos/stores/modal.js
+++ b/modules/@apostrophecms/ui/ui/apos/stores/modal.js
@@ -21,10 +21,10 @@ export const useModalStore = defineStore('modal', () => {
     }
 
     modal.resolve(modal.result);
-    apos.bus.$emit('modal-resolved', modal);
     stack.value = stack.value.filter(modal => id !== modal.id);
     const current = getAt(-1);
     activeId.value = current.id || null;
+    apos.bus.$emit('modal-resolved', modal);
   }
 
   function get(id) {


### PR DESCRIPTION
[PRO-6137](https://linear.app/apostrophecms/issue/PRO-6137/fix-commands-shortcuts-openingclosing)

## Summary

* Fixes `TheAposCommandMenu` modals not computing shortcuts from the current opened modal.

## What are the specific steps to test this change?

You can open modals then the apos command menu that matches the right modal.
When leaving a modal it computes the new context.

Cypress tests running [here](https://github.com/apostrophecms/testbed/actions/runs/9362961049) 🟠 

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
