### PR TITLE
Pro 6468 big upload import export

### DIFF
--- a/lib/big-upload-client.js
+++ b/lib/big-upload-client.js
@@ -39,7 +39,7 @@ module.exports = async (url, options) => {
   const chunkSize = options.chunkSize || defaultChunkSize;
   const http = options.http || window.apos?.http;
   const progress = options.progress || (n => {});
-  const files = options.files || [];
+  const files = options.files || {};
   const info = {};
   let totalBytes = 0;
   let sentBytes = 0;

--- a/modules/@apostrophecms/http/lib/big-upload-middleware.js
+++ b/modules/@apostrophecms/http/lib/big-upload-middleware.js
@@ -72,34 +72,38 @@ module.exports = (self) => ({
     await self.bigUploadCleanup();
     try {
       const id = self.apos.util.generateId();
-      files = Object.fromEntries(Object.entries(files).map(([ param, info ]) => {
-        if ((typeof param) !== 'string') {
-          throw invalid('param');
-        }
-        if (((typeof info) !== 'object') || (info == null)) {
-          throw invalid('info');
-        }
-        if ((typeof info.name) !== 'string') {
-          throw invalid('name');
-        }
-        if (!info.name.length) {
-          throw invalid('name empty');
-        }
-        if ((typeof info.size) !== 'number') {
-          throw invalid('size');
-        }
-        if ((typeof info.chunks) !== 'number') {
-          throw invalid('chunks');
-        }
-        return [ param, {
-          name: info.name,
-          size: info.size,
-          chunks: info.chunks
-        } ];
-      }));
+      const formattedFiles = Object.fromEntries(
+        Object.entries(files).map(([ param, info ]) => {
+          if ((typeof param) !== 'string') {
+            throw invalid('param');
+          }
+          if (((typeof info) !== 'object') || (info == null)) {
+            throw invalid('info');
+          }
+          if ((typeof info.name) !== 'string') {
+            throw invalid('name');
+          }
+          if (!info.name.length) {
+            throw invalid('name empty');
+          }
+          if ((typeof info.size) !== 'number') {
+            throw invalid('size');
+          }
+          if ((typeof info.chunks) !== 'number') {
+            throw invalid('chunks');
+          }
+          console.log('info here', info);
+          return [ param, {
+            name: info.name,
+            size: info.size,
+            type: info.type,
+            chunks: info.chunks
+          } ];
+        })
+      );
       await self.bigUploads.insert({
         _id: id,
-        files,
+        files: formattedFiles,
         start: Date.now()
       });
       return req.res.send({
@@ -161,15 +165,9 @@ module.exports = (self) => ({
       }
       let n = 0;
       req.files = {};
-      for (const [ param, {
-        name, chunks
-      } ] of Object.entries(bigUpload.files)) {
-        let ext = require('path').extname(name);
-        if (ext) {
-          ext = ext.substring(1);
-        } else {
-          ext = 'tmp';
-        }
+      for (const [ param, { name, chunks } ] of Object.entries(bigUpload.files)) {
+        const extname = require('path').extname(name);
+        const ext = extname ? extname.substring(1) : 'tmp';
         const tmp = `${ufs.getTempPath()}/${id}-${n}.${ext}`;
         const out = await open(tmp, 'w');
         for (let i = 0; (i < chunks); i++) {

--- a/modules/@apostrophecms/http/lib/big-upload-middleware.js
+++ b/modules/@apostrophecms/http/lib/big-upload-middleware.js
@@ -92,7 +92,6 @@ module.exports = (self) => ({
           if ((typeof info.chunks) !== 'number') {
             throw invalid('chunks');
           }
-          console.log('info here', info);
           return [ param, {
             name: info.name,
             size: info.size,
@@ -165,7 +164,9 @@ module.exports = (self) => ({
       }
       let n = 0;
       req.files = {};
-      for (const [ param, { name, chunks } ] of Object.entries(bigUpload.files)) {
+      for (const [ param, {
+        name, type, chunks
+      } ] of Object.entries(bigUpload.files)) {
         const extname = require('path').extname(name);
         const ext = extname ? extname.substring(1) : 'tmp';
         const tmp = `${ufs.getTempPath()}/${id}-${n}.${ext}`;
@@ -189,7 +190,8 @@ module.exports = (self) => ({
         n++;
         req.files[param] = {
           name,
-          path: tmp
+          path: tmp,
+          type
         };
       }
       return next();

--- a/modules/@apostrophecms/http/ui/apos/big-upload-client.js
+++ b/modules/@apostrophecms/http/ui/apos/big-upload-client.js
@@ -35,7 +35,7 @@ const defaultChunkSize = 1024 * 1024 * 4;
 // may be specified otherwise the standard Apostrophe `apos.http` object
 // and the browser's `FormData` are used.
 
-module.exports = async (url, options) => {
+export default async (url, options) => {
   const chunkSize = options.chunkSize || defaultChunkSize;
   const http = options.http || window.apos?.http;
   const progress = options.progress || (n => {});
@@ -48,6 +48,7 @@ module.exports = async (url, options) => {
     info[param] = {
       name: file.name,
       size: file.size,
+      type: file.type,
       chunks: Math.ceil(file.size / chunkSize)
     };
   }

--- a/modules/@apostrophecms/http/ui/apos/package.json
+++ b/modules/@apostrophecms/http/ui/apos/package.json
@@ -1,0 +1,4 @@
+{
+  "description": "NOTE: needed for testing in test/utils.js, for js files to be treated as ESM",
+  "type": "module"
+}

--- a/test/big-upload.js
+++ b/test/big-upload.js
@@ -4,8 +4,7 @@ const fs = require('fs');
 const qs = require('qs');
 
 const t = require('../test-lib/test.js');
-const bigUpload = require('../lib/big-upload-client.js');
-
+const getBigUpload = async () => import('../modules/@apostrophecms/http/ui/apos/big-upload-client.js');
 const buffer = fs.readFileSync(path.resolve(__dirname, 'data/upload_tests/crop_image.png'));
 
 describe('Big Upload', function() {
@@ -19,7 +18,7 @@ describe('Big Upload', function() {
 
   this.timeout(t.timeout);
 
-  it('init apos', async function() {
+  before(async function() {
     apos = await t.create({
       root: module,
       modules: {
@@ -96,7 +95,7 @@ describe('Big Upload', function() {
         return result.json();
       }
     };
-
+    const { default: bigUpload } = await getBigUpload();
     const result = await bigUpload('/api/v1/test/big-upload-test', {
       files: {
         file


### PR DESCRIPTION
[PRO-6468](https://linear.app/apostrophecms/issue/PRO-6468/[importexport]-utilize-the-new-bigupload-feature-to-accommodate)

## Summary
* Stores and passes to finale route the file types (needed for import-export).
* Moves client function to allow bundling to work properly (works in dev mode too). Frontend code should exist in `ui/apos`.

## What are the specific steps to test this change?

⚠️ Should be tested with [this PR](https://github.com/apostrophecms/import-export/pull/103)

Make sure you can import files bigger than 4Mb, they will be sent by chunks.

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated