### PR TITLE
Pro 6226/global line height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixes
 
+* Removes unnecessary, broadly applied line-height setting that may cause logged-in vs logged-out visual discrepencies.
 * Remove double GET request when saving image update.
 * Fix filter menu forgetting selecting filters and not instantiating them.
 * Remove blur emit for filter buttons and search bar to avoid re requesting when clicking outside…

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -89,6 +89,7 @@ export default {
   align-items: center;
   height: 35px;
   padding: 10px 20px;
+  line-height: var(--a-line-base);
   border-bottom: 1px solid var(--a-base-9);
 }
 

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarMenu.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarMenu.vue
@@ -176,6 +176,7 @@ export default {
 .apos-admin-bar__items {
   display: flex;
   flex-grow: 1;
+  line-height: var(--a-line-base);
   margin: 0;
   padding: 0;
 }

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -461,6 +461,7 @@ export default {
   .apos-media-editor__lip {
     display: flex;
     justify-content: flex-end;
+    line-height: var(--a-line-base);
 
     & > .apos-context-menu, & > .apos-button__wrapper {
       margin-left: 7.5px;

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -422,6 +422,7 @@ function close() {
     display: flex;
     align-items: center;
     padding: $spacing-double;
+    line-height: var(--a-line-base);
   }
 
   .apos-modal__header__main {

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModalToolbar.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModalToolbar.vue
@@ -33,6 +33,7 @@ export default {
   .apos-toolbar {
     display: flex;
     justify-content: space-between;
+    line-height: var(--a-line-base);
   }
 
   .apos-toolbar__group {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposSchema.vue
@@ -89,6 +89,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+  .apos-schema {
+    line-height: var(--a-line-base);
+  }
+
   .apos-schema :deep(.apos-field__wrapper) {
     max-width: $input-max-width;
   }

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -243,6 +243,7 @@ async function setDropdownPosition() {
 .apos-context-menu__dropdown-content {
   z-index: $z-index-notifications;
   position: absolute;
+  line-height: var(--a-line-base);
   width: max-content;
 
   &[aria-hidden='true'] {

--- a/modules/@apostrophecms/ui/ui/apos/scss/global/_normalize.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/_normalize.scss
@@ -1,4 +1,3 @@
 [class*='apos-'] {
-  line-height: var(--a-line-base);
   box-sizing: content-box;
 }

--- a/modules/@apostrophecms/ui/ui/apos/scss/global/_tables.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/_tables.scss
@@ -1,6 +1,7 @@
 .apos-table {
   width: 100%;
   border-collapse: collapse;
+  line-height: var(--a-line-base);
 }
 
 .apos-table__header {


### PR DESCRIPTION
## Summary

- Removes unnecessary, broadly applied `line-height` property used in our admin UI that may conflict with project-level CSS

https://gitlab-dcadcx.michelin.net/pa/apostrophe-enhancements/-/issues/1163
https://linear.app/apostrophecms/issue/PRO-6226/page-rendering-discrepancies-between-logged-and-anonymous-users-edit