### PR TITLE
Modify disabled prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* Modifies the `AposAreaMenu.vue` component to set the `disabled` attribute to `true` if the max number of widgets have been added in an area with `expanded: true`.
+
 ## 4.8.0 (2024-10-03)
 
 ### Adds

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaMenu.vue
@@ -2,7 +2,7 @@
   <AposButton
     v-if="options.expanded"
     v-bind="buttonOptions"
-    :disabled="disabled"
+    :disabled="isDisabled"
     role="button"
     @click="openExpandedMenu(index)"
   />
@@ -15,7 +15,7 @@
     :widget-options="options.widgets"
     :options="options"
     :max-reached="maxReached"
-    :disabled="disabled"
+    :disabled="isDisabled"
     :menu-id="menuId"
     @add="$emit('add', $event);"
   />
@@ -76,6 +76,13 @@ export default {
         iconSize: this.empty ? 20 : 11,
         disableFocus: !this.tabbable
       };
+    },
+    isDisabled() {
+      let flag = this.disabled;
+      if (this.maxReached) {
+        flag = true;
+      }
+      return flag;
     }
   },
   methods: {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
This PR is in response to a customer complaint that when an area has `expanded: true` then the `max` option is no longer respected. The `AposAreaMenu.vue` component passes both `disabled: false` and `max-reached` props. The `AposAreaContextualMenu.vue` component then sets `disabled` using both the passed values of disabled and max-reached. The button component, that allows the opening of the expanded widget preview, does not check the value of max-reached, only disabled. This change alters the value of `disabled` being passed so that the expanded menu respects max-reached. Closes PRO-6621.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

From the [zendesk ticket](https://apostrophetechnologies.zendesk.com/agent/tickets/1014):
For any given widget whose type is area.
1. Case1: set the expanded: true and max: 2
2. Case2: set the expanded: false or better remove expanded field, and max:2
3. Observe that in case1, max:2 doesn't work, it shouldn't let you add widget after second time.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
