### PR TITLE
Pro 6678 mobile preview dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Takes care of an edge case where Media Manager would duplicate search results.
 * Modules can now have a `before: "module-name"` property in their configuration to run (initialization) before another module.
 * Adds AI-generated missing translations
+* Adds the mobile preview dropdown for non visibles breakpoints. Uses the new `shortcut` property to display breakpoints out of the dropdown.
+* Adds possibility to have two icons in a button.
+* Adds a `isActive` state to context menu items. Also adds possibility to add icons to context menu items.
 
 ### Fixes
 

--- a/modules/@apostrophecms/admin-bar/index.js
+++ b/modules/@apostrophecms/admin-bar/index.js
@@ -42,6 +42,9 @@ module.exports = {
       if (index === 9) {
         break;
       }
+      if (!screen.shortcut) {
+        continue;
+      }
 
       breakpointPreviewModeCommands[`${self.__meta.name}:toggle-breakpoint-preview-mode:${name}`] = {
         type: 'item',

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBar.vue
@@ -118,10 +118,6 @@ export default {
   margin-left: auto;
 }
 
-:deep(.apos-context-menu__pane) {
-  min-width: 150px;
-}
-
 :deep(.flip-enter) { // to the ground
   transform: translateY(-20%);
   opacity: 0;

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBreakpointPreviewMode.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBreakpointPreviewMode.vue
@@ -255,7 +255,7 @@ export default {
 
 .apos-admin-bar__breakpoint-preview-mode-dropdown {
   :deep(.apos-admin-bar__breakpoint-preview-mode-dropdown-btn .apos-button) {
-    padding: $spacing-base;
+    padding: $spacing-three-quarters $spacing-base;
     border-radius: var(--a-border-radius);
     border-color: var(--a-base-8);
 

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBreakpointPreviewMode.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBreakpointPreviewMode.vue
@@ -24,6 +24,7 @@
       })"
     />
     <AposContextMenu
+      v-if="showDropdown"
       class="apos-admin-bar__breakpoint-preview-mode-dropdown"
       :button="button"
       :menu="breakpoints"
@@ -66,7 +67,7 @@ export default {
       originalBodyBackground: null,
       shortcuts: this.getShortcuts(),
       breakpoints: this.getBreakpointItems(),
-      screenItems: []
+      showDropdown: false
     };
   },
   computed: {
@@ -90,6 +91,7 @@ export default {
     }
   },
   mounted() {
+    this.setShowDropdown();
     apos.bus.$on(
       'command-menu-admin-bar-toggle-breakpoint-preview-mode',
       this.toggleBreakpointPreviewMode
@@ -225,6 +227,9 @@ export default {
         width,
         height
       });
+    },
+    setShowDropdown() {
+      this.showDropdown = Object.values(this.screens).some(({ shortcut }) => !shortcut);
     }
   }
 };

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBreakpointPreviewMode.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBreakpointPreviewMode.vue
@@ -77,8 +77,8 @@ export default {
       return {
         class: 'apos-admin-bar__breakpoint-preview-mode-dropdown-btn',
         label: {
-          key: this.activeScreen?.width || 'Responsive',
-          localize: false
+          key: this.activeScreen?.label || 'Preview', // TODO: Temporary waiting for new design
+          localize: true
         },
         icon: 'chevron-down-icon',
         secondIcon: this.activeScreen
@@ -196,7 +196,7 @@ export default {
       return Object.entries(this.screens).map(([ name, screen ]) => ({
         name,
         action: name,
-        label: screen.width,
+        label: screen.label,
         width: screen.width,
         height: screen.height,
         icon: this.getScreenIcon(screen)

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBreakpointPreviewMode.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBreakpointPreviewMode.vue
@@ -70,15 +70,20 @@ export default {
     };
   },
   computed: {
+    activeScreen() {
+      return this.mode && this.screens[this.mode];
+    },
     button() {
       return {
         class: 'apos-admin-bar__breakpoint-preview-mode-dropdown-btn',
         label: {
-          key: 'Responsive',
+          key: this.activeScreen?.width || 'Responsive',
           localize: false
         },
         icon: 'chevron-down-icon',
-        secondIcon: 'monitor-icon',
+        secondIcon: this.activeScreen
+          ? this.getScreenIcon(this.activeScreen)
+          : 'monitor-icon',
         modifiers: [ 'icon-right', 'no-motion' ],
         type: 'outline'
       };
@@ -194,10 +199,15 @@ export default {
         label: screen.width,
         width: screen.width,
         height: screen.height,
-        icon: screen.icon || this.getScreenIcon(parseInt(screen.width))
+        icon: this.getScreenIcon(screen)
       }));
     },
-    getScreenIcon(width) {
+    getScreenIcon(screen) {
+      if (screen.icon) {
+        return screen.icon;
+      }
+
+      const width = parseInt(screen.width);
       if (width > 1024) {
         return 'monitor-icon';
       } else if (width > 540) {

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBreakpointPreviewMode.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBreakpointPreviewMode.vue
@@ -18,6 +18,19 @@
       :class="{ 'apos-is-active': mode === name }"
       @click="toggleBreakpointPreviewMode({ mode: name, label: screen.label, width: screen.width, height: screen.height })"
     />
+
+    <AposContextMenu
+      class="apos-admin-bar__breakpoint-preview-mode-dropdown"
+      :button="button"
+      :menu="screenItems"
+      :center-on-icon="true"
+      menu-placement="bottom-end"
+      @item-clicked="emitEvent"
+    >
+      <template #prebutton>
+        <div>icon</div>
+      </template>
+    </AposContextMenu>
   </div>
 </template>
 <script>
@@ -49,8 +62,23 @@ export default {
   data() {
     return {
       mode: null,
-      originalBodyBackground: null
+      originalBodyBackground: null,
+      screenItems: []
     };
+  },
+  computed: {
+    button() {
+      return {
+        class: 'apos-admin-bar__breakpoint-preview-mode-dropdown-btn',
+        label: {
+          key: 'toto',
+          localize: false
+        },
+        icon: 'chevron-down-icon',
+        modifiers: [ 'icon-right', 'no-motion' ],
+        type: 'outline'
+      };
+    }
   },
   mounted() {
     apos.bus.$on('command-menu-admin-bar-toggle-breakpoint-preview-mode', this.toggleBreakpointPreviewMode);
@@ -161,6 +189,14 @@ export default {
     background-color: var(--a-base-10);
     border-radius: var(--a-border-radius);
     outline: 1px solid var(--a-base-7);
+  }
+}
+
+.apos-admin-bar__breakpoint-preview-mode-dropdown {
+  :deep(.apos-admin-bar__breakpoint-preview-mode-dropdown-btn .apos-button) {
+    padding: 5px 10px;
+    border-radius: 3px;
+    border-color: var(--a-base-8);
   }
 }
 </style>

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBreakpointPreviewMode.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBreakpointPreviewMode.vue
@@ -255,12 +255,20 @@ export default {
 
 .apos-admin-bar__breakpoint-preview-mode-dropdown {
   :deep(.apos-admin-bar__breakpoint-preview-mode-dropdown-btn .apos-button) {
-    padding: 7.5px 10px;
-    border-radius: 3.9px;
+    padding: $spacing-base;
+    border-radius: var(--a-border-radius);
     border-color: var(--a-base-8);
 
     &.apos-is-active {
       background-color: transparent;
+    }
+
+    .apos-button__icon {
+      margin-left: $spacing-double;
+    }
+
+    .apos-button__second-icon {
+      margin-right: $spacing-three-quarters;
     }
   }
 }

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextTitle.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextTitle.vue
@@ -201,6 +201,10 @@ export default {
 
   &__document {
     margin-top: 3.5px;
+
+    :deep(.apos-context-menu__pane) {
+      min-width: 150px;
+    }
   }
 }
 

--- a/modules/@apostrophecms/asset/index.js
+++ b/modules/@apostrophecms/asset/index.js
@@ -64,19 +64,22 @@ module.exports = {
           label: 'apostrophe:breakpointPreviewDesktop',
           width: '1440px',
           height: '900px',
-          icon: 'monitor-icon'
+          icon: 'monitor-icon',
+          shortcut: true
         },
         tablet: {
           label: 'apostrophe:breakpointPreviewTablet',
           width: '1024px',
           height: '768px',
-          icon: 'tablet-icon'
+          icon: 'tablet-icon',
+          shortcut: true
         },
         mobile: {
           label: 'apostrophe:breakpointPreviewMobile',
           width: '414px',
           height: '896px',
-          icon: 'cellphone-icon'
+          icon: 'cellphone-icon',
+          shortcut: true
         }
       },
       // Transform method used on media feature

--- a/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
@@ -33,9 +33,9 @@
       <div class="apos-button__content">
         <AposIndicator
           v-if="icon"
+          class="apos-button__icon"
           :icon="icon"
           :icon-size="iconSize"
-          class="apos-button__icon"
           :icon-color="iconFill"
           @icon="$emit('icon', $event)"
         />
@@ -44,6 +44,13 @@
             {{ $t(label, interpolate) }}
           </span>
         </slot>
+        <AposIndicator
+          v-if="secondIcon"
+          class="apos-button__second-icon"
+          :icon="secondIcon"
+          :icon-size="iconSize"
+          :icon-color="iconFill"
+        />
       </div>
     </component>
   </span>
@@ -137,10 +144,15 @@ export default {
     target: {
       type: String,
       default: null
+    },
+    secondIcon: {
+      type: String,
+      default: null
     }
   },
   emits: [ 'click', 'icon' ],
   data() {
+    console.log('this.secondIcon', this.secondIcon);
     return {
       id: createId()
     };
@@ -464,6 +476,11 @@ export default {
       margin-right: 0;
       margin-left: 5px;
     }
+
+    .apos-button__second-icon {
+      margin-right: 5px;
+      margin-left: 0;
+    }
   }
 
   .apos-button--outline {
@@ -632,6 +649,10 @@ export default {
 
   .apos-button__icon {
     margin-right: 5px;
+  }
+
+  .apos-button__second-icon {
+    margin-left: 5px;
   }
 
   .apos-button--danger-on-hover:hover {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposButton.vue
@@ -152,7 +152,6 @@ export default {
   },
   emits: [ 'click', 'icon' ],
   data() {
-    console.log('this.secondIcon', this.secondIcon);
     return {
       id: createId()
     };

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -35,6 +35,7 @@
           :menu-placement="placement"
           :class-list="classList"
           :menu="menu"
+          :active-item="activeItem"
           :is-open="isOpen"
           @item-clicked="menuItemClicked"
           @set-arrow="setArrow"
@@ -117,6 +118,10 @@ const props = defineProps({
   centerOnIcon: {
     type: Boolean,
     default: false
+  },
+  activeItem: {
+    type: String,
+    default: null
   }
 });
 

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
@@ -23,6 +23,7 @@
             :key="item.action"
             :data-apos-test-context-menu-item="item.action"
             :menu-item="item"
+            :is-active="item.name === activeItem"
             :open="isOpen"
             @clicked="menuItemClicked"
           />
@@ -63,8 +64,14 @@ const props = defineProps({
   hasTip: {
     type: Boolean,
     default: true
+  },
+  activeItem: {
+    type: String,
+    default: null
   }
 });
+
+console.log('props.activeItem', props.activeItem);
 
 const emit = defineEmits([ 'item-clicked', 'set-arrow' ]);
 

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
@@ -71,8 +71,6 @@ const props = defineProps({
   }
 });
 
-console.log('props.activeItem', props.activeItem);
-
 const emit = defineEmits([ 'item-clicked', 'set-arrow' ]);
 
 const menuPositions = computed(() => {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuItem.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuItem.vue
@@ -11,7 +11,16 @@
       :data-apos-test-disabled="disabled"
       v-on="disabled ? {} : { click: click }"
     >
-      {{ $t(label) }}
+      <AposIndicator
+        v-if="menuItem.icon"
+        class="apos-context-menu__icon"
+        :icon="menuItem.icon"
+        :icon-size="menuItem.iconSize"
+        :icon-color="menuItem.iconFill"
+      />
+      <span class="apos-context-menu__label">
+        {{ $t(label) }}
+      </span>
     </button>
   </li>
 </template>
@@ -24,7 +33,11 @@ export default {
       type: Object,
       required: true
     },
-    open: Boolean
+    open: Boolean,
+    isActive: {
+      type: Boolean,
+      default: false
+    }
   },
   emits: [ 'clicked' ],
   computed: {
@@ -46,6 +59,9 @@ export default {
         this.menuItem.modifiers.forEach((modifier) => {
           classes.push(`apos-context-menu__button--${modifier}`);
         });
+      }
+      if (this.isActive) {
+        classes.push('apos-context-menu__active');
       }
       return classes.join(' ');
     },
@@ -71,19 +87,23 @@ export default {
 <style lang="scss" scoped>
 .apos-context-menu__item {
   display: flex;
+
 }
 
 .apos-context-menu__button {
   @include type-base;
 
   & {
-    display: inline-block;
+    display: inline-flex;
     flex-grow: 1;
+    align-items: center;
     width: 100%;
-    padding: 10px 20px;
+    margin: 0 10px;
+    padding: 10px;
     border: none;
     color: var(--a-base-1);
     text-align: left;
+    border-radius: 3px;
     background-color: var(--a-background-primary);
   }
 
@@ -134,5 +154,13 @@ export default {
       color: var(--a-base-5);
     }
   }
+
+  .apos-context-menu__icon {
+    margin-right: 7px;
+  }
+}
+
+.apos-context-menu__active {
+  background-color: var(--a-base-10)
 }
 </style>


### PR DESCRIPTION
[PRO-6678](https://linear.app/apostrophecms/issue/PRO-6678/as-a-developer-i-want-all-breakpoints-to-display-in-a-dropdown-menu-so)

## Summary

### Global changes
* Adds possibility to have two icons on `AposButton`.
* Adds possibility to have icons in `AposContextMenuItem.vue`.
* Adds an `active` state for context menu items (only if `isActive` prop is passed).

### Feature changes
* Adds a dropdown for non shortcuts screen of the mobile preview breakpoints.
* Show dropdown only if some screens exist without the prop `shortcut` set to true.

![image](https://github.com/user-attachments/assets/4bfcedde-3631-411d-8fcc-356c252267a4)

![image](https://github.com/user-attachments/assets/ecdbd37d-ce03-405e-ba05-d849346b81bd)

⚠️  For now, when nothing is selected, the button shows `Preview` next ticket is being designed.

## What are the specific steps to test this change?

Play with the config `breakpointPreviewMode` in the asset modules adding breakpoints and check the dropdown reacts well.

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated