### PR TITLE
PRO-6438: API to expose locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * To aid debugging, when a file extension is unacceptable as an Apostrophe attachment the rejected extension is now printed as part of the error message.
 * The new `big-upload-client` module can now be used to upload very large files to any route that uses the new `big-upload-middleware`.
+* The `@apostrophecms/i18n` module now exposes a `locales` HTTP GET API to aid in implementation of native apps for localized sites.
 
 ## 4.6.0 (2024-08-08)
 

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -369,6 +369,9 @@ module.exports = {
   apiRoutes(self) {
     return {
       get: {
+        locales(req) {
+          return self.locales;
+        },
         async localesPermissions(req) {
           const action = self.apos.launder.string(req.query.action);
           const type = self.apos.launder.string(req.query.type);


### PR DESCRIPTION
A simple GET API at `/api/v1/@apostrophecms/i18n/locales` which returns the configured locales of the site. This is a public API intended to ease the implementation of locale switching in headless applications.