### PR TITLE
adds logic in relationship field validate to add to projection sub re…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 * Prevent un-publishing the `@apostrophecms/global` doc and more generally all singletons.
 * When opening a context menu while another is already opened, prevent from focusing the button of the first one instead of the newly opened menu.
 * Updates `isEqual` method of `area` field type to avoid comparing an area having temporary properties with one having none.
+* In a relationship field, when asking for sub relationships using `withRelationships` an dot notion. 
+If this is done in combination with a projection, this projection is updated to add the id storage fields of the needed relationships for the whole `withRelationships` path. 
 
 
 ## 4.7.2 and 4.8.1 (2024-10-09)

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1758,10 +1758,11 @@ module.exports = {
               add.push('metaType');
             }
 
+            const type = query.get('type');
             // Add relationships storage fields in projection
             if (relationships && Object.keys(projection).length) {
               console.log('relationships', relationships);
-              const type = query.get('type');
+              console.log('type', type);
               const manager = self.apos.doc.getManager(type);
               if (Array.isArray(relationships)) {
                 relationships.forEach(relPath => {
@@ -1777,6 +1778,26 @@ module.exports = {
                 /* const relationships = self.apos.schema.findRelationships(self.schema); */
               }
             }
+
+            // Add relationships storage fields in projection
+            /* if (relationships && Object.keys(projection).length) { */
+            /*   const type = query.get('type'); */
+            /*   console.log('type', type); */
+            /*   const manager = self.apos.doc.getManager(type); */
+            /*   console.dir(manager, { depth: 0 }); */
+            /**/
+            /*   if (manager) { */
+            /*     for (const field of manager.schema) { */
+            /*       if (field.type !== 'relationship') { */
+            /*         continue; */
+            /*       } */
+            /**/
+            /*       if (relationships === true || relationships.includes(field.name)) { */
+            /*         add.push(field.idsStorage); */
+            /*       } */
+            /*     } */
+            /*   } */
+            /* } */
 
             for (const [ key, val ] of Object.entries(projection)) {
               if (!val) {

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1779,6 +1779,9 @@ module.exports = {
 
                   if (relationships === true || directRelations.includes(field.name)) {
                     add.push(field.idsStorage);
+                    if (field.fieldsStorage) {
+                      add.push(field.fieldsStorage);
+                    }
                   }
                 }
               }

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1758,46 +1758,27 @@ module.exports = {
               add.push('metaType');
             }
 
-            const type = query.get('type');
             // Add relationships storage fields in projection
             if (relationships && Object.keys(projection).length) {
-              console.log('relationships', relationships);
-              console.log('type', type);
+              // Didn't find any other way, should work
+              const type = query.get('type');
               const manager = self.apos.doc.getManager(type);
-              if (Array.isArray(relationships)) {
-                relationships.forEach(relPath => {
-                  const [ relName ] = relPath.split('.');
-                  const relField = manager.schema.find((field) => field.name === relName);
-                  console.log('relField', relField);
-                  if (relField) {
-                    add.push(relField.idsStorage);
+              const directRelations = Array.isArray(relationships)
+                ? relationships.map(rel => rel.split('.')[0])
+                : [];
+
+              if (manager) {
+                for (const field of manager.schema) {
+                  if (field.type !== 'relationship') {
+                    continue;
                   }
-                });
-              } else {
-                // TODO: How? Get all relationships from schema?
-                /* const relationships = self.apos.schema.findRelationships(self.schema); */
+
+                  if (relationships === true || directRelations.includes(field.name)) {
+                    add.push(field.idsStorage);
+                  }
+                }
               }
             }
-
-            // Add relationships storage fields in projection
-            /* if (relationships && Object.keys(projection).length) { */
-            /*   const type = query.get('type'); */
-            /*   console.log('type', type); */
-            /*   const manager = self.apos.doc.getManager(type); */
-            /*   console.dir(manager, { depth: 0 }); */
-            /**/
-            /*   if (manager) { */
-            /*     for (const field of manager.schema) { */
-            /*       if (field.type !== 'relationship') { */
-            /*         continue; */
-            /*       } */
-            /**/
-            /*       if (relationships === true || relationships.includes(field.name)) { */
-            /*         add.push(field.idsStorage); */
-            /*       } */
-            /*     } */
-            /*   } */
-            /* } */
 
             for (const [ key, val ] of Object.entries(projection)) {
               if (!val) {

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1759,7 +1759,11 @@ module.exports = {
             }
 
             // Add relationships storage fields in projection
-            if (relationships && Object.keys(projection).length) {
+            if (
+              relationships &&
+              Object.keys(projection).length &&
+              !Object.values(projection).some((val) => !val)
+            ) {
               // Didn't find any other way, should work
               const type = query.get('type');
               const manager = self.apos.doc.getManager(type);

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -934,7 +934,10 @@ module.exports = {
               _.each(_objects, function (object) {
                 if (object[relationship.name]) {
                   const locale = `${req.locale}:${req.mode}`;
-                  object[relationship.name] = self.apos.util.orderById(object[relationship.idsStorage].map(id => `${id}:${locale}`), object[relationship.name]);
+                  object[relationship.name] = self.apos.util.orderById(
+                    object[relationship.idsStorage].map(id => `${id}:${locale}`),
+                    object[relationship.name]
+                  );
                 }
               });
             }

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -1061,9 +1061,21 @@ module.exports = (self) => {
 
     relate: async function (req, field, objects, options) {
       if ((!self.apos.doc?.replicateReached) && (!field.idsStorage)) {
-        self.apos.util.warnDevOnce('premature-relationship-query', 'Database queries for types with relationships may fail if made before the @apostrophecms/doc:beforeReplicate event');
+        self.apos.util.warnDevOnce(
+          'premature-relationship-query',
+          'Database queries for types with relationships may fail if made before the @apostrophecms/doc:beforeReplicate event'
+        );
       }
-      return self.relationshipDriver(req, joinr.byArray, false, objects, field.idsStorage, field.fieldsStorage, field.name, options);
+      return self.relationshipDriver(
+        req,
+        joinr.byArray,
+        false,
+        objects,
+        field.idsStorage,
+        field.fieldsStorage,
+        field.name,
+        options
+      );
     },
 
     addQueryBuilder(field, query) {
@@ -1129,6 +1141,7 @@ module.exports = (self) => {
       if (!field.withType) {
         fail('withType property is missing. Hint: it must match the name of a doc type module.');
       }
+
       if (Array.isArray(field.withType)) {
         _.each(field.withType, function (type) {
           lintType(type);
@@ -1152,6 +1165,14 @@ module.exports = (self) => {
           const fields = fieldsOption && fieldsOption.add;
           field.fields = fields && klona(fields);
           field.schema = self.fieldsToArray(`Relationship field ${field.name}`, field.fields);
+        }
+
+        if (field.withRelationships && field.builders?.project) {
+          for (const relName of field.withRelationships) {
+            const relManager = self.apos.doc.getManager(field.withType);
+            const relField = relManager.schema.find((f) => f.name === relName);
+            field.builders.project[relField.idsStorage] = 1;
+          }
         }
       }
       validateSchema(field);

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -1166,14 +1166,6 @@ module.exports = (self) => {
           field.fields = fields && klona(fields);
           field.schema = self.fieldsToArray(`Relationship field ${field.name}`, field.fields);
         }
-
-        if (field.withRelationships && field.builders?.project) {
-          for (const relName of field.withRelationships) {
-            const relManager = self.apos.doc.getManager(field.withType);
-            const relField = relManager.schema.find((f) => f.name === relName);
-            field.builders.project[relField.idsStorage] = 1;
-          }
-        }
       }
       validateSchema(field);
       if (field.filters) {

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -1141,7 +1141,6 @@ module.exports = (self) => {
       if (!field.withType) {
         fail('withType property is missing. Hint: it must match the name of a doc type module.');
       }
-
       if (Array.isArray(field.withType)) {
         _.each(field.withType, function (type) {
           lintType(type);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "eslint-fix": "npm run eslint -- --fix",
     "i18n": "node scripts/lint-i18n",
     "stylelint": "stylelint modules/**/*.{scss,vue}",
-    "lint": "npm run eslint && npm run i18n && npm run stylelint"
+    "lint": "npm run eslint && npm run i18n && npm run stylelint",
+    "mocha": "mocha"
   },
   "repository": {
     "type": "git",

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -611,21 +611,19 @@ describe('Pieces', function() {
     assert(person._things.length === 2);
   });
 
-  it('people cannot find things via a relationship with an inadequate projection', function() {
+  it('people can find things via a relationship with relationship storage fields in projection', async function() {
     const req = apos.task.getReq();
-    return apos.doc.getManager('person').find(req, {}, {
+    const person = await apos.person.find(req, {}, {
       // Use the options object rather than a chainable method
       project: {
         title: 1
       }
-    }).toObject()
-      .then(function(person) {
-        assert(person);
-        assert(person.title === 'Bob');
-        // Verify projection
-        assert(!person.slug);
-        assert((!person._things) || (person._things.length === 0));
-      });
+    }).toObject();
+
+    assert(person);
+    assert(person.title === 'Bob');
+    assert(!person.slug);
+    assert(person._things.length === 2);
   });
 
   it('people can find things via a relationship with a "projection" of the relationship name', function() {

--- a/test/relationships.js
+++ b/test/relationships.js
@@ -1,0 +1,193 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert');
+
+describe('Relationships', function() {
+
+  let apos;
+  let req;
+
+  before(async function() {
+    apos = await t.create({
+      root: module,
+      modules: getModules()
+    });
+
+    req = apos.task.getReq();
+    await insertRelationships(apos);
+  });
+
+  after(async function () {
+    await t.destroy(apos);
+  });
+
+  this.timeout(t.timeout);
+
+  it('should get multiple levels of relationships when withRelationships is an array', async function() {
+    const homePage = await apos.page.find(req, { slug: '/' }).toObject();
+
+    assert.equal(homePage.main.items[0]._relPage[0]._articles[0].title, 'article 1');
+  });
+
+  it('should get one level of relationships when withRelationships is true', async function() {
+    const paper = await apos.paper.find(req, { title: 'paper 1' }).toObject();
+    console.log('paper', paper);
+
+  });
+
+});
+
+async function insertRelationships(apos) {
+  const req = apos.task.getReq();
+
+  const topic = await apos.topic.insert(req, {
+    ...apos.topic.newInstance(),
+    title: 'topic 1'
+  });
+
+  const article1 = await apos.article.insert(req, {
+    ...apos.article.newInstance(),
+    title: 'article 1',
+    _topics: [ topic ]
+  });
+
+  const article2 = await apos.article.insert(req, {
+    ...apos.article.newInstance(),
+    title: 'article 2',
+    _topics: []
+  });
+
+  await apos.paper.insert(req, {
+    ...apos.paper.newInstance(),
+    title: 'paper 1',
+    _articles: [ article1, article2 ]
+  });
+
+  const page = await apos.page.insert(req, '_home', 'lastChild', {
+    ...apos.modules['default-page'].newInstance(),
+    title: 'page 1',
+    slug: '/page-1',
+    _articles: [ article1 ]
+  });
+
+  const homePage = await apos.page.find(req, { slug: '/' }).toObject();
+
+  homePage.main.items = [
+    {
+      title: 'Random',
+      _id: 'e5vrmk1lodf0qaogb92ge3b9',
+      metaType: 'widget',
+      type: 'random',
+      aposPlaceholder: false,
+      relPageIds: [ page.aposDocId ],
+      relPageFields: { [page.aposDocId]: {} }
+    }
+  ];
+
+  await apos.page.update(req, homePage);
+};
+
+function getModules() {
+  return {
+    '@apostrophecms/home-page': {
+      fields: {
+        add: {
+          main: {
+            type: 'area',
+            options: {
+              widgets: {
+                random: {}
+              }
+            }
+          }
+        }
+      }
+    },
+    'random-widget': {
+      extend: '@apostrophecms/widget-type',
+      fields: {
+        add: {
+          title: {
+            label: 'Title',
+            type: 'string',
+            required: true
+          },
+          _relPage: {
+            label: 'Rel page',
+            type: 'relationship',
+            withType: 'default-page',
+            withRelationships: true,
+            builders: {
+              project: {
+                title: 1
+              }
+            }
+          }
+        }
+      }
+    },
+    'default-page': {
+      extend: '@apostrophecms/page-type',
+      fields: {
+        add: {
+          _articles: {
+            label: 'Articles',
+            type: 'relationship',
+            withType: 'article',
+            builders: {
+              project: {
+                title: 1
+              }
+            }
+          }
+        }
+      }
+    },
+    paper: {
+      extend: '@apostrophecms/piece-type',
+      options: {
+        alias: 'paper'
+      },
+      fields: {
+        add: {
+          _articles: {
+            label: 'Articles',
+            type: 'relationship',
+            withType: 'article',
+            withRelationships: true,
+            builders: {
+              project: {
+                title: 1
+              }
+            }
+          }
+        }
+      }
+    },
+    article: {
+      extend: '@apostrophecms/piece-type',
+      options: {
+        alias: 'article',
+        publicApiProjection: {
+          title: 1,
+          _url: 1
+        }
+      },
+      fields: {
+        add: {
+          _topics: {
+            label: 'Topics',
+            type: 'relationship',
+            withType: 'topic',
+            required: false
+          }
+        }
+      }
+    },
+    topic: {
+      extend: '@apostrophecms/piece-type',
+      options: {
+        alias: 'topic'
+      }
+    }
+  };
+}

--- a/test/relationships.js
+++ b/test/relationships.js
@@ -24,7 +24,24 @@ describe('Relationships', function() {
 
   it('should get multiple levels of relationships when withRelationships is an array', async function() {
     const homePage = await apos.page.find(req, { slug: '/' }).toObject();
-    assert.equal(homePage.main.items[0]._pages[0]._articles[0].title, 'article 1');
+    const subPage = homePage.main.items[0]._pages[0];
+    const subArticle = subPage._articles[0];
+    const subTopic = subArticle._topics[0];
+
+    const expected = {
+      subArticleTitle: 'article 1',
+      subTopicTitle: 'topic 1',
+      hasArticlesFields: true,
+      hasTopcicsFields: true
+    };
+    const actual = {
+      subArticleTitle: subArticle.title,
+      subTopicTitle: subTopic.title,
+      hasArticlesFields: Boolean(subPage.articlesFields),
+      hasTopcicsFields: Boolean(subArticle.topicsFields)
+    };
+
+    assert.deepEqual(actual, expected);
   });
 
   it('should get one level of relationships when withRelationships is true', async function() {


### PR DESCRIPTION
[PRO-6535](https://linear.app/apostrophecms/issue/PRO-6535/projection-not-working-with-nested-relationships)

## Summary

When validating relationship fields, if there `withRelationships` and `builders.project` are set, add needed `idsStorage` fields to project in order to be able to retrieve sub relationship.

## New behavior

If `withRelationships` is set to `\true` we take all first level relationships,
```javascript
          _pages: {
            label: 'Pages',
            type: 'relationship',
            withType: 'default-page',
            withRelationships: true,
            builders: {
              project: {
                title: 1,
                _url: 1
              }
            }
          }
```
In this case if the `default-page` has relationships to foodArticles and sportArticles, it will incluce both.
But if foodArticles has a relationship to topics, it won't take it.
this behavior already worked but was not documented, I just made sure it still works with missing projections.

If `withRelationships` is an array with one or multiple levels of relationships using the dot notation. for each one having a projection, we add the missing fields to build these relationships.

```javascript
          _pages: {
            label: 'Rel page',
            type: 'relationship',
            withType: 'default-page',
            withRelationships: [ '_articles._topics' ],
            builders: {
              project: {
                title: 1
              }
            }
          }
```

In this case we will get pages, their articles and the topics of the articles. Even if the projections on each level do not include the needed relationship properties.

⚠️ It might change some existing behavior since if relationship is not explicitly false we take the first level of relationship even if the projection does not include the right field. I would argue that it's not a problematic change since it's the normal behavior when no projection.

## What are the specific steps to test this change?

See Ticket description:
* Create widget with relationship to a page
* create piece
* add relationship from page to piece
In widget, if a project is added to page (even without idsStorage for the sub relationship) it should work.

If you don't want to spend time configuring a project to test it, I created a branch for you:
https://github.com/ValJed/a3-wp/tree/pro-6535-projections-sub-relationships

It reproduces the behavior described in the ticket.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
