### PR TITLE
[A3] Fix duplicate icons breaking the build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* Registering duplicate icon is no longer breaking the build.
+
 ## 3.67.2 (2024-08-08)
 
 ### Changes

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -572,11 +572,15 @@ module.exports = {
               registerCode: ''
             };
 
+            const importIndex = [];
             for (const [ registerAs, importFrom ] of Object.entries(self.iconMap)) {
-              if (importFrom.substring(0, 1) === '~') {
-                output.importCode += `import ${importFrom}Icon from '${importFrom.substring(1)}';\n`;
-              } else {
-                output.importCode += `import ${importFrom}Icon from 'vue-material-design-icons/${importFrom}.vue';\n`;
+              if (!importIndex.includes(importFrom)) {
+                if (importFrom.substring(0, 1) === '~') {
+                  output.importCode += `import ${importFrom}Icon from '${importFrom.substring(1)}';\n`;
+                } else {
+                  output.importCode += `import ${importFrom}Icon from 'vue-material-design-icons/${importFrom}.vue';\n`;
+                }
+                importIndex.push(importFrom);
               }
               output.registerCode += `Vue.component('${registerAs}', ${importFrom}Icon);\n`;
             }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

When one and the same Vue material icon is registered (via a module option) even with different "name", the Apostrophe UI build is failing. This patch fixes that.

## What are the specific steps to test this change?

* In a module "A" declare an icon `something-icon: 'Download'`
* In a module "B" declare an icon `another-icon: 'Download'`
* The build should pass, both icons should be visible

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
