### PR TITLE
Handle permission

### DIFF
--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -385,7 +385,7 @@ export default {
       this.instantiateCopiedDoc();
     } else {
       await this.$nextTick();
-      await this.instantiateNewInstance();
+      await this.instantiateNewDoc();
     }
     apos.bus.$on('content-changed', this.onContentChanged);
   },
@@ -453,7 +453,7 @@ export default {
       this.docReady = true;
       this.modal.triggerFocusRefresh++;
     },
-    async instantiateNewInstance () {
+    async instantiateNewDoc () {
       this.docReady = false;
       const newInstance = await this.getNewInstance();
       this.original = newInstance;
@@ -865,7 +865,7 @@ export default {
       } else {
         this.currentId = '';
         this.docType = this.moduleName;
-        await this.instantiateNewInstance();
+        await this.instantiateNewDoc();
       }
     },
     getRequestBody({ newInstance = false, update = false }) {

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocLocalePicker.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocLocalePicker.vue
@@ -97,19 +97,15 @@ async function checkCreatePermission() {
   const locales = Object.keys(window.apos.i18n.locales)
     .filter((locale) => !localized.value[locale]);
 
-  try {
-    const allowed = await apos.http.get(`${i18nAction}/locales-permissions`, {
-      qs: {
-        type: props.moduleOptions.name,
-        locales,
-        action: 'create'
-      }
-    });
+  const allowed = await apos.http.get(`${i18nAction}/locales-permissions`, {
+    qs: {
+      type: props.moduleOptions.name,
+      locales,
+      action: 'create'
+    }
+  });
 
-    forbidden.value = locales.filter((locale) => !allowed.includes(locale));
-  } catch (err) {
-    console.err(err);
-  }
+  forbidden.value = locales.filter((locale) => !allowed.includes(locale));
 }
 
 async function switchLocale(locale) {

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocLocalePicker.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocLocalePicker.vue
@@ -16,6 +16,7 @@
         :current-locale="locale"
         :localized="localized"
         :forbidden="forbidden"
+        :forbidden-tooltip="forbiddenTooltip"
         @switch-locale="switchLocale"
       />
     </AposContextMenu>
@@ -50,8 +51,11 @@ const props = defineProps({
   }
 });
 
-const i18nAction = apos.modules['@apostrophecms/i18n'].action;
 const $t = inject('i18n');
+const i18nAction = apos.modules['@apostrophecms/i18n'].action;
+const forbiddenTooltip = $t('apostrophe:localeSwitcherPermissionToCreate', {
+  docType: props.moduleOptions.label.toLowerCase()
+});
 const menu = ref(null);
 const localized = ref({});
 const forbidden = ref([]);
@@ -89,14 +93,6 @@ async function open() {
   }
 };
 
-function wait(time = 500) {
-  return new Promise((resolve, reject) => {
-    setTimeout(() => {
-      resolve();
-    }, time);
-  });
-}
-
 async function checkCreatePermission() {
   const locales = Object.keys(window.apos.i18n.locales)
     .filter((locale) => !localized.value[locale]);
@@ -111,15 +107,17 @@ async function checkCreatePermission() {
     });
 
     forbidden.value = locales.filter((locale) => !allowed.includes(locale));
-    console.log('forbidden.value', forbidden.value);
   } catch (err) {
     console.err(err);
   }
 }
 
 async function switchLocale(locale) {
-  menu.value.hide();
+  if (forbidden.value.includes(locale.name)) {
+    return;
+  };
 
+  menu.value.hide();
   if (locale.name === props.locale) {
     return;
   }

--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -243,6 +243,7 @@
   "localeSwitcherDiscardChangesAffirmative": "Save as draft and switch",
   "localeSwitcherDiscardChangesNegative": "Discard changes and switch",
   "localeSwitcherDiscardChangesPrompt": "Do you want to discard changes to this {{ docType }} before switching locales?",
+  "localeSwitcherPermissionToCreate": "You don't have permission to create a new {{ docType }} in this locale",
   "localize": "Localize...",
   "localizeAllRelated": "Localize all related documents and overwrite existing documents",
   "localizeContent": "Localize Content",

--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -243,7 +243,7 @@
   "localeSwitcherDiscardChangesAffirmative": "Save as draft and switch",
   "localeSwitcherDiscardChangesNegative": "Discard changes and switch",
   "localeSwitcherDiscardChangesPrompt": "Do you want to discard changes to this {{ docType }} before switching locales?",
-  "localeSwitcherPermissionToCreate": "You don't have permission to create a new {{ docType }} in this locale",
+  "localeSwitcherPermissionToCreate": "You do not have permission to create a new {{ docType }} in this locale",
   "localize": "Localize...",
   "localizeAllRelated": "Localize all related documents and overwrite existing documents",
   "localizeContent": "Localize Content",

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -368,6 +368,16 @@ module.exports = {
   },
   apiRoutes(self) {
     return {
+      get: {
+        async localesPermissions(req) {
+          const action = self.apos.launder.string(req.query.action);
+          const type = self.apos.launder.string(req.query.type);
+          const locales = self.apos.launder.strings(req.query.locales);
+          const allowed = await self.getLocalesPermissions(req, action, type, locales);
+
+          return allowed;
+        }
+      },
       post: {
         async locale(req) {
           const sanitizedLocale = self.sanitizeLocaleName(req.body.locale);
@@ -685,6 +695,23 @@ module.exports = {
         }
         verifyLocales(locales, self.apos.options.baseUrl);
         return locales;
+      },
+      async getLocalesPermissions(req, action, type, locales) {
+        const fakeDocs = locales.map((locale) => {
+          return {
+            _id: 'fake',
+            type,
+            aposLocale: locale
+          };
+        });
+
+        const allowed = [];
+        for (const doc of fakeDocs) {
+          if (await self.apos.permission.can(req, action, doc)) {
+            allowed.push(doc.aposLocale);
+          }
+        }
+        return allowed;
       },
       sanitizeLocaleName(locale) {
         locale = self.apos.launder.string(locale);

--- a/modules/@apostrophecms/ui/ui/apos/components/AposLocalePicker.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposLocalePicker.vue
@@ -15,6 +15,7 @@
       <li
         v-for="locale in filteredLocales"
         :key="locale.name"
+        v-apos-tooltip="getForbiddenTooltip(locale)"
         :class="localeClasses(locale)"
         class="apos-locale-picker__item"
         data-apos-test="localeItem"
@@ -66,9 +67,7 @@
 </template>
 
 <script setup>
-import {
-  ref, computed
-} from 'vue';
+import { ref, computed } from 'vue';
 
 const emit = defineEmits([ 'switch-locale' ]);
 const props = defineProps({
@@ -83,6 +82,10 @@ const props = defineProps({
   forbidden: {
     type: Array,
     default: () => ([])
+  },
+  forbiddenTooltip: {
+    type: String,
+    default: null
   }
 });
 
@@ -129,6 +132,13 @@ function localeClasses(locale) {
     'apos-active': isActive(locale),
     'apos-exists': isLocalized(locale),
     'apos-forbidden': isForbidden(locale)
+  };
+}
+
+function getForbiddenTooltip(locale) {
+  return isForbidden(locale) && {
+    content: props.forbiddenTooltip,
+    placement: 'left'
   };
 }
 </script>
@@ -192,6 +202,10 @@ function localeClasses(locale) {
     transform: translateY(-50%);
     color: var(--a-primary);
     stroke: var(--a-primary);
+
+    :deep(.material-design-icon__svg) {
+      stroke: none;
+    }
   }
 
   .apos-locale-picker__localized {
@@ -213,7 +227,7 @@ function localeClasses(locale) {
 
 .apos-forbidden {
   color: var(--a-base-5);
-  cursor: forbidden;
+  cursor: not-allowed;
 
   &:hover {
     background-color: var(--a-base-10);

--- a/modules/@apostrophecms/ui/ui/apos/components/AposLocalePicker.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposLocalePicker.vue
@@ -22,9 +22,17 @@
       >
         <span class="apos-locale-picker__locale-display">
           <AposIndicator
-            v-if="isActive(locale)"
+            v-if="isForbidden(locale)"
+            icon="lock-icon"
+            icon-color="var(--a-base-5)"
+            class="apos-locale-picker__check"
+            :icon-size="12"
+            :title="$t('apostrophe:primary')"
+          />
+          <AposIndicator
+            v-else-if="isActive(locale)"
             icon="check-bold-icon"
-            fill-color="var(--a-primary)"
+            icon-color="var(--a-primary)"
             class="apos-locale-picker__check"
             :icon-size="12"
             :title="$t('apostrophe:currentLocale')"
@@ -58,7 +66,9 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue';
+import {
+  ref, computed
+} from 'vue';
 
 const emit = defineEmits([ 'switch-locale' ]);
 const props = defineProps({
@@ -69,6 +79,10 @@ const props = defineProps({
   localized: {
     type: Object,
     required: true
+  },
+  forbidden: {
+    type: Array,
+    default: () => ([])
   }
 });
 
@@ -102,17 +116,20 @@ function isActive(locale) {
   return props.currentLocale === locale.name;
 }
 
+function isForbidden(locale) {
+  return props.forbidden.includes(locale.name);
+}
+
 function switchLocale(locale) {
   emit('switch-locale', locale);
 }
 
 function localeClasses(locale) {
-  const classes = {};
-  if (isActive(locale)) {
-    classes['apos-active'] = true;
-  }
-  classes['apos-exists'] = isLocalized(locale);
-  return classes;
+  return {
+    'apos-active': isActive(locale),
+    'apos-exists': isLocalized(locale),
+    'apos-forbidden': isForbidden(locale)
+  };
 }
 </script>
 
@@ -191,6 +208,15 @@ function localeClasses(locale) {
       background-color: var(--a-success);
       border-color: var(--a-success);
     }
+  }
+}
+
+.apos-forbidden {
+  color: var(--a-base-5);
+  cursor: forbidden;
+
+  &:hover {
+    background-color: var(--a-base-10);
   }
 }
 

--- a/modules/@apostrophecms/ui/ui/apos/lib/tooltip.js
+++ b/modules/@apostrophecms/ui/ui/apos/lib/tooltip.js
@@ -1,7 +1,7 @@
 // Vue plugin. Create a new directive with i18n support by applying the decorator
 import { $t } from './i18next';
 import {
-  computePosition, arrow, offset, shift
+  computePosition, arrow, offset, flip, shift
 } from '@floating-ui/dom';
 import { createId } from '@paralleldrive/cuid2';
 import { isEqual } from 'lodash';
@@ -122,6 +122,7 @@ export default {
           middleware: [
             offset(11),
             shift({ padding: 5 }),
+            flip(),
             arrow({
               element: arrowEl,
               padding: 10


### PR DESCRIPTION
## Summary

Blocks user from accessing the create editor modal in a locale he cannot create this type of document.
Adds new route to get permissions for type and a list of locales.

## What are the specific steps to test this change?

If a user has edit permissions but no create permission for a piece he shouldn't be able to switch to a locale where he cannot create a document.
Also a tooltip has been added:

![image](https://github.com/user-attachments/assets/cdfbbfe4-db9e-435c-8c10-ec87bfa90526)

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

