### PR TITLE
Pro 6810 search empty broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ did not actually use any noncompliant cookie names or values, so there was no vu
 * Rich text "Styles" toolbar now has visually focused state.
 * The `renderPermalinks` and `renderImages` methods of the `@apostrophecms/rich-text` module now correctly resolve the final URLs of page links and inline images in rich text widgets, even when the user has editing privileges. Formerly this was mistakenly prevented by logic intended to preserve the editing experience. The editing experience never actually relied on the
 rendered output.
+* Search bar will perform the search even if the bar is empty allowing to reset a search.
 
 ### Adds
 

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposDocsManager.vue
@@ -427,8 +427,6 @@ export default {
         queryExtras.autocomplete = query;
       } else if ('autocomplete' in this.queryExtras) {
         queryExtras.autocomplete = undefined;
-      } else {
-        return {};
       }
       const { total, ...pieces } = await this.requestData(1, queryExtras);
 


### PR DESCRIPTION
[PRO-6810](https://linear.app/apostrophecms/issue/PRO-6810/search-feature-bug-tags-not-showing-after-clearing-search-field)

## Summary

Performs the search even if the last is empty. Allows to reset the search to its initial state.

## What are the specific steps to test this change?

Make search on pieces, them empty it, should work.

[Cypress tests](https://github.com/apostrophecms/testbed/actions/runs/11918428484) 🟢 

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated