### PR TITLE
Pro 6156 tiptap firefox jump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ if document changes it re-renders schema fields.
 * Fixes issues in `AposInputArray` on production build to be able to add, remove and edit array items after `required` error.
 * Relationships browse button isn't disabled when max is reached.
 * In media manaer images checkboxes are disabled when max is reached.
+* Fixes tiptap bubble menu jumping on firefow when clicking on buttons. Also fixes the fact that 
+double clicking on bubble menu out of buttons would prevent it from closing when unfocusing the rich text area.
 
 ## 4.3.2 (2024-05-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ if document changes it re-renders schema fields.
 * Fixes select boxes of relationships, we can now check manually published relationships, and `AposSlatList` renders properly checked relationships.
 * Fixes issues in `AposInputArray` on production build to be able to add, remove and edit array items after `required` error.
 * Relationships browse button isn't disabled when max is reached.
-* In media manaer images checkboxes are disabled when max is reached.
+* In media manager image checkboxes are disabled when max is reached.
 * Fixes tiptap bubble menu jumping on Firefox when clicking on buttons. Also fixes the fact that 
 double clicking on bubble menu out of buttons would prevent it from closing when unfocusing the rich text area.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ if document changes it re-renders schema fields.
 * Fixes issues in `AposInputArray` on production build to be able to add, remove and edit array items after `required` error.
 * Relationships browse button isn't disabled when max is reached.
 * In media manaer images checkboxes are disabled when max is reached.
-* Fixes tiptap bubble menu jumping on firefow when clicking on buttons. Also fixes the fact that 
+* Fixes tiptap bubble menu jumping on Firefox when clicking on buttons. Also fixes the fact that 
 double clicking on bubble menu out of buttons would prevent it from closing when unfocusing the rich text area.
 
 ## 4.3.2 (2024-05-18)

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -852,9 +852,7 @@ function traverseNextNode(node) {
   }
 
   .apos-rich-text-editor__editor :deep([data-tippy-root]) {
-    transition: all 400ms var(--a-transition-timing-bounce);
-    /* stylelint-disable-next-line time-min-milliseconds */
-    transition-delay: 100ms;
+    transition: transform 400ms var(--a-transition-timing-bounce) 100ms;
   }
 
   .apos-rich-text-editor__editor :deep(.tippy-box[data-animation='fade'][data-state='hidden']) {

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -1,5 +1,8 @@
 <template>
-  <div :aria-controls="`insert-menu-${modelValue._id}`" @keydown="handleUIKeydown">
+  <div
+    :aria-controls="`insert-menu-${modelValue._id}`"
+    @keydown="handleUIKeydown"
+  >
     <bubble-menu
       v-if="editor"
       class="bubble-menu"
@@ -9,7 +12,8 @@
         zIndex: 2000,
         animation: 'fade',
         inertia: true,
-        placement: 'bottom'
+        placement: 'bottom',
+        hideOnClick: true
       }"
       :editor="editor"
     >


### PR DESCRIPTION
[PRO-6156](https://linear.app/apostrophecms/issue/PRO-6156/tip-tap-anchor-buggy)

## Summary

* Fixes tiptap bubble menu jumping on firefox when clicking on buttons. 
* Fixes the fact that double clicking on bubble menu out of buttons would prevent it from closing when unfocusing the rich text area.

Cypress tests running [here](https://github.com/apostrophecms/testbed/actions/runs/9482181140) 🟠 

## What are the specific steps to test this change?

Check that above described points are resolved.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
