### PR TITLE
Fix rtw colorpicker options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Adds
 
 * Allow to disable shortcut by setting the option `shortcut: false`
-* Adds a new color picker tool for the rich-text-widget toolbar that matches the existing `color` schema field. This also adds the same `colorPicker` and `format` options to the rich-text-widget confirmation that exist in the `color` schema field.
+* Adds a new color picker tool for the rich-text-widget toolbar that matches the existing `color` schema field. This also adds the same `pickerOptions` and `format` options to the rich-text-widget configuration that exist in the `color` schema field.
 * Add missing UI translation keys.
 * Infite scroll in media manager instead of pagination. Makes the header containing the search fix.
 * Improves loaders by using new `AposLoadingBlock` that uses `AposLoading` instead of the purple screen in media manager.

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -918,7 +918,7 @@ module.exports = {
           linkWithType: Array.isArray(self.options.linkWithType) ? self.options.linkWithType : [ self.options.linkWithType ],
           linkSchema: self.linkSchema,
           imageStyles: self.options.imageStyles,
-          colorPicker: self.options.colorPicker,
+          pickerOptions: self.options.pickerOptions,
           format: self.options.format
         };
         return finalData;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
Fixes the new rich-text-widget color picker options to align with the options used in the color schema field.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly
1. Add an area with a rich-text widget with the following in the configuration:
```
pickerOptions: {
   presetColors: [ '#000000', '#ffffff', '#ff0000', '#00ff00', '#0000ff'],
   disableAlpha: true,
   disableFields: true
}
```
This should change the swatches and disable all of the input fields for the color picker.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
