### PR TITLE
Pro 6535 revision

### DIFF
--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1760,16 +1760,14 @@ module.exports = {
 
             // Add relationships storage fields in projection
             if (
-              relationships &&
+              Array.isArray(relationships) &&
               Object.keys(projection).length &&
               !Object.values(projection).some((val) => !val)
             ) {
               // Didn't find any other way, should work
               const type = query.get('type');
               const manager = self.apos.doc.getManager(type);
-              const directRelations = Array.isArray(relationships)
-                ? relationships.map(rel => rel.split('.')[0])
-                : [];
+              const directRelations = relationships.map(rel => rel.split('.')[0]);
 
               if (manager) {
                 for (const field of manager.schema) {
@@ -2233,7 +2231,7 @@ module.exports = {
           finalize() {
             const type = query.get('type');
             if (type) {
-              query.and({ type: type });
+              query.and({ type });
             }
           }
         },

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -611,19 +611,21 @@ describe('Pieces', function() {
     assert(person._things.length === 2);
   });
 
-  it('people can find things via a relationship with relationship storage fields in projection', async function() {
+  it('people cannot find things via a relationship with an inadequate projection', function() {
     const req = apos.task.getReq();
-    const person = await apos.person.find(req, {}, {
+    return apos.doc.getManager('person').find(req, {}, {
       // Use the options object rather than a chainable method
       project: {
         title: 1
       }
-    }).toObject();
-
-    assert(person);
-    assert(person.title === 'Bob');
-    assert(!person.slug);
-    assert(person._things.length === 2);
+    }).toObject()
+      .then(function(person) {
+        assert(person);
+        assert(person.title === 'Bob');
+        // Verify projection
+        assert(!person.slug);
+        assert((!person._things) || (person._things.length === 0));
+      });
   });
 
   it('people can find things via a relationship with a "projection" of the relationship name', function() {

--- a/test/relationships.js
+++ b/test/relationships.js
@@ -44,7 +44,7 @@ describe('Relationships', function() {
     assert.deepEqual(actual, expected);
   });
 
-  it('should get one level of relationships when withRelationships is true', async function() {
+  it('should get one level of relationships when withRelationships set to one level array', async function() {
     const paper = await apos.paper.find(req, { title: 'paper 1' }).toObject();
 
     const { _articles } = paper._pages[0];
@@ -183,7 +183,7 @@ function getModules() {
             label: 'Pages',
             type: 'relationship',
             withType: 'default-page',
-            withRelationships: true,
+            withRelationships: [ '_articles' ],
             builders: {
               project: {
                 title: 1,


### PR DESCRIPTION
[PRO-6535](https://linear.app/apostrophecms/issue/PRO-6535/projection-not-working-with-nested-relationships)

## Summary

Revision of done work, Still works well when `relationships` is an array and asks specifically for a relationships (that can be nested using dot notation).
Remove support when `relationships` is true, that I modified to make it get only the first level of relationships.

One thing that could be improve in the future could be the support for abstract relationships projections, eg `_article: 1`.

## What are the specific steps to test this change?

Rollbacks test is green.
New ones too.

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated