### PR TITLE
Fix media image select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* Fixes a bug where images in Media manager are not selectable (click on an image does nothing) in both default and relationship mode.
+
 ## 4.11.1 (2024-12-18)
 
 ### Fixes

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
@@ -10,8 +10,8 @@
         @create-placeholder="$emit('create-placeholder', $event)"
       />
       <div
-        v-for="item in items"
-        :key="idFor(item)"
+        v-for="item in itemsWithKeys"
+        :key="item.__key"
         class="apos-media-manager-display__cell"
         :class="{'apos-is-selected': checked.includes(item._id)}"
         :style="getCellStyles(item)"
@@ -162,6 +162,12 @@ export default {
             : val
         );
       }
+    },
+    itemsWithKeys() {
+      return this.items.map((item) => ({
+        ...item,
+        __key: this.idFor(item)
+      }));
     }
   },
   watch: {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Fixes a regression, where images  in Media manager are not selectable (click on an image does nothing) in both default and relationship mode.

The source of the problem is a `:key` prop that is randomized on click, probably due to an immediate (outside) re-rendering of the component. The provided solution: memoize media item keys so that the "key" is attached to an image item just once.

## What are the specific steps to test this change?

Selecting an image in Media Manager works as expected.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
