### PR TITLE
if we cannot parse a mongodb URL ourselves just give it to the driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fixes the rich text link tool's detection and display of the Remove Link button for removing existing links
 * Fixes the rich text link tool's detection and display of Apostrophe Page relationship field.
 * Overriding standard Vue.js components with `editorModal` and `managerModal` are now applied all the time.
+* Accommodate old-style replica set URIs with comma-separated servers by passing any MongoDB URIs that Node.js cannot parse directly to the MongoDB driver.
 
 ## 4.5.4 (2024-07-22)
 

--- a/lib/mongodb-connect.js
+++ b/lib/mongodb-connect.js
@@ -16,8 +16,15 @@ module.exports = async (uri, options) => {
     useNewUrlParser: true,
     ...options
   };
-  const parsed = new URL(uri);
-  if ((parsed.protocol !== 'mongodb:') || (parsed.hostname !== 'localhost')) {
+  let parsed;
+  try {
+    parsed = new URL(uri);
+  } catch (e) {
+    // Parse failed, e.g. old school replica set URI
+    // with commas, just let the mongo driver handle it
+    return mongo.MongoClient.connect(uri, connectOptions);
+  }
+  if (!parsed || (parsed.protocol !== 'mongodb:') || (parsed.hostname !== 'localhost')) {
     return mongo.MongoClient.connect(parsed.toString(), connectOptions);
   }
   const records = await dns.promises.lookup('localhost', { all: true });


### PR DESCRIPTION
Just as it says.

I tested this by throwing an error instead of setting `parsed` and it did allow the URL to fall through successfully to the mongodb driver. (On a Mac that could cause a failure because of localhost not resolving to ip4 etc., which is why we parse the mongodb URI at all. On Linux it was easier to test.)

I didn't test this with an actual replica set but passing the URL as-is to the driver is pretty much all we can do here.