### PR TITLE
PRO-6418: skipReplace for changeDocIds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * To aid debugging, when a file extension is unacceptable as an Apostrophe attachment the rejected extension is now printed as part of the error message.
 * The new `big-upload-client` module can now be used to upload very large files to any route that uses the new `big-upload-middleware`.
+* Add option `skipReplace` for `apos.doc.changeDocIds` method to skip the replacing of the "old" document in the database.
 
 ## 4.6.0 (2024-08-08)
 

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -334,8 +334,12 @@ module.exports = {
       // new document's content wins in the event of a conflict.
       // If `keep` is not set, a `conflict` error is thrown in the
       // event of a conflict.
+      //
+      // If `skipReplace` is set to `true`, the method will not attempt to remove
+      // the old document, but will still update the new document. The new _id
+      // for each pair will be used for retrieving the "existing" document in this case.
 
-      async changeDocIds(pairs, { keep } = {}) {
+      async changeDocIds(pairs, { keep, skipReplace = false } = {}) {
         let renamed = 0;
         let kept = 0;
         // Get page paths up front so we can avoid multiple queries when working on path changes
@@ -347,13 +351,15 @@ module.exports = {
         }).toArray();
         for (const pair of pairs) {
           const [ from, to ] = pair;
-          const existing = await self.apos.doc.db.findOne({ _id: from });
+          const oldAposDocId = from.split(':')[0];
+          const existing = await self.apos.doc.db.findOne({ _id: skipReplace ? to : from });
           if (!existing) {
             throw self.apos.error('notfound');
           }
           const replacement = klona(existing);
-          await self.apos.doc.db.removeOne({ _id: from });
-          const oldAposDocId = existing.aposDocId;
+          if (!skipReplace) {
+            await self.apos.doc.db.removeOne({ _id: from });
+          }
           replacement._id = to;
           const parts = to.split(':');
           replacement.aposDocId = parts[0];
@@ -366,8 +372,10 @@ module.exports = {
             replacement.path = existing.path.replace(existing.aposDocId, replacement.aposDocId);
           }
           try {
-            await self.apos.doc.db.insertOne(replacement);
-            renamed++;
+            if (!skipReplace) {
+              await self.apos.doc.db.insertOne(replacement);
+              renamed++;
+            }
           } catch (e) {
             // First reinsert old doc to prevent content loss on new doc insert failure
             await self.apos.doc.db.insertOne(existing);
@@ -404,7 +412,7 @@ module.exports = {
               throw self.apos.error('conflict');
             }
           }
-          if (isPage) {
+          if (isPage && !skipReplace) {
             for (const page of pages) {
               if (page.path.includes(oldAposDocId)) {
                 await self.apos.doc.db.updateOne({


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Add option `skipReplace` for `apos.doc.changeDocIds` method to skip the replacing of the "old" document in the database.

## What are the specific steps to test this change?

Opting in for this option, results in no DB operations related with the "old" document and the "new" document ID used as a reference for retrieving the "existent" document from the database. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
