### PR TITLE
PRO-6835: Determine Best AssetUrl is in easy mode with the new build system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* Fixes broken widget preview URL when the image is overridden (module improve) and external build module is registered.
+
 ## 4.10.0 (2024-11-20)
 
 ### Fixes

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -818,7 +818,8 @@ module.exports = {
         let urlOption = self.options[`${name}Url`];
         const imageOption = self.options[`${name}Image`];
         if (!urlOption) {
-          if (imageOption) {
+          // Webpack and the legacy asset pipeline
+          if (imageOption && !self.apos.asset.hasBuildModule()) {
             const chain = [ ...self.__meta.chain ].reverse();
             for (const entry of chain) {
               const path = `${entry.dirname}/public/${name}.${imageOption}`;
@@ -827,6 +828,10 @@ module.exports = {
                 break;
               }
             }
+          }
+          // The new external module asset pipeline
+          if (imageOption && self.apos.asset.hasBuildModule()) {
+            urlOption = `/modules/${self.__meta.name}/${name}.${imageOption}`;
           }
         }
         if (urlOption && urlOption.startsWith('/modules')) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

The new build system (when external build module is self-registered) doesn't need any computations about "what is the override of a given module". The asset override is done on `fs` level and the path doesn't need "my-*" prefix in the URL. However, the legacy Webpack system still needs the computations. This patch fixes it all in a BC way. 

## What are the specific steps to test this change?

Override a preview image for `@apostrophecms/image-widget` in `modules/@apostrophecms/image-widget/public/preview.jpg` (project level).

When no external build module (Vite) is registered the preview will be resolved (and properly shown) to:
```
/apos-frontend/default/modules/@apostrophecms/my-image-widget/preview.jpg
```

When external build module (Vite) IS registered the preview will be resolved (and properly shown) to:
```
/apos-frontend/default/modules/@apostrophecms/image-widget/preview.jpg
```

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
