### PR TITLE
remove focus blockers in page relationship editor

### DIFF
--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -71,7 +71,6 @@
               v-if="options.bulkSelect && index === 0"
               v-model="checkedProxy"
               class="apos-tree__row__checkbox"
-              tabindex="-1"
               :field="{
                 name: row._id,
                 hideLabel: true,
@@ -79,7 +78,6 @@
                   key: 'apostrophe:toggleSelectionOf',
                   title: row.title
                 }),
-                disableFocus: true,
                 readOnly: maxReached && !checked.includes(row._id)
               }"
               :choice="{ value: row._id }"


### PR DESCRIPTION
## Summary

- Removes focus blocker props from checkboxes in the page relationship editor. You can now tab focus the checkbox
https://linear.app/apostrophecms/issue/PRO-4435/%5Baccessibility%5D-make-checkboxes-focusable-and-clickable

## What are the specific steps to test this change?

1. link a demo, npm run
2. in a page relationship field (like SEO Canonical link), test the tab-ability of the page picker

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other