### PR TITLE
PRO-6418: Add replaces configuration for editor context menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Context menus can be supplied a `menuId` so that interested components can listen to their opening/closing.
 * Add batch operations to pages.
 * Add shortcuts to pages manager.
+* Add `replaces` (boolean, `false` by default) option to the context operation definition (registered via `apos.doc.addContextOperation()`) to allow the operation to require a replace confirmation before being executed. The user confirmation results in the Editor modal being closed and the operation being executed. The operation is not executed if the user cancels the confirmation.
 
 ### Changes
 

--- a/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
+++ b/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
@@ -429,6 +429,18 @@ export default {
 
     },
     async customAction(doc, operation) {
+      if (operation.replaces) {
+        const confirm = await apos.confirm({
+          heading: 'apostrophe:replaceHeadingPrompt',
+          description: this.$t('apostrophe:replaceDescPrompt'),
+          affirmativeLabel: 'apostrophe:replace',
+          icon: false
+        });
+        if (!confirm) {
+          return;
+        }
+        this.$emit('close', doc);
+      }
       const props = {
         moduleName: operation.moduleName || this.moduleName,
         // For backwards compatibility

--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -405,6 +405,8 @@
   "removeLink": "Remove Link",
   "removeRichTextAnchor": "Remove Rich Text Anchor",
   "replace": "Replace",
+  "replaceHeadingPrompt": "Replace Document?",
+  "replaceDescPrompt": "This operation will replace the contents of this document. Are you sure?",
   "resolveErrorsBeforeSaving": "Resolve errors before saving.",
   "resolveErrorsFirst": "Resolve errors first.",
   "restore": "Restore",


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Add `replaces` (boolean, `false` by default) option to the context operation definition (registered via `apos.doc.addContextOperation()`) to allow the operation to require a replace confirmation before being executed. The user confirmation results in the Editor modal being closed and the operation being executed. The operation is not executed if the user cancels the confirmation.

## What are the specific steps to test this change?

Using a menu item, having `replaces: true` configuration option, results in a confirmation dialog. Confirming closes the editor modal and executes the operation, canceling does not execute the operation and does not close the editor modal.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
