### PR TITLE
PRO-7472 hotfix: release 4.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.14.1 (2025-03-31)
+
+### Fixes
+
+* Hotfix: fixes a bug in which the same on-demand cache was used across multiple sites in the presence of `@apostrophecms/multisite`. In rare cases, this bug could cause the home page of site "A" to be displayed on a request for site "B," but only if requests were simultaneous. This bug did not impact single-site projects.
+
 ## 4.14.0 (2025-03-19)
 
 ### Adds

--- a/modules/@apostrophecms/express/index.js
+++ b/modules/@apostrophecms/express/index.js
@@ -156,6 +156,7 @@ const qs = require('qs');
 const expressBearerToken = require('express-bearer-token');
 const cors = require('cors');
 const Promise = require('bluebird');
+const expressCacheOnDemand = require('express-cache-on-demand');
 
 module.exports = {
   async init(self) {
@@ -170,6 +171,7 @@ module.exports = {
       self.apos.util.error('Set it as a global option (a property of the main object passed to apostrophe).');
       self.apos.util.error('When you do so other modules will also pick up on it and make URLs absolute.');
     }
+    self.createCacheOnDemand();
   },
   tasks(self) {
     return {
@@ -773,8 +775,14 @@ module.exports = {
             }
           }
         }
-
         self.finalModuleMiddlewareAndRoutes = labeledList.map(item => (item.prepending || []).concat(item.middleware || item.routes)).flat();
+      },
+      createCacheOnDemand() {
+        const { enableCacheOnDemand = true } = self.options;
+        if (enableCacheOnDemand) {
+          // Instantiate independently for this instance of ApostropheCMS
+          self.apos.expressCacheOnDemand = expressCacheOnDemand();
+        }
       }
     };
   }

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -2,7 +2,6 @@ const _ = require('lodash');
 const path = require('path');
 const { klona } = require('klona');
 const { SemanticAttributes } = require('@opentelemetry/semantic-conventions');
-const expressCacheOnDemand = require('express-cache-on-demand')();
 
 module.exports = {
   cascades: [ 'filters', 'batchOperations', 'utilityOperations' ],
@@ -241,9 +240,6 @@ module.exports = {
     };
   },
   async init(self) {
-    const { enableCacheOnDemand = true } = self.apos
-      .modules['@apostrophecms/express'].options;
-    self.enableCacheOnDemand = enableCacheOnDemand;
     self.typeChoices = self.options.types || [];
     // If "park" redeclares something with a parkedId present in "minimumPark",
     // the later one should win
@@ -284,7 +280,7 @@ module.exports = {
       // `_publishedDoc` property to each draft that also exists in a published form.
 
       getAll: [
-        ...self.enableCacheOnDemand ? [ expressCacheOnDemand ] : [],
+        ...self.apos.expressCacheOnDemand ? [ self.apos.expressCacheOnDemand ] : [],
         async (req) => {
           await self.publicApiCheckAsync(req);
           const all = self.apos.launder.boolean(req.query.all);
@@ -410,7 +406,7 @@ module.exports = {
       // `_home` or `_archive`
 
       getOne: [
-        ...self.enableCacheOnDemand ? [ expressCacheOnDemand ] : [],
+        ...self.apos.expressCacheOnDemand ? [ self.apos.expressCacheOnDemand ] : [],
         async (req, _id) => {
           _id = self.inferIdLocaleAndMode(req, _id);
           // Edit access to draft is sufficient to fetch either
@@ -1089,8 +1085,8 @@ database.`);
         addServeRoute() {
           self.apos.app.get('*',
             (req, res, next) => {
-              return self.enableCacheOnDemand
-                ? expressCacheOnDemand(req, res, next)
+              return self.apos.expressCacheOnDemand
+                ? self.apos.expressCacheOnDemand(req, res, next)
                 : next();
             },
             self.serve

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -1,5 +1,4 @@
 const _ = require('lodash');
-const expressCacheOnDemand = require('express-cache-on-demand')();
 
 module.exports = {
   extend: '@apostrophecms/doc-type',
@@ -239,12 +238,9 @@ module.exports = {
     self.addEditorModal();
   },
   restApiRoutes(self) {
-    const { enableCacheOnDemand = true } = self.apos
-      .modules['@apostrophecms/express'].options;
-
     return {
       getAll: [
-        ...enableCacheOnDemand ? [ expressCacheOnDemand ] : [],
+        ...self.apos.expressCacheOnDemand ? [ self.apos.expressCacheOnDemand ] : [],
         async (req) => {
           await self.publicApiCheckAsync(req);
           const query = self.getRestQuery(req);
@@ -287,7 +283,7 @@ module.exports = {
         }
       ],
       getOne: [
-        ...enableCacheOnDemand ? [ expressCacheOnDemand ] : [],
+        ...self.apos.expressCacheOnDemand ? [ self.apos.expressCacheOnDemand ] : [],
         async (req, _id) => {
           _id = self.inferIdLocaleAndMode(req, _id);
           await self.publicApiCheckAsync(req);


### PR DESCRIPTION
See changelog. The `express-cache-on-demand` middleware should be instantiated separately for each instance of ApostropheCMS, it must not be instantiated at top level.

In addition, there is no need for multiple instances of the middleware within a single instance of ApostropheCMS, so create a single one and attach it to `self.apos` in `@apostrophecms/express`.