### PR TITLE
target only data-apos-refreshable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,14 @@ with dynamic choices in this way.
 * Adds AI-generated missing translations
 * Adds the mobile preview dropdown for non visibles breakpoints. Uses the new `shortcut` property to display breakpoints out of the dropdown.
 * Adds possibility to have two icons in a button.
+* Breakpoint preview only targets `[data-apos-refreshable]`.
 * Adds a `isActive` state to context menu items. Also adds possibility to add icons to context menu items.
 * Add a postcss plugin to handle `vh` and `vw` values on breakpoint preview mode.
-* Breakpoint preview only targets `[data-apos-refreshable]`.
 
 ### Changes
 
 * Silence deprecation warnings from Sass 1.80+ regarding the use of `@import`. The Sass team [has stated there will be a two-year transition period](https://sass-lang.com/documentation/breaking-changes/import/#transition-period) before the feature is actually removed. The use of `@import` is common practice in the Apostrophe codebase and in many project codebases. We will arrange for an orderly migration to the new `@use` directive before Sass 3.x appears.
+* Move saving indicator after breakpoint preview.
 * Internal methods `mergeConfiguration`, `autodetectBundles`, `lintModules`, `nestedModuleSubdirs` and `testDir` are now async.
 * `express.getSessionOptions` is now async.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ with dynamic choices in this way.
 * Adds possibility to have two icons in a button.
 * Adds a `isActive` state to context menu items. Also adds possibility to add icons to context menu items.
 * Add a postcss plugin to handle `vh` and `vw` values on breakpoint preview mode.
+* Breakpoint preview only targets `[data-apos-refreshable]`.
 
 ### Changes
 

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
@@ -6,10 +6,6 @@
           :v-if="editMode"
           :can-undo="canUndo"
           :can-redo="canRedo"
-          :retrying="retrying"
-          :editing="editing"
-          :saving="saving"
-          :saved="saved"
           @undo="undo"
           @redo="redo"
         />
@@ -19,6 +15,13 @@
           :resizable="breakpointPreviewModeResizable"
           @switch-breakpoint-preview-mode="addContextLabel"
           @reset-breakpoint-preview-mode="removeContextLabel"
+        />
+        <TheAposSavingIndicator
+          :key="'status'"
+          :retrying="retrying"
+          :editing="editing"
+          :saving="saving"
+          :saved="saved"
         />
       </div>
 

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBreakpointPreviewMode.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBreakpointPreviewMode.vue
@@ -280,14 +280,13 @@ export default {
   align-items: center;
   margin-left: $spacing-base;
 
-  // NOTE Restore this when BP's CSS re-writes ignore apos admin styles
-  // &:not(&--no-dropdown) .apos-admin-bar__breakpoint-preview-mode-shortcuts {
-  //   display: none;
+  &:not(&--no-dropdown) .apos-admin-bar__breakpoint-preview-mode-shortcuts {
+    display: none;
 
-  //   @include media-up(hands-wide) {
-  //     display: flex;
-  //   }
-  // }
+    @include media-up(hands-wide) {
+      display: flex;
+    }
+  }
 }
 
 .apos-admin-bar__breakpoint-preview-mode-button {

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextUndoRedo.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextUndoRedo.vue
@@ -35,13 +35,6 @@
         @click="redo"
       />
     </div>
-    <TheAposSavingIndicator
-      :key="'status'"
-      :retrying="retrying"
-      :editing="editing"
-      :saving="saving"
-      :saved="saved"
-    />
   </transition-group>
 </template>
 
@@ -51,11 +44,7 @@ export default {
   name: 'TheAposContextUndoRedo',
   props: {
     canUndo: Boolean,
-    canRedo: Boolean,
-    retrying: Boolean,
-    editing: Boolean,
-    saving: Boolean,
-    saved: Boolean
+    canRedo: Boolean
   },
   emits: [ 'undo', 'redo' ],
   computed: {

--- a/modules/@apostrophecms/ui/ui/apos/scss/global/_breakpoint_preview.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/_breakpoint_preview.scss
@@ -10,6 +10,7 @@
 }
 
 body[data-breakpoint-preview-mode] {
+  container-type: size;
   background: var(--a-base-10);
 
   [data-apos-context-label] {
@@ -27,7 +28,9 @@ body[data-breakpoint-preview-mode] {
     background-color: var(--a-background-primary);
 
     &[data-resizable="false"] {
-      transition: width 400ms ease, height 400ms ease;
+      transition:
+        width 400ms ease,
+        height 400ms ease;
     }
 
     &[data-resizable="true"] {
@@ -35,5 +38,4 @@ body[data-breakpoint-preview-mode] {
       overflow: scroll;
     }
   }
-
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Target only data-apos-refreshable + move saving indicator after breakpoint preview

## What are the specific steps to test this change?

1. in `modules/@apostrophecms/asset/index.js`, set one breakpoint with `shortcut: false` and another one with `shortcut: true`
2. enable breakpoint preview and navigate between the shortcut preview and the non shortcut preview + check the display of the breakpoint preview in the admin bar
3. edit a rich-text and look for the saving indicator next to the breakpoint preview icon in the admin bar
![image](https://github.com/user-attachments/assets/02fbf986-0452-45a2-87bd-563c5ae593cd)


## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
