### PR TITLE
set editorModal and managerModal in components browserData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* Overriding standard Vue.js components with `editorModal` and `managerModal` are now applied all the time.
+
 ## 4.5.2 (2024-07-11)
 
 ### Fixes

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -873,8 +873,8 @@ database.`);
           components: {}
         });
         _.defaults(browserOptions.components, {
-          editorModal: 'AposDocEditor',
-          managerModal: 'AposPagesManager'
+          editorModal: self.getComponentName('editorModal', 'AposDocEditor'),
+          managerModal: self.getComponentName('managerModal', 'AposPagesManager')
         });
 
         if (req.data.bestPage) {

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -1146,8 +1146,8 @@ module.exports = {
           components: {}
         });
         _.defaults(browserOptions.components, {
-          editorModal: 'AposDocEditor',
-          managerModal: 'AposDocsManager'
+          editorModal: self.getComponentName('editorModal', 'AposDocEditor'),
+          managerModal: self.getComponentName('managerModal', 'AposDocsManager')
         });
         browserOptions.managerApiProjection = self.getManagerApiProjection(req);
 

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -300,7 +300,7 @@ async function setDropdownPosition() {
   list-style-type: none;
   width: max-content;
   margin: none;
-  margin-block: 0 0;
+  margin-block: 0;
   padding: 10px 0;
 }
 </style>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
@@ -140,7 +140,7 @@ function emitSetArrow(arrowEl) {
   list-style-type: none;
   width: max-content;
   margin: none;
-  margin-block: 0 0;
+  margin-block: 0;
   padding: 10px 0;
 }
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Fixes `editorModal` and `managerModal` overrides

## What are the specific steps to test this change?

1. Add `article` module `modules/article/index.js`
```javascript
module.exports = {
  extend: '@apostrophecms/piece-type',
  options: {
    label: 'Article',
    pluralLabel: 'Articles',
    components: {
      editorModal: 'CustomArticleEditor'
    }
  },
  fields: {
    add: {
      title: {
        type: 'string',
        label: 'Title'
      }
    }
  }
};
```
2. Duplicate `[AposDocEditor](https://github.com/apostrophecms/apostrophe/blob/main/modules/%40apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue)` as `modules/article/ui/apos/components/CustomArticleEditor.vue`
3. Change the `background-color` in `CustomArticleEditor
4. Open the articles manager modal and when you use `New Article` button, check the background color
5. Use the quick create to create an article, and check the background color

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
