### PR TITLE
Pro 6252 fix context menu position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### Fixes
 * Identify and mark server validation errors in the admin UI. This helps editors identify already existing data fields, having validation errors when schema changes (e.g. optional field becomes required).
-
+* Removes `menu-offset` props that were causing `AposContextMenu` to not display properly. 
+Allows to pass a number or an array to `ApodContextMenu` to set the offset of the context menu (main and cross axis see `floating-ui` documentation).
 
 ## 4.4.3 (2024-06-17)
 

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextTitle.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextTitle.vue
@@ -31,7 +31,6 @@
           :button="draftButton"
           :menu="draftMenu"
           :disabled="hasCustomUi || isUnpublished"
-          menu-offset="13, 10"
           menu-placement="bottom-end"
           @item-clicked="switchDraftMode"
         />

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputColor.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputColor.vue
@@ -12,7 +12,6 @@
           <AposContextMenu
             :button="buttonOptions"
             menu-placement="bottom-start"
-            menu-offset="5, 20"
             :disabled="field.readOnly"
             :tooltip="tooltip"
             @open="open"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposButtonSplit.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposButtonSplit.vue
@@ -14,7 +14,6 @@
       :menu="menu"
       :button="contextMenuButton"
       :disabled="disabled"
-      menu-offset="1, 10"
       menu-placement="bottom-end"
       @open="menuOpen"
       @close="menuClose"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -116,9 +116,7 @@ const dropdown = ref();
 const dropdownContent = ref();
 const dropdownContentStyle = ref({});
 const arrowEl = ref();
-const menuOffset = ref(
-  Array.isArray(props.menuOffset) ? props.menuOffset : [ props.menuOffset, 0 ]
-);
+const menuOffset = getMenuOffset();
 
 defineExpose({
   hide,
@@ -176,6 +174,13 @@ onBeforeUnmount(() => {
   apos.bus.$off('widget-focus', hide);
 });
 
+function getMenuOffset() {
+  return {
+    mainAxis: Array.isArray(props.menuOffset) ? props.menuOffset[0] : props.menuOffset,
+    crossAxis: Array.isArray(props.menuOffset) ? (props.menuOffset[1] ?? 0) : 0
+  };
+}
+
 function hideWhenOtherOpen(id) {
   if (menuId.value !== id) {
     hide();
@@ -210,10 +215,7 @@ async function setDropdownPosition() {
   } = await computePosition(dropdown.value, dropdownContent.value, {
     placement: props.menuPlacement,
     middleware: [
-      offset({
-        mainAxis: menuOffset.value[0],
-        crossAxis: menuOffset.value[1]
-      }),
+      offset(menuOffset),
       shift({ padding: 5 }),
       flip(),
       arrow({

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -87,7 +87,7 @@ const props = defineProps({
     default: 'bottom'
   },
   menuOffset: {
-    type: [ Number, String ],
+    type: [ Number, Array ],
     default: 15
   },
   disabled: {
@@ -116,6 +116,9 @@ const dropdown = ref();
 const dropdownContent = ref();
 const dropdownContentStyle = ref({});
 const arrowEl = ref();
+const menuOffset = ref(
+  Array.isArray(props.menuOffset) ? props.menuOffset : [ props.menuOffset, 0 ]
+);
 
 defineExpose({
   hide,
@@ -207,7 +210,10 @@ async function setDropdownPosition() {
   } = await computePosition(dropdown.value, dropdownContent.value, {
     placement: props.menuPlacement,
     middleware: [
-      offset(props.menuOffset),
+      offset({
+        mainAxis: menuOffset.value[0],
+        crossAxis: menuOffset.value[1]
+      }),
       shift({ padding: 5 }),
       flip(),
       arrow({

--- a/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposSlat.vue
@@ -33,7 +33,6 @@
           :button="more.button"
           :menu="more.menu"
           menu-placement="bottom-start"
-          menu-offset="40, 10"
           :disabled="disabled"
           @item-clicked="$emit('item-clicked', item)"
         />


### PR DESCRIPTION
[PRO-6252](https://linear.app/apostrophecms/issue/PRO-6252/page-context-menu-is-badly-displayed)

## Summary

Fixes display of context menu by removing unnecessary offsets.
Update Context menu to accept array of offset or single number.

## What are the specific steps to test this change?

Where the offset have been removed the `AposContextMenu` is a good position.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
