### PR TITLE
PRO-6591: parked slug overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 * Uploaded SVGs now permit `<use>` tags granted their `xlink:href` property is a local reference and begins with the `#` character. This improves SVG support while mitgating XSS vulnerabilities.
 * Default properties of object fields present in a widget now populate correctly even if never focused in the editor.
-* Ensure `slug` is not modified for parked pages when not configured in `_defaults`.
+* Ensure parked fields are not modified for parked pages when not configured in `_defaults`.
 
 ## 4.7.0 (2024-09-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 * Uploaded SVGs now permit `<use>` tags granted their `xlink:href` property is a local reference and begins with the `#` character. This improves SVG support while mitgating XSS vulnerabilities.
 * Default properties of object fields present in a widget now populate correctly even if never focused in the editor.
+* Ensure `slug` is not modified for parked pages when not configured in `_defaults`.
 
 ## 4.7.0 (2024-09-05)
 

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -846,6 +846,20 @@ module.exports = {
   },
   handlers(self) {
     return {
+      '@apostrophecms/page-type:beforeSave': {
+        handleParkedSlugOverride(req, doc) {
+          if (!doc.parkedId) {
+            return;
+          }
+          const parked = self.parked.find(p => p.parkedId === doc.parkedId);
+          if (!parked) {
+            return;
+          }
+          if (parked.slug && !parked._defaults?.slug) {
+            doc.slug = parked.slug;
+          }
+        }
+      },
       beforeSend: {
         async addLevelAttributeToBody(req) {
           // Add level as a data attribute on the body tag

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -847,7 +847,7 @@ module.exports = {
   handlers(self) {
     return {
       '@apostrophecms/page-type:beforeSave': {
-        handleParkedSlugOverride(req, doc) {
+        handleParkedFieldsOverride(req, doc) {
           if (!doc.parkedId) {
             return;
           }
@@ -855,8 +855,9 @@ module.exports = {
           if (!parked) {
             return;
           }
-          if (parked.slug && !parked._defaults?.slug) {
-            doc.slug = parked.slug;
+          const parkedFields = Object.keys(parked).filter(field => field !== '_defaults');
+          for (const parkedField of parkedFields) {
+            doc[parkedField] = parked[parkedField];
           }
         }
       },

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -242,6 +242,7 @@ module.exports = {
     self.addDuplicateParkedPagesMigration();
     self.apos.migration.add('deduplicateRanks2', self.deduplicateRanks2Migration);
     self.apos.migration.add('missingLastPublishedAt', self.missingLastPublishedAtMigration);
+    self.apos.migration.add('ensureHomeSlug', self.ensureHomeSlugMigration);
     await self.createIndexes();
     self.composeFilters();
   },
@@ -2978,6 +2979,22 @@ database.`);
           }, {
             $set: {
               lastPublishedAt: draft.lastPublishedAt
+            }
+          });
+        });
+      },
+      ensureHomeSlugMigration() {
+        return self.apos.migration.eachDoc({
+          parkedId: 'home'
+        }, async doc => {
+          if (doc.slug === '/') {
+            return;
+          }
+          await self.apos.doc.db.updateOne({
+            _id: doc._id
+          }, {
+            $set: {
+              slug: '/'
             }
           });
         });

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -242,7 +242,6 @@ module.exports = {
     self.addDuplicateParkedPagesMigration();
     self.apos.migration.add('deduplicateRanks2', self.deduplicateRanks2Migration);
     self.apos.migration.add('missingLastPublishedAt', self.missingLastPublishedAtMigration);
-    self.apos.migration.add('ensureHomeSlug', self.ensureHomeSlugMigration);
     await self.createIndexes();
     self.composeFilters();
   },
@@ -2979,22 +2978,6 @@ database.`);
           }, {
             $set: {
               lastPublishedAt: draft.lastPublishedAt
-            }
-          });
-        });
-      },
-      ensureHomeSlugMigration() {
-        return self.apos.migration.eachDoc({
-          parkedId: 'home'
-        }, async doc => {
-          if (doc.slug === '/') {
-            return;
-          }
-          await self.apos.doc.db.updateOne({
-            _id: doc._id
-          }, {
-            $set: {
-              slug: '/'
             }
           });
         });

--- a/test/content-i18n.js
+++ b/test/content-i18n.js
@@ -96,7 +96,7 @@ describe('content-i18n', function() {
     peoplePageFrCA = await apos.page.find(frCAReq, {
       parkedId: 'people'
     }).toObject();
-    assert(peoplePageFrCA.title === 'Altered');
+    assert(peoplePageFrCA.title === 'People');
   });
 
   let home;

--- a/test/events2.js
+++ b/test/events2.js
@@ -45,10 +45,12 @@ describe('Promisified Events: @apostrophecms/doc-type:beforeInsert', function() 
               {
                 type: 'default-page',
                 findMeAgain: true,
-                title: 'Test',
                 slug: '/test',
                 visibility: 'public',
-                parkedId: 'test'
+                parkedId: 'test',
+                _defaults: {
+                  title: 'Test'
+                }
               }
             ]
           }

--- a/test/parked-pages.js
+++ b/test/parked-pages.js
@@ -272,7 +272,7 @@ describe('Parked Pages', function() {
     await validate(apos6, [ '/', '/archive', '/default1', '/default2', '/default3', '/default3/child1' ]);
   });
 
-  it('slug override on save is possible only when slug is configured as default', async function () {
+  it('field override on save is possible only when it is configured as default', async function () {
     this.timeout(20000);
     await t.destroy(apos6);
     apos6 = await t.create({

--- a/test/parked-pages.js
+++ b/test/parked-pages.js
@@ -271,6 +271,81 @@ describe('Parked Pages', function() {
     });
     await validate(apos6, [ '/', '/archive', '/default1', '/default2', '/default3', '/default3/child1' ]);
   });
+
+  it('slug override on save is possible only when slug is configured as default', async function () {
+    this.timeout(20000);
+    await t.destroy(apos6);
+    apos6 = await t.create({
+      root: module,
+      modules: {
+        '@apostrophecms/page': {
+          options: {
+            park: [
+              ...park2,
+              {
+                parkedId: 'default3',
+                type: 'default-page',
+                title: 'Default 3',
+                slug: '/default3'
+              },
+              {
+                parkedId: 'default4',
+                type: 'default-page',
+                title: 'Default 4',
+                _defaults: {
+                  slug: '/default4'
+                }
+              }
+            ]
+          }
+        },
+        'default-page': {}
+      }
+    });
+    const manager = apos6.doc.getManager('default-page');
+    const req = apos.task.getReq({ mode: 'draft' });
+
+    // slug override not possible, slug is NOT configured in defaults
+    {
+      const page = await manager.find(req, {
+        parkedId: 'default3',
+        aposMode: 'draft'
+      }).toObject();
+      assert.strictEqual(page.slug, '/default3');
+      assert.deepStrictEqual(page.parked, [ 'parkedId', 'type', 'title', 'slug' ]);
+
+      page.slug = '/default3-overridden';
+      await manager.update(req, page);
+      const updated = await manager.find(req, {
+        parkedId: 'default3',
+        aposMode: 'draft'
+      }).toObject();
+
+      assert.strictEqual(updated.slug, '/default3');
+    }
+
+    // slug override is possible because slug is configured in defaults
+    {
+      const page = await manager.find(req, {
+        parkedId: 'default4',
+        aposMode: 'draft'
+      }).toObject();
+      assert.strictEqual(page.slug, '/default4');
+      assert.deepStrictEqual(page.parked, [ 'parkedId', 'type', 'title' ]);
+
+      page.slug = '/default4-overridden';
+      await manager.update(req, page);
+      const updated = await manager.find(req, {
+        parkedId: 'default4',
+        aposMode: 'draft'
+      }).toObject();
+
+      assert.strictEqual(updated.slug, '/default4-overridden');
+    }
+
+    await t.destroy(apos6);
+    apos6 = null;
+  });
 });
 
 async function validate(apos, expected) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Ensure `slug` is not modified for parked pages when not configured in `_defaults`. Migrate any site having "home" parked doc with slug different than `/`,

## What are the specific steps to test this change?

Slug of parked page can't be changed if not present in the `_defaults` configuration.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
