### PR TITLE
removes use of mobile preview plugin for apos build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fixes broken widget preview URL when the image is overridden (module improve) and external build module is registered.
 * Inject dynamic custom bundle CSS when using external build module with no CSS entry point.
 * Range field now correctly takes 0 into account.
+* Apos style does not go through `postcss-viewport-to-container-toggle` plugin anymore to avoid UI bugs.
 
 ### Adds
 

--- a/modules/@apostrophecms/asset/lib/webpack/apos/webpack.scss.js
+++ b/modules/@apostrophecms/asset/lib/webpack/apos/webpack.scss.js
@@ -1,14 +1,5 @@
-const postcssViewportToContainerToggle = require('postcss-viewport-to-container-toggle');
-
 module.exports = (options, apos) => {
   const postcssPlugins = [
-    ...apos.asset.options.breakpointPreviewMode?.enable === true ? [
-      postcssViewportToContainerToggle({
-        modifierAttr: 'data-breakpoint-preview-mode',
-        debug: apos.asset.options.breakpointPreviewMode?.debug === true,
-        transform: apos.asset.options.breakpointPreviewMode?.transform || null
-      })
-    ] : [],
     'autoprefixer',
     {}
   ];


### PR DESCRIPTION
[PRO-6901](https://linear.app/apostrophecms/issue/PRO-6901/apostrophe-manager-and-edit-modals-are-broken-in-testbed-environments)

## Summary

Apos style does not go through mobile preview plugin.

## What are the specific steps to test this change?

No more apos broken UI.
mobile preview still transforms public styles

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated