### PR TITLE
Pro 6387 images errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Add a locale switcher in pieces and pages editor modals. This is available for localized documents only, and allows you to switch between locales for the same document.
   The locale can be switche at only one level, meaning that sub documents of a document that already switched locale will not be able to switch locale itself.
 * Adds visual focus states and keyboard handlers for engaging with areas and widgets in-context
+* Adds method `simulateRelationshipsFromStorage` method in schema module, for generate relationships in documents from database, doing the opposite than `prepareForStorage`.
+* Adds new option `fetchRelationships` to fields `convert` to avoid to fetch relationships and to remove data when not found. 
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@
 * Add a locale switcher in pieces and pages editor modals. This is available for localized documents only, and allows you to switch between locales for the same document.
   The locale can be switche at only one level, meaning that sub documents of a document that already switched locale will not be able to switch locale itself.
 * Adds visual focus states and keyboard handlers for engaging with areas and widgets in-context
-* Adds method `simulateRelationshipsFromStorage` method in schema module, for generate relationships in documents from database, doing the opposite than `prepareForStorage`.
-* Adds new option `fetchRelationships` to fields `convert` to avoid to fetch relationships and to remove data when not found. 
+* Adds method `simulateRelationshipsFromStorage` method in schema module. 
+This method populates the relationship field with just enough information to allow convert to accept it. It does not fully fetch the related documents. It does the opposite of prepareForStorage.
+* A new options object has been added to the convert method. 
+Setting the `fetchRelationships` option to false will prevent convert from actually fetching relationships to check which related documents currently exist. 
+The shape of the relationship field is still validated.
 
 ### Changes
 

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -294,15 +294,19 @@ module.exports = {
       // options to sanitize against. Thus h5 can be legal
       // in one rich text widget and not in another.
       //
+      // The `convertOptions` parameter allows to pass options
+      // to the convert method to alter them.
+      //
       // If any errors occur sanitizing the individual widgets,
       // an array of errors with `path` and `error` properties
       // is thrown.
       //
       // Returns a new array of sanitized items.
-      async sanitizeItems(req, items, fieldOptions = {}, convertOptions) {
+      async sanitizeItems(req, items, options, convertOptions = {}) {
+        options = options || {};
         const result = [];
         const errors = [];
-        const widgetsOptions = self.getWidgets(fieldOptions);
+        const widgetsOptions = self.getWidgets(options);
 
         for (let i = 0; i < items.length; i++) {
           const item = items[i];

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -299,11 +299,10 @@ module.exports = {
       // is thrown.
       //
       // Returns a new array of sanitized items.
-      async sanitizeItems(req, items, options) {
-        options = options || {};
+      async sanitizeItems(req, items, fieldOptions = {}, convertOptions) {
         const result = [];
         const errors = [];
-        const widgetsOptions = self.getWidgets(options);
+        const widgetsOptions = self.getWidgets(fieldOptions);
 
         for (let i = 0; i < items.length; i++) {
           const item = items[i];
@@ -322,7 +321,7 @@ module.exports = {
           }
           let newItem;
           try {
-            newItem = await manager.sanitize(req, item, widgetOptions);
+            newItem = await manager.sanitize(req, item, widgetOptions, convertOptions);
             newItem._id = self.apos.launder.id(item._id) || self.apos.util.generateId();
           } catch (e) {
             if (Array.isArray(e)) {

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -785,7 +785,7 @@ module.exports = {
           };
         }
         const convertOptions = {
-          fetchRelationships: options.fetchRelationships
+          fetchRelationships: options.fetchRelationships !== false
         };
         await self.apos.schema.convert(req, schema, input, doc, convertOptions);
 

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -759,6 +759,7 @@ module.exports = {
 
       async convert(req, input, doc, options = {
         presentFieldsOnly: false,
+        fetchRelationships: true,
         type: null,
         copyingId: null,
         createId: null
@@ -783,8 +784,10 @@ module.exports = {
             ...input
           };
         }
-
-        await self.apos.schema.convert(req, schema, input, doc);
+        const convertOptions = {
+          fetchRelationships: options.fetchRelationships
+        };
+        await self.apos.schema.convert(req, schema, input, doc, convertOptions);
 
         if (options.createId) {
           doc.aposDocId = options.createId;

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -1734,14 +1734,13 @@ module.exports = {
         }
 
         function forSchema(schema, doc) {
+          if (!doc) {
+            return;
+          }
           for (const field of schema) {
             if (field.type === 'area' && doc[field.name] && doc[field.name].items) {
               for (const widget of doc[field.name].items) {
-                self.walkByMetaType(widget, {
-                  arrayItem: handlers.arrayItem,
-                  object: handlers.object,
-                  relationship: handlers.relationship
-                });
+                self.walkByMetaType(widget, handlers);
               }
             } else if (field.type === 'array') {
               if (doc[field.name]) {
@@ -1752,14 +1751,10 @@ module.exports = {
               }
             } else if (field.type === 'object') {
               const value = doc[field.name];
-              if (value) {
-                handlers.object(field, value);
-                forSchema(field.schema, value);
-              }
+              handlers.object(field, value);
+              forSchema(field.schema, value);
             } else if (field.type === 'relationship') {
-              if (Array.isArray(doc[field.name])) {
-                handlers.relationship(field, doc);
-              }
+              handlers.relationship(field, doc, true);
             }
           }
         }

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -1754,7 +1754,7 @@ module.exports = {
               handlers.object(field, value);
               forSchema(field.schema, value);
             } else if (field.type === 'relationship') {
-              handlers.relationship(field, doc, true);
+              handlers.relationship(field, doc);
             }
           }
         }

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -599,7 +599,7 @@ module.exports = {
       // set error class names, etc. If the error is not a string, it is a
       // database error etc. and should not be displayed in the browser directly.
 
-      async convert(req, schema, data, destination) {
+      async convert(req, schema, data, destination, options) {
         if (Array.isArray(req)) {
           throw new Error('convert invoked without a req, do you have one in your context?');
         }
@@ -629,7 +629,8 @@ module.exports = {
                   required: isRequired
                 },
                 data,
-                destination
+                destination,
+                options
               );
             } catch (error) {
               if (Array.isArray(error)) {

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1039,7 +1039,7 @@ module.exports = {
 
         const handlers = {
           arrayItem: (field, object) => {
-            if (!can(field)) {
+            if (!object || !can(field)) {
               return;
             }
 
@@ -1048,7 +1048,7 @@ module.exports = {
             object.scopedArrayName = field.scopedArrayName;
           },
           object: (field, object) => {
-            if (!can(field)) {
+            if (!object || !can(field)) {
               return;
             }
 
@@ -1056,7 +1056,7 @@ module.exports = {
             object.scopedObjectName = field.scopedObjectName;
           },
           relationship: (field, doc) => {
-            if (!can(field)) {
+            if (!Array.isArray(doc[field.name]) || !can(field)) {
               return;
             }
 

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1089,7 +1089,7 @@ module.exports = {
             const itemIds = object[field.idsStorage] || [];
             object[field.name] = itemIds.map(id => ({
               _id: setId(id),
-              fields: object[field.fieldsStorage]?.[id] || {}
+              _fields: object[field.fieldsStorage]?.[id] || {}
             }));
           }
         };

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -599,7 +599,7 @@ module.exports = {
       // set error class names, etc. If the error is not a string, it is a
       // database error etc. and should not be displayed in the browser directly.
 
-      async convert(req, schema, data, destination, options) {
+      async convert(req, schema, data, destination, options = { fetchRelationships: true }) {
         if (Array.isArray(req)) {
           throw new Error('convert invoked without a req, do you have one in your context?');
         }

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -599,7 +599,8 @@ module.exports = {
       // set error class names, etc. If the error is not a string, it is a
       // database error etc. and should not be displayed in the browser directly.
 
-      async convert(req, schema, data, destination, options = { fetchRelationships: true }) {
+      async convert(req, schema, data, destination, { fetchRelationships = true } = {}) {
+        const options = { fetchRelationships };
         if (Array.isArray(req)) {
           throw new Error('convert invoked without a req, do you have one in your context?');
         }

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1077,7 +1077,7 @@ module.exports = {
         self.apos.doc.walkByMetaType(doc, handlers);
       },
 
-      simulateRelationshipsFromStorage(req, doc, schema) {
+      simulateRelationshipsFromStorage(req, doc) {
         const handlers = {
           relationship: (field, object) => {
             const manager = self.apos.doc.getManager(field.withType);

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1076,6 +1076,25 @@ module.exports = {
         self.apos.doc.walkByMetaType(doc, handlers);
       },
 
+      simulateRelationshipsFromStorage(req, doc, schema) {
+        const handlers = {
+          relationship: (field, object) => {
+            const manager = self.apos.doc.getManager(field.withType);
+            const setId = (id) => manager.options.localized !== false
+              ? `${id}:${doc.aposLocale}`
+              : id;
+
+            const itemIds = object[field.idsStorage] || [];
+            object[field.name] = itemIds.map(id => ({
+              _id: setId(id),
+              fields: object[field.fieldsStorage]?.[id] || {}
+            }));
+          }
+        };
+
+        self.apos.doc.walkByMetaType(doc, handlers);
+      },
+
       // Add a new field type. The `type` object may contain the following properties:
       //
       // ### `name`

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -1027,7 +1027,6 @@ module.exports = (self) => {
         return;
       }
       const results = await manager.find(req, { $or: clauses }).relationships(false).toArray();
-      console.log('results', results);
       // Must maintain input order. Also discard things not actually found in the db
       const actualDocs = [];
       for (const item of input) {

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -972,7 +972,7 @@ module.exports = (self) => {
     // properties is handled at a lower level in a beforeSave
     // handler of the doc-type module.
 
-    async convert(req, field, data, destination) {
+    async convert(req, field, data, destination, options = { fetchRelationships: true }) {
       const manager = self.apos.doc.getManager(field.withType);
       if (!manager) {
         throw Error('relationship with type ' + field.withType + ' unrecognized');
@@ -991,6 +991,10 @@ module.exports = (self) => {
       if (field.max && field.max < input.length) {
         throw self.apos.error('max', `Maximum ${field.withType} required reached.`);
       }
+      if (!options.fetchRelationships) {
+        return;
+      }
+
       const ids = [];
       const titlesOrIds = [];
       for (const item of input) {

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -992,6 +992,7 @@ module.exports = (self) => {
         throw self.apos.error('max', `Maximum ${field.withType} required reached.`);
       }
       if (options.fetchRelationships === false) {
+        console.log('input', input);
         destination[field.name] = input;
         return;
       }
@@ -1039,7 +1040,11 @@ module.exports = (self) => {
           const result = results.find(doc => (doc._id === item._id));
           if (result) {
             if (field.schema) {
-              result._fields = { ...(destination[field.name]?.find?.(doc => doc._id === item._id)?._fields || {}) };
+              result._fields = {
+                ...(destination[field.name]
+                  ?.find?.(doc => doc._id === item._id)
+                  ?._fields || {})
+              };
               if (item && ((typeof item._fields === 'object'))) {
                 await self.convert(req, field.schema, item._fields || {}, result._fields, options);
               }

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -10,7 +10,8 @@ const dateRegex = /^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/;
 module.exports = (self) => {
   self.addFieldType({
     name: 'area',
-    async convert(req, field, data, destination, options) {
+    async convert(req, field, data, destination, { fetchRelationships = true } = {}) {
+      const options = { fetchRelationships };
       const _id = self.apos.launder.id(data[field.name] && data[field.name]._id) || self.apos.util.generateId();
       if (typeof data[field.name] === 'string') {
         destination[field.name] = self.apos.area.fromPlaintext(data[field.name]);
@@ -775,7 +776,8 @@ module.exports = (self) => {
 
   self.addFieldType({
     name: 'array',
-    async convert(req, field, data, destination, options) {
+    async convert(req, field, data, destination, { fetchRelationships = true } = {}) {
+      const options = { fetchRelationships };
       const schema = field.schema;
       data = data[field.name];
       if (!Array.isArray(data)) {
@@ -876,7 +878,8 @@ module.exports = (self) => {
 
   self.addFieldType({
     name: 'object',
-    async convert(req, field, data, destination, options) {
+    async convert(req, field, data, destination, { fetchRelationships = true } = {}) {
+      const options = { fetchRelationships };
       data = data[field.name];
       const schema = field.schema;
       const errors = [];

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -992,8 +992,27 @@ module.exports = (self) => {
         throw self.apos.error('max', `Maximum ${field.withType} required reached.`);
       }
       if (options.fetchRelationships === false) {
-        console.log('input', input);
-        destination[field.name] = input;
+        destination[field.name] = [];
+
+        for (const relation of input) {
+          if (typeof relation === 'string') {
+            destination[field.name].push({
+              _id: self.apos.launder.id(relation),
+              _fields: {}
+            });
+            continue;
+          }
+
+          const _fields = {};
+          if (field.schema?.length) {
+            await self.convert(req, field.schema, relation.fields || {}, _fields, options);
+          }
+
+          destination[field.name].push({
+            _id: self.apos.launder.id(relation._id),
+            _fields
+          });
+        }
         return;
       }
 

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -972,7 +972,8 @@ module.exports = (self) => {
     // properties is handled at a lower level in a beforeSave
     // handler of the doc-type module.
 
-    async convert(req, field, data, destination, options = { fetchRelationships: true }) {
+    async convert(req, field, data, destination, { fetchRelationships = true } = {}) {
+      const options = { fetchRelationships };
       const manager = self.apos.doc.getManager(field.withType);
       if (!manager) {
         throw Error('relationship with type ' + field.withType + ' unrecognized');
@@ -991,7 +992,7 @@ module.exports = (self) => {
       if (field.max && field.max < input.length) {
         throw self.apos.error('max', `Maximum ${field.withType} required reached.`);
       }
-      if (options.fetchRelationships === false) {
+      if (fetchRelationships === false) {
         destination[field.name] = [];
 
         for (const relation of input) {

--- a/modules/@apostrophecms/widget-type/index.js
+++ b/modules/@apostrophecms/widget-type/index.js
@@ -311,7 +311,7 @@ module.exports = {
       //
       // Returns a new, sanitized widget object.
 
-      async sanitize(req, input, options) {
+      async sanitize(req, input, options, convertOptions) {
         if (!input || typeof input !== 'object') {
           // Do not crash
           input = {};
@@ -325,7 +325,7 @@ module.exports = {
         output.aposPlaceholder = self.apos.launder.boolean(input.aposPlaceholder);
         if (!output.aposPlaceholder) {
           const schema = self.allowedSchema(req);
-          await self.apos.schema.convert(req, schema, input, output);
+          await self.apos.schema.convert(req, schema, input, output, convertOptions);
         }
         return output;
       },

--- a/modules/@apostrophecms/widget-type/index.js
+++ b/modules/@apostrophecms/widget-type/index.js
@@ -311,7 +311,8 @@ module.exports = {
       //
       // Returns a new, sanitized widget object.
 
-      async sanitize(req, input, options, convertOptions) {
+      async sanitize(req, input, options, { fetchRelationships = true } = {}) {
+        const convertOptions = { fetchRelationships };
         if (!input || typeof input !== 'object') {
           // Do not crash
           input = {};

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -2556,13 +2556,13 @@ describe('Schemas', function() {
       rel: [
         {
           _id: 'reyvb1txf54noynckm1xy34a:en:draft',
-          fields: {}
+          _fields: {}
         }
       ],
       area: [
         {
           _id: 'u2gcjvq9wvds1hkd8xibn9h1:en:draft',
-          fields: {
+          _fields: {
             top: null,
             left: null,
             width: null,
@@ -2575,17 +2575,17 @@ describe('Schemas', function() {
       array: [
         {
           _id: 'nkr88dg4lds8noal9l4vrcgv:en:draft',
-          fields: {}
+          _fields: {}
         }
       ],
       object: [
         {
           _id: 'nkr88dg4lds8noal9l4vrcgv:en:draft',
-          fields: {}
+          _fields: {}
         },
         {
           _id: 'az82H8dg4lds8noal9l4vazd:en:draft',
-          fields: {}
+          _fields: {}
         }
       ]
     };

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -2694,12 +2694,12 @@ describe('Schemas', function() {
     const expected = {
       rel: [ {
         _id: 'reyvb1txf54noynckm1xy34a:en:draft',
-        fields: {}
+        _fields: {}
       } ],
       area: [
         {
           _id: 'u2gcjvq9wvds1hkd8xibn9h1:en:draft',
-          fields: {
+          _fields: {
             top: null,
             left: null,
             width: null,
@@ -2711,16 +2711,16 @@ describe('Schemas', function() {
       ],
       array: [ {
         _id: 'nkr88dg4lds8noal9l4vrcgv:en:draft',
-        fields: {}
+        _fields: {}
       } ],
       object: [
         {
           _id: 'nkr88dg4lds8noal9l4vrcgv:en:draft',
-          fields: {}
+          _fields: {}
         },
         {
           _id: 'az82H8dg4lds8noal9l4vazd:en:draft',
-          fields: {}
+          _fields: {}
         }
       ]
     };

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -2460,7 +2460,7 @@ describe('Schemas', function() {
 
   it('should allow to simulate a populate of relationships on database data', async function() {
     const req = apos.task.getReq();
-    const piece = {
+    const doc = {
       _id: 'gvoyi3l0ncsj2yq36743zeum:en:draft',
       title: 'topic',
       array: [
@@ -2543,13 +2543,13 @@ describe('Schemas', function() {
       }
     };
 
-    apos.schema.simulateRelationshipsFromStorage(req, piece);
+    apos.schema.simulateRelationshipsFromStorage(req, doc);
 
     const actual = {
-      rel: piece._rel,
-      area: piece.area.items[0]._image,
-      array: piece.array[0]._arrayRel,
-      object: piece.object._objectRel
+      rel: doc._rel,
+      area: doc.area.items[0]._image,
+      array: doc.array[0]._arrayRel,
+      object: doc.object._objectRel
     };
 
     const expected = {
@@ -2578,6 +2578,141 @@ describe('Schemas', function() {
           fields: {}
         }
       ],
+      object: [
+        {
+          _id: 'nkr88dg4lds8noal9l4vrcgv:en:draft',
+          fields: {}
+        },
+        {
+          _id: 'az82H8dg4lds8noal9l4vazd:en:draft',
+          fields: {}
+        }
+      ]
+    };
+
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should allow to convert a document without fetching relationships', async function() {
+    const req = apos.task.getReq();
+    const doc = {
+      _id: 'gvoyi3l0ncsj2yq36743zeum:en:draft',
+      title: 'topic',
+      array: [
+        {
+          _id: 'hy56r2znrs427m47e15yesfb',
+          metaType: 'arrayItem',
+          scopedArrayName: 'doc.topic.array',
+          arrayRelIds: [ 'nkr88dg4lds8noal9l4vrcgv' ],
+          arrayRelFields: { nkr88dg4lds8noal9l4vrcgv: {} }
+        }
+      ],
+      object: {
+        _id: 'tfpq5v6lwlwomuampavh6zi8',
+        metaType: 'object',
+        scopedObjectName: 'doc.topic.object',
+        objectRelIds: [ 'nkr88dg4lds8noal9l4vrcgv', 'az82H8dg4lds8noal9l4vazd' ],
+        objectRelFields: {
+          nkr88dg4lds8noal9l4vrcgv: {},
+          az82H8dg4lds8noal9l4vazd: {}
+        }
+      },
+      slug: 'topic',
+      visibility: 'public',
+      scheduledPublish: null,
+      scheduledUnpublish: null,
+      aposIsTemplate: false,
+      aposPreviewImage: {
+        _id: 'gx4ankjn1s0i2g16qs16is0q',
+        items: [],
+        metaType: 'area'
+      },
+      userPermissions: [],
+      groupPermissions: [],
+      archived: false,
+      type: 'topic',
+      aposLocale: 'en:draft',
+      aposMode: 'draft',
+      aposDocId: 'gvoyi3l0ncsj2yq36743zeum',
+      metaType: 'doc',
+      createdAt: '2024-08-07T07:11:34.234Z',
+      updatedAt: '2024-08-07T07:24:17.889Z',
+      cacheInvalidatedAt: '2024-08-07T07:24:17.889Z',
+      updatedBy: {
+        _id: 'vndh00in6p565asvbivvzjos',
+        title: 'admin',
+        username: 'admin'
+      },
+      titleSortified: 'topic',
+      highSearchText: 'topic topic topic topic public',
+      highSearchWords: [ 'topic', 'public' ],
+      lowSearchText: 'topic topic topic topic public',
+      searchSummary: '',
+      aposPermissions: [],
+      modified: false,
+      lastPublishedAt: '2024-08-07T07:24:17.956Z',
+      relIds: [ 'reyvb1txf54noynckm1xy34a' ],
+      relFields: { reyvb1txf54noynckm1xy34a: {} },
+      area: {
+        _id: 'hfwxext12500kxy74coc3nf1',
+        items: [
+          {
+            _id: 'x38pvsmyqie83vzy57akpwb2',
+            metaType: 'widget',
+            type: '@apostrophecms/image',
+            aposPlaceholder: false,
+            imageIds: [ 'u2gcjvq9wvds1hkd8xibn9h1' ],
+            imageFields: {
+              u2gcjvq9wvds1hkd8xibn9h1: {
+                top: null,
+                left: null,
+                width: null,
+                height: null,
+                x: null,
+                y: null
+              }
+            }
+          }
+        ],
+        metaType: 'area'
+      }
+    };
+
+    apos.schema.simulateRelationshipsFromStorage(req, doc);
+    const docToInsert = doc;
+    const schema = apos.doc.getManager('topic').schema;
+    await apos.schema.convert(req, schema, doc, docToInsert, {
+      fetchRelationships: false
+    });
+
+    const actual = {
+      rel: docToInsert._rel,
+      area: docToInsert.area.items[0]._image,
+      array: docToInsert.array[0]._arrayRel,
+      object: docToInsert.object._objectRel
+    };
+    const expected = {
+      rel: [ {
+        _id: 'reyvb1txf54noynckm1xy34a:en:draft',
+        fields: {}
+      } ],
+      area: [
+        {
+          _id: 'u2gcjvq9wvds1hkd8xibn9h1:en:draft',
+          fields: {
+            top: null,
+            left: null,
+            width: null,
+            height: null,
+            x: null,
+            y: null
+          }
+        }
+      ],
+      array: [ {
+        _id: 'nkr88dg4lds8noal9l4vrcgv:en:draft',
+        fields: {}
+      } ],
       object: [
         {
           _id: 'nkr88dg4lds8noal9l4vrcgv:en:draft',

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -326,6 +326,63 @@ describe('Schemas', function() {
               }
             };
           }
+        },
+        topic: {
+          extend: '@apostrophecms/piece-type',
+          options: {
+            alias: 'topic'
+          },
+          fields(self) {
+            return {
+              add: {
+                title: {
+                  label: 'Title',
+                  type: 'string',
+                  required: true
+                },
+                area: {
+                  label: 'Area',
+                  type: 'area',
+                  options: {
+                    widgets: {
+                      '@apostrophecms/image': {}
+                    }
+                  }
+                },
+                _rel: {
+                  label: 'Rel',
+                  type: 'relationship',
+                  withType: 'article'
+                },
+                array: {
+                  label: 'Array',
+                  type: 'array',
+                  fields: {
+                    add: {
+                      _arrayRel: {
+                        label: 'Array Rel',
+                        type: 'relationship',
+                        withType: 'article'
+                      }
+                    }
+                  }
+                },
+                object: {
+                  label: 'Object',
+                  type: 'object',
+                  fields: {
+                    add: {
+                      _objectRel: {
+                        label: 'Object Rel',
+                        type: 'relationship',
+                        withType: 'article'
+                      }
+                    }
+                  }
+                }
+              }
+            };
+          }
         }
       }
     });
@@ -2396,6 +2453,141 @@ describe('Schemas', function() {
       changes11: [],
       changes12: [ 'title', 'slug' ],
       changes23: [ 'title', 'slug', 'area', 'array' ]
+    };
+
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should allow to simulate a populate of relationships on database data', async function() {
+    const req = apos.task.getReq();
+    const piece = {
+      _id: 'gvoyi3l0ncsj2yq36743zeum:en:draft',
+      title: 'topic',
+      array: [
+        {
+          _id: 'hy56r2znrs427m47e15yesfb',
+          metaType: 'arrayItem',
+          scopedArrayName: 'doc.topic.array',
+          arrayRelIds: [ 'nkr88dg4lds8noal9l4vrcgv' ],
+          arrayRelFields: { nkr88dg4lds8noal9l4vrcgv: {} }
+        }
+      ],
+      object: {
+        _id: 'tfpq5v6lwlwomuampavh6zi8',
+        metaType: 'object',
+        scopedObjectName: 'doc.topic.object',
+        objectRelIds: [ 'nkr88dg4lds8noal9l4vrcgv', 'az82H8dg4lds8noal9l4vazd' ],
+        objectRelFields: {
+          nkr88dg4lds8noal9l4vrcgv: {},
+          az82H8dg4lds8noal9l4vazd: {}
+        }
+      },
+      slug: 'topic',
+      visibility: 'public',
+      scheduledPublish: null,
+      scheduledUnpublish: null,
+      aposIsTemplate: false,
+      aposPreviewImage: {
+        _id: 'gx4ankjn1s0i2g16qs16is0q',
+        items: [],
+        metaType: 'area'
+      },
+      userPermissions: [],
+      groupPermissions: [],
+      archived: false,
+      type: 'topic',
+      aposLocale: 'en:draft',
+      aposMode: 'draft',
+      aposDocId: 'gvoyi3l0ncsj2yq36743zeum',
+      metaType: 'doc',
+      createdAt: '2024-08-07T07:11:34.234Z',
+      updatedAt: '2024-08-07T07:24:17.889Z',
+      cacheInvalidatedAt: '2024-08-07T07:24:17.889Z',
+      updatedBy: {
+        _id: 'vndh00in6p565asvbivvzjos',
+        title: 'admin',
+        username: 'admin'
+      },
+      titleSortified: 'topic',
+      highSearchText: 'topic topic topic topic public',
+      highSearchWords: [ 'topic', 'public' ],
+      lowSearchText: 'topic topic topic topic public',
+      searchSummary: '',
+      aposPermissions: [],
+      modified: false,
+      lastPublishedAt: '2024-08-07T07:24:17.956Z',
+      relIds: [ 'reyvb1txf54noynckm1xy34a' ],
+      relFields: { reyvb1txf54noynckm1xy34a: {} },
+      area: {
+        _id: 'hfwxext12500kxy74coc3nf1',
+        items: [
+          {
+            _id: 'x38pvsmyqie83vzy57akpwb2',
+            metaType: 'widget',
+            type: '@apostrophecms/image',
+            aposPlaceholder: false,
+            imageIds: [ 'u2gcjvq9wvds1hkd8xibn9h1' ],
+            imageFields: {
+              u2gcjvq9wvds1hkd8xibn9h1: {
+                top: null,
+                left: null,
+                width: null,
+                height: null,
+                x: null,
+                y: null
+              }
+            }
+          }
+        ],
+        metaType: 'area'
+      }
+    };
+
+    apos.schema.simulateRelationshipsFromStorage(req, piece);
+
+    const actual = {
+      rel: piece._rel,
+      area: piece.area.items[0]._image,
+      array: piece.array[0]._arrayRel,
+      object: piece.object._objectRel
+    };
+
+    const expected = {
+      rel: [
+        {
+          _id: 'reyvb1txf54noynckm1xy34a:en:draft',
+          fields: {}
+        }
+      ],
+      area: [
+        {
+          _id: 'u2gcjvq9wvds1hkd8xibn9h1:en:draft',
+          fields: {
+            top: null,
+            left: null,
+            width: null,
+            height: null,
+            x: null,
+            y: null
+          }
+        }
+      ],
+      array: [
+        {
+          _id: 'nkr88dg4lds8noal9l4vrcgv:en:draft',
+          fields: {}
+        }
+      ],
+      object: [
+        {
+          _id: 'nkr88dg4lds8noal9l4vrcgv:en:draft',
+          fields: {}
+        },
+        {
+          _id: 'az82H8dg4lds8noal9l4vazd:en:draft',
+          fields: {}
+        }
+      ]
     };
 
     assert.deepEqual(actual, expected);


### PR DESCRIPTION
[PRO-6387](https://linear.app/apostrophecms/issue/PRO-6387/[import-export]-images-not-displayed-after-import-in)
[PRO-6420](https://linear.app/apostrophecms/issue/PRO-6420/convert-call-made-by-importer-should-be-altered-not-to-actually-fetch)

## Summary

Rework in core to allow running `convert` method on data from DB.
To do so, add a method `simulateRelationshipsFromStorage` that does the opposite than `prepareForStorage` partially.
It adds a property to relationships that can be converted.

Also add an option to convert to be able to not check if relationships already exist. In the case of imports we cannot verify the order of insertion, especially when a document is a relation to different documents of the same import.

Update convert methods for different fields where needed like: `area` (as well as the sanitize method that call convert), `object`, `array`, `relationship`.

Add tests for method `simulateRelationshipsFromStorage` as well as the new convert option. Test relationships in areas, objects, arrays, or relationship fields.

## What are the specific steps to test this change?

Tests 🟢 

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated