### PR TITLE
hotfix to get tests passing after a change in the sitemap module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.11.1 (2024-12-18)
+
+### Fixes
+
+* Corrected a unit test that relies on the sitemap module, as it now makes explicit that the project level `baseUrl` must be set for a successful experience, and the module level `baseUrl` was set earlier. No other changes.
+
 ## 4.11.0 (2024-12-18)
 
 ### Adds

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {

--- a/test/esm-project/app.js
+++ b/test/esm-project/app.js
@@ -1,16 +1,13 @@
 export default {
   root: import.meta,
   shortName: 'esm-project',
+  baseUrl: 'http://localhost:3000',
   modules: {
     '@apostrophecms/express': {
       options: {
         address: '127.0.0.1'
       }
     },
-    '@apostrophecms/sitemap': {
-      options: {
-        baseUrl: 'http://localhost:3000'
-      }
-    }
+    '@apostrophecms/sitemap': {}
   }
 };

--- a/test/workspaces-project/app.js
+++ b/test/workspaces-project/app.js
@@ -1,16 +1,13 @@
 module.exports = {
   root: module,
   shortName: 'workspaces-project',
+  baseUrl: 'http://localhost:3000',
   modules: {
     '@apostrophecms/express': {
       options: {
         address: '127.0.0.1'
       }
     },
-    '@apostrophecms/sitemap': {
-      options: {
-        baseUrl: 'http://localhost:3000'
-      }
-    }
+    '@apostrophecms/sitemap': {}
   }
 };


### PR DESCRIPTION
a necessary bug fix in the site map module broke the apostrophe core tests, no actual functionality changes in core