### PR TITLE
Fix menu focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * `pnpm: true` option in `app.js` is no longer breaking the application. 
 * Remove unused `vue-template-compiler` dependency.
 * Prevent un-publishing the `@apostrophecms/global` doc and more generally all singletons.
+* When opening a context menu while another is already opened, prevent from focusing the button of the first one instead of the newly opened menu.
 
 ## 4.7.2 and 4.8.1 (2024-10-09)
 

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -131,6 +131,7 @@ const dropdownContentStyle = ref({});
 const arrowEl = ref(null);
 const iconToCenterTo = ref(null);
 const menuOffset = getMenuOffset();
+const otherMenuOpened = ref(false);
 
 defineExpose({
   hide,
@@ -176,8 +177,11 @@ watch(isOpen, (newVal) => {
     window.removeEventListener('resize', setDropdownPosition);
     window.removeEventListener('scroll', setDropdownPosition);
     window.removeEventListener('keydown', handleKeyboard);
-    dropdown.value.querySelector('[tabindex]').focus();
+    if (!otherMenuOpened.value) {
+      dropdown.value.querySelector('[tabindex]').focus();
+    }
   }
+  otherMenuOpened.value = false;
 }, { flush: 'post' });
 
 const { themeClass } = useAposTheme();
@@ -201,6 +205,7 @@ function getMenuOffset() {
 
 function hideWhenOtherOpen({ menuId }) {
   if (props.menuId !== menuId) {
+    otherMenuOpened.value = true;
     hide();
   }
 }


### PR DESCRIPTION
## Summary

See changelog

## What are the specific steps to test this change?

Open a context menu, then, without closing this one, open another one.
The secondly opened menu should be focused and not the button of the first one that has been closed.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated