### PR TITLE
4.4.2: hotfix for _parent bringing in too much recursion risk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 4.4.2 (2024-06-14)
+
+### Fixes
+
+* Hotfix: the new `_parent` property of pieces, which refers to the same piece page as `_parentUrl`, is now a carefully pruned
+subset to avoid the risk of infinite recursion when the piece page has a relationship to a piece. Those who want `_parent`
+to be more complete can extend the new `pruneParent` method of the relevant piece page module. This regression was
+introduced in version 4.4.0.
+
 ## 4.4.1 (2024-06-12)
 
 ### Fixes

--- a/modules/@apostrophecms/piece-page-type/index.js
+++ b/modules/@apostrophecms/piece-page-type/index.js
@@ -273,9 +273,10 @@ module.exports = {
           type: parent.type,
           title: parent.title,
           slug: parent.slug,
-          // Already a well-pruned projection,
-          // necessary for breadcrumb trails
-          _ancestors: parent._ancestors
+          // These are already pruned projections and
+          // necessary for various types of navigation
+          _ancestors: parent._ancestors,
+          _children: parent._children
         };
       },
 

--- a/modules/@apostrophecms/piece-page-type/index.js
+++ b/modules/@apostrophecms/piece-page-type/index.js
@@ -250,11 +250,33 @@ module.exports = {
           const parentPage = self.chooseParentPage(req.aposParentPageCache[pieceName], piece);
           if (parentPage) {
             piece._url = self.buildUrl(req, parentPage, piece);
-            piece._parent = parentPage;
+            piece._parent = self.pruneParent(parentPage);
             piece._parentUrl = parentPage._url;
             piece._parentSlug = parentPage.slug;
           }
         });
+      },
+
+      // The _parent property of a piece is useful for
+      // breadcrumb navigation but we don't want it to lead
+      // to runaway recursion etc., so make a shallow clone
+      // of relevant properties only. Use extendMethods
+      // if you want to return more (or less)
+      pruneParent(parent) {
+        return {
+          _id: parent._id,
+          aposDocId: parent.aposDocId,
+          aposLocale: parent.aposLocale,
+          aposMode: parent.aposMode,
+          path: parent.path,
+          level: parent.level,
+          type: parent.type,
+          title: parent.title,
+          slug: parent.slug,
+          // Already a well-pruned projection,
+          // necessary for breadcrumb trails
+          _ancestors: parent._ancestors
+        };
       },
 
       // Returns a query suitable for finding pieces-page-type for the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {

--- a/test/search.js
+++ b/test/search.js
@@ -75,6 +75,8 @@ describe('Search', function() {
   it('should carry the _ancestors property', async function() {
     const response1 = await apos.http.get('/search?q=event');
     const [ piece ] = JSON.parse(response1);
+    assert(piece._parent.title === 'Events');
+    assert(piece._parent.type === 'event-page');
     assert(piece._parent.slug === '/events');
     assert(piece._parent._ancestors[0].slug === '/');
     assert(piece._parent._ancestors[0]._ancestors.length === 0);


### PR DESCRIPTION
Resolve excessive recursion risk introduced by `_parent` in 4.4.0