### PR TITLE
range field now correctly takes 0 into account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * a11y improvements for context menus.
 * Fixes broken widget preview URL when the image is overridden (module improve) and external build module is registered.
 * Inject dynamic custom bundle CSS when using external build module with no CSS entry point.
+* Range field now correctly takes 0 into account.
 
 ### Adds
 

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposInputRange.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposInputRange.js
@@ -32,7 +32,7 @@ export default {
     // The range spec defaults to a value of midway between the min and max
     // Example: a range with an unset value and a min of 0 and max of 100 will become 50
     // This does not allow ranges to go unset :(
-    if (!this.next) {
+    if (!this.next && this.next !== 0) {
       this.unset();
     }
   },
@@ -47,7 +47,7 @@ export default {
     },
     validate(value) {
       if (this.field.required) {
-        if (!value) {
+        if (!value && value !== 0) {
           return 'required';
         }
       }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Fix range component to make it take into account the `0` value.

## What are the specific steps to test this change?

In a piece or widget, add the following field:

```js
rangeRequired: {
        label: 'range',
        type: 'range',
        min: -70,
        max: 70,
        def: 5,
        required: true
}
```

Edit the piece/widget and set the range value to `0`.
Save
Re-open, the range field should be set to `0`, not set to the default value.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated -> https://github.com/apostrophecms/testbed/pull/313

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
