### PR TITLE
fix nested area margin collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Fixes the focus styling on AposTable headers.
 * Proper errors when widgets are badly configured in expanded mode.
 * More reliable Media Manager infinite scroll pagination.
+* Fixes margin collapse in nested areas by switching to `padding` instead of `margin`
 
 ## 4.13.0 (2025-02-19)
 

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -1,6 +1,5 @@
 <template>
   <div
-    zuppa
     :data-apos-area="areaId"
     class="apos-area"
     :class="themeClass"

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    zuppa
     :data-apos-area="areaId"
     class="apos-area"
     :class="themeClass"

--- a/modules/@apostrophecms/ui/ui/apos/scss/global/_widgets.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/_widgets.scss
@@ -1,5 +1,5 @@
 [data-apos-area] [data-apos-area] {
-  margin: var(--a-widget-margin);
+  padding: var(--a-widget-margin);
 }
 
 [data-rich-text] p:empty::after {


### PR DESCRIPTION
## Summary

* Fixes margin collapse in nested areas by switching to `padding` instead of `margin`