### PR TITLE
release 4.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## UNRELEASED
+## 4.11.2 (2024-12-29)
 
 ### Fixes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "4.11.1",
+  "version": "4.11.2",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes a bug where images in Media manager are not selectable (click on an image does nothing) in both default and relationship mode.