### PR TITLE
Pro 6209 vue3 satan bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ We will now end up with page B slug as `/peer/page` and not `/peer/peer/page` as
 Instead, makes the AposSchema for loop keys more unique using `modelValue.data._id`, 
 if document changes it re-renders schema fields.
 * Fixes `TheAposCommandMenu` modals not computing shortcuts from the current opened modal.
+* Fixes Vue 3 race condition in a simple but temporary way, waiting to create a reproducible test case for vue team.
 
 ## 4.3.2 (2024-05-18)
 

--- a/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposArrayEditor.vue
@@ -65,9 +65,9 @@
               <div class="apos-modal-array-item__pane">
                 <div class="apos-array-item__body">
                   <AposSchema
-                    v-if="currentId"
+                    v-show="currentId"
                     ref="schema"
-                    :schema="schema"
+                    :schema="currentId ? schema : []"
                     :trigger-validation="triggerValidation"
                     :following-values="followingValues()"
                     :conditional-fields="conditionalFields"

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposSchema.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposSchema.js
@@ -54,7 +54,10 @@ export default {
         return [];
       }
     },
-    triggerValidation: Boolean,
+    triggerValidation: {
+      type: Boolean,
+      default: false
+    },
     utilityRail: {
       type: Boolean,
       default() {
@@ -120,7 +123,7 @@ export default {
               required
             },
             value: {
-              data: this.modelValue[item.name]
+              data: this.modelValue && this.modelValue[item.name]
             },
             serverError: this.serverErrors && this.serverErrors[item.name],
             modifiers: [
@@ -224,6 +227,9 @@ export default {
       return options;
     },
     populateDocData() {
+      if (!this.modelValue) {
+        return;
+      }
       this.schemaReady = false;
       const next = {
         hasErrors: false,

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@tiptap/extension-underline": "^2.0.3",
     "@tiptap/starter-kit": "^2.0.3",
     "@tiptap/vue-3": "^2.0.3",
-    "@vue/compiler-sfc": "^3.3.8",
     "autoprefixer": "^10.4.1",
     "bluebird": "^3.7.2",
     "body-parser": "^1.18.2",


### PR DESCRIPTION
[PRO-6209](https://linear.app/apostrophecms/issue/PRO-6209/production-build-array-editing-still-has-a-bug)

## Summary

Temporary but simple fix to avoid vue 3 bug race condition that happens when inserting a node and not finding the parent `insertBefore` vue 3 method having `parent` param `null`.
In our case happened in array editor when triggering a field error before to delete the element.

## What are the specific steps to test this change?

Add a basic item in an array with a required field, make the file showing the error, then make the error disappear and finally delete the item, you shouldn't have a big obscure console error.

Cypress tests running [here](https://github.com/apostrophecms/testbed/actions/runs/9403570776) 🟠 

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
