### PR TITLE
PRO-7152: Fix media manager edit when image not loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Fixes the focus styling on AposTable headers.
 * Proper errors when widgets are badly configured in expanded mode.
 * More reliable Media Manager infinite scroll pagination.
+* Fixes Edit in Media Manager when the image is not in the currently loaded images. This may happen when the the Media Manager is in a relationship mode. 
 
 ## 4.13.0 (2025-02-19)
 

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -455,7 +455,10 @@ export default {
       this.checked = [];
     },
     async updateEditing(id) {
-      const item = this.items.find(item => item._id === id);
+      let item = this.items.find(item => item._id === id);
+      if (!item) {
+        item = this.checkedDocs.find(item => item._id === id);
+      }
       // We only care about the current doc for this prompt,
       // we are not in danger of discarding a selection when
       // we switch images


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Fixes an issue, when a selected from a relationship image is not present in the currently loaded images and not editable. 


## What are the specific steps to test this change?

1. Modify an image widget.
2. Click on Browse Images.
3. Select an image from page 2 or later in the image manager modal.
4. Save the widget.
5. Reopen the Modify Image Widget.
6. Click Browse Images again.
7. Click on Edit in the preview of the previously selected image.
8. Edit works as expected.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
