### PR TITLE
Improve context menu positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 * The `@apostrophecms/i18n` module now exposes a `locales` HTTP GET API to aid in implementation of native apps for localized sites.
 * Context menus can be supplied a `menuId` so that interested components can listen to their opening/closing.
 
+### Fixes
+
+* Adds an option to center the context menu arrow on the button icon. Sets this new option on some context menus in the admin UI.
+
 ## 4.6.1 (2024-08-26)
 
 ### Fixes

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarLocale.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarLocale.vue
@@ -5,6 +5,7 @@
     identifier="localePickerTrigger"
     :button="button"
     :unpadded="true"
+    :center-on-icon="true"
     menu-placement="bottom-end"
     @open="open"
     @close="isOpen = false"

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarUser.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarUser.vue
@@ -3,6 +3,7 @@
     class="apos-admin-user"
     :button="button"
     :menu="items"
+    :center-on-icon="true"
     menu-placement="bottom-end"
     @item-clicked="emitEvent"
   >

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextTitle.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextTitle.vue
@@ -31,6 +31,7 @@
           :button="draftButton"
           :menu="draftMenu"
           :disabled="hasCustomUi || isUnpublished"
+          :center-on-icon="true"
           menu-placement="bottom-end"
           @item-clicked="switchDraftMode"
         />

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocLocalePicker.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocLocalePicker.vue
@@ -9,6 +9,7 @@
       identifier="localePickerTrigger"
       :button="button"
       :unpadded="true"
+      :center-on-icon="true"
       menu-placement="bottom-end"
       @open="open"
       @close="isOpen = false"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
@@ -37,6 +37,7 @@
           :icon-size="iconSize"
           class="apos-button__icon"
           :icon-color="iconFill"
+          @icon="$emit('icon', $event)"
         />
         <slot name="label">
           <span class="apos-button__label" :class="{ 'apos-sr-only' : (iconOnly || type === 'color') }">
@@ -138,7 +139,7 @@ export default {
       default: null
     }
   },
-  emits: [ 'click' ],
+  emits: [ 'click', 'icon' ],
   data() {
     return {
       id: createId()

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -16,25 +16,25 @@
         :tooltip="tooltip"
         :attrs="{
           'aria-haspopup': 'menu',
-          'aria-expanded': isOpen ? true : false
+          'aria-expanded': isMenuVisible ? true : false
         }"
         @click.stop="buttonClicked($event)"
       />
       <div
-        v-if="isOpen"
+        v-show="isMenuVisible"
         ref="dropdownContent"
         v-click-outside-element="hide"
         class="apos-context-menu__dropdown-content"
         :class="popoverClass"
         data-apos-menu
         :style="dropdownContentStyle"
-        :aria-hidden="!isOpen"
+        :aria-hidden="!isMenuVisible"
       >
         <AposContextMenuDialog
           :menu-placement="placement"
           :class-list="classList"
           :menu="menu"
-          :is-open="isOpen"
+          :is-open="isMenuVisible"
           @item-clicked="menuItemClicked"
           @set-arrow="setArrow"
         >
@@ -118,6 +118,7 @@ const props = defineProps({
 const emit = defineEmits([ 'open', 'close', 'item-clicked' ]);
 
 const isOpen = ref(false);
+const positionComputed = ref(false);
 const placement = ref(props.menuPlacement);
 const event = ref(null);
 const dropdown = ref();
@@ -129,6 +130,10 @@ const menuOffset = getMenuOffset();
 defineExpose({
   hide,
   setDropdownPosition
+});
+
+const isMenuVisible = computed(() => {
+  return isOpen.value && positionComputed.value;
 });
 
 const popoverClass = computed(() => {
@@ -165,8 +170,10 @@ watch(isOpen, (newVal) => {
     window.addEventListener('scroll', setDropdownPosition);
     window.addEventListener('keydown', handleKeyboard);
     setDropdownPosition();
+    positionComputed.value = true;
     dropdownContent.value.querySelector('[tabindex]')?.focus();
   } else {
+    positionComputed.value = false;
     window.removeEventListener('resize', setDropdownPosition);
     window.removeEventListener('scroll', setDropdownPosition);
     window.removeEventListener('keydown', handleKeyboard);

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -113,6 +113,10 @@ const props = defineProps({
     default() {
       return createId();
     }
+  },
+  centerOnIcon: {
+    type: Boolean,
+    default: false
   }
 });
 
@@ -208,9 +212,8 @@ function hideWhenOtherOpen({ menuId }) {
   }
 }
 
-// Center arrow on chevron-down-icon
 function setIconToCenterTo(el) {
-  if (el && props.button.icon === 'chevron-down-icon') {
+  if (el && props.centerOnIcon) {
     iconToCenterTo.value = el;
   }
 }

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -18,6 +18,7 @@
           'aria-haspopup': 'menu',
           'aria-expanded': isMenuVisible ? true : false
         }"
+        @icon="setIconToCenterTo"
         @click.stop="buttonClicked($event)"
       />
       <div
@@ -125,6 +126,7 @@ const dropdown = ref();
 const dropdownContent = ref();
 const dropdownContentStyle = ref({});
 const arrowEl = ref();
+const iconToCenterTo = ref(null);
 const menuOffset = getMenuOffset();
 
 defineExpose({
@@ -206,6 +208,13 @@ function hideWhenOtherOpen({ menuId }) {
   }
 }
 
+// Center arrow on chevron-down-icon
+function setIconToCenterTo(el) {
+  if (el && props.button.icon === 'chevron-down-icon') {
+    iconToCenterTo.value = el;
+  }
+}
+
 function hide() {
   isOpen.value = false;
 }
@@ -232,9 +241,10 @@ async function setDropdownPosition() {
   if (!dropdown.value || !dropdownContent.value) {
     return;
   }
+  const centerArrowIcon = iconToCenterTo.value || dropdown.value;
   const {
     x, y, middlewareData, placement: dropdownPlacement
-  } = await computePosition(dropdown.value, dropdownContent.value, {
+  } = await computePosition(centerArrowIcon, dropdownContent.value, {
     placement: props.menuPlacement,
     middleware: [
       offset(menuOffset),

--- a/modules/@apostrophecms/ui/ui/apos/components/AposIndicator.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposIndicator.vue
@@ -1,5 +1,6 @@
 <template>
   <span
+    ref="icon"
     v-apos-tooltip="tooltip"
     class="apos-indicator"
     :aria-hidden="decorative"
@@ -43,6 +44,10 @@ export default {
       type: Boolean,
       default: true
     }
+  },
+  emits: [ 'icon' ],
+  mounted() {
+    this.$emit('icon', this.$refs.icon);
   }
 };
 </script>


### PR DESCRIPTION
[PRO-6316](https://linear.app/apostrophecms/issue/PRO-6316/fix-context-menu-position)

## Summary

find a way to center to a specific button icon when asked to, instead of manually placing arrows with padding that could break when zooming or with different wording.

So AposButton and AposIndicator emit the icon element. If we asked to the context menu to center on the icon, it will do it. Pretty simple.

## What are the specific steps to test this change?

Check that context menu arrow is properly centered on:
*  `draft/published` switch on admin bar.
* User settings in admin bar
* Locale switch on admin bar
* New locale switcher in doc editor

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
