### PR TITLE
PRO-4492: Fix widget Editor focus and cross modal focusing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* Focus properly Widget Editor modals when opened. Keep the previous active focus on the modal when closing the widget editor.
+
 ## 4.10.0 (2024-11-20)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * Focus properly Widget Editor modals when opened. Keep the previous active focus on the modal when closing the widget editor.
+* a11y improvements for context menus.
 
 ## 4.10.0 (2024-11-20)
 
@@ -15,7 +16,6 @@
 * Fix permission grid tooltip display.
 * Fixes a bug that crashes external frontend applications.
 * Fixes a false positive warning for module not in use for project level submodules (e.g. `widges/module.js`) and dot-folders (e.g. `.DS_Store`).
-* a11y improvements for context menus.
 * Bumped `express-bearer-token` dependency to address a low-severity `npm audit` warning regarding noncompliant cookie names and values. Apostrophe
 did not actually use any noncompliant cookie names or values, so there was no vulnerability in Apostrophe.
 * Rich text "Styles" toolbar now has visually focused state.

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -429,11 +429,11 @@ export default {
     },
 
     attachKeyboardFocusHandler() {
-      this.$refs.wrapper.addEventListener('keydown', this.handleKeyboardFocus);
+      this.$refs.wrapper?.addEventListener('keydown', this.handleKeyboardFocus);
     },
 
     removeKeyboardFocusHandler() {
-      this.$refs.wrapper.removeEventListener('keydown', this.handleKeyboardFocus);
+      this.$refs.wrapper?.removeEventListener('keydown', this.handleKeyboardFocus);
     },
 
     // Focus parent, useful for obtrusive UI

--- a/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -13,7 +13,7 @@
       aria-modal="true"
       :aria-labelledby="props.modalData.id"
       data-apos-modal
-      @focus.capture="storeFocusedElement"
+      @focus.capture="captureFocus"
       @esc="close"
       @keydown.tab="onTab"
     >
@@ -262,6 +262,11 @@ function onLeave() {
   store.remove(props.modalData.id);
   focusLastModalFocusedElement();
   emit('no-modal');
+}
+
+function captureFocus(e) {
+  storeFocusedElement(e);
+  store.updateModalData(props.modalData.id, { focusedElement: e.target });
 }
 
 async function trapFocus() {

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -51,7 +51,6 @@
       />
       <AposButton
         type="primary"
-        data-apos-focus-priority
         :label="saveLabel"
         :disabled="errorCount > 0"
         @click="save"


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

When tabbing into a widget editor, the focus should work again. Also when closing the widget, the previous modal (if available) should keep its focus. 

## What are the specific steps to test this change?

Focus works as described

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
