### PR TITLE
Pro 5949 relationship browse button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add `T,D` shortcut to open the Submitted Drafts.
 * Add a scrollbar to the shortcut list.
 * Add breadcrumbs to search results page.
+* Pages relationships have now their checkboxes disabled when max is reached.
 
 ### Changes
 
@@ -47,6 +48,8 @@ Instead, makes the AposSchema for loop keys more unique using `modelValue.data._
 if document changes it re-renders schema fields.
 * Fixes `TheAposCommandMenu` modals not computing shortcuts from the current opened modal.
 * Fixes select boxes of relationships, we can now check manually published relationships, and `AposSlatList` renders properly checked relationships.
+* Relationships browse button isn't disabled when max is reached.
+* In media manaer images checkboxes are disabled when max is reached.
 
 ## 4.3.2 (2024-05-18)
 

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
@@ -27,7 +27,7 @@
               hideLabel: true,
               label: `Toggle selection of ${item.title}`,
               disableFocus: true,
-              disabled: options.disableUnchecked && !checked.includes(item._id)
+              readOnly: options.disableUnchecked && !checked.includes(item._id)
             }"
             :choice="{ value: item._id }"
           />

--- a/modules/@apostrophecms/page/ui/apos/logic/AposPagesManager.js
+++ b/modules/@apostrophecms/page/ui/apos/logic/AposPagesManager.js
@@ -49,7 +49,8 @@ export default {
       treeOptions: {
         bulkSelect: !!this.relationshipField,
         draggable: true,
-        ghostUnpublished: true
+        ghostUnpublished: true,
+        max: this.relationshipField.max || null
       },
       moreMenu: [
         {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputRelationship.vue
@@ -45,7 +45,7 @@
           <AposButton
             v-if="field.browse !== false"
             class="apos-input-relationship__button"
-            :disabled="field.readOnly || limitReached"
+            :disabled="field.readOnly"
             :label="browseLabel"
             :modifiers="buttonModifiers"
             type="input"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -79,7 +79,8 @@
                   key: 'apostrophe:toggleSelectionOf',
                   title: row.title
                 },
-                disableFocus: true
+                disableFocus: true,
+                readOnly: maxReached && !checked.includes(row._id)
               }"
               :choice="{ value: row._id }"
             />
@@ -217,6 +218,9 @@ export default {
         ghostClass: 'apos-is-dragging',
         filter: '.apos-is-parked'
       };
+    },
+    maxReached() {
+      return this.options.max != null && this.checked.length >= this.options.max;
     }
   },
   mounted() {


### PR DESCRIPTION
[PRO-5949](https://linear.app/apostrophecms/issue/PRO-5949/relationship-fields-with-max-n-browse-button-should-always-remain)

## Summary

For relationship fields:
* Browse button isn't disabled when limit is reached
* Pages relationships editor modal now disables checkboxes when limit is reached.
* Fixes Media manager not disabling checkboxes when limit is reached.

## What are the specific steps to test this change?

Verify above points.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
