### PR TITLE
add <use> tag to DOMPurify allow list when sanitizing uploaded SVGS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 
+* Uploaded SVGs now permit `<use>` tags granted their `xlink:href` property is a local reference and begins with the `#` character. This improves SVG support while mitgating XSS vulnerabilities.
 * Default properties of object fields present in a widget now populate correctly even if never focused in the editor.
 
 ## 4.7.0 (2024-09-05)

--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -519,6 +519,11 @@ module.exports = {
         const writeFile = require('util').promisify(fs.writeFile);
         const window = new JSDOM('').window;
         const DOMPurify = createDOMPurify(window);
+        DOMPurify.addHook('afterSanitizeAttributes', node => {
+          if (node.hasAttribute('xlink:href') && !node.getAttribute('xlink:href').match(/^#/)) {
+            node.remove();
+          }
+        });
         const dirty = await readFile(path);
         const clean = DOMPurify.sanitize(dirty, {
           ADD_TAGS: [ 'use' ]

--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -520,7 +520,9 @@ module.exports = {
         const window = new JSDOM('').window;
         const DOMPurify = createDOMPurify(window);
         const dirty = await readFile(path);
-        const clean = DOMPurify.sanitize(dirty);
+        const clean = DOMPurify.sanitize(dirty, {
+          ADD_TAGS: [ 'use' ]
+        });
         return writeFile(path, clean);
       },
       getFileGroup(extension) {


### PR DESCRIPTION
## Summary

- Adds `<use>` tag to DOMPurify allow list config on svg upload

## What are the specific steps to test this change?

Test file
![illustration_gift](https://github.com/user-attachments/assets/cfea1739-931d-471b-8098-c5cd7977274a)

### What it looks like when broken
<img width="471" alt="image" src="https://github.com/user-attachments/assets/35dde6c8-c87d-40be-af26-f33397c59aa2">

### What it looks like when `<use>` is allowed
<img width="815" alt="image" src="https://github.com/user-attachments/assets/61cb106c-bfa9-4ba3-99a4-31b111a8988c">

## Notes
There is a configuration profile specifically for SVGs, I would have felt better of using that just *worked*, but it did not. That would look like.
```
// allow all safe SVG elements and SVG Filters, no HTML or MathML
const clean = DOMPurify.sanitize(dirty, {USE_PROFILES: {svg: true, svgFilters: true}});
```
