### PR TITLE
fix source maps for admin UI build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Overriding standard Vue.js components with `editorModal` and `managerModal` are now applied all the time.
 * Accommodate old-style replica set URIs with comma-separated servers by passing any MongoDB URIs that Node.js cannot parse directly to the MongoDB driver, and avoiding unnecessary parsing of the URI in general.
 * Bump `oembetter` dependency to guarantee compatibility with YouTube. YouTube recently deployed broken `link rel="undefined"` tags on some of their video pages.
+* It is now possible to see the right filename and line number when debugging the admin UI build in the browser. This is automatically disabled when `@apostrophecms/security-headers` is installed, because its defaults are incompatible by design.
 
 ## 4.5.4 (2024-07-22)
 

--- a/modules/@apostrophecms/asset/lib/webpack/apos/webpack.config.js
+++ b/modules/@apostrophecms/asset/lib/webpack/apos/webpack.config.js
@@ -25,6 +25,15 @@ module.exports = ({
 
   const mode = process.env.NODE_ENV || 'development';
   const pnpmModulePath = apos.isPnpm ? [ path.join(apos.selfDir, '../') ] : [];
+  const dev = (mode === 'development');
+  // The default behavior of the security-headers module
+  // blocks eval, and only eval-source-map currently associates
+  // errors with the right file. With regular source-map the
+  // results are worse than no source map. A developer who wishes
+  // to experiment can set the devSourceMap option of the asset module
+  const csp = apos.modules['@apostrophecms/security-headers'];
+  const fallbackSourceMap = csp ? false : 'eval-source-map';
+  const devtool = dev ? (apos.asset.options.devSourceMap || fallbackSourceMap) : false;
   const config = {
     performance: {
       hints: false
@@ -36,7 +45,7 @@ module.exports = ({
     optimization: {
       minimize: process.env.NODE_ENV === 'production'
     },
-    devtool: 'source-map',
+    devtool,
     output: {
       path: outputPath,
       filename: outputFilename


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*

## What are the specific steps to test this change?

* Throw an uncaught exception, reference an undefined variable on purpose, or otherwise crash at runtime in admin UI code, like in apostrophe core or a custom field type or whatever.
* Make sure your admin UI is rebuilt: be sure to do `APOS_DEV=1 npm run dev`
* In the Chrome console you should get the right line of the right source file, not the compiled bundle and/or wrong file like before.
* Verify that if the `@apostrophecms/security-headers` module is enabled, you do NOT get source maps, you just get the error line in the compiled bundle, because it is incompatible by design (forbids eval, and eval-source-map is the only kind that currently works with Vue SFC it seems)

I did the above while debugging my own Apostrophe app with custom admin UI code, couldn't take it anymore.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
