### PR TITLE
PRO-6742: don't fall over if there is no context page or piece

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ with dynamic choices in this way.
 * Updates `isEqual` method of `area` field type to avoid comparing an area having temporary properties with one having none.
 * In a relationship field, when asking for sub relationships using `withRelationships` an dot notion. 
 If this is done in combination with a projection, this projection is updated to add the id storage fields of the needed relationships for the whole `withRelationships` path. 
+* The admin UI no longer fails to function when the HTML page is rendered with a direct `sendPage` call and there is no current "in context" page or piece.
 
 ## 4.7.2 and 4.8.1 (2024-10-09)
 

--- a/modules/@apostrophecms/admin-bar/index.js
+++ b/modules/@apostrophecms/admin-bar/index.js
@@ -377,6 +377,7 @@ module.exports = {
         }
         const items = self.getVisibleItems(req);
         const context = req.data.piece || req.data.page;
+        console.log(`for ${req.url} the context is: ${context?.slug}`);
         // Page caching is never desirable when possibly
         // editing that page
         if (context && context._edit) {

--- a/modules/@apostrophecms/admin-bar/index.js
+++ b/modules/@apostrophecms/admin-bar/index.js
@@ -377,7 +377,6 @@ module.exports = {
         }
         const items = self.getVisibleItems(req);
         const context = req.data.piece || req.data.page;
-        console.log(`for ${req.url} the context is: ${context?.slug}`);
         // Page caching is never desirable when possibly
         // editing that page
         if (context && context._edit) {

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBar.vue
@@ -756,8 +756,8 @@ export default {
       }
     },
     async getPublished() {
-      const moduleOptions = window.apos.modules[this.context.type];
-      const manuallyPublished = moduleOptions.localized && !this.autopublish;
+      const moduleOptions = window.apos.modules?.[this.context.type];
+      const manuallyPublished = moduleOptions?.localized && !this.autopublish;
       if (manuallyPublished && this.context.lastPublishedAt) {
         const action = window.apos.modules[this.context.type].action;
         try {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

The admin UI now functions reasonably when the current URL was rendered directly with `sendPage` and there is no "in context" page or piece.

## What are the specific steps to test this change?

I tested this fix in BM's project, then gave them a simpler way since their situation really did call for a "current page" to exist anyway (they were implementing fancy rendering of a parked page and didn't know about dispatch yet).

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
