### PR TITLE
`detectDocChange` now returns `true` when one of the docs contains `modified: true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ with dynamic choices in this way.
 * Move saving indicator after breakpoint preview.
 * Internal methods `mergeConfiguration`, `autodetectBundles`, `lintModules`, `nestedModuleSubdirs` and `testDir` are now async.
 * `express.getSessionOptions` is now async.
+* `detectDocChange` now returns `true` when one of the docs contains `modified: true`.
 
 ### Fixes
 

--- a/modules/@apostrophecms/schema/ui/apos/lib/detectChange.js
+++ b/modules/@apostrophecms/schema/ui/apos/lib/detectChange.js
@@ -24,6 +24,9 @@ export function detectDocChange(schema, v1, v2, options = {}) {
     });
     return differences;
   } else {
+    if (v1.modified || v2.modified) {
+      return true;
+    }
     return schema.some(field => {
       return detectFieldChange(field, v1[field.name], v2[field.name]);
     });


### PR DESCRIPTION

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

See https://github.com/apostrophecms/import-export/pull/95

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
