### PR TITLE
area / widget focus states and keyboard accessibility 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Refresh `checked` in manager modal after archive action.
 * Updates rich text link tool's keyboard key detection strategy.
 
+### Adds
+ * Adds visual focus states and keyboard handlers for engaging with areas and widgets in-context
+
 ### Fixes
 
 * Fixes the rich text link tool's detection and display of the Remove Link button for removing existing links


### PR DESCRIPTION
## Summary
> @haroun note that this is a follow-on PR to the original admin bar accessibility PR

- adds handlers and visual states for engaging with areas and widgets in-context

## What are the specific steps to test this change?
https://github.com/user-attachments/assets/675bb9ed-1c51-4c13-b13c-8f4ecaa13d35

The above video shows the scope of this change. In the video, the user's keyboard focus travels down from the admin bar to the areas and widgets below. Each area wrapper has a visual focus state. If a widget is focused and the user hits Enter or Space, the admin UI engages the widget and displays its controls (in Apostrophe we call this part 'focus'). The user can then keyboard tab through the newly displayed controls. The user can also use Escape to disengage Apostrophe focus.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other