### PR TITLE
PRO 6870 Export Templates / pass module labels to AposDocContextMenu for modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Ability to disable the color spectrum UI of a color picker
 * Accessibility improvement for the rich text editor Typography toolbar item.
+* Adds `moduleLabels` prop to `AposDocContextMenu` to pass it to opened modals from custom operations (used by templates to define labels to display on the export modal).
 
 ### Changes
 

--- a/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
+++ b/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
@@ -12,10 +12,6 @@ export default {
       type: Object,
       required: true
     },
-    type: {
-      type: String,
-      default: null
-    },
     // If editing in a modal, pass the current value object from the editor here
     // so that the visibility of options takes unsaved changes into account
     current: {
@@ -91,6 +87,10 @@ export default {
     localeSwitched: {
       type: Boolean,
       default: false
+    },
+    moduleLabels: {
+      type: Object,
+      default: null
     }
   },
   emits: [ 'menu-open', 'menu-close', 'close' ],
@@ -222,9 +222,6 @@ export default {
       });
     },
     moduleName() {
-      if (this.type) {
-        return this.type;
-      }
       if (apos.modules[this.context.type].action === apos.modules['@apostrophecms/page'].action) {
         return '@apostrophecms/page';
       }
@@ -453,6 +450,7 @@ export default {
       }
       const props = {
         moduleName: operation.moduleName || this.moduleName,
+        moduleLabels: this.moduleLabels,
         // For backwards compatibility
         doc,
         ...docProps(doc),

--- a/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
+++ b/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
@@ -12,6 +12,10 @@ export default {
       type: Object,
       required: true
     },
+    type: {
+      type: String,
+      default: null
+    },
     // If editing in a modal, pass the current value object from the editor here
     // so that the visibility of options takes unsaved changes into account
     current: {
@@ -207,7 +211,8 @@ export default {
 
         ifProps = ifProps || {};
         moduleIf = moduleIf || {};
-        const canSeeOperation = checkIfConditions(this.doc, ifProps) && checkIfConditions(this.moduleOptions, moduleIf);
+        const canSeeOperation = checkIfConditions(this.doc, ifProps) &&
+            checkIfConditions(this.moduleOptions, moduleIf);
 
         if (!canSeeOperation) {
           return false;
@@ -217,11 +222,13 @@ export default {
       });
     },
     moduleName() {
+      if (this.type) {
+        return this.type;
+      }
       if (apos.modules[this.context.type].action === apos.modules['@apostrophecms/page'].action) {
         return '@apostrophecms/page';
-      } else {
-        return this.context.type;
       }
+      return this.context.type;
     },
     moduleOptions() {
       return apos.modules[this.moduleName];

--- a/modules/@apostrophecms/modal/ui/apos/components/AposDocsManagerToolbar.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposDocsManagerToolbar.vue
@@ -135,7 +135,7 @@ export default {
     },
     checkedTypes: {
       type: Array,
-      default: () => []
+      default: null
     },
     checkedCount: {
       type: Number,

--- a/modules/@apostrophecms/page/ui/apos/logic/AposPagesManager.js
+++ b/modules/@apostrophecms/page/ui/apos/logic/AposPagesManager.js
@@ -118,7 +118,8 @@ export default {
       return this.moduleOptions.canCreate;
     },
     checkedTypes() {
-      return this.checkedDocs.map(doc => doc.type);
+      const types = this.checkedDocs.map(doc => doc.type);
+      return [ ...new Set(types) ];
     }
   },
   created() {


### PR DESCRIPTION
[PRO-6871](https://linear.app/apostrophecms/issue/PRO-6871/missing-space-between-templates-and-the-menu-above-it-in-the-template)
[PRO-6870](https://linear.app/apostrophecms/issue/PRO-6870/when-i-try-to-export-a-document-template-from-within-the-templates)

## PRs
- https://github.com/apostrophecms/apostrophe/pull/4834
- https://github.com/apostrophecms/import-export/pull/99
- https://github.com/apostrophecms/doc-template-library/pull/79

## Summary

* Add margin top to grid
* Gets related types in export modal for all checked doc types (and not for the doc template module itself).

## What are the specific steps to test this change?

* There is a nice margin between the manager toolbar and the grid.
* When export batching, the related types you can check should match all the types of templates you checked (and not the related types of the template module).

[Cypress tests](https://github.com/apostrophecms/testbed/actions/runs/12652876783): 🟠 

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
