### PR TITLE
PRO-6587: access to fully rendered rich text widgets without giving up all access to other area properties or logging out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * Bumped `express-bearer-token` dependency to address a low-severity `npm audit` warning regarding noncompliant cookie names and values. Apostrophe
 did not actually use any noncompliant cookie names or values, so there was no vulnerability in Apostrophe.
 * Rich text "Styles" toolbar now has visually focused state.
+* The `renderPermalinks` and `renderImages` methods of the `@apostrophecms/rich-text` module now correctly resolve the final URLs of page links and inline images in rich text widgets, even when the user has editing privileges. Formerly this was mistakenly prevented by logic intended to preserve the editing experience. The editing experience never actually relied on the
+rendered output.
 
 ### Adds
 
@@ -19,6 +21,7 @@ did not actually use any noncompliant cookie names or values, so there was no vu
 * Adds asset module option `options.modulePreloadPolyfill` (default `true`) to allow disabling the polyfill preload for e.g. external front-ends. 
 * Adds `bundleMarkup` to the data sent to the external front-end, containing all markup for injecting Apostrophe UI in the front-end.
 * Warns users when two page types have the same field name, but a different field type. This may cause errors or other problems when an editor switches page types.
+* The piece and page `GET` REST APIs now support `?render-areas=inline`. When this parameter is used, an HTML rendering of each widget is added to that specific widget in each area's `items` array as a new `_rendered` property. The existing `?render-areas=1` parameter is still supported to render the entire area as a single `_rendered` property. Note that this older option also causes `items` to be omitted from the response.
 
 ### Changes
 

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -417,8 +417,12 @@ module.exports = {
           if (!result) {
             throw self.apos.error('notfound');
           }
-          if (self.apos.launder.boolean(req.query['render-areas']) === true) {
-            await self.apos.area.renderDocsAreas(req, [ result ]);
+          const renderAreas = req.query['render-areas'];
+          const inline = renderAreas === 'inline';
+          if (inline || self.apos.launder.boolean(renderAreas)) {
+            await self.apos.area.renderDocsAreas(req, [ result ], {
+              inline
+            });
           }
           // Attach `_url` and `_urls` properties
           self.apos.attachment.all(result, { annotate: true });

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -251,8 +251,12 @@ module.exports = {
           result.currentPage = query.get('page') || 1;
           result.results = (await query.toArray())
             .map(doc => self.removeForbiddenFields(req, doc));
-          if (self.apos.launder.boolean(req.query['render-areas']) === true) {
-            await self.apos.area.renderDocsAreas(req, result.results);
+          const renderAreas = req.query['render-areas'];
+          const inline = renderAreas === 'inline';
+          if (inline || self.apos.launder.boolean(renderAreas)) {
+            await self.apos.area.renderDocsAreas(req, result.results, {
+              inline
+            });
           }
           if (query.get('choicesResults')) {
             result.choices = query.get('choicesResults');
@@ -291,8 +295,12 @@ module.exports = {
           if (!doc) {
             throw self.apos.error('notfound');
           }
-          if (self.apos.launder.boolean(req.query['render-areas']) === true) {
-            await self.apos.area.renderDocsAreas(req, [ doc ]);
+          const renderAreas = req.query['render-areas'];
+          const inline = renderAreas === 'inline';
+          if (inline || self.apos.launder.boolean(renderAreas)) {
+            await self.apos.area.renderDocsAreas(req, [ doc ], {
+              inline
+            });
           }
           self.apos.attachment.all(doc, { annotate: true });
           return doc;

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -731,7 +731,8 @@ module.exports = {
       },
 
       // Quickly replaces rich text permalink placeholder URLs with
-      // actual, SEO-friendly URLs based on `widget._relatedDocs`
+      // actual, SEO-friendly URLs based on `widget._relatedDocs`.
+
       linkPermalinks(widget, content) {
         // "Why no regexps?" We need to do this as quickly as we can.
         // indexOf and lastIndexOf are much faster.
@@ -756,13 +757,11 @@ module.exports = {
             const left = content.lastIndexOf('<', i);
             const href = content.indexOf(' href="', left);
             const close = content.indexOf('"', href + 7);
-            if (!widget._edit) {
-              if ((left !== -1) && (href !== -1) && (close !== -1)) {
-                content = content.substring(0, href + 6) + doc._url + content.substring(close + 1);
-              } else {
-                // So we don't get stuck in an infinite loop
-                break;
-              }
+            if ((left !== -1) && (href !== -1) && (close !== -1)) {
+              content = content.substring(0, href + 6) + doc._url + content.substring(close + 1);
+            } else {
+              // So we don't get stuck in an infinite loop
+              break;
             }
             if (!updateTitle) {
               continue;
@@ -777,11 +776,8 @@ module.exports = {
         return content;
       },
       // Quickly replaces inline image placeholder URLs with
-      // actual, SEO-friendly URLs based on `widget._relatedDocs`
+      // actual, SEO-friendly URLs based on `widget._relatedDocs`.
       linkImages(widget, content) {
-        if (widget._edit) {
-          return content;
-        }
         // "Why no regexps?" We need to do this as quickly as we can.
         // indexOf and lastIndexOf are much faster.
         let i;
@@ -799,13 +795,11 @@ module.exports = {
             const left = content.lastIndexOf('<', i);
             const src = content.indexOf(' src="', left);
             const close = content.indexOf('"', src + 6);
-            if (!widget._edit) {
-              if ((left !== -1) && (src !== -1) && (close !== -1)) {
-                content = content.substring(0, src + 5) + doc.attachment._urls[self.apos.modules['@apostrophecms/image'].getLargestSize()] + content.substring(close + 1);
-              } else {
-                // So we don't get stuck in an infinite loop
-                break;
-              }
+            if ((left !== -1) && (src !== -1) && (close !== -1)) {
+              content = content.substring(0, src + 5) + doc.attachment._urls[self.apos.modules['@apostrophecms/image'].getLargestSize()] + content.substring(close + 1);
+            } else {
+              // So we don't get stuck in an infinite loop
+              break;
             }
           }
         }


### PR DESCRIPTION
…

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

See changelog

## What are the specific steps to test this change?

* npm link into `starter-kit-essentials`
* make an inline permalink (not a pasted URL link) to another page, refresh page — it is still recognized as such by the link dialog
* same for inline images in rich text — still recognized as an existing inline image by the editor on next visit
* note the incognito view still fully resolves the URLs of linked pages and inline images (desirable behavior, except in the editor)
* Now, while logged in, use the GET REST API to access the home page at `http://localhost:3000/api/v1/@apostrophecms/page/_home`
* Note that inline images and permalinks are *not* fully resolved (appropriate because we might be editing)
* Now add `?render-areas=inline`
* Note that each widget now has an additional `_rendered` property containing fully rendered markup for that widget, *including* fully resolved inline images and permalinks

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
