### PR TITLE
Fix media scroll after upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ was old, but was masked in some situations until the release of version `4.4.3`.
 * Adds styles for 1 column expanded area ([#4608](https://github.com/apostrophecms/apostrophe/issues/4608))
 * Fixes weird slug computations based on followed values like title. Simplifies based on the new tech design.
 * Prevent broken admin UI when there is a missing widget.
+* Fixes media manager not loading images when last infinite scroll page have been reached (when uploading image for example).
 
 ### Changes
 

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -166,7 +166,15 @@ export default {
         emoji: '🖼'
       },
       cancelDescription: 'apostrophe:discardImageChangesPrompt',
-      debouncedGetMedia: debounce(this.getMedia, DEBOUNCE_TIMEOUT)
+      debouncedGetMedia: debounce(this.getMedia, DEBOUNCE_TIMEOUT),
+      loadObserver: new IntersectionObserver(
+        this.handleIntersect,
+        {
+          root: null,
+          rootMargin: '30px',
+          threshold: 0
+        }
+      )
     };
   },
   computed: {
@@ -549,18 +557,9 @@ export default {
       }
     },
     observeLoadRef() {
-      this.disconnectObserver();
       if (this.totalPages < 2) {
         return;
       }
-      this.loadObserver = new IntersectionObserver(
-        this.handleIntersect,
-        {
-          root: null,
-          rootMargin: '30px',
-          threshold: 0
-        }
-      );
 
       this.loadObserver.observe(this.loadRef);
     },
@@ -572,8 +571,9 @@ export default {
     },
 
     setLoadRef(ref) {
+      this.loadRef = ref;
+      this.disconnectObserver();
       if (ref) {
-        this.loadRef = ref;
         this.observeLoadRef();
       }
     }

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
@@ -50,7 +50,6 @@
             class="apos-media-manager-display__placeholder"
             :style="getPlaceholderStyles(item)"
           />
-          <!-- TODO: make sure using TITLE is the correct alt tag application here. -->
           <img
             v-else
             class="apos-media-manager-display__media"
@@ -59,8 +58,6 @@
           >
         </button>
       </div>
-      <!-- We need a placeholder display cell to generate the first image
-      placeholder. -->
       <div
         v-if="items.length === 0"
         class="apos-media-manager-display__cell apos-is-hidden"
@@ -165,6 +162,12 @@ export default {
             : val
         );
       }
+    }
+  },
+  watch: {
+    async isLastPage(val) {
+      await this.$nextTick();
+      this.$emit('set-load-ref', this.$refs.scrollLoad);
     }
   },
   mounted() {


### PR DESCRIPTION
FIX

## Summary

* Fixes media manager not loading images when last infinite scroll page have been reached (when uploading image for example).

## What are the specific steps to test this change?

Reach end of infinite scroll, then upload image then scroll again, it should work.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
