### PR TITLE
Fix extra bundle detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* Extra bundle detection when using external build module works properly now.
+
 ## 4.9.0 (2024-10-31)
 
 ### Adds

--- a/modules/@apostrophecms/template/lib/bundlesLoader.js
+++ b/modules/@apostrophecms/template/lib/bundlesLoader.js
@@ -45,15 +45,23 @@ module.exports = (self) => {
 
     const templateType = template.substring(template.lastIndexOf(':') + 1);
     const pageModule = page.type && self.apos.modules[page.type];
-    const { webpack = {} } = pageModule ? pageModule.__meta : {};
+    const metadata = pageModule
+      ? (
+        self.apos.asset.hasBuildModule()
+          ? pageModule.__meta.build
+          : pageModule.__meta.webpack
+      ) : {};
 
     const rebundleConfigs = rebundleModules.filter(entry => {
       const names = pageModule?.__meta?.chain?.map(c => c.name) ?? [ page.type ];
       return names.includes(entry.name);
     });
 
-    const configs = Object.entries(webpack || {})
+    const configs = Object.entries(metadata || {})
       .reduce((acc, [ moduleName, config ]) => {
+        if (self.apos.asset.hasBuildModule()) {
+          config = config?.[self.apos.asset.getBuildModuleAlias()];
+        }
         if (!config || !config.bundles) {
           return acc;
         }

--- a/modules/@apostrophecms/widget-type/index.js
+++ b/modules/@apostrophecms/widget-type/index.js
@@ -192,13 +192,13 @@ module.exports = {
 
         return self.render(req, self.template, {
           widget: effectiveWidget,
-          options: options,
+          options,
           manager: self,
           contextOptions: _with
         });
       },
 
-      getWidgetsBundles (widgetType) {
+      getWidgetsBundles(widgetType) {
         const widget = self.apos.modules[widgetType];
 
         if (!widget) {
@@ -212,8 +212,16 @@ module.exports = {
           return names.includes(entry.name);
         });
 
-        return Object.entries(widget.__meta.webpack || {})
+        const metadata = self.apos.asset.hasBuildModule()
+          ? widget.__meta.build
+          : widget.__meta.webpack;
+
+        return Object.entries(metadata || {})
           .reduce((acc, [ moduleName, config ]) => {
+            if (self.apos.asset.hasBuildModule()) {
+              config = config?.[self.apos.asset.getBuildModuleAlias()];
+            }
+
             if (!config || !config.bundles) {
               return acc;
             }
@@ -406,7 +414,7 @@ module.exports = {
           previewIcon: self.options.previewIcon,
           previewUrl: self.options.previewUrl,
           action: self.action,
-          schema: schema,
+          schema,
           contextual: self.options.contextual,
           placeholderClass: self.options.placeholderClass,
           className: self.options.className,


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Extra bundle detection should take into account the new `build` module property and normalize when an external build module is available.

## What are the specific steps to test this change?

Extra bundles detection for the current page (based on the page AND widgets) now works correctly when external build module is registered.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
