### PR TITLE
Pro 6275 duplicated slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ was old, but was masked in some situations until the release of version `4.4.3`.
 * Identify and mark server validation errors in the admin UI. This helps editors identify already existing data fields, having validation errors when schema changes (e.g. optional field becomes required).
 * Removes `menu-offset` props that were causing `AposContextMenu` to not display properly. 
 Allows to pass a number or an array to `ApodContextMenu` to set the offset of the context menu (main and cross axis see `floating-ui` documentation).
+* Fixes weird slug computations based on followed values like title. Simplifies based on the new tech design.
 
 ## 4.4.3 (2024-06-17)
 

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
@@ -92,7 +92,6 @@ export default {
 
         // If this is a page slug, the parent slug hasn't been changed
         // and the title matches the slug we only replace its last section.
-
         const parentSlug = this.getParentSlug(this.next);
         if (this.originalParentSlug === parentSlug) {
           // TODO: handle page archives.

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
@@ -14,7 +14,7 @@ export default {
     return {
       conflict: false,
       isArchived: null,
-      originalSlugPartsLength: null
+      originalParentSlug: ''
     };
   },
   computed: {
@@ -86,31 +86,23 @@ export default {
         }
 
         if (!this.field.page) {
-          this.next = this.slugify(newValue);
+          this.next = this.slugify(value);
           return;
         }
 
-        // If this is a page slug, we only replace the last section of the slug.
+        // If this is a page slug, the parent slug hasn't been changed
+        // and the title matches the slug we only replace its last section.
         const parts = this.next
           .split('/')
           .filter(part => part.length > 0);
 
-        if (
-          (!this.originalSlugPartsLength && parts.length) ||
-          (this.originalSlugPartsLength && parts.length === (this.originalSlugPartsLength - 1))
-        ) {
-          // If we pop in this if, it adds a new section to the slug when we type in title
-          // when the slug has a different length..
-          // It makes sense to pop last section whenever we push a new one???
-          // Maybe if the size is different it means the user already updated
-          // the slug and we do nothing if the size isn't the same
-
-        }
-        // Remove last path component so we can replace it
         parts.pop();
-        parts.push(this.slugify(value, { componentOnly: true }));
-        // TODO: handle page archives.
-        this.next = `/${parts.join('/')}`;
+        const parentSlug = `/${parts.join('/')}`;
+        if (this.originalParentSlug === parentSlug) {
+          // TODO: handle page archives.
+          const slug = this.slugify(value, { componentOnly: true });
+          this.next = `${parentSlug}/${slug}`;
+        }
       }
     }
   },
@@ -119,8 +111,7 @@ export default {
     if (this.next.length) {
       await this.debouncedCheckConflict();
     }
-
-    this.originalSlugPartsLength = this.next.split('/').length;
+    this.originalParentSlug = this.next.split('/').slice(0, -1).join('/') || '/';
   },
   methods: {
     async watchNext() {

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
@@ -179,39 +179,23 @@ export default {
         preserveDash = true;
       }
 
-      s = sluggo(s, options);
+      let slug = sluggo(s, options);
       if (preserveDash) {
-        s += '-';
+        slug += '-';
       }
 
       if (this.field.page && !componentOnly) {
-        if (!this.followingValues?.title) {
-          const nextParts = this.next.split('/');
-          if (s === nextParts[nextParts.length - 1]) {
-            s = '';
-            if (this.originalSlugPartsLength === nextParts.length) {
-              nextParts.pop();
-            }
-            this.next = nextParts.join('/');
-          }
-        }
         if (!s.charAt(0) !== '/') {
-          s = `/${s}`;
+          slug = `/${slug}`;
         }
-        s = s.replace(/\/+/g, '/');
-        if (s !== '/') {
-          s = s.replace(/\/$/, '');
-        }
-        if (!this.followingValues?.title && s.length) {
-          s += '/';
-        }
+        slug = s.replace(/\/+/g, '/');
       }
 
       if (!componentOnly) {
-        s = this.setPrefix(s);
+        slug = this.setPrefix(slug);
       }
 
-      return s;
+      return slug;
     },
     setPrefix (slug) {
       // Get a fresh clone of the slug.

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
@@ -185,10 +185,10 @@ export default {
       }
 
       if (this.field.page && !componentOnly) {
-        if (!s.charAt(0) !== '/') {
+        if (!slug.charAt(0) !== '/') {
           slug = `/${slug}`;
         }
-        slug = s.replace(/\/+/g, '/');
+        slug = slug.replace(/\/+/g, '/');
       }
 
       if (!componentOnly) {

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
@@ -92,12 +92,8 @@ export default {
 
         // If this is a page slug, the parent slug hasn't been changed
         // and the title matches the slug we only replace its last section.
-        const parts = this.next
-          .split('/')
-          .filter(part => part.length > 0);
 
-        parts.pop();
-        const parentSlug = `/${parts.join('/')}`;
+        const parentSlug = this.getParentSlug(this.next);
         if (this.originalParentSlug === parentSlug) {
           // TODO: handle page archives.
           const slug = this.slugify(value, { componentOnly: true });
@@ -111,9 +107,14 @@ export default {
     if (this.next.length) {
       await this.debouncedCheckConflict();
     }
-    this.originalParentSlug = this.next.split('/').slice(0, -1).join('/') || '/';
+    this.originalParentSlug = this.getParentSlug(this.next);
   },
   methods: {
+    getParentSlug(slug = '') {
+      return slug.slice(-1) === '/'
+        ? slug.substring(0, slug.length - 1)
+        : slug.split('/').slice(0, -1).join('/');
+    },
     async watchNext() {
       this.next = this.slugify(this.next);
       this.validateAndEmit();

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposInputSlug.js
@@ -65,6 +65,7 @@ export default {
         delete newClone.archived;
         delete oldClone.archived;
 
+        // TODO: Do we really need to rely on all following values?
         const oldVal = Object
           .values(oldClone)
           .join(' ')
@@ -74,6 +75,10 @@ export default {
           .values(newClone)
           .join(' ')
           .replace(/\//g, ' ');
+
+        if (oldVal === value) {
+          return;
+        }
 
         const isCompat = this.compatible(oldVal, this.next);
         if (!isCompat || newValue.archived) {
@@ -92,12 +97,17 @@ export default {
 
         if (
           (!this.originalSlugPartsLength && parts.length) ||
-          (this.originalSlugPartsLength &&
-          parts.length === (this.originalSlugPartsLength - 1))
+          (this.originalSlugPartsLength && parts.length === (this.originalSlugPartsLength - 1))
         ) {
-          // Remove last path component so we can replace it
-          parts.pop();
+          // If we pop in this if, it adds a new section to the slug when we type in title
+          // when the slug has a different length..
+          // It makes sense to pop last section whenever we push a new one???
+          // Maybe if the size is different it means the user already updated
+          // the slug and we do nothing if the size isn't the same
+
         }
+        // Remove last path component so we can replace it
+        parts.pop();
         parts.push(this.slugify(value, { componentOnly: true }));
         // TODO: handle page archives.
         this.next = `/${parts.join('/')}`;
@@ -109,6 +119,7 @@ export default {
     if (this.next.length) {
       await this.debouncedCheckConflict();
     }
+
     this.originalSlugPartsLength = this.next.split('/').length;
   },
   methods: {


### PR DESCRIPTION
[PRO-6275](https://linear.app/apostrophecms/issue/PRO-6275/cms-pages-show-the-slug-twice-in-the-url)

## Summary

Fixes weird frontend behaviors around slug:
* Infinite recursion between watcher and slugify methods is fixed, deep watcher removed since followingValues is always recomputed from scratch and we verify old and new value to run the code in watcher.
* Check if parent slug has changed since mounted, if yes we don't update slug.
* Fixes ICIMS issus about duplication.

## What are the specific steps to test this change?

Play with slugs
[Cypress tests](https://github.com/apostrophecms/testbed/actions/runs/9779699120) 🟢 

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
