### PR TITLE
PRO-6223 fix for unsettled dynamic select choices breaking premature validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 * Adds a new color picker tool for the rich-text-widget toolbar that matches the existing `color` schema field. This also adds the same `colorPicker` and `format` options to the rich-text-widget confirmation that exist in the `color` schema field.
 * Add missing UI translation keys.
 
+### Fixes
+
+* Schema validation now waits for dynamic `select`, `radio` and `checkboxes` choices and
+other API calls still "in flight" to settle before proceeding.
+* Rollbacks watcher on `checked` array. Fixes, checked docs not being properly updated.
+
 ## 4.4.3 (2024-06-17)
 
 ### Fixes
@@ -14,7 +20,6 @@
 If you wish a field to be mandatory use `required: true`.
 * As a convenience, using `POST` for pieces and pages with `_newInstance: true` keeps any additional `req.body` properties in the API response.
 This feature unofficially existed before, it is now supported.
-* Rollbacks watcher on `checked` array. Fixes, checked docs not being properly updated.
 
 ## 4.4.2 (2024-06-14)
 

--- a/modules/@apostrophecms/busy/ui/apos/components/TheAposBusy.vue
+++ b/modules/@apostrophecms/busy/ui/apos/components/TheAposBusy.vue
@@ -8,15 +8,24 @@
 </template>
 
 <script>
+// Implements the global busy spinner, and sets/clears the `busy` reactive
+// property of the `modalStore` when appropriate
+
 import AposThemeMixin from 'Modules/@apostrophecms/ui/mixins/AposThemeMixin';
+
 export default {
   name: 'TheAposBusy',
   mixins: [ AposThemeMixin ],
   data() {
     return {
-      busy: false,
-      busyCount: 0
+      busyCount: 0,
+      busy: false
     };
+  },
+  watch: {
+    busy(newValue) {
+      apos.busy.busy = newValue;
+    }
   },
   computed: {
     classes() {

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -433,23 +433,20 @@ export default {
   },
   methods: {
     async saveHandler(action) {
-      this.triggerValidation = true;
-      this.$nextTick(async () => {
-        if (this.savePreference !== action) {
-          this.setSavePreference(action);
-        }
-        if (!this.errorCount) {
-          this[action]();
-        } else {
-          this.triggerValidation = false;
-          await apos.notify('apostrophe:resolveErrorsBeforeSaving', {
-            type: 'warning',
-            icon: 'alert-circle-icon',
-            dismiss: true
-          });
-          this.focusNextError();
-        }
+      await this.triggerValidate();
+      if (this.savePreference !== action) {
+        this.setSavePreference(action);
+      }
+      if (!this.errorCount) {
+        this[action]();
+        return;
+      }
+      await apos.notify('apostrophe:resolveErrorsBeforeSaving', {
+        type: 'warning',
+        icon: 'alert-circle-icon',
+        dismiss: true
       });
+      this.focusNextError();
     },
     async loadDoc() {
       let docData;

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -195,11 +195,31 @@ export default {
         });
       }
     },
-    triggerValidate() {
+    // Triggers validation, after first waiting for the UI to settle,
+    // including any active API requests e.g. loading of choices etc.
+    // as well as nextTick
+    async triggerValidate() {
+      console.log('settle 1');
+      await this.settle();
+      console.log('triggered');
       this.triggerValidation = true;
-      this.$nextTick(async () => {
-        this.triggerValidation = false;
-      });
+      console.log('settle 2');
+      await this.settle();
+      console.log('settled');
+      this.triggerValidation = false;
+      console.log('cleared');
+    },
+    async settle() {
+      console.log('before nextTick');
+      await this.$nextTick();
+      console.log('after nextTick');
+      while (apos.busy.busy) {
+        console.log('delaying due to busy');
+        await delay(100);
+        // Allows for another HTTP request to possibly set busy again
+        await this.$nextTick();
+      }
+      console.log('end of settle');
     },
     // Perform any postprocessing required by direct or nested schema fields
     // before the object can be saved
@@ -247,3 +267,7 @@ export default {
     }
   }
 };
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -197,29 +197,21 @@ export default {
     },
     // Triggers validation, after first waiting for the UI to settle,
     // including any active API requests e.g. loading of choices etc.
-    // as well as nextTick
+    // as well as nextTick. This provides for waiting on API requests
+    // that lead to other API requests
     async triggerValidate() {
-      console.log('settle 1');
       await this.settle();
-      console.log('triggered');
       this.triggerValidation = true;
-      console.log('settle 2');
       await this.settle();
-      console.log('settled');
       this.triggerValidation = false;
-      console.log('cleared');
     },
     async settle() {
-      console.log('before nextTick');
       await this.$nextTick();
-      console.log('after nextTick');
       while (apos.busy.busy) {
-        console.log('delaying due to busy');
         await delay(100);
         // Allows for another HTTP request to possibly set busy again
         await this.$nextTick();
       }
-      console.log('end of settle');
     },
     // Perform any postprocessing required by direct or nested schema fields
     // before the object can be saved

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposArrayEditor.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposArrayEditor.js
@@ -258,9 +258,13 @@ export default {
     },
     async validate(validateItem, validateLength) {
       if (validateItem && this.next.length > 0 && this.currentId) {
-        this.triggerValidation = true;
+        await this.triggerValidate();
+      } else {
+        // Not doing sub-validation, but still want to make sure the UI
+        // has settled according to the original logic which waited on
+        // nextTick regardless of whether it triggered validation
+        await this.settle();
       }
-      await this.$nextTick();
       if (validateLength) {
         this.updateMinMax();
       }

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposSubform.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposSubform.js
@@ -111,16 +111,15 @@ export default {
       this.evaluateConditions();
     },
     async submit() {
-      this.triggerValidation = true;
-      this.$nextTick(async () => {
-        if (this.docFields.hasErrors) {
-          this.triggerValidation = false;
-          return;
-        }
-        this.$emit('submit', {
-          name: this.subform.name,
-          values: this.docFields.data
-        });
+      await this.triggerValidate();
+      if (this.docFields.hasErrors) {
+        return;
+      }
+      // Formerly triggerValidation remained true in this case,
+      // I think that was a bug
+      this.$emit('submit', {
+        name: this.subform.name,
+        values: this.docFields.data
       });
     },
     async cancel() {


### PR DESCRIPTION
…ation

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

* Wait for Apostrophe's "busy" mechanism to settle before allowing validation to proceed. Because the API calls that power dynamic select choices and similar always use the "busy" mechanism this should resolve the issue.
* However I don't really have working steps to reproduce this issue, it's not clear when it would happen, except for if you switch items really fast (faster than the dynamic select API in question). I'm discussing that with Val. If it's just about switching items really fast it is straightforward for me to test that with an intentionally slow API.

## What are the specific steps to test this change?

* See PRO-6223. Query out to Val for clarification on how hard it should be to reproduce it. We can use a super-slow dynamic select function server side if need be.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
