### PR TITLE
PRO-6279: simpler fix for simpler problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 * `this.modified` was not working properly (set to false when saving). We can now avoid to reload images when saving no changes.
 * In media manager images checkboxes are disabled when max is reached.
 * In media manager when updating an image or archiving, update the list instead of fetching and update checked documents to see changes in the right panel selected list.
+* The `password` field type now has a proper fallback default, the empty string, just like the string field type
+and its derivatives. This resolves bugs in which the unexpected `null` caused problems during validation.
 
 ### Fixes
 * Identify and mark server validation errors in the admin UI. This helps editors identify already existing data fields, having validation errors when schema changes (e.g. optional field becomes required).

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -722,7 +722,8 @@ module.exports = (self) => {
 
         destination[field.name] = checkStringLength(destination[field.name], field.min, field.max);
       }
-    }
+    },
+    def: ''
   });
 
   self.addFieldType({


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

The password field needs a fallback default that makes sense given its representation in the field, just like string fields and their "subclasses"

We don't need all that other fancy null testing! Phew

## What are the specific steps to test this change?

See my PR on multisite-dashboard, this allows it to work with just a one-line fix in core

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
