### PR TITLE
Pro 6666 page move setting page as modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 * Remove unused `vue-template-compiler` dependency.
 * Prevent un-publishing the `@apostrophecms/global` doc and more generally all singletons.
 * When opening a context menu while another is already opened, prevent from focusing the button of the first one instead of the newly opened menu.
+* Updates `isEqual` method of `area` field type to avoid comparing an area having temporary properties with one having none.
+
 
 ## 4.7.2 and 4.8.1 (2024-10-09)
 

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -46,10 +46,15 @@ module.exports = (self) => {
       return self.apos.area.isEmpty({ area: value });
     },
     isEqual (req, field, one, two) {
-      if (self.apos.area.isEmpty({ area: one[field.name] }) && self.apos.area.isEmpty({ area: two[field.name] })) {
+      const oneArea = self.apos.util.clonePermanent(one[field.name] || {});
+      const twoArea = self.apos.util.clonePermanent(two[field.name] || {});
+      if (
+        self.apos.area.isEmpty({ area: oneArea }) &&
+        self.apos.area.isEmpty({ area: twoArea })
+      ) {
         return true;
       }
-      return _.isEqual(one[field.name], two[field.name]);
+      return _.isEqual(oneArea, twoArea);
     },
     validate: function (field, options, warn, fail) {
       let widgets = (field.options && field.options.widgets) || {};


### PR DESCRIPTION
[PRO-6666](https://linear.app/apostrophecms/issue/PRO-6666/when-i-drag-and-drop-a-page-into-a-different-order-the-pending-updates)

## Summary

Fix pages being marked with `Pending Updates` when moved.
It appeared because the areas comparison was comparing draft areas with temporary properties (`_edit`, `_docId`) and areas without.

## What are the specific steps to test this change?

Move pages, you should never see a `Pending Updates` that wasn't here before appearing after a page move.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
