### PR TITLE
Pro 6843 context menu additional items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Adds support for supplying CSS variable names to a color field's `presetColors` array as selectable values.
 * Adds support for dynamic focus trap in Context menus (prop `dynamicFocus`). When set to `true`, the focusable elements are recalculated on each cycle step.
 * Adds option to disable `tabindex` on `AposToggle` component. A new prop `disableFocus` can be set to `false` to disable the focus on the toggle button. It's enabled by default.
+* Adds new prop `additionalMenuItems` to `AposDocContextMenu`. Allow to pass additional menu items that can trigger an action when clicked, or simply pass the action as the close event parameter.
 
 ## 4.10.0 (2024-11-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * Adds support for supplying CSS variable names to a color field's `presetColors` array as selectable values.
 * Adds support for dynamic focus trap in Context menus (prop `dynamicFocus`). When set to `true`, the focusable elements are recalculated on each cycle step.
 * Adds option to disable `tabindex` on `AposToggle` component. A new prop `disableFocus` can be set to `false` to disable the focus on the toggle button. It's enabled by default.
-* Adds new prop `additionalMenuItems` to `AposDocContextMenu`. Allow to pass additional menu items that can trigger an action when clicked, or simply pass the action as the close event parameter.
+* Adds support for event on `addContextOperation`, an option `type` can now be passed and can be `modal` (default) or `event`, in this case it does not try to open a modal but emit a bus event using the action as name.
 
 ## 4.10.0 (2024-11-20)
 

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
@@ -14,7 +14,7 @@
     }"
     @item-clicked="menuHandler"
     @open="$emit('menu-open')"
-    @close="$emit('menu-close')"
+    @close="$emit('menu-close', $event)"
   />
 </template>
 

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocContextMenu.vue
@@ -14,7 +14,7 @@
     }"
     @item-clicked="menuHandler"
     @open="$emit('menu-open')"
-    @close="$emit('menu-close', $event)"
+    @close="$emit('menu-close')"
   />
 </template>
 
@@ -24,7 +24,6 @@ import AposDocContextMenuLogic from 'Modules/@apostrophecms/doc-type/logic/AposD
 export default {
   name: 'AposDocContextMenu',
   mixins: [ AposDocContextMenuLogic ],
-  // Satisfy linting.
   emits: [ 'menu-open', 'menu-close', 'close' ]
 };
 </script>

--- a/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
+++ b/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
@@ -87,10 +87,6 @@ export default {
     localeSwitched: {
       type: Boolean,
       default: false
-    },
-    additionalMenuItems: {
-      type: Array,
-      default: []
     }
   },
   emits: [ 'menu-open', 'menu-close', 'close' ],

--- a/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
+++ b/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
@@ -403,9 +403,10 @@ export default {
         this.customAction(this.context, operation);
         return;
       }
-      const additionalItem = this.additionalMenuItem.find(item => item.action === action);
+      const additionalItem = this.additionalMenuItems.find(item => item.action === action);
       if (additionalItem?.emitEvent) {
-        this.emit(additionalItem.action);
+        this.$emit('close', additionalItem.action);
+        return;
       }
 
       this[action](this.context);

--- a/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
+++ b/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
@@ -405,7 +405,7 @@ export default {
       }
       const additionalItem = this.additionalMenuItems.find(item => item.action === action);
       if (additionalItem?.emitEvent) {
-        this.$emit('close', additionalItem.action);
+        this.$emit('close', this.context, additionalItem.action);
         return;
       }
 

--- a/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
+++ b/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
@@ -87,6 +87,10 @@ export default {
     localeSwitched: {
       type: Boolean,
       default: false
+    },
+    additionalMenuItems: {
+      type: Array,
+      default: []
     }
   },
   emits: [ 'menu-open', 'menu-close', 'close' ],
@@ -168,6 +172,11 @@ export default {
           }
         ] : [])
       ];
+
+      for (const additionalMenuItem of this.additionalMenuItems) {
+        menu.push(additionalMenuItem);
+      }
+
       return menu;
     },
     customMenusByContext() {
@@ -394,6 +403,11 @@ export default {
         this.customAction(this.context, operation);
         return;
       }
+      const additionalItem = this.additionalMenuItem.find(item => item.action === action);
+      if (additionalItem?.emitEvent) {
+        this.emit(additionalItem.action);
+      }
+
       this[action](this.context);
     },
     async edit(doc) {

--- a/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
+++ b/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
@@ -173,10 +173,6 @@ export default {
         ] : [])
       ];
 
-      for (const additionalMenuItem of this.additionalMenuItems) {
-        menu.push(additionalMenuItem);
-      }
-
       return menu;
     },
     customMenusByContext() {
@@ -403,11 +399,6 @@ export default {
         this.customAction(this.context, operation);
         return;
       }
-      const additionalItem = this.additionalMenuItems.find(item => item.action === action);
-      if (additionalItem?.emitEvent) {
-        this.$emit('close', this.context, additionalItem.action);
-        return;
-      }
 
       this[action](this.context);
     },
@@ -464,6 +455,10 @@ export default {
         ...docProps(doc),
         ...operation.props
       };
+      if (operation.type === 'event') {
+        apos.bus.$emit(operation.action, props);
+        return;
+      }
       await apos.modal.execute(operation.modal, props);
       function docProps(doc) {
         return Object.fromEntries(Object.entries(operation.docProps || {}).map(([ key, value ]) => {

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -1486,7 +1486,7 @@ module.exports = {
         ];
 
         function validate ({
-          action, context, label, modal, conditions, if: ifProps
+          action, context, type = 'modal', label, modal, conditions, if: ifProps
         }) {
           const allowedConditions = [
             'canPublish',
@@ -1503,8 +1503,12 @@ module.exports = {
             'canShareDraft'
           ];
 
-          if (!action || !context || !label || !modal) {
-            throw self.apos.error('invalid', 'addContextOperation requires action, context, label and modal properties.');
+          if (![ 'event', 'modal' ].includes(type)) {
+            throw self.apos.error('invalid', '`type` option must be `modal` (default) or `event`');
+          }
+
+          if (!action || !context || !label || (type === 'modal' && !modal)) {
+            throw self.apos.error('invalid', 'addContextOperation requires action, context, label and modal (if type is set to `modal` or unset) properties.');
           }
 
           if (


### PR DESCRIPTION
[PRO-6843](https://linear.app/apostrophecms/issue/PRO-6843/as-a-user-i-want-to-be-able-to-move-palette-so-that-i-can-see-elements)

## Summary

I need to add in palette a new item in the context menu.
This item should not open any modal but just emit an event I could listen to know user clicked on it. So I cannot use `customOperations` here.

I just added the possibility to pass an array of extra items to a `AposDocContextMenu` component.
This one can be used to call an action like we already do, or to emit a simple event when closing to the parent, like I do with palette.

It allows me to do this in palette:
```javascript
          <AposDocContextMenu
            :doc="docFields.data"
            :show-edit="false"
            :additional-menu-items="[{
              label: 'aposPalette:resetPalettePosition',
              action: 'reset-position',
              emitEvent: true
            }]"
            @close="menuCloseHandler"
          />
       ...
    menuCloseHandler(_doc, action) {
      if (action === 'reset-position') {
        this.resetPosition();
      }
    }
```
If I pass `emitEvent` it will simply emit close with the `action` as parameter.

## What are the specific steps to test this change?
See above

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
