### PR TITLE
Fix locale switcher perm

### DIFF
--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocLocalePicker.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocLocalePicker.vue
@@ -94,18 +94,20 @@ async function open() {
 };
 
 async function checkCreatePermission() {
-  const locales = Object.keys(window.apos.i18n.locales)
+  const localesWithNoDocs = Object.keys(apos.i18n.locales)
     .filter((locale) => !localized.value[locale]);
 
   const allowed = await apos.http.get(`${i18nAction}/locales-permissions`, {
     qs: {
       type: props.moduleOptions.name,
-      locales,
-      action: 'create'
+      locales: localesWithNoDocs,
+      action: 'create',
+      aposMode: 'draft'
     }
   });
 
-  forbidden.value = locales.filter((locale) => !allowed.includes(locale));
+  forbidden.value = localesWithNoDocs
+    .filter((locale) => !allowed.includes(locale));
 }
 
 async function switchLocale(locale) {

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -698,14 +698,14 @@ module.exports = {
       },
       async getLocalesPermissions(req, action, type, locales) {
         const allowed = [];
-        const originLocale = req.locale;
         for (const locale of locales) {
-          req.locale = locale;
-          if (await self.apos.permission.can(req, action, type)) {
+          const clonedReq = req.clone({
+            locale
+          });
+          if (await self.apos.permission.can(clonedReq, action, type)) {
             allowed.push(locale);
           }
         }
-        req.locale = originLocale;
         return allowed;
       },
       sanitizeLocaleName(locale) {

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -697,20 +697,15 @@ module.exports = {
         return locales;
       },
       async getLocalesPermissions(req, action, type, locales) {
-        const fakeDocs = locales.map((locale) => {
-          return {
-            _id: 'fake',
-            type,
-            aposLocale: locale
-          };
-        });
-
         const allowed = [];
-        for (const doc of fakeDocs) {
-          if (await self.apos.permission.can(req, action, doc)) {
-            allowed.push(doc.aposLocale);
+        const originLocale = req.locale;
+        for (const locale of locales) {
+          req.locale = locale;
+          if (await self.apos.permission.can(req, action, type)) {
+            allowed.push(locale);
           }
         }
+        req.locale = originLocale;
         return allowed;
       },
       sanitizeLocaleName(locale) {


### PR DESCRIPTION
## Summary

* pass draft option to check if users have create permission in draft since they should be able to save draft and submit.
* slightly refactor the method that check locales perm by not using fake docs.

## What are the specific steps to test this change?

Tests are green.
Works with and without advanced permission.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

