### PR TITLE
improve docs lock system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 * Improve docs locking system messages.
+* Refresh stale docs locks that have the current context ID.
 
 ## 2.227.9 (2024-08-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+* Improve docs locking system messages.
+
 ## 2.227.9 (2024-08-19)
 
 * Update CKEDITOR combo styles to target all combos in the toolbar.

--- a/lib/modules/apostrophe-docs/lib/api.js
+++ b/lib/modules/apostrophe-docs/lib/api.js
@@ -1078,7 +1078,7 @@ module.exports = function(self, options) {
   self.verifyLock = function(req, id, contextId, callback) {
 
     if (!(req && req.res)) {
-      return callback(new Error('You forgot to pass req as the first argument'));
+      return callback('no req', 'You forgot to pass req as the first argument');
     }
 
     if (!id) {
@@ -1117,14 +1117,16 @@ module.exports = function(self, options) {
         { advisoryLock: 1 },
         function(err, info) {
           if (err) {
-            return callback(err);
+            message = err.message;
+            return callback('error');
           }
           if (!info) {
             return callback('notfound');
           }
           // A stale lock is effectively a missing lock
           if (info.advisoryLock && info.advisoryLock.updatedAt < self.getAdvisoryLockExpiration()) {
-            return callback('notfound');
+            message = req.__ns('apostrophe', 'The lock has expired.');
+            return callback('stale-lock');
           }
           if ((!info.advisoryLock) || (info.advisoryLock._id !== contextId)) {
             if (info.advisoryLock && info.advisoryLock.username === req.user.username) {

--- a/lib/modules/apostrophe-docs/lib/api.js
+++ b/lib/modules/apostrophe-docs/lib/api.js
@@ -1101,8 +1101,11 @@ module.exports = function(self, options) {
       // Refresh the timestamp of an existing lock, if we still hold it
       var criteria = {
         _id: id,
-        'advisoryLock._id': contextId,
-        'advisoryLock.updatedAt': { $gte: self.getAdvisoryLockExpiration() }
+        'advisoryLock._id': contextId
+
+        // The following line was commented in order to force-refresh a stale lock,
+        // as long as the context ID is the same (same tab, so no risk of docs editing conflicts):
+        // 'advisoryLock.updatedAt': { $gte: self.getAdvisoryLockExpiration() }
       };
       return self.db.update(criteria, {
         $set: {

--- a/lib/modules/apostrophe-docs/lib/routes.js
+++ b/lib/modules/apostrophe-docs/lib/routes.js
@@ -31,7 +31,7 @@ module.exports = function(self, options) {
       req.htmlPageId,
       function(err, message) {
         if (err) {
-          return next(err, null, { message: message });
+          return next(err, null, { message: message || err.message || err });
         }
         return next(null);
       }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

- do refresh a stale lock in order to avoid having the popup (+ refresh) when the lock for a doc is stale, as long as the context id (ie. tab) is the same

- improve messages:

| before | after |
|--------|--------|
| <img width="480" alt="image" src="https://github.com/user-attachments/assets/5d1a9054-43ad-4365-bc83-0ca688f3b2a5" /> | <img width="462" alt="image" src="https://github.com/user-attachments/assets/d24b2cec-536f-4bb8-811f-bef9e6b00b53" /> | 

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
