### PR TITLE
rich text link tool bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@
 * Add `title` and `_url` to select all projection.
 * Display `Select all` message on all pages in the manager modal.
 * Refresh `checked` in manager modal after archive action.
+* Updates rich text link tool's keyboard key detection strategy.
 
 ### Fixes
 
+* Fixes the rich text link tool's detection and display of the Remove Link button for removing existing links
+* Fixes the rich text link tool's detection and display of Apostrophe Page relationship field.
 * Overriding standard Vue.js components with `editorModal` and `managerModal` are now applied all the time.
 
 ## 4.5.4 (2024-07-22)

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
@@ -138,7 +138,7 @@ export default {
     },
     active(newVal) {
       if (newVal) {
-        this.hasLinkOnOpen = !!(this.docFields.data.href);
+        this.hasLinkOnOpen = !!(this.attributes.href);
         window.addEventListener('keydown', this.keyboardHandler);
       } else {
         window.removeEventListener('keydown', this.keyboardHandler);
@@ -207,10 +207,10 @@ export default {
       });
     },
     keyboardHandler(e) {
-      if (e.keyCode === 27) {
+      if (e.key === 'Escape') {
         this.close();
       }
-      if (e.keyCode === 13) {
+      if (e.key === 'Enter') {
         if (this.docFields.data.href || e.metaKey) {
           this.save();
           this.close();
@@ -268,6 +268,7 @@ export default {
       } finally {
         this.generation++;
       }
+      this.evaluateConditions();
     }
   }
 };


### PR DESCRIPTION
## Summary

- Fix a bug where the Remove Link button was not displayed when editing existing links
- Fix a bug where the Apostrophe Page relationship field was not displayed when editing an existing link to an apos page
- update the key detection strategy for keyboard handling