### PR TITLE
we forgot to configure the tags filter for files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add `translate` boolean option for report modal header configuration to force translation of the relevant items value (table cells).
 * Adds feature to generate a table from an imported CSV file inside the rich-text-widget.
 * Add data-test attributes to the login page.
+* Adds the missing "Tags" filter to the chooser/manager view of files.
 
 ### Changes
 

--- a/modules/@apostrophecms/file/index.js
+++ b/modules/@apostrophecms/file/index.js
@@ -82,7 +82,12 @@ module.exports = {
     }
   },
   filters: {
-    remove: [ 'visibility' ]
+    remove: [ 'visibility' ],
+    add: {
+      _tags: {
+        label: 'apostrophe:tags'
+      }
+    }
   },
   methods(self) {
     return {


### PR DESCRIPTION
We already have a file tags piece type and the means to populate that relationship, but forgot to include it on the "Filters" dropdown so users can have some joy of it.