### PR TITLE
warnDev now prefixes in the expected way

### DIFF
--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -589,8 +589,11 @@ module.exports = {
         self.logger.warn(...self.convertLegacyLogPayload(args));
       },
 
-      // Identical to `apos.util.warn`, except that the warning is
-      // not displayed if `process.env.NODE_ENV` is `production`.
+      // Identical to `apos.util.warn`, except that (1) the warning is
+      // not displayed if `process.env.NODE_ENV` is `production`, and
+      // (2) if the warning's first argument is a message it is
+      // automatically prefixed with a warning icon.
+      //
       // Also see `warnDevOnce` which is less likely to irritate
       // the developer until they stop paying attention.
 
@@ -601,6 +604,8 @@ module.exports = {
         const m = args[0];
         if ((typeof m) === 'string') {
           args[0] = `⚠️  ${m}`;
+        } else {
+          // Just call warn normally
         }
         self.warn(...args);
       },

--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -598,7 +598,11 @@ module.exports = {
         if (process.env.NODE_ENV === 'production') {
           return;
         }
-        self.warn(...[ '\n⚠️ ', ...args, '\n' ]);
+        const m = args[0];
+        if ((typeof m) === 'string') {
+          args[0] = `⚠️  ${m}`;
+        }
+        self.warn(...args);
       },
 
       // Identical to `apos.util.warnDev`, except that the warning is

--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -604,8 +604,6 @@ module.exports = {
         const m = args[0];
         if ((typeof m) === 'string') {
           args[0] = `⚠️  ${m}`;
-        } else {
-          // Just call warn normally
         }
         self.warn(...args);
       },

--- a/test/log.js
+++ b/test/log.js
@@ -1288,15 +1288,13 @@ describe('structured logging', function () {
       savedArgs = [];
       apos.util.warnDev('some message');
       assert.deepEqual(savedArgs, [ {
-        msg: 'some message',
-        args: [ '\n⚠️ ', '\n' ]
+        msg: '⚠️  some message'
       } ]);
 
       savedArgs = [];
       apos.util.warnDev({ foo: 'bar' });
       assert.deepEqual(savedArgs, [ {
-        foo: 'bar',
-        args: [ '\n⚠️ ', '\n' ]
+        foo: 'bar'
       }
       ]);
 
@@ -1304,16 +1302,15 @@ describe('structured logging', function () {
       apos.util.warnDev('some message', { foo: 'bar' });
       assert.deepEqual(savedArgs, [ {
         foo: 'bar',
-        msg: 'some message',
-        args: [ '\n⚠️ ', '\n' ]
+        msg: '⚠️  some message'
       } ]);
 
       savedArgs = [];
       apos.util.warnDev('some message', 'more', { foo: 'bar' });
       assert.deepEqual(savedArgs, [ {
         foo: 'bar',
-        msg: 'some message',
-        args: [ '\n⚠️ ', 'more', '\n' ]
+        msg: '⚠️  some message',
+        args: [ 'more' ]
       } ]);
 
       savedArgs = [];
@@ -1321,7 +1318,7 @@ describe('structured logging', function () {
       assert.deepEqual(savedArgs, [ {
         foo: 'bar',
         msg: 'some message',
-        args: [ '\n⚠️ ', 'more', '\n' ]
+        args: [ 'more' ]
       } ]);
 
       apos.util.logger.warn = saved;


### PR DESCRIPTION
Before:

<img width="748" alt="image" src="https://github.com/user-attachments/assets/90428e30-abd6-4633-8497-a0a904b6d30b">

After:

<img width="793" alt="image" src="https://github.com/user-attachments/assets/cb8476b4-2c4c-4e4c-b2f1-26b266673470">

This regressed when we introduced structured logging and has looked kind of doofy ever since.