### PR TITLE
PRO-6660: modules order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Adds
 
-* Modules can now have a `before: "module-name"` property in their configuration to run (initialization) before another module.
+* Modules can now have a `before: "module-name"` property in their configuration to run (initialization) before another module. That works only for target modules that are initializable. 
 
 ### Fixes
-
+  
 * Modifies the `AposAreaMenu.vue` component to set the `disabled` attribute to `true` if the max number of widgets have been added in an area with `expanded: true`.
 
 ## 4.8.0 (2024-10-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### Adds
+
+* Modules can now have a `before: "module-name"` property in their configuration to run (initialization) before another module.
+
 ### Fixes
 
 * Modifies the `AposAreaMenu.vue` component to set the `disabled` attribute to `true` if the max number of widgets have been added in an area with `expanded: true`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Adds
 
-* Modules can now have a `before: "module-name"` property in their configuration to run (initialization) before another module. That works only for target modules that are initializable. 
+* Modules can now have a `before: "module-name"` property in their configuration to run (initialization) before another module.
 
 ### Fixes
   

--- a/index.js
+++ b/index.js
@@ -611,12 +611,10 @@ async function apostrophe(options, telemetry, rootSpan) {
       const m = modules[name];
       const before = m.before;
       if (m.before === name) {
-        console.warn(`Module "${name}" has a 'before' property that references itself. Skipping.`);
-        continue;
+        throw new Error(`Module "${name}" has a 'before' property that references itself. Skipping.`);
       }
       if (!modules[before]) {
-        console.warn(`Module "${name}" has a 'before' property that references a non-existent module: "${before}". Skipping.`);
-        continue;
+        throw new Error(`Module "${name}" has a 'before' property that references a non-existent module: "${before}". Skipping.`);
       }
       // Add the current module name to the target's beforeSelf.
       modules[before].beforeSelf.push(name);

--- a/index.js
+++ b/index.js
@@ -611,10 +611,10 @@ async function apostrophe(options, telemetry, rootSpan) {
       const m = modules[name];
       const before = m.before;
       if (m.before === name) {
-        throw new Error(`Module "${name}" has a 'before' property that references itself. Skipping.`);
+        throw new Error(`Module "${name}" has a 'before' property that references itself.`);
       }
       if (!modules[before]) {
-        throw new Error(`Module "${name}" has a 'before' property that references a non-existent module: "${before}". Skipping.`);
+        throw new Error(`Module "${name}" has a 'before' property that references a non-existent module: "${before}".`);
       }
       // Add the current module name to the target's beforeSelf.
       modules[before].beforeSelf.push(name);

--- a/index.js
+++ b/index.js
@@ -636,7 +636,6 @@ async function apostrophe(options, telemetry, rootSpan) {
       // Add all the modules that want to be before this one to the target's beforeSelf.
       // Do this recursively for every module from the beforeSelf array that has own `beforeSelf` members.
       addBeforeSelfRecursive(name, m.beforeSelf, target.beforeSelf);
-
     }
 
     // Fill in the sorted array, first wins when uniquefy-ing.

--- a/lib/moog.js
+++ b/lib/moog.js
@@ -141,6 +141,7 @@ module.exports = function(options) {
       'beforeSuperClass',
       'init',
       'afterAllSections',
+      'before',
       'extend',
       'improve',
       'methods',

--- a/test/modules-order.js
+++ b/test/modules-order.js
@@ -67,7 +67,7 @@ describe('Modules Order', function() {
     assert.strictEqual(apos.modules.first.before, undefined);
 
     // Ensure we have the same number of modules when not reordering
-    const actualModuleCount = apos.modules.length;
+    const expectedModuleCount = apos.modules.length;
     await t.destroy(apos);
 
     apos = await t.create({
@@ -96,7 +96,7 @@ describe('Modules Order', function() {
         }
       }
     });
-    assert.strictEqual(apos.modules.length, actualModuleCount, 'module count is not the same');
+    assert.strictEqual(apos.modules.length, expectedModuleCount, 'module count is not the same');
 
     {
       // ...and the natural order should be preserved

--- a/test/modules-order.js
+++ b/test/modules-order.js
@@ -1,0 +1,118 @@
+const assert = require('node:assert/strict');
+const t = require('../test-lib/test.js');
+
+describe('Modules Order', function() {
+
+  let apos;
+
+  this.timeout(t.timeout);
+
+  after(async function () {
+    await t.destroy(apos);
+    apos = null;
+  });
+
+  it('should sort modules based on their "before" property', async function() {
+    apos = await t.create({
+      root: module,
+      modules: {
+        // Before third, but also before first and schema (recursion)
+        strange: {
+          before: 'third',
+          init() { }
+        },
+        // before schema
+        first: {
+          before: '@apostrophecms/schema',
+          init() { }
+        },
+        // before schema, but after first (keep order)
+        second: {
+          before: '@apostrophecms/schema',
+          init() { }
+        },
+        // before first, but also before schema (recursion)
+        third: {
+          before: 'first',
+          init() { }
+        },
+        // before @apostrophecms/image (`before` in a module definition)
+        'test-before': {},
+        usual: {
+          init() { }
+        },
+        // The `before` module is missing, shouldn't be sorted (keep order)
+        missing: {
+          before: 'nope',
+          init() { }
+        }
+      }
+    });
+
+    const expected = [
+      'strange',
+      'third',
+      'first',
+      'second',
+      '@apostrophecms/schema',
+      'test-before',
+      '@apostrophecms/image',
+      'usual',
+      'missing'
+    ];
+    const actual = Object.keys(apos.modules).filter(m => expected.includes(m));
+    assert.deepEqual(actual, expected, 'modules are not sorted as expected');
+
+    // We don't mess with the module owned context.
+    assert.strictEqual(apos.modules.first.before, undefined);
+
+    // Ensure we have the same number of modules when not reordering
+    const actualModuleCount = apos.modules.length;
+    await t.destroy(apos);
+
+    apos = await t.create({
+      root: module,
+      modules: {
+        strange: {
+          init() { }
+        },
+        first: {
+          init() { }
+        },
+        second: {
+          init() { }
+        },
+        third: {
+          init() { }
+        },
+        'test-before': {
+          before: null
+        },
+        usual: {
+          init() { }
+        },
+        missing: {
+          init() { }
+        }
+      }
+    });
+    assert.strictEqual(apos.modules.length, actualModuleCount, 'module count is not the same');
+
+    {
+      // ...and the natural order should be preserved
+      const expected = [
+        '@apostrophecms/schema',
+        '@apostrophecms/image',
+        'strange',
+        'first',
+        'second',
+        'third',
+        'test-before',
+        'usual',
+        'missing'
+      ];
+      const actual = Object.keys(apos.modules).filter(m => expected.includes(m));
+      assert.deepEqual(actual, expected, 'modules are not matching the natural order');
+    }
+  });
+});

--- a/test/modules-order.js
+++ b/test/modules-order.js
@@ -40,11 +40,6 @@ describe('Modules Order', function() {
         'test-before': {},
         usual: {
           init() { }
-        },
-        // The `before` module is missing, shouldn't be sorted (keep order)
-        missing: {
-          before: 'nope',
-          init() { }
         }
       }
     });
@@ -57,8 +52,7 @@ describe('Modules Order', function() {
       '@apostrophecms/schema',
       'test-before',
       '@apostrophecms/image',
-      'usual',
-      'missing'
+      'usual'
     ];
     const actual = Object.keys(apos.modules).filter(m => expected.includes(m));
     assert.deepEqual(actual, expected, 'modules are not sorted as expected');
@@ -90,9 +84,6 @@ describe('Modules Order', function() {
         },
         usual: {
           init() { }
-        },
-        missing: {
-          init() { }
         }
       }
     });
@@ -108,8 +99,7 @@ describe('Modules Order', function() {
         'second',
         'third',
         'test-before',
-        'usual',
-        'missing'
+        'usual'
       ];
       const actual = Object.keys(apos.modules).filter(m => expected.includes(m));
       assert.deepEqual(actual, expected, 'modules are not matching the natural order');

--- a/test/modules-order.js
+++ b/test/modules-order.js
@@ -115,4 +115,28 @@ describe('Modules Order', function() {
       assert.deepEqual(actual, expected, 'modules are not matching the natural order');
     }
   });
+
+  it('should handle circular "before" references', async function () {
+    await t.destroy(apos);
+    apos = await t.create({
+      root: module,
+      modules: {
+        first: {
+          before: 'second',
+          init() { }
+        },
+        second: {
+          before: 'first',
+          init() { }
+        }
+      }
+    });
+
+    const expected = [
+      'second',
+      'first'
+    ];
+    const actual = Object.keys(apos.modules).filter(m => expected.includes(m));
+    assert.deepEqual(actual, expected, 'modules are not sorted as expected');
+  });
 });

--- a/test/modules/test-before/index.js
+++ b/test/modules/test-before/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  before: '@apostrophecms/image',
+  init() {}
+};


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

 Modules can now have a `before: "module-name"` property in their configuration to run (initialization) before another module. That works only for target modules that are initializable. 

## What are the specific steps to test this change?

```js
// my-module/index.js
module.exports = {
  // will be initialized before the core image piece
  before: '@apostrophecms/image'
}
```

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
