### PR TITLE
PRO-6790: express-bearer-token updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Fix permission grid tooltip display.
 * Fixes a bug that crashes external frontend applications.
 * Fixes a false positive warning for module not in use for project level submodules (e.g. `widges/module.js`) and dot-folders (e.g. `.DS_Store`).
+* Bumped `express-bearer-token` dependency to address a low-severity `npm audit` warning regarding noncompliant cookie names and values. Apostrophe
+did not actually use any noncompliant cookie names or values, so there was no vulnerability in Apostrophe.
 
 ### Adds
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "dayjs": "^1.9.8",
     "dompurify": "^2.3.1",
     "express": "^4.16.4",
-    "express-bearer-token": "^2.4.0",
+    "express-bearer-token": "^3.0.0",
     "express-cache-on-demand": "^1.0.3",
     "express-session": "^1.17.1",
     "form-data": "^4.0.0",


### PR DESCRIPTION
New major version because the better validation in the underlying `cookie` module could be a problem for some. It's not for us. This resolves an npm audit warning.