### PR TITLE
Keep widget focused when menu is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Fixes
 
-* Registering duplicate icon is no longer breaking the build. 
+* Registering duplicate icon is no longer breaking the build.
+* Fix widget focus state so that the in-context Add Content menu stays visible during animation
+* Fix UI of areas in schemas so that their context menus are layered overtop sibling schema fields UI
 
 ### Adds
 
@@ -12,6 +14,7 @@
 * The new `big-upload-client` module can now be used to upload very large files to any route that uses the new `big-upload-middleware`.
 * Add option `skipReplace` for `apos.doc.changeDocIds` method to skip the replacing of the "old" document in the database.
 * The `@apostrophecms/i18n` module now exposes a `locales` HTTP GET API to aid in implementation of native apps for localized sites.
+* Context menus can be supplied a `menuId` so that interested components can listen to their opening/closing and close them by id.
 
 ## 4.6.0 (2024-08-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * The new `big-upload-client` module can now be used to upload very large files to any route that uses the new `big-upload-middleware`.
 * Add option `skipReplace` for `apos.doc.changeDocIds` method to skip the replacing of the "old" document in the database.
 * The `@apostrophecms/i18n` module now exposes a `locales` HTTP GET API to aid in implementation of native apps for localized sites.
-* Context menus can be supplied a `menuId` so that interested components can listen to their opening/closing and close them by id.
+* Context menus can be supplied a `menuId` so that interested components can listen to their opening/closing.
 
 ## 4.6.0 (2024-08-08)
 

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaContextualMenu.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaContextualMenu.vue
@@ -6,6 +6,7 @@
       :disabled="isDisabled"
       :button="buttonOptions"
       :popover-modifiers="inContext ? ['z-index-in-context'] : []"
+      :menu-id="menuId"
     >
       <ul class="apos-area-menu__wrapper">
         <li
@@ -117,6 +118,12 @@ export default {
       default: function() {
         return {};
       }
+    },
+    menuId: {
+      type: String,
+      default() {
+        return `areaMenu-${createId()}`;
+      }
     }
   },
   emits: [ 'add' ],
@@ -182,9 +189,6 @@ export default {
       } else {
         return menu;
       }
-    },
-    menuId() {
-      return `areaMenu-${createId()}`;
     }
   },
   mounted() {

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
@@ -16,6 +16,7 @@
     :options="options"
     :max-reached="maxReached"
     :disabled="disabled"
+    :menu-id="menuId"
     @add="$emit('add', $event);"
   />
 </template>
@@ -58,6 +59,10 @@ export default {
     tabbable: {
       type: Boolean,
       default: false
+    },
+    menuId: {
+      type: String,
+      required: true
     }
   },
   emits: [ 'add' ],

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -75,6 +75,8 @@
           :options="options"
           :disabled="disabled"
           :tabbable="isHovered || isFocused"
+          :menu-id="`${widget._id}-widget-menu-top`"
+          :class="{[classes.open]: menuOpen === 'top'}"
           @add="$emit('add', $event);"
         />
       </div>
@@ -148,6 +150,8 @@
           :options="options"
           :disabled="disabled"
           :tabbable="isHovered || isFocused"
+          :menu-id="`${widget._id}-widget-menu-bottom`"
+          :class="{[classes.open]: menuOpen === 'bottom'}"
           @add="$emit('add', $event)"
         />
       </div>
@@ -251,6 +255,7 @@ export default {
     return {
       mounted: false, // hack around needing DOM to be rendered for computed classes
       isSuppressed: false,
+      menuOpen: null,
       classes: {
         show: 'apos-is-visible',
         open: 'apos-is-open',
@@ -345,7 +350,8 @@ export default {
     },
     addClasses() {
       return {
-        [this.classes.show]: this.isHovered || this.isFocused
+        [this.classes.show]: this.isHovered || this.isFocused,
+        [`${this.classes.open}--menu-${this.menuOpen}`]: !!this.menuOpen
       };
     },
     foreign() {
@@ -358,6 +364,7 @@ export default {
       if (newVal) {
         this.$refs.wrapper.addEventListener('keydown', this.handleKeyboardUnfocus);
       } else {
+        this.menuOpen = null;
         this.$refs.wrapper.removeEventListener('keydown', this.handleKeyboardUnfocus);
       }
     }
@@ -377,6 +384,7 @@ export default {
     // AposAreaEditor is listening for keyboard input that triggers
     // a 'focus my parent' plea
     apos.bus.$on('widget-focus-parent', this.focusParent);
+    apos.bus.$on('context-menu-opened', this.getFocusForMenu);
 
     this.breadcrumbs.$lastEl = this.$el;
 
@@ -394,6 +402,22 @@ export default {
     apos.bus.$off('widget-focus-parent', this.focusParent);
   },
   methods: {
+
+    getFocusForMenu({ menuId, isOpen }) {
+      if (
+        (
+          menuId === `${this.widget._id}-widget-menu-top` ||
+          menuId === `${this.widget._id}-widget-menu-bottom`
+        ) &&
+        isOpen
+      ) {
+        const whichMenu = menuId.split('-')[menuId.split('-').length - 1];
+        this.menuOpen = whichMenu;
+        this.getFocus(null, this.widget._id);
+      } else {
+        this.menuOpen = null;
+      }
+    },
 
     // Determine whether or not we should adjust the label based on its position to the admin bar
     adjustUi() {
@@ -427,7 +451,9 @@ export default {
 
     // Ask the parent AposAreaEditor to make us focused
     getFocus(e, id) {
-      e.stopPropagation();
+      // if (e) {
+      e?.stopPropagation();
+      // }
       this.isSuppressed = false;
       apos.bus.$emit('widget-focus', id);
     },
@@ -515,6 +541,26 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@mixin showButton() {
+  transform: scale(1.15);
+  background-size: 150% 100%;
+  border-radius: 10px;
+  transition-duration: 500ms;
+
+  /* stylelint-disable-next-line max-nesting-depth */
+  .apos-button__label {
+    max-width: 100px;
+    max-height: 100px;
+    transition-duration: 500ms;
+    padding: 0 5px 0 0;
+  }
+
+  /* stylelint-disable-next-line max-nesting-depth */
+  .apos-button__icon {
+    margin-right: 5px;
+  }
+}
+
   .apos-area-widget-guard {
     position: absolute;
     top: 0;
@@ -657,6 +703,21 @@ export default {
     top: 0;
     left: 50%;
     transform: translate(-50%, -50%);
+    &.apos-area-widget-controls--add--top.apos-is-open--menu-top,
+    &.apos-area-widget-controls--add--bottom.apos-is-open--menu-bottom {
+      z-index: $z-index-widget-focused-controls;
+    }
+  }
+
+  .apos-area-widget-controls--add {
+    &.apos-area-widget-controls--add--top.apos-is-open--menu-top,
+    &.apos-area-widget-controls--add--bottom.apos-is-open--menu-bottom {
+      :deep(.apos-button__wrapper) {
+        .apos-button:not([disabled]) {
+          @include showButton;
+        }
+      }
+    }
   }
 
   .apos-area-widget-controls--add {
@@ -664,23 +725,7 @@ export default {
       padding: 8px;
 
       &:hover .apos-button:not([disabled]) {
-        transform: scale(1.15);
-        background-size: 150% 100%;
-        border-radius: 10px;
-        transition-duration: 500ms;
-
-        /* stylelint-disable-next-line max-nesting-depth */
-        .apos-button__label {
-          max-width: 100px;
-          max-height: 100px;
-          transition-duration: 500ms;
-          padding: 0 5px 0 0;
-        }
-
-        /* stylelint-disable-next-line max-nesting-depth */
-        .apos-button__icon {
-          margin-right: 5px;
-        }
+        @include showButton;
       }
     }
 

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -384,7 +384,7 @@ export default {
     // AposAreaEditor is listening for keyboard input that triggers
     // a 'focus my parent' plea
     apos.bus.$on('widget-focus-parent', this.focusParent);
-    apos.bus.$on('context-menu-opened', this.getFocusForMenu);
+    apos.bus.$on('context-menu-toggled', this.getFocusForMenu);
 
     this.breadcrumbs.$lastEl = this.$el;
 

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -451,9 +451,9 @@ export default {
 
     // Ask the parent AposAreaEditor to make us focused
     getFocus(e, id) {
-      // if (e) {
-      e?.stopPropagation();
-      // }
+      if (e) {
+        e.stopPropagation();
+      }
       this.isSuppressed = false;
       apos.bus.$emit('widget-focus', id);
     },

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -703,6 +703,7 @@ export default {
     top: 0;
     left: 50%;
     transform: translate(-50%, -50%);
+
     &.apos-area-widget-controls--add--top.apos-is-open--menu-top,
     &.apos-area-widget-controls--add--bottom.apos-is-open--menu-bottom {
       z-index: $z-index-widget-focused-controls;
@@ -712,10 +713,10 @@ export default {
   .apos-area-widget-controls--add {
     &.apos-area-widget-controls--add--top.apos-is-open--menu-top,
     &.apos-area-widget-controls--add--bottom.apos-is-open--menu-bottom {
-      :deep(.apos-button__wrapper) {
-        .apos-button:not([disabled]) {
-          @include showButton;
-        }
+
+      /* stylelint-disable-next-line max-nesting-depth */
+      :deep(.apos-button__wrapper .apos-button:not([disabled])) {
+        @include showButton;
       }
     }
   }

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -326,6 +326,9 @@ export default {
         if (this.pending) {
           this.emitWidgetUpdate();
         }
+      } else {
+        apos.bus.$emit('close-context-menu', `${this.modelValue._id}-widget-menu-top`);
+        apos.bus.$emit('close-context-menu', `${this.modelValue._id}-widget-menu-bottom`);
       }
     },
     isShowingInsert(newVal) {

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -327,8 +327,7 @@ export default {
           this.emitWidgetUpdate();
         }
       } else {
-        apos.bus.$emit('close-context-menu', `${this.modelValue._id}-widget-menu-top`);
-        apos.bus.$emit('close-context-menu', `${this.modelValue._id}-widget-menu-bottom`);
+        apos.bus.$emit('close-context-menus');
       }
     },
     isShowingInsert(newVal) {

--- a/modules/@apostrophecms/schema/ui/apos/components/AposInputWrapper.vue
+++ b/modules/@apostrophecms/schema/ui/apos/components/AposInputWrapper.vue
@@ -127,6 +127,11 @@ export default {
   max-width: 100%;
 }
 
+.apos-field__wrapper.apos-field__wrapper--area {
+  z-index: $z-index-area-schema-ui;
+  position: relative;
+}
+
 .apos-field {
   border-width: 0;
   padding: 0;

--- a/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
@@ -138,7 +138,7 @@ export default {
       default: null
     }
   },
-  emits: [ 'click', 'clunk' ],
+  emits: [ 'click' ],
   data() {
     return {
       id: createId()
@@ -222,8 +222,6 @@ export default {
   },
   methods: {
     click($event) {
-      console.log($event);
-      this.$emit('clunk', $event);
       this.$emit('click', $event);
     }
   }

--- a/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
@@ -138,7 +138,7 @@ export default {
       default: null
     }
   },
-  emits: [ 'click' ],
+  emits: [ 'click', 'clunk' ],
   data() {
     return {
       id: createId()
@@ -222,6 +222,8 @@ export default {
   },
   methods: {
     click($event) {
+      console.log($event);
+      this.$emit('clunk', $event);
       this.$emit('click', $event);
     }
   }

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -179,13 +179,11 @@ const { themeClass } = useAposTheme();
 onMounted(() => {
   apos.bus.$on('context-menu-toggled', hideWhenOtherOpen);
   apos.bus.$on('close-context-menu', hideMe);
-  // apos.bus.$on('widget-focus', hide);
 });
 
 onBeforeUnmount(() => {
   apos.bus.$off('context-menu-toggled', hideWhenOtherOpen);
   apos.bus.$off('close-context-menu', hideMe);
-  // apos.bus.$off('widget-focus', hide);
 });
 
 function getMenuOffset() {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -117,7 +117,6 @@ const props = defineProps({
 
 const emit = defineEmits([ 'open', 'close', 'item-clicked' ]);
 
-// const menuId = ref();
 const isOpen = ref(false);
 const placement = ref(props.menuPlacement);
 const event = ref(null);
@@ -195,13 +194,8 @@ function getMenuOffset() {
 }
 
 function hideWhenOtherOpen({ menuId }) {
-  console.log(menuId);
-  console.log(props.menuId);
-  console.log('====');
   if (props.menuId !== menuId) {
     hide();
-  } else {
-    console.log('dont hide me');
   }
 }
 

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -106,12 +106,18 @@ const props = defineProps({
     default() {
       return [];
     }
+  },
+  menuId: {
+    type: String,
+    default() {
+      return createId();
+    }
   }
 });
 
 const emit = defineEmits([ 'open', 'close', 'item-clicked' ]);
 
-const menuId = ref(createId());
+// const menuId = ref();
 const isOpen = ref(false);
 const placement = ref(props.menuPlacement);
 const event = ref(null);
@@ -173,12 +179,12 @@ const { themeClass } = useAposTheme();
 
 onMounted(() => {
   apos.bus.$on('context-menu-opened', hideWhenOtherOpen);
-  apos.bus.$on('widget-focus', hide);
+  // apos.bus.$on('widget-focus', hide);
 });
 
 onBeforeUnmount(() => {
   apos.bus.$off('context-menu-opened', hideWhenOtherOpen);
-  apos.bus.$off('widget-focus', hide);
+  // apos.bus.$off('widget-focus', hide);
 });
 
 function getMenuOffset() {
@@ -188,9 +194,14 @@ function getMenuOffset() {
   };
 }
 
-function hideWhenOtherOpen(id) {
-  if (menuId.value !== id) {
+function hideWhenOtherOpen({ menuId }) {
+  console.log(menuId);
+  console.log(props.menuId);
+  console.log('====');
+  if (props.menuId !== menuId) {
     hide();
+  } else {
+    console.log('dont hide me');
   }
 }
 
@@ -199,8 +210,11 @@ function hide() {
 }
 
 function buttonClicked(e) {
-  apos.bus.$emit('context-menu-opened', menuId.value);
   isOpen.value = !isOpen.value;
+  apos.bus.$emit('context-menu-opened', {
+    menuId: props.menuId,
+    isOpen: isOpen.value
+  });
   event.value = e;
 }
 

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -177,12 +177,14 @@ watch(isOpen, (newVal) => {
 const { themeClass } = useAposTheme();
 
 onMounted(() => {
-  apos.bus.$on('context-menu-opened', hideWhenOtherOpen);
+  apos.bus.$on('context-menu-toggled', hideWhenOtherOpen);
+  apos.bus.$on('close-context-menu', hideMe);
   // apos.bus.$on('widget-focus', hide);
 });
 
 onBeforeUnmount(() => {
-  apos.bus.$off('context-menu-opened', hideWhenOtherOpen);
+  apos.bus.$off('context-menu-toggled', hideWhenOtherOpen);
+  apos.bus.$off('close-context-menu', hideMe);
   // apos.bus.$off('widget-focus', hide);
 });
 
@@ -199,13 +201,19 @@ function hideWhenOtherOpen({ menuId }) {
   }
 }
 
+function hideMe(menuId) {
+  if (props.menuId === menuId) {
+    hide();
+  }
+}
+
 function hide() {
   isOpen.value = false;
 }
 
 function buttonClicked(e) {
   isOpen.value = !isOpen.value;
-  apos.bus.$emit('context-menu-opened', {
+  apos.bus.$emit('context-menu-toggled', {
     menuId: props.menuId,
     isOpen: isOpen.value
   });

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -178,12 +178,12 @@ const { themeClass } = useAposTheme();
 
 onMounted(() => {
   apos.bus.$on('context-menu-toggled', hideWhenOtherOpen);
-  apos.bus.$on('close-context-menu', hideMe);
+  apos.bus.$on('close-context-menus', hide);
 });
 
 onBeforeUnmount(() => {
   apos.bus.$off('context-menu-toggled', hideWhenOtherOpen);
-  apos.bus.$off('close-context-menu', hideMe);
+  apos.bus.$off('close-context-menus', hide);
 });
 
 function getMenuOffset() {
@@ -195,12 +195,6 @@ function getMenuOffset() {
 
 function hideWhenOtherOpen({ menuId }) {
   if (props.menuId !== menuId) {
-    hide();
-  }
-}
-
-function hideMe(menuId) {
-  if (props.menuId === menuId) {
     hide();
   }
 }

--- a/modules/@apostrophecms/ui/ui/apos/scss/mixins/_zindex.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/mixins/_zindex.scss
@@ -12,6 +12,7 @@ $z-index-widget-label: 2;
 $z-index-widget-controls: 3;
 $z-index-manager-toolbar: 3;
 $z-index-widget-focused-controls: 4;
+$z-index-area-schema-ui: 5;
 $z-index-admin-bar: 1000;
 $z-index-modal: 2000;
 $z-index-notifications: 2003;


### PR DESCRIPTION
## Summary

The idea for this fix is that when a widget's context menu is open that widget should assume focus until something else takes it. With this we can ensure all the proper UI stays on the screen without exact pointer interactions
