### PR TITLE
make widget operations dynamic to add custom ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Adds
 
 * To display a live preview on the page as changes are made to widgets, set the `preview: true` option on any widget module. To turn it on for all widgets, you can set it on the `@apostrophecms/widget-type` module, the base class of all widget modules. This works especially well when `range` fields are used to achieve visual effects.
+* Add `apos.area.addWidgetOperation` to display custom widget operations at the primary level or secondary, via a 3-dots menu.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## UNRELEASED
+
+### Adds
+
+* The new `apos.area.addWidgetOperation` method can be used to display custom operations for widgets.
+A wrapper is available in the `@apostrophecms/widget-type` module to register operations only for widgets that match the type of the module where the wrapper is invoked.
+For example, calling `self.addWidgetOperation` in the ``@apostrophecms/image-widget`` module will apply the operation exclusively to image widgets.
+A `secondaryLevel: true` option is available to add operations to the widget's controls context menu.
+
 ## 4.15.0 (2025-04-16)
 
 ### Adds
@@ -7,10 +16,6 @@
 * To display a live preview on the page as changes are made to widgets, set the `preview: true` option on any widget module. To turn it on for all widgets, you can set it on the `@apostrophecms/widget-type` module, the base class of all widget modules. This works especially well when `range` fields are used to achieve visual effects.
 * Adds separate control bar for editing tables in rich text
 * Adds ability to drag-resize rich text table columns
-* The new `apos.area.addWidgetOperation` method can be used to display custom operations for widgets.
-A wrapper is available in the `@apostrophecms/widget-type` module to register operations only for widgets that match the type of the module where the wrapper is invoked.
-For example, calling `self.addWidgetOperation` in the ``@apostrophecms/image-widget`` module will apply the operation exclusively to image widgets.
-A `secondaryLevel: true` option is available to add operations to the widget's controls context menu.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@
 * To display a live preview on the page as changes are made to widgets, set the `preview: true` option on any widget module. To turn it on for all widgets, you can set it on the `@apostrophecms/widget-type` module, the base class of all widget modules. This works especially well when `range` fields are used to achieve visual effects.
 * Adds separate control bar for editing tables in rich text
 * Adds ability to drag-resize rich text table columns
-* Add `apos.area.addWidgetOperation` to display custom widget operations at the primary level or secondary, via a 3-dots menu.
+* The new `apos.area.addWidgetOperation` method can be used to display custom operations for widgets.
+A wrapper is available in the `@apostrophecms/widget-type` module to register operations only for widgets that match the type of the module where the wrapper is invoked.
+For example, calling `self.addWidgetOperation` in the ``@apostrophecms/image-widget`` module will apply the operation exclusively to image widgets.
+A `secondaryLevel: true` option is available to add operations to the widget's controls context menu.
 
 ### Changes
 

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarMenu.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarMenu.vue
@@ -42,7 +42,7 @@
         :modifiers="['no-motion']"
         class="apos-admin-bar__btn"
         role="menuitem"
-        @click="emitEvent(item.action)"
+        @click="emitEvent(item)"
       />
     </li>
     <li
@@ -85,7 +85,7 @@
           :label="item.label"
           :action="item.action"
           :state="trayItemState[item.name] ? [ 'active' ] : []"
-          @click="emitEvent(item.action)"
+          @click="emitEvent(item)"
         />
       </template>
     </li>
@@ -122,10 +122,9 @@ export default {
     }
   },
   async mounted() {
-    apos.bus.$on('admin-menu-click', this.onAdminMenuClick);
-
     const itemsSet = klona(this.items);
-    this.menuItems = itemsSet.filter(item => !(item.options && item.options.contextUtility))
+    this.menuItems = itemsSet
+      .filter(item => !(item.options && item.options.contextUtility))
       .map(item => {
         if (item.items) {
           item.items.forEach(subitem => {
@@ -148,12 +147,31 @@ export default {
     });
   },
   methods: {
-    emitEvent(name) {
-      apos.bus.$emit('admin-menu-click', name);
+    emitEvent(item) {
+      apos.bus.$emit('admin-menu-click', item.action || item);
+
+      console.log('item.action', item.action);
+      console.log('item', item);
+
+      // Maintain a knowledge of which tray item toggles are active
+      const name = item.itemName || item.name || item;
+      const trayItem = this.trayItems.find(item => item.name === name);
+      //   console.log('trayItem', trayItem);
+
+      if (trayItem && trayItem.options.toggle) {
+        this.trayItemState = {
+          ...this.trayItemState,
+          [name]: !this.trayItemState[name]
+        };
+      }
     },
     trayItemTooltip(item) {
       if (item.options.toggle) {
-        if (this.trayItemState[item.name] && item.options.tooltip && item.options.tooltip.deactivate) {
+        if (
+          this.trayItemState[item.name] &&
+            item.options.tooltip &&
+            item.options.tooltip.deactivate
+        ) {
           return {
             content: item.options.tooltip.deactivate,
             placement: 'bottom'
@@ -168,17 +186,6 @@ export default {
         }
       } else {
         return item.options.tooltip;
-      }
-    },
-    // Maintain a knowledge of which tray item toggles are active
-    onAdminMenuClick(e) {
-      const name = e.itemName || e;
-      const trayItem = this.trayItems.find(item => item.name === name);
-      if (trayItem && trayItem.options.toggle) {
-        this.trayItemState = {
-          ...this.trayItemState,
-          [name]: !this.trayItemState[name]
-        };
       }
     }
   }

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarMenu.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarMenu.vue
@@ -13,7 +13,7 @@
         class="apos-admin-bar__btn"
         :modifiers="['no-motion']"
         role="menuitem"
-        @click="emitEvent('@apostrophecms/page:manager')"
+        @click="emitEvent({ action: '@apostrophecms/page:manager' })"
       />
     </li>
     <li
@@ -148,20 +148,15 @@ export default {
   },
   methods: {
     emitEvent(item) {
-      apos.bus.$emit('admin-menu-click', item.action || item);
-
-      console.log('item.action', item.action);
-      console.log('item', item);
+      apos.bus.$emit('admin-menu-click', item.action);
 
       // Maintain a knowledge of which tray item toggles are active
-      const name = item.itemName || item.name || item;
-      const trayItem = this.trayItems.find(item => item.name === name);
-      //   console.log('trayItem', trayItem);
+      const trayItem = this.trayItems.find(trayItem => trayItem.name === item.action);
 
       if (trayItem && trayItem.options.toggle) {
         this.trayItemState = {
           ...this.trayItemState,
-          [name]: !this.trayItemState[name]
+          [item.action]: !this.trayItemState[item.action]
         };
       }
     },

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarUser.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarUser.vue
@@ -43,9 +43,8 @@ export default {
     }
   },
   methods: {
-    emitEvent(name) {
-      console.log('admin-menu-click', name);
-      apos.bus.$emit('admin-menu-click', name);
+    emitEvent(item) {
+      apos.bus.$emit('admin-menu-click', item.action);
     }
   }
 };

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarUser.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposAdminBarUser.vue
@@ -44,6 +44,7 @@ export default {
   },
   methods: {
     emitEvent(name) {
+      console.log('admin-menu-click', name);
       apos.bus.$emit('admin-menu-click', name);
     }
   }

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBreakpointPreviewMode.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextBreakpointPreviewMode.vue
@@ -255,10 +255,10 @@ export default {
       }
       return 'cellphone-icon';
     },
-    selectBreakpoint(selected) {
+    selectBreakpoint(item) {
       const {
         name, label, width, height
-      } = this.breakpoints.find(({ name }) => name === selected);
+      } = this.breakpoints.find(({ name }) => name === item.action);
       this.toggleBreakpointPreviewMode({
         mode: name,
         label,

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextModeAndSettings.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextModeAndSettings.vue
@@ -6,7 +6,8 @@
   >
     <!--
       TODO: Each div at this level serves as a discrete context menu state
-      Modules should be able to provide their own menus here to complete tasks specific to them.
+      Modules should be able to provide their own menus here to complete
+      tasks specific to them.
       It might also be worth breaking up the core menus into their own vue components to
       further illustrate this concept.
     -->
@@ -107,7 +108,11 @@ export default {
       if (this.canPublish) {
         if (this.context.lastPublishedAt) {
           // Document went from unpublished to published and has nothing staged
-          if (this.hasBeenPublishedThisPageload && !this.readyToPublish && this.hasBeenPublishedButNotUpdated) {
+          if (
+            this.hasBeenPublishedThisPageload &&
+            !this.readyToPublish &&
+            this.hasBeenPublishedButNotUpdated
+          ) {
             return 'apostrophe:published';
           // Document *has* had changes published this page load, but nothing staged now
           } else if (this.hasBeenPublishedThisPageload && !this.readyToPublish) {
@@ -135,7 +140,11 @@ export default {
       }
     },
     publishTooltip() {
-      if (this.canPublish && this.context.lastPublishedAt && !this.hasBeenPublishedThisPageload) {
+      if (
+        this.canPublish &&
+        this.context.lastPublishedAt &&
+        !this.hasBeenPublishedThisPageload
+      ) {
         return {
           content: 'apostrophe:updateTooltip',
           placement: 'bottom'
@@ -145,10 +154,13 @@ export default {
       return false;
     },
     isAutopublished() {
-      return this.context._aposAutopublish ?? (window.apos.modules[this.context.type].autopublish || false);
+      return this.context._aposAutopublish ??
+        (window.apos.modules[this.context.type].autopublish || false);
     },
     hasBeenPublishedThisPageload() {
-      return (this.context.lastPublishedAt > this.mountedAt) || ((this.context.submitted && this.context.submitted.at) > this.mountedAt);
+      return (
+        this.context.lastPublishedAt > this.mountedAt) ||
+        ((this.context.submitted && this.context.submitted.at) > this.mountedAt);
     },
     canSwitchToEditMode() {
       return !this.editMode;
@@ -188,9 +200,6 @@ export default {
         this.hasBeenPublishedButNotUpdated = false;
       }
       this.$emit('publish');
-    },
-    emitEvent(name) {
-      apos.bus.$emit('admin-menu-click', name);
     }
   }
 };

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextTitle.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextTitle.vue
@@ -137,8 +137,9 @@ export default {
   methods: {
     togglePublishDraftMode() {
       if (this.canTogglePublishDraftMode) {
-        const mode = this.draftMode === 'draft' ? 'published' : 'draft';
-        this.$emit('switch-draft-mode', mode);
+        this.switchDraftMode({
+          action: this.draftMode === 'draft' ? 'published' : 'draft'
+        });
       }
     },
     switchDraftMode(item) {

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextTitle.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextTitle.vue
@@ -124,7 +124,8 @@ export default {
       return window.apos.adminBar;
     },
     isAutopublished() {
-      return this.context._aposAutopublish ?? (window.apos.modules[this.context.type].autopublish || false);
+      return this.context._aposAutopublish ??
+        (window.apos.modules[this.context.type].autopublish || false);
     }
   },
   mounted() {
@@ -137,11 +138,11 @@ export default {
     togglePublishDraftMode() {
       if (this.canTogglePublishDraftMode) {
         const mode = this.draftMode === 'draft' ? 'published' : 'draft';
-        this.switchDraftMode(mode);
+        this.$emit('switch-draft-mode', mode);
       }
     },
-    switchDraftMode(mode) {
-      this.$emit('switch-draft-mode', mode);
+    switchDraftMode(item) {
+      this.$emit('switch-draft-mode', item.action);
     }
   }
 };

--- a/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextTitle.vue
+++ b/modules/@apostrophecms/admin-bar/ui/apos/components/TheAposContextTitle.vue
@@ -178,7 +178,7 @@ export default {
   &__document {
     margin-top: 3.5px;
 
-    :deep(.apos-context-menu__pane) {
+    :deep(.apos-context-menu__items) {
       min-width: 150px;
     }
   }

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -718,7 +718,6 @@ module.exports = {
 
         const widgetOperations = self.widgetOperations.filter(({ permission }) => {
           if (permission?.action && permission?.type) {
-            console.log('can', self.apos.permission.can(req, permission.action, permission.type, permission.mode || 'draft'));
             return self.apos.permission.can(req, permission.action, permission.type, permission.mode || 'draft');
           }
           return true;

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -2,9 +2,10 @@ const _ = require('lodash');
 const { stripIndent } = require('common-tags');
 
 // An area is a series of zero or more widgets, in which users can add
-// and remove widgets and drag them to reorder them. This module implements
-// areas, with the help of a query builder in the doc module. This module also
-// provides browser-side support for invoking the players of widgets in an area and for editing areas.
+// and remove widgets and drag them to reorder them.
+// This module implements areas, with the help of a query builder in the doc module.
+// This module also provides browser-side suppor
+// for invoking the players of widgets in an area and for editing areas.
 
 module.exports = {
   options: { alias: 'area' },
@@ -231,7 +232,12 @@ module.exports = {
         }
         if (inline) {
           for (const item of area.items) {
-            item._rendered = await self.renderWidget(req, item.type, item, widgets[item.type]);
+            item._rendered = await self.renderWidget(
+              req,
+              item.type,
+              item,
+              widgets[item.type]
+            );
           }
           return null;
         }
@@ -299,7 +305,12 @@ module.exports = {
         async function render(area, path, context, opts) {
           const preppedArea = self.prepForRender(area, context, path);
 
-          const areaRendered = await self.apos.area.renderArea(req, preppedArea, context, { inline });
+          const areaRendered = await self.apos.area.renderArea(
+            req,
+            preppedArea,
+            context,
+            { inline }
+          );
           if (inline) {
             return;
           }
@@ -435,7 +446,12 @@ module.exports = {
           }
           const existingArea = _.get(doc, dotPath);
           const existingItems = existingArea && (existingArea.items || []);
-          if (_.isEqual(self.apos.util.clonePermanent(items), self.apos.util.clonePermanent(existingItems))) {
+          if (
+            _.isEqual(
+              self.apos.util.clonePermanent(items),
+              self.apos.util.clonePermanent(existingItems)
+            )
+          ) {
             // No real change — don't waste a version and clutter the database.
             // Sometimes only the server-side sanitizers can tell accurately that
             // nothing has changed. -Tom
@@ -539,7 +555,8 @@ module.exports = {
       // you wish a different delimiter or the empty string.
       //
       // Whitespace is trimmed off the leading and trailing edges of the string, and
-      // consecutive newlines are condensed to one, to better match reasonable expectations
+      // consecutive newlines are condensed to one,
+      // to better match reasonable expectations
       // re: text that began as HTML.
       //
       // Pass `options.limit` to limit the number of characters. This method will
@@ -568,8 +585,9 @@ module.exports = {
         return self.apos.util.truncatePlaintext(plaintext, options.limit, ellipsis);
       },
       // Very handy for imports of all kinds: convert plaintext to an area with
-      // one `@apostrophecms/rich-text` widget if it is not blank, otherwise an empty area. null and
-      // undefined are tolerated and converted to empty areas.
+      // one `@apostrophecms/rich-text` widget if it is not blank,
+      // otherwise an empty area.
+      // null and undefined are tolerated and converted to empty areas.
       fromPlaintext(plaintext) {
         return self.fromRichText(self.apos.util.escapeHtml(plaintext, true));
       },
@@ -716,7 +734,8 @@ module.exports = {
           widgetIsContextual[name] = manager.options.contextual;
           widgetPreview[name] = manager.options.preview;
           widgetHasPlaceholder[name] = manager.options.placeholder;
-          widgetHasInitialModal[name] = !manager.options.placeholder && manager.options.initialModal !== false;
+          widgetHasInitialModal[name] =
+            !manager.options.placeholder && manager.options.initialModal !== false;
           contextualWidgetDefaultData[name] = manager.options.defaultData || {};
         });
 
@@ -765,10 +784,12 @@ module.exports = {
   helpers(self) {
     return {
       // Returns the rich text markup of all `@apostrophecms/rich-text` widgets
-      // within the provided doc or area, concatenated as a single string. In future this method
-      // may improve to return the content of other widgets that consider themselves primarily
-      // providers of rich text, such as subclasses of `@apostrophecms/rich-text`,
-      // which will **not** be regarded as a bc break. However it will never return images, videos, etc.
+      // within the provided doc or area, concatenated as a single string.
+      // In future this method may improve to return the content of other widgets
+      // that consider themselves primarily providers of rich text,
+      // such as subclasses of `@apostrophecms/rich-text`,
+      // which will **not** be regarded as a bc break.
+      // However it will never return images, videos, etc.
       //
       // By default the rich text contents of the widgets are joined with
       // a newline between. You may pass your own `options.delimiter` string if

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -27,19 +27,6 @@ module.exports = {
     self.widgetManagers = {};
     self.widgetOperations = [];
 
-    // TODO: remove following
-    self.addWidgetOperation({
-      type: 'modal',
-      modal: 'AposSettingsManager',
-      label: 'Create Section',
-      icon: 'group-icon',
-      secondaryLevel: true,
-      permission: {
-        action: 'create',
-        type: '@apostrophecms-pro/doc-template-library'
-      }
-    });
-
     self.enableBrowserData();
     self.addDeduplicateWidgetIdsMigration();
   },

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -30,14 +30,13 @@ module.exports = {
     // TODO: remove following
     self.addWidgetOperation({
       name: 'createSection',
-      // modal: 'AposSectionEditor',
       modal: 'AposSettingsManager',
       label: 'Create Section',
       icon: 'group-icon',
       secondaryLevel: true,
       permission: {
         action: 'create',
-        type: '@apostrophecms-pro/section-template-library'
+        type: '@apostrophecms-pro/doc-template-library'
       }
     });
 

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -660,6 +660,10 @@ module.exports = {
           throw self.apos.error('invalid', 'addWidgetOperation requires name, label and modal properties.');
         }
 
+        if (operation.secondaryLevel !== true && !operation.icon) {
+          throw self.apos.error('invalid', 'addWidgetOperation requires the icon property at primary level.');
+        }
+
         self.widgetOperations = self.widgetOperations.filter(
           ({ name }) => name !== operation.name
         );

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -34,7 +34,7 @@ module.exports = {
       modal: 'AposSettingsManager',
       label: 'Create Section',
       icon: 'group-icon',
-      nested: true,
+      secondaryLevel: true,
       permission: {
         action: 'create',
         type: '@apostrophecms-pro/section-template-library'

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -668,19 +668,6 @@ module.exports = {
           }
         });
       },
-
-      // Usage example:
-      //
-      // self.addWidgetOperation({
-      //   modal: 'AposSomeModal',
-      //   label: 'Some label',
-      //   icon: 'some-icon',
-      //   secondaryLevel: true,
-      //   permission: {
-      //     action: 'create',
-      //     type: 'article'
-      //   }
-      // });
       addWidgetOperation(operation) {
         if (!operation.label || !operation.modal) {
           throw self.apos.error('invalid', 'addWidgetOperation requires label and modal properties.');

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -23,11 +23,23 @@ module.exports = {
       'rank',
       'level'
     ];
-    self.widgetManagers = {};
     self.richTextWidgetTypes = [];
     self.widgetManagers = {};
     self.widgetOperations = [];
-    self.addWidgetOperations();
+
+    // TODO: remove following
+    self.addWidgetOperation({
+      name: 'createSection',
+      // modal: 'AposSectionEditor',
+      modal: 'AposSettingsManager',
+      label: 'Create Section',
+      icon: 'group-icon',
+      nested: true,
+      permission: {
+        action: 'create',
+        type: '@apostrophecms-pro/section-template-library'
+      }
+    });
     self.enableBrowserData();
     self.addDeduplicateWidgetIdsMigration();
   },
@@ -656,19 +668,18 @@ module.exports = {
           }
         });
       },
-      addWidgetOperations() {
-        self.widgetOperations = [
-          ...self.widgetOperations,
-        ];
-      },
       addWidgetOperation(operation) {
-        validate(operation);
-        self.contextOperations = [
-          ...self.contextOperations
-            .filter(op => op.action !== operation.action),
-          operation
-        ];
+        console.log('operation', operation);
+        // validate(operation);
 
+        self.widgetOperations = self.widgetOperations.filter(widgetOperation =>
+          widgetOperation.action !== operation.action &&
+          widgetOperation.modal !== operation.modal
+        );
+
+        self.widgetOperations.push(operation);
+
+        console.log('self.widgetOperations', self.widgetOperations);
         function validate ({
           action, context, type = 'modal', label, modal, conditions, if: ifProps
         }) {

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -656,12 +656,12 @@ module.exports = {
         });
       },
       addWidgetOperation(operation) {
-        if (!operation.label || !operation.modal) {
-          throw self.apos.error('invalid', 'addWidgetOperation requires label and modal properties.');
+        if (!operation.name || !operation.label || !operation.modal) {
+          throw self.apos.error('invalid', 'addWidgetOperation requires name, label and modal properties.');
         }
 
         self.widgetOperations = self.widgetOperations.filter(
-          ({ modal }) => modal !== operation.modal
+          ({ name }) => name !== operation.name
         );
 
         self.widgetOperations.push(operation);

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -40,6 +40,7 @@ module.exports = {
         type: '@apostrophecms-pro/section-template-library'
       }
     });
+
     self.enableBrowserData();
     self.addDeduplicateWidgetIdsMigration();
   },

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaMenuItem.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaMenuItem.vue
@@ -51,6 +51,7 @@ export default {
   },
   methods: {
     click() {
+      console.log('click');
       this.$emit('click');
     }
   }

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaMenuItem.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaMenuItem.vue
@@ -51,7 +51,6 @@ export default {
   },
   methods: {
     click() {
-      console.log('click');
       this.$emit('click');
     }
   }

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -121,6 +121,7 @@
           @copy="$emit('copy', i);"
           @clone="$emit('clone', i);"
           @down="$emit('down', i);"
+          @update="$emit('update')"
         />
       </div>
       <!-- Still used for contextual editing components -->

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -108,7 +108,6 @@
           :first="i === 0"
           :last="i === next.length - 1"
           :options="{ contextual: isContextual }"
-          :foreign="foreign"
           :disabled="disabled"
           :max-reached="maxReached"
           :tabbable="isFocused"

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -112,6 +112,7 @@
           :disabled="disabled"
           :max-reached="maxReached"
           :tabbable="isFocused"
+          :model-value="widget"
           @up="$emit('up', i);"
           @remove="$emit('remove', i);"
           @edit="$emit('edit', i);"

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -113,6 +113,7 @@
           :max-reached="maxReached"
           :tabbable="isFocused"
           :model-value="widget"
+          :area-field="field"
           @up="$emit('up', i);"
           @remove="$emit('remove', i);"
           @edit="$emit('edit', i);"

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -133,7 +133,7 @@ export default {
         controls.push({
           ...this.widgetDefaultControl,
           label: 'apostrophe:edit',
-          icon: 'pencil-icon',
+          icon: 'playlist-edit-icon',
           disabled: this.disabled,
           tooltip: {
             content: 'apostrophe:editWidget',

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -8,7 +8,7 @@
         v-for="control in widgetPrimaryControls"
         :key="control.action"
         v-bind="control"
-        @click="handlePrimaryControlClick(control)"
+        @click="handleClick(control)"
       />
 
       <AposContextMenu
@@ -25,12 +25,12 @@
           type: 'subtle',
           modifiers: ['small', 'no-motion']
         }"
-        @item-clicked="handleSecondaryControlClick"
+        @item-clicked="handleClick"
       />
 
       <AposButton
         v-bind="widgetPrimaryControlsRemove"
-        @click="handlePrimaryControlClick({ action: 'remove' })"
+        @click="handleClick({ action: 'remove' })"
       />
     </AposButtonGroup>
   </div>
@@ -40,6 +40,10 @@
 
 export default {
   props: {
+    modelValue: {
+      type: Object,
+      required: true
+    },
     first: {
       type: Boolean,
       required: true
@@ -71,15 +75,7 @@ export default {
       default: false
     }
   },
-  emits: [
-    'remove',
-    'edit',
-    'cut',
-    'copy',
-    'clone',
-    'up',
-    'down'
-  ],
+  emits: [ 'remove', 'edit', 'cut', 'copy', 'clone', 'up', 'down' ],
   data() {
     const { widgetOperations = [] } = apos.modules['@apostrophecms/area'];
 
@@ -148,12 +144,14 @@ export default {
       }
 
       // Custom widget operations displayed in the primary controls
-      const customWidgetPrimaryControls = this.widgetPrimaryOperations
-        .map(operation => ({
+      if (this.widgetPrimaryOperations.length) {
+        const customWidgetControls = this.widgetPrimaryOperations.map(operation => ({
           ...this.widgetDefaultControl,
           ...operation
         }));
-      controls.push(...customWidgetPrimaryControls);
+
+        controls.push(...customWidgetControls);
+      }
 
       return controls;
     },
@@ -197,13 +195,15 @@ export default {
         action: 'clone'
       });
 
-      // Custom widget operations displayed in the primary controls
-      const customWidgetSecondaryControls = this.widgetPrimaryOperations
-        .map(operation => ({
+      // Custom widget operations displayed in the secondary controls
+      if (this.widgetSecondaryOperations.length) {
+        const customWidgetControls = this.widgetSecondaryOperations.map(operation => ({
           ...this.widgetDefaultControl,
           ...operation
         }));
-      controls.push(...customWidgetSecondaryControls);
+
+        controls.push(...customWidgetControls);
+      }
 
       return controls;
     },
@@ -222,17 +222,15 @@ export default {
     }
   },
   methods: {
-    handlePrimaryControlClick({ action, modal }) {
-      if (modal) {
-        apos.modal.execute(modal);
-      }
-
+    handleClick({ action, modal }) {
       if (action) {
         this.$emit(action);
       }
-    },
-    handleSecondaryControlClick(action) {
-      this.$emit(action);
+      if (modal) {
+        apos.modal.execute(modal, {
+          modelValue: this.modelValue
+        });
+      }
     }
   }
 };

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -175,7 +175,10 @@ export default {
         label: 'apostrophe:duplicate',
         icon: 'content-duplicate-icon',
         action: 'clone',
-        ...(this.disabled || this.maxReached) && { modifiers: [ 'disabled' ] }
+        modifiers: [
+          'separator',
+          ...(this.disabled || this.maxReached) ? [ 'disabled' ] : []
+        ]
       });
 
       // Custom widget operations displayed in the secondary controls

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -44,6 +44,10 @@ export default {
       type: Object,
       required: true
     },
+    areaField: {
+      type: Object,
+      default: null
+    },
     first: {
       type: Boolean,
       required: true
@@ -206,8 +210,10 @@ export default {
         this.$emit(action);
       }
       if (modal) {
+        // FIXME: why is areaField empty?
         apos.modal.execute(modal, {
-          modelValue: this.modelValue
+          widget: this.modelValue,
+          field: this.areaField
         });
       }
     }

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -133,7 +133,7 @@ export default {
         controls.push({
           ...this.widgetDefaultControl,
           label: 'apostrophe:edit',
-          icon: 'playlist-edit-icon',
+          icon: 'pencil-icon',
           disabled: this.disabled,
           tooltip: {
             content: 'apostrophe:editWidget',

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="apos-area-modify-controls">
-    <AposButtonGroup
-      v-if="!foreign"
-      :modifiers="[ 'vertical' ]"
-    >
+    <AposButtonGroup :modifiers="[ 'vertical' ]">
       <AposButton
         v-for="control in widgetPrimaryControls"
         :key="control.action"
@@ -61,10 +58,6 @@ export default {
       default() {
         return {};
       }
-    },
-    foreign: {
-      type: Boolean,
-      required: true
     },
     disabled: {
       type: Boolean,

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -220,10 +220,11 @@ $z-index-button-background: 1;
 $z-index-button-foreground: 2;
 
 .apos-area-modify-controls {
-  :deep(.apos-context-menu__items)
-    .apos-context-menu__item:has(.apos-context-menu__button--separator) {
+  :deep(.apos-context-menu__items) .apos-context-menu__item {
+    &:has(.apos-context-menu__button--separator):not(:last-child) {
       border-bottom: 1px solid var(--a-base-9);
     }
+  }
 
   :deep(.apos-button__content) {
     z-index: $z-index-button-foreground;

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -81,16 +81,9 @@ export default {
   },
   emits: [ 'remove', 'edit', 'cut', 'copy', 'clone', 'up', 'down', 'update' ],
   data() {
-    const { widgetOperations = [] } = apos.modules['@apostrophecms/area'];
-    const filteredOperations = widgetOperations.filter(operation => {
-      return !operation.type || operation.type === `${this.modelValue.type}-widget`;
-    });
-
     return {
-      widgetPrimaryOperations: filteredOperations
-        .filter(operation => !operation.secondaryLevel),
-      widgetSecondaryOperations: filteredOperations
-        .filter(operation => operation.secondaryLevel)
+      widgetPrimaryOperations: this.getOperations({ secondaryLevel: false }),
+      widgetSecondaryOperations: this.getOperations({ secondaryLevel: true })
     };
   },
   computed: {
@@ -218,8 +211,17 @@ export default {
     }
   },
   methods: {
-    filterByWidgetType(operation) {
-      return !operation.type || operation.type === this.modelValue.type;
+    getOperations({ secondaryLevel }) {
+      const { widgetOperations = [] } = apos.modules['@apostrophecms/area'];
+
+      return widgetOperations
+        .filter(operation => !operation.type || operation.type === `${this.modelValue.type}-widget`)
+        .filter(operation => {
+          if (secondaryLevel) {
+            return operation.secondaryLevel;
+          }
+          return !operation.secondaryLevel;
+        });
     },
     async handleClick({ action, modal }) {
       if (action) {

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -16,6 +16,7 @@
         :menu="widgetSecondaryControls"
         :disabled="disabled || (widgetSecondaryControls.length === 0)"
         menu-placement="left"
+        identifier="secondary-controls"
         :has-tip="false"
         :button="{
           label: 'apostrophe:moreOptions',

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -160,38 +160,23 @@ export default {
 
       // Cut
       controls.push({
-        ...this.widgetDefaultControl,
         label: 'apostrophe:cut',
         icon: 'content-cut-icon',
-        tooltip: {
-          content: 'apostrophe:cut',
-          placement: 'left'
-        },
         action: 'cut'
       });
 
       // Copy
       controls.push({
-        ...this.widgetDefaultControl,
         label: 'apostrophe:copy',
         icon: 'content-copy-icon',
-        tooltip: {
-          content: 'apostrophe:copy',
-          placement: 'left'
-        },
         action: 'copy'
       });
 
       // Clone
       controls.push({
-        ...this.widgetDefaultControl,
         label: 'apostrophe:duplicate',
         icon: 'content-duplicate-icon',
         disabled: this.disabled || this.maxReached,
-        tooltip: {
-          content: 'apostrophe:duplicate',
-          placement: 'left'
-        },
         action: 'clone'
       });
 

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -4,11 +4,46 @@
       :modifiers="[ 'vertical' ]"
     >
       <AposButton
-        v-for="widgetControl in widgetControls"
-        :key="widgetControl.action"
-        v-bind="widgetControl"
-        @click="handleClick(widgetControl.action)"
+        v-for="control in widgetPrimaryControlsBefore"
+        :key="control.action"
+        v-bind="control"
+        @click="handleClick(control.action)"
       />
+
+      <!-- <AposContextMenu -->
+      <!--   class="apos-admin-bar_context-button" -->
+      <!--   :menu="menu" -->
+      <!--   :disabled="disabled || (menu.length === 0)" -->
+      <!--   menu-placement="bottom-end" -->
+      <!--   :button="{ -->
+      <!--     tooltip: { content: 'apostrophe:moreOptions', placement: 'bottom' }, -->
+      <!--     label: 'apostrophe:moreOptions', -->
+      <!--     icon: 'dots-horizontal-icon', -->
+      <!--     iconOnly: true, -->
+      <!--     type: 'subtle', -->
+      <!--     modifiers: ['small', 'no-motion'] -->
+      <!--   }" -->
+      <!--   @item-clicked="menuHandler" -->
+      <!--   @open="$emit('menu-open')" -->
+      <!--   @close="$emit('menu-close')" -->
+      <!-- /> -->
+
+      <AposButton
+        v-for="control in widgetPrimaryControlsAfter"
+        :key="control.action"
+        v-bind="control"
+        @click="handleClick(control.action)"
+      />
+
+      <!-- <AposContextMenuDialog -->
+      <!--   :menu-placement="placement" -->
+      <!--   :class-list="classList" -->
+      <!--   :menu="menu" -->
+      <!--   :active-item="activeItem" -->
+      <!--   :is-open="isOpen" -->
+      <!--   @item-clicked="menuItemClicked" -->
+      <!--   @set-arrow="setArrow" -->
+      <!-- > -->
     </AposButtonGroup>
   </div>
 </template>
@@ -50,15 +85,8 @@ export default {
   },
   emits: [ 'remove', 'edit', 'cut', 'copy', 'clone', 'up', 'down' ],
   computed: {
-    widgetControls() {
-      if (this.foreign) {
-        return [];
-      }
-
-      const { widgetOperations } = apos.modules['@apostrophecms/area'];
-      console.log('widgetOperations', widgetOperations);
-
-      const defaultControl = {
+    widgetDefaultControl() {
+      return {
         iconOnly: true,
         icon: 'plus-icon',
         type: 'group',
@@ -68,11 +96,20 @@ export default {
         iconSize: 16,
         disableFocus: !this.tabbable
       };
+    },
+    widgetPrimaryControlsBefore() {
+      if (this.foreign) {
+        return [];
+      }
+
+      const { widgetOperations } = apos.modules['@apostrophecms/area'];
+      console.log('widgetOperations', widgetOperations);
+
       const controls = [];
 
       // Move up
       controls.push({
-        ...defaultControl,
+        ...this.widgetDefaultControl,
         label: 'apostrophe:nudgeUp',
         icon: 'arrow-up-icon',
         disabled: this.first || this.disabled,
@@ -85,7 +122,7 @@ export default {
 
       // Move down
       controls.push({
-        ...defaultControl,
+        ...this.widgetDefaultControl,
         label: 'apostrophe:nudgeDown',
         icon: 'arrow-down-icon',
         disabled: this.last || this.disabled,
@@ -99,7 +136,7 @@ export default {
       // Edit
       if (!this.options.contextual) {
         controls.push({
-          ...defaultControl,
+          ...this.widgetDefaultControl,
           label: 'apostrophe:edit',
           icon: 'playlist-edit-icon',
           disabled: this.disabled,
@@ -111,46 +148,55 @@ export default {
         });
       }
 
-      // Cut
-      controls.push({
-        ...defaultControl,
-        label: 'apostrophe:cut',
-        icon: 'content-cut-icon',
-        tooltip: {
-          content: 'apostrophe:cut',
-          placement: 'left'
-        },
-        action: 'cut'
-      });
+      /* // Cut */
+      /* controls.push({ */
+      /*   ...this.widgetDefaultControl, */
+      /*   label: 'apostrophe:cut', */
+      /*   icon: 'content-cut-icon', */
+      /*   tooltip: { */
+      /*     content: 'apostrophe:cut', */
+      /*     placement: 'left' */
+      /*   }, */
+      /*   action: 'cut' */
+      /* }); */
+      /**/
+      /* // Copy */
+      /* controls.push({ */
+      /*   ...this.widgetDefaultControl, */
+      /*   label: 'apostrophe:copy', */
+      /*   icon: 'clipboard-plus-outline-icon', */
+      /*   tooltip: { */
+      /*     content: 'apostrophe:copy', */
+      /*     placement: 'left' */
+      /*   }, */
+      /*   action: 'copy' */
+      /* }); */
+      /**/
+      /* // Clone */
+      /* controls.push({ */
+      /*   ...this.widgetDefaultControl, */
+      /*   label: 'apostrophe:clone', */
+      /*   icon: 'content-copy-icon', */
+      /*   disabled: this.disabled || this.maxReached, */
+      /*   tooltip: { */
+      /*     content: 'apostrophe:duplicate', */
+      /*     placement: 'left' */
+      /*   }, */
+      /*   action: 'clone' */
+      /* }); */
 
-      // Copy
-      controls.push({
-        ...defaultControl,
-        label: 'apostrophe:copy',
-        icon: 'clipboard-plus-outline-icon',
-        tooltip: {
-          content: 'apostrophe:copy',
-          placement: 'left'
-        },
-        action: 'copy'
-      });
+      return controls;
+    },
+    widgetPrimaryControlsAfter() {
+      if (this.foreign) {
+        return [];
+      }
 
-      // Clone
-      controls.push({
-        ...defaultControl,
-        label: 'apostrophe:clone',
-        icon: 'content-copy-icon',
-        disabled: this.disabled || this.maxReached,
-        tooltip: {
-          content: 'apostrophe:duplicate',
-          placement: 'left'
-        },
-        action: 'clone'
-      });
+      const controls = [];
 
       // Remove
       controls.push({
-        ...defaultControl,
+        ...this.widgetDefaultControl,
         label: 'apostrophe:remove',
         icon: 'trash-can-outline-icon',
         disabled: this.disabled,
@@ -162,7 +208,7 @@ export default {
       });
 
       return controls;
-    },
+    }
   },
   methods: {
     handleClick(action) {

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -220,9 +220,10 @@ $z-index-button-background: 1;
 $z-index-button-foreground: 2;
 
 .apos-area-modify-controls {
-  :deep(.apos-context-menu__items) .apos-context-menu__item:nth-child(3) {
-    border-bottom: 1px solid var(--a-base-9);
-  }
+  :deep(.apos-context-menu__items)
+    .apos-context-menu__item:has(.apos-context-menu__button--separator) {
+      border-bottom: 1px solid var(--a-base-9);
+    }
 
   :deep(.apos-button__content) {
     z-index: $z-index-button-foreground;

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -144,14 +144,12 @@ export default {
       }
 
       // Custom widget operations displayed in the primary controls
-      if (this.widgetPrimaryOperations.length) {
-        const customWidgetControls = this.widgetPrimaryOperations.map(operation => ({
+      controls.push(
+        ...this.widgetPrimaryOperations.map(operation => ({
           ...this.widgetDefaultControl,
           ...operation
-        }));
-
-        controls.push(...customWidgetControls);
-      }
+        }))
+      );
 
       return controls;
     },
@@ -176,19 +174,12 @@ export default {
       controls.push({
         label: 'apostrophe:duplicate',
         icon: 'content-duplicate-icon',
-        disabled: this.disabled || this.maxReached,
-        action: 'clone'
+        action: 'clone',
+        ...(this.disabled || this.maxReached) && { modifiers: [ 'disabled' ] }
       });
 
       // Custom widget operations displayed in the secondary controls
-      if (this.widgetSecondaryOperations.length) {
-        const customWidgetControls = this.widgetSecondaryOperations.map(operation => ({
-          ...this.widgetDefaultControl,
-          ...operation
-        }));
-
-        controls.push(...customWidgetControls);
-      }
+      controls.push(...this.widgetSecondaryOperations);
 
       return controls;
     },

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -151,7 +151,12 @@ export default {
       controls.push(
         ...this.widgetPrimaryOperations.map(operation => ({
           ...this.widgetDefaultControl,
-          ...operation
+          ...operation,
+          disabled: this.disabled,
+          tooltip: {
+            content: operation.label,
+            placement: 'left'
+          }
         }))
       );
 

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -82,11 +82,14 @@ export default {
   emits: [ 'remove', 'edit', 'cut', 'copy', 'clone', 'up', 'down' ],
   data() {
     const { widgetOperations = [] } = apos.modules['@apostrophecms/area'];
+    const filteredOperations = widgetOperations.filter(operation => {
+      return !operation.type || operation.type === `${this.modelValue.type}-widget`;
+    });
 
     return {
-      widgetPrimaryOperations: widgetOperations
+      widgetPrimaryOperations: filteredOperations
         .filter(operation => !operation.secondaryLevel),
-      widgetSecondaryOperations: widgetOperations
+      widgetSecondaryOperations: filteredOperations
         .filter(operation => operation.secondaryLevel)
     };
   },
@@ -215,6 +218,9 @@ export default {
     }
   },
   methods: {
+    filterByWidgetType(operation) {
+      return !operation.type || operation.type === this.modelValue.type;
+    },
     handleClick({ action, modal }) {
       if (action) {
         this.$emit(action);

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -7,7 +7,7 @@
         v-for="control in widgetPrimaryControlsBefore"
         :key="control.action"
         v-bind="control"
-        @click="handleClick(control.action)"
+        @click="handleClick(control)"
       />
 
       <!-- <AposContextMenu -->
@@ -32,7 +32,7 @@
         v-for="control in widgetPrimaryControlsAfter"
         :key="control.action"
         v-bind="control"
-        @click="handleClick(control.action)"
+        @click="handleClick(control)"
       />
 
       <!-- <AposContextMenuDialog -->
@@ -148,6 +148,16 @@ export default {
         });
       }
 
+      // Custom widget operations
+      if (widgetOperations.length) {
+        controls.push(
+          ...widgetOperations.map(operation => ({
+            ...this.widgetDefaultControl,
+            ...operation
+          }))
+        );
+      }
+
       /* // Cut */
       /* controls.push({ */
       /*   ...this.widgetDefaultControl, */
@@ -211,9 +221,17 @@ export default {
     }
   },
   methods: {
-    handleClick(action) {
+    handleClick({ action, modal }) {
       console.log('action', action);
-      this.$emit(action);
+      console.log('modal', modal);
+
+      if (modal) {
+        apos.modal.execute(modal);
+      }
+
+      if (action) {
+        this.$emit(action);
+      }
     }
   }
 };

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -3,61 +3,11 @@
     <AposButtonGroup
       :modifiers="[ 'vertical' ]"
     >
-      <template v-if="!foreign">
-        <AposButton
-          v-for="widgetControl in widgetControls"
-          :key="widgetControl.action"
-          v-bind="widgetControl"
-          @click="handleClick(widgetControl.action)"
-        />
-      </template>
       <AposButton
-        v-if="!foreign && !options.contextual"
-        v-bind="editButton"
-        :disabled="disabled"
-        :tooltip="{
-          content: 'apostrophe:editWidget',
-          placement: 'left'
-        }"
-        @click="$emit('edit')"
-      />
-      <AposButton
-        v-if="!foreign"
-        v-bind="cutButton"
-        :tooltip="{
-          content: 'apostrophe:cut',
-          placement: 'left'
-        }"
-        @click="$emit('cut')"
-      />
-      <AposButton
-        v-if="!foreign"
-        v-bind="copyButton"
-        :tooltip="{
-          content: 'apostrophe:copy',
-          placement: 'left'
-        }"
-        @click="$emit('copy')"
-      />
-      <AposButton
-        v-if="!foreign"
-        v-bind="cloneButton"
-        :disabled="disabled || maxReached"
-        :tooltip="{
-          content: 'apostrophe:duplicate',
-          placement: 'left'
-        }"
-        @click="$emit('clone')"
-      />
-      <AposButton
-        v-if="!foreign"
-        v-bind="removeButton"
-        :disabled="disabled"
-        :tooltip="{
-          content: 'apostrophe:delete',
-          placement: 'left'
-        }"
-        @click="$emit('remove')"
+        v-for="widgetControl in widgetControls"
+        :key="widgetControl.action"
+        v-bind="widgetControl"
+        @click="handleClick(widgetControl.action)"
       />
     </AposButtonGroup>
   </div>
@@ -99,15 +49,16 @@ export default {
     }
   },
   emits: [ 'remove', 'edit', 'cut', 'copy', 'clone', 'up', 'down' ],
-  data() {
-    const { widgetOperations } = apos.modules['@apostrophecms/area'];
-    console.log(widgetOperations);
-
-    return {};
-  },
   computed: {
-    widgetControlsDefaults() {
-      return {
+    widgetControls() {
+      if (this.foreign) {
+        return [];
+      }
+
+      const { widgetOperations } = apos.modules['@apostrophecms/area'];
+      console.log('widgetOperations', widgetOperations);
+
+      const defaultControl = {
         iconOnly: true,
         icon: 'plus-icon',
         type: 'group',
@@ -117,68 +68,101 @@ export default {
         iconSize: 16,
         disableFocus: !this.tabbable
       };
-    },
-    widgetControls() {
-      return [
-        {
-          ...this.widgetControlsDefaults,
-          label: 'apostrophe:nudgeUp',
-          icon: 'arrow-up-icon',
-          disabled: this.first || this.disabled,
-          tooltip: {
-            content: this.first || this.disabled ? null : 'apostrophe:nudgeUp',
-            placement: 'left'
-          },
-          action: 'up'
+      const controls = [];
+
+      // Move up
+      controls.push({
+        ...defaultControl,
+        label: 'apostrophe:nudgeUp',
+        icon: 'arrow-up-icon',
+        disabled: this.first || this.disabled,
+        tooltip: {
+          content: this.first || this.disabled ? null : 'apostrophe:nudgeUp',
+          placement: 'left'
         },
-        {
-          ...this.widgetControlsDefaults,
-          label: 'apostrophe:nudgeDown',
-          icon: 'arrow-down-icon',
-          disabled: this.last || this.disabled,
+        action: 'up'
+      });
+
+      // Move down
+      controls.push({
+        ...defaultControl,
+        label: 'apostrophe:nudgeDown',
+        icon: 'arrow-down-icon',
+        disabled: this.last || this.disabled,
+        tooltip: {
+          content: this.last || this.disabled ? null : 'apostrophe:nudgeDown',
+          placement: 'left'
+        },
+        action: 'down'
+      });
+
+      // Edit
+      if (!this.options.contextual) {
+        controls.push({
+          ...defaultControl,
+          label: 'apostrophe:edit',
+          icon: 'playlist-edit-icon',
+          disabled: this.disabled,
           tooltip: {
-            content: this.last || this.disabled ? null : 'apostrophe:nudgeDown',
+            content: 'apostrophe:editWidget',
             placement: 'left'
           },
-          action: 'down'
-        }
-      ];
-    },
-    cloneButton() {
-      return {
-        ...this.buttonDefaults,
-        label: 'apostrophe:clone',
-        icon: 'content-copy-icon'
-      };
-    },
-    removeButton() {
-      return {
-        ...this.buttonDefaults,
-        label: 'apostrophe:remove',
-        icon: 'trash-can-outline-icon'
-      };
-    },
-    editButton() {
-      return {
-        ...this.buttonDefaults,
-        label: 'apostrophe:edit',
-        icon: 'pencil-icon'
-      };
-    },
-    cutButton() {
-      return {
-        ...this.buttonDefaults,
+          action: 'edit'
+        });
+      }
+
+      // Cut
+      controls.push({
+        ...defaultControl,
         label: 'apostrophe:cut',
-        icon: 'content-cut-icon'
-      };
-    },
-    copyButton() {
-      return {
-        ...this.buttonDefaults,
+        icon: 'content-cut-icon',
+        tooltip: {
+          content: 'apostrophe:cut',
+          placement: 'left'
+        },
+        action: 'cut'
+      });
+
+      // Copy
+      controls.push({
+        ...defaultControl,
         label: 'apostrophe:copy',
-        icon: 'clipboard-plus-outline-icon'
-      };
-    }
+        icon: 'clipboard-plus-outline-icon',
+        tooltip: {
+          content: 'apostrophe:copy',
+          placement: 'left'
+        },
+        action: 'copy'
+      });
+
+      // Clone
+      controls.push({
+        ...defaultControl,
+        label: 'apostrophe:clone',
+        icon: 'content-copy-icon',
+        disabled: this.disabled || this.maxReached,
+        tooltip: {
+          content: 'apostrophe:duplicate',
+          placement: 'left'
+        },
+        action: 'clone'
+      });
+
+      // Remove
+      controls.push({
+        ...defaultControl,
+        label: 'apostrophe:remove',
+        icon: 'trash-can-outline-icon',
+        disabled: this.disabled,
+        tooltip: {
+          content: 'apostrophe:delete',
+          placement: 'left'
+        },
+        action: 'remove'
+      });
+
+      return controls;
+    },
   },
   methods: {
     handleClick(action) {

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -3,16 +3,14 @@
     <AposButtonGroup
       :modifiers="[ 'vertical' ]"
     >
-      <AposButton
-        v-if="!foreign"
-        v-bind="upButton"
-        :disabled="first || disabled"
-        :tooltip="{
-          content: (!disabled && !first) ? 'apostrophe:nudgeUp' : null,
-          placement: 'left'
-        }"
-        @click="$emit('up')"
-      />
+      <template v-if="!foreign">
+        <AposButton
+          v-for="widgetControl in widgetControls"
+          :key="widgetControl.action"
+          v-bind="widgetControl"
+          @click="handleClick(widgetControl.action)"
+        />
+      </template>
       <AposButton
         v-if="!foreign && !options.contextual"
         v-bind="editButton"
@@ -61,16 +59,6 @@
         }"
         @click="$emit('remove')"
       />
-      <AposButton
-        v-if="!foreign"
-        v-bind="downButton"
-        :disabled="last || disabled"
-        :tooltip="{
-          content: (!disabled && !last) ? 'apostrophe:nudgeDown' : null,
-          placement: 'left'
-        }"
-        @click="$emit('down')"
-      />
     </AposButtonGroup>
   </div>
 </template>
@@ -111,8 +99,14 @@ export default {
     }
   },
   emits: [ 'remove', 'edit', 'cut', 'copy', 'clone', 'up', 'down' ],
+  data() {
+    const { widgetOperations } = apos.modules['@apostrophecms/area'];
+    console.log(widgetOperations);
+
+    return {};
+  },
   computed: {
-    buttonDefaults() {
+    widgetControlsDefaults() {
       return {
         iconOnly: true,
         icon: 'plus-icon',
@@ -124,19 +118,31 @@ export default {
         disableFocus: !this.tabbable
       };
     },
-    upButton() {
-      return {
-        ...this.buttonDefaults,
-        label: 'apostrophe:nudgeUp',
-        icon: 'arrow-up-icon'
-      };
-    },
-    downButton() {
-      return {
-        ...this.buttonDefaults,
-        label: 'apostrophe:nudgeDown',
-        icon: 'arrow-down-icon'
-      };
+    widgetControls() {
+      return [
+        {
+          ...this.widgetControlsDefaults,
+          label: 'apostrophe:nudgeUp',
+          icon: 'arrow-up-icon',
+          disabled: this.first || this.disabled,
+          tooltip: {
+            content: this.first || this.disabled ? null : 'apostrophe:nudgeUp',
+            placement: 'left'
+          },
+          action: 'up'
+        },
+        {
+          ...this.widgetControlsDefaults,
+          label: 'apostrophe:nudgeDown',
+          icon: 'arrow-down-icon',
+          disabled: this.last || this.disabled,
+          tooltip: {
+            content: this.last || this.disabled ? null : 'apostrophe:nudgeDown',
+            placement: 'left'
+          },
+          action: 'down'
+        }
+      ];
     },
     cloneButton() {
       return {
@@ -172,6 +178,12 @@ export default {
         label: 'apostrophe:copy',
         icon: 'clipboard-plus-outline-icon'
       };
+    }
+  },
+  methods: {
+    handleClick(action) {
+      console.log('action', action);
+      this.$emit(action);
     }
   }
 };

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -241,6 +241,10 @@ $z-index-button-background: 1;
 $z-index-button-foreground: 2;
 
 .apos-area-modify-controls {
+  :deep(.apos-context-menu__items) .apos-context-menu__item:nth-child(3) {
+    border-bottom: 1px solid var(--a-base-9);
+  }
+
   :deep(.apos-button__content) {
     z-index: $z-index-button-foreground;
     position: relative;

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -18,7 +18,6 @@
         menu-placement="left"
         :has-tip="false"
         :button="{
-          tooltip: { content: 'apostrophe:moreOptions', placement: 'left' },
           label: 'apostrophe:moreOptions',
           icon: 'dots-horizontal-icon',
           iconOnly: true,
@@ -185,10 +184,15 @@ export default {
         icon: 'content-duplicate-icon',
         action: 'clone',
         modifiers: [
-          'separator',
           ...(this.disabled || this.maxReached) ? [ 'disabled' ] : []
         ]
       });
+
+      if (this.widgetSecondaryOperations.length) {
+        controls.push({
+          separator: true
+        });
+      }
 
       // Custom widget operations displayed in the secondary controls
       controls.push(...this.widgetSecondaryOperations);
@@ -230,15 +234,13 @@ $z-index-button-background: 1;
 $z-index-button-foreground: 2;
 
 .apos-area-modify-controls {
-  :deep(.apos-context-menu__items) .apos-context-menu__item {
-    &:has(.apos-context-menu__button--separator):not(:last-child) {
-      border-bottom: 1px solid var(--a-base-9);
-    }
-  }
-
   :deep(.apos-button__content) {
     z-index: $z-index-button-foreground;
     position: relative;
+  }
+
+  :deep(.apos-context-menu__items) {
+    min-width: 250px;
   }
 
   :deep(.apos-button__icon) {

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -232,7 +232,7 @@ export default {
           widget: this.modelValue,
           field: this.areaField
         });
-        if (result.widget) {
+        if (result?.widget) {
           // TODO: make sure the update method from
           // modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
           // does the job and does not mess with the widget type and _id:

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -79,7 +79,7 @@ export default {
       default: false
     }
   },
-  emits: [ 'remove', 'edit', 'cut', 'copy', 'clone', 'up', 'down' ],
+  emits: [ 'remove', 'edit', 'cut', 'copy', 'clone', 'up', 'down', 'update' ],
   data() {
     const { widgetOperations = [] } = apos.modules['@apostrophecms/area'];
     const filteredOperations = widgetOperations.filter(operation => {
@@ -221,15 +221,21 @@ export default {
     filterByWidgetType(operation) {
       return !operation.type || operation.type === this.modelValue.type;
     },
-    handleClick({ action, modal }) {
+    async handleClick({ action, modal }) {
       if (action) {
         this.$emit(action);
       }
       if (modal) {
-        apos.modal.execute(modal, {
+        const result = await apos.modal.execute(modal, {
           widget: this.modelValue,
           field: this.areaField
         });
+        if (result.widget) {
+          // TODO: make sure the update method from
+          // modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+          // does the job and does not mess with the widget type and _id:
+          this.$emit('update', result.widget);
+        }
       }
     }
   }

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -215,7 +215,6 @@ export default {
         this.$emit(action);
       }
       if (modal) {
-        // FIXME: why is areaField empty?
         apos.modal.execute(modal, {
           widget: this.modelValue,
           field: this.areaField

--- a/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposWidgetControls.vue
@@ -29,7 +29,7 @@
       />
 
       <AposButton
-        v-bind="widgetPrimaryControlsRemove"
+        v-bind="widgetRemoveControl"
         @click="handleClick({ action: 'remove' })"
       />
     </AposButtonGroup>
@@ -207,7 +207,7 @@ export default {
 
       return controls;
     },
-    widgetPrimaryControlsRemove() {
+    widgetRemoveControl() {
       return {
         ...this.widgetDefaultControl,
         label: 'apostrophe:remove',

--- a/modules/@apostrophecms/asset/lib/globalIcons.js
+++ b/modules/@apostrophecms/asset/lib/globalIcons.js
@@ -44,6 +44,7 @@ module.exports = {
   'content-cut-icon': 'ContentCut',
   'cursor-default-click-icon': 'CursorDefaultClick',
   'delete-icon': 'Delete',
+  'dots-horizontal-icon': 'DotsHorizontal',
   'dots-vertical-icon': 'DotsVertical',
   'drag-icon': 'Apps',
   'eye-icon': 'Eye',

--- a/modules/@apostrophecms/asset/lib/globalIcons.js
+++ b/modules/@apostrophecms/asset/lib/globalIcons.js
@@ -104,6 +104,7 @@ module.exports = {
   'pencil-icon': 'Pencil',
   'phone-icon': 'Phone',
   'play-box-icon': 'PlayBox',
+  'playlist-edit-icon': 'PlaylistEdit',
   'plus-icon': 'Plus',
   'redo-icon': 'RedoVariant',
   'refresh-icon': 'Refresh',

--- a/modules/@apostrophecms/asset/lib/globalIcons.js
+++ b/modules/@apostrophecms/asset/lib/globalIcons.js
@@ -66,6 +66,7 @@ module.exports = {
   'format-superscript-icon': 'FormatSuperscript',
   'format-text-icon': 'FormatText',
   'format-underline-icon': 'FormatUnderline',
+  'group-icon': 'Group', // TODO: remove
   'help-circle-icon': 'HelpCircle',
   'image-edit-outline': 'ImageEditOutline',
   'image-icon': 'Image',

--- a/modules/@apostrophecms/asset/lib/globalIcons.js
+++ b/modules/@apostrophecms/asset/lib/globalIcons.js
@@ -107,6 +107,7 @@ module.exports = {
   'pencil-icon': 'Pencil',
   'phone-icon': 'Phone',
   'play-box-icon': 'PlayBox',
+  'playlist-edit-icon': 'PlaylistEdit',
   'plus-icon': 'Plus',
   'redo-icon': 'RedoVariant',
   'refresh-icon': 'Refresh',

--- a/modules/@apostrophecms/asset/lib/globalIcons.js
+++ b/modules/@apostrophecms/asset/lib/globalIcons.js
@@ -107,7 +107,6 @@ module.exports = {
   'pencil-icon': 'Pencil',
   'phone-icon': 'Phone',
   'play-box-icon': 'PlayBox',
-  'playlist-edit-icon': 'PlaylistEdit',
   'plus-icon': 'Plus',
   'redo-icon': 'RedoVariant',
   'refresh-icon': 'Refresh',

--- a/modules/@apostrophecms/asset/lib/globalIcons.js
+++ b/modules/@apostrophecms/asset/lib/globalIcons.js
@@ -42,6 +42,7 @@ module.exports = {
   'cog-icon': 'Cog',
   'content-copy-icon': 'ContentCopy',
   'content-cut-icon': 'ContentCut',
+  'content-duplicate-icon': 'ContentDuplicate',
   'cursor-default-click-icon': 'CursorDefaultClick',
   'delete-icon': 'Delete',
   'dots-horizontal-icon': 'DotsHorizontal',

--- a/modules/@apostrophecms/asset/lib/globalIcons.js
+++ b/modules/@apostrophecms/asset/lib/globalIcons.js
@@ -67,7 +67,6 @@ module.exports = {
   'format-superscript-icon': 'FormatSuperscript',
   'format-text-icon': 'FormatText',
   'format-underline-icon': 'FormatUnderline',
-  'group-icon': 'Group', // TODO: remove
   'help-circle-icon': 'HelpCircle',
   'image-edit-outline': 'ImageEditOutline',
   'image-icon': 'Image',

--- a/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
+++ b/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
@@ -423,14 +423,14 @@ export default {
         }
       }
     },
-    menuHandler(action) {
-      const operation = this.customOperations.find(op => op.action === action);
+    menuHandler(item) {
+      const operation = this.customOperations.find(op => op.action === item.action);
       if (operation) {
         this.customAction(this.context, operation);
         return;
       }
 
-      this[action](this.context);
+      this[item.action](this.context);
     },
     async edit(doc) {
       await apos.modal.execute(

--- a/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
+++ b/modules/@apostrophecms/doc-type/ui/apos/logic/AposDocContextMenu.js
@@ -402,7 +402,7 @@ export default {
   methods: {
     customDiscardDraft() {
       if (this.showDiscardDraft && this.canDiscardDraft) {
-        this.menuHandler('discardDraft');
+        this.menuHandler({ action: 'discardDraft' });
       }
     },
     async onContentChanged({ doc, docIds }) {

--- a/modules/@apostrophecms/i18n/i18n/de.json
+++ b/modules/@apostrophecms/i18n/i18n/de.json
@@ -81,7 +81,6 @@
   "chooseDocType": "{{ type }} auswählen",
   "clear": "Löschen",
   "clearSelection": "Auswahl löschen",
-  "clone": "Duplizieren",
   "close": "Schliessen",
   "closeGlobal": "Globale Einstellungen schliessen",
   "collapseAll": "Alles einklappen",

--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -81,7 +81,6 @@
   "chooseDocType": "Choose {{ type }}",
   "clear": "Clear",
   "clearSelection": "Clear Selection",
-  "clone": "Clone",
   "close": "Close",
   "closeGlobal": "Close Global Site Settings",
   "collapseAll": "Collapse all",

--- a/modules/@apostrophecms/i18n/i18n/es.json
+++ b/modules/@apostrophecms/i18n/i18n/es.json
@@ -81,7 +81,6 @@
   "chooseDocType": "Elegir {{ type }}",
   "clear": "Borrar",
   "clearSelection": "Borrar Selección",
-  "clone": "Clonar",
   "close": "Cerrar",
   "closeGlobal": "Cerrar Configuración Global del Sitio",
   "collapseAll": "Colapsar todo",

--- a/modules/@apostrophecms/i18n/i18n/fr.json
+++ b/modules/@apostrophecms/i18n/i18n/fr.json
@@ -81,7 +81,6 @@
   "chooseDocType": "Choisir {{ type }}",
   "clear": "Effacer",
   "clearSelection": "Effacer la sélection",
-  "clone": "Cloner",
   "close": "Fermer",
   "closeGlobal": "Fermer les paramètres globaux du site",
   "collapseAll": "Tout réduire",

--- a/modules/@apostrophecms/i18n/i18n/it.json
+++ b/modules/@apostrophecms/i18n/i18n/it.json
@@ -81,7 +81,6 @@
   "chooseDocType": "Scegli {{ type }}",
   "clear": "Cancella",
   "clearSelection": "Cancella selezione",
-  "clone": "Clona",
   "close": "Chiudi",
   "closeGlobal": "Chiudi impostazioni globali del sito",
   "collapseAll": "Collassa tutto",

--- a/modules/@apostrophecms/i18n/i18n/pt-BR.json
+++ b/modules/@apostrophecms/i18n/i18n/pt-BR.json
@@ -81,7 +81,6 @@
   "chooseDocType": "Escolher {{ type }}",
   "clear": "Limpar",
   "clearSelection": "Limpar Seleção",
-  "clone": "Clonar",
   "close": "Fechar",
   "closeGlobal": "Fechar Configurações Globais do Site",
   "collapseAll": "Colapsar todos",

--- a/modules/@apostrophecms/i18n/i18n/sk.json
+++ b/modules/@apostrophecms/i18n/i18n/sk.json
@@ -81,7 +81,6 @@
   "chooseDocType": "Vyberte {{ type }}",
   "clear": "Vymazať",
   "clearSelection": "Vymazať Výber",
-  "clone": "Klonovať",
   "close": "Zavrieť",
   "closeGlobal": " Zatvorte globálne nastavenia webu",
   "collapseAll": "Zbaliť všetko",

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -96,6 +96,8 @@
       <div
         class="apos-media-editor__lip"
       >
+        <!-- TODO: here, search for all "<AposContextMenu" and "@item-clicked",
+              and adapt event handle to make it receive { action } -->
         <AposContextMenu
           v-if="!restoreOnly"
           :button="{

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -96,8 +96,6 @@
       <div
         class="apos-media-editor__lip"
       >
-        <!-- TODO: here, search for all "<AposContextMenu" and "@item-clicked",
-              and adapt event handle to make it receive { action } -->
         <AposContextMenu
           v-if="!restoreOnly"
           :button="{
@@ -262,8 +260,8 @@ export default {
     this.$emit('modified', false);
   },
   methods: {
-    moreMenuHandler(action) {
-      this[action]();
+    moreMenuHandler(item) {
+      this[item.action]();
     },
     async updateActiveDoc(newMedia) {
       newMedia = newMedia || {};

--- a/modules/@apostrophecms/modal/ui/apos/components/AposDocsManagerToolbar.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposDocsManagerToolbar.vue
@@ -43,7 +43,7 @@
           }"
           :disabled="!checkedCount"
           :menu="operations"
-          @item-clicked="(a) => beginGroupedOperation(a, operations)"
+          @item-clicked="(item) => beginGroupedOperation(item, operations)"
         />
       </div>
     </template>
@@ -275,8 +275,8 @@ export default {
 
       return this.confirmOperation(operation);
     },
-    async beginGroupedOperation(action, operations) {
-      const operation = operations.find(o => o.action === action);
+    async beginGroupedOperation(item, operations) {
+      const operation = operations.find(o => o.action === item.action);
 
       operation.modal
         ? await this.modalOperation(operation)

--- a/modules/@apostrophecms/modal/ui/apos/components/AposWidgetModalTabs.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposWidgetModalTabs.vue
@@ -139,7 +139,7 @@ export default {
       this.$emit('select-tab', id);
     },
     moreMenuHandler(item) {
-      this.$emit('select-tab', item);
+      this.$emit('select-tab', item.action);
     }
   }
 };

--- a/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
@@ -29,6 +29,7 @@ export default {
       // property is merged with the props supplied by the server-side configuration.
 
       apos.bus.$on('admin-menu-click', async (itemName) => {
+        console.log('itemName', itemName);
         let item;
         if (itemName === '@apostrophecms/global:singleton-editor') {
           // Special case: the global doc is a singleton, and we know its

--- a/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/TheAposModals.vue
@@ -29,7 +29,6 @@ export default {
       // property is merged with the props supplied by the server-side configuration.
 
       apos.bus.$on('admin-menu-click', async (itemName) => {
-        console.log('itemName', itemName);
         let item;
         if (itemName === '@apostrophecms/global:singleton-editor') {
           // Special case: the global doc is a singleton, and we know its

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposUtilityOperations.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposUtilityOperations.vue
@@ -61,12 +61,12 @@ export default {
   },
 
   methods: {
-    async handleUtilityOperation(action) {
+    async handleUtilityOperation(item) {
       const operation = [
         ...this.utilityOperations.menu,
         ...this.utilityOperations.buttons
       ]
-        .find((op) => op.action === action);
+        .find((op) => op.action === item.action);
 
       if (!operation) {
         // eslint-disable-next-line no-console
@@ -86,7 +86,7 @@ export default {
         await apos.modal.execute(modal, {
           moduleName: this.moduleOptions.name,
           moduleAction: this.moduleOptions.action,
-          action,
+          action: item.action,
           labels: this.moduleLabels,
           messages: operation.messages,
           ...modalOptions

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposInputArray.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposInputArray.js
@@ -429,7 +429,7 @@ export default {
       );
     },
     inlineMenuHandler(event, { index, id }) {
-      switch (event) {
+      switch (event.action) {
         case 'move-up':
           this.moveUpdate({
             oldIndex: index,

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -349,7 +349,6 @@ function setArrow(el) {
 }
 
 function menuItemClicked(item) {
-  console.log('AposContextMenu menuItemClicked item', item);
   emit('item-clicked', item);
   hide();
 }

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -461,8 +461,8 @@ function handleKeyboard(event) {
 }
 
 .apos-context-menu__popup--tb-padded .apos-context-menu__pane{
-  padding-top: 20px;
-  padding-bottom: 20px;
+  padding-top: $spacing-double;
+  padding-bottom: $spacing-double;
 }
 
 .apos-context-menu__popup {
@@ -482,9 +482,10 @@ function handleKeyboard(event) {
   @include type-base;
 
   & {
-    padding: 20px;
-    border: 1px solid var(--a-base-8);
-    border-radius: var(--a-border-radius);
+    padding: $spacing-half 0;
+    border: 1px solid var(--a-base-9);
+    border-radius: var(--a-border-radius-large);
+    font-size: var(--a-type-menu);
     box-shadow: var(--a-box-shadow);
     background-color: var(--a-background-primary);
   }
@@ -501,9 +502,8 @@ function handleKeyboard(event) {
     display: inline-block;
     list-style-type: none;
     width: max-content;
-    margin: none;
     margin-block: 0;
-    padding: 10px 0;
+    margin: $spacing-half 0;
   }
 }
 </style>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -46,6 +46,7 @@
           :menu="menu"
           :active-item="activeItem"
           :is-open="isOpen"
+          :has-tip="hasTip"
           @item-clicked="menuItemClicked"
           @set-arrow="setArrow"
         >
@@ -158,6 +159,10 @@ const props = defineProps({
   centerTipEl: {
     type: Object,
     default: null
+  },
+  hasTip: {
+    type: Boolean,
+    default: true
   }
 });
 
@@ -373,6 +378,10 @@ async function setDropdownPosition() {
     left: `${x}px`,
     top: `${y}px`
   };
+
+  if (!arrowEl.value) {
+    return;
+  }
 
   const { x: arrowX, y: arrowY } = middlewareData.arrow;
   Object.assign(arrowEl.value.style, {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -348,8 +348,9 @@ function setArrow(el) {
   arrowEl.value = el;
 }
 
-function menuItemClicked(name) {
-  emit('item-clicked', name);
+function menuItemClicked(item) {
+  console.log('AposContextMenu menuItemClicked item', item);
+  emit('item-clicked', item);
   hide();
 }
 

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
@@ -131,8 +131,9 @@ function emitSetArrow(arrowEl) {
 
   & {
     padding: 20px;
-    border: 1px solid var(--a-base-8);
-    border-radius: var(--a-border-radius);
+    border: 1px solid var(--a-base-9);
+    font-size: var(--a-type-menu);
+    border-radius: var(--a-border-radius-large);
     box-shadow: var(--a-box-shadow);
     background-color: var(--a-background-primary);
   }
@@ -145,28 +146,27 @@ function emitSetArrow(arrowEl) {
     display: inline-block;
     list-style-type: none;
     width: max-content;
-    margin: none;
     margin-block: 0;
-    padding: 10px 0;
+    margin: $spacing-three-quarters 0;
   }
 }
 
 .apos-context-menu__dialog :deep(.apos-schema .apos-field) {
-  margin-bottom: 20px;
+  margin-bottom: $spacing-double;
 
   .apos-field__help {
-    margin-top: 5px;
+    margin-top: $spacing-half;
   }
 }
 
 .apos-context-menu__tip[x-placement^='bottom'] {
-  top: -10px;
+  top: -$spacing-base;
   bottom: auto;
 }
 
 .apos-context-menu__tip[x-placement^='top'] {
   top: auto;
-  bottom: -10px;
+  bottom: -$spacing-base;
   transform: rotate(180deg);
 }
 </style>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
@@ -93,8 +93,8 @@ const classes = computed(() => {
   return classes.join(' ');
 });
 
-function menuItemClicked(action) {
-  emit('item-clicked', action);
+function menuItemClicked(menuItem) {
+  emit('item-clicked', menuItem);
 }
 
 function emitSetArrow(arrowEl) {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
@@ -21,7 +21,7 @@
           <AposContextMenuItem
             v-for="item in menu"
             :key="item.action"
-            :data-apos-test-context-menu-item="item.action"
+            :data-apos-test-context-menu-item="item.action || item.modal"
             :menu-item="item"
             :is-active="item.name === activeItem"
             :open="isOpen"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
@@ -94,6 +94,7 @@ const classes = computed(() => {
 });
 
 function menuItemClicked(menuItem) {
+  console.log('AposContextMenuDialog menuItem', { ...menuItem });
   emit('item-clicked', menuItem);
 }
 

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
@@ -94,7 +94,6 @@ const classes = computed(() => {
 });
 
 function menuItemClicked(menuItem) {
-  console.log('AposContextMenuDialog menuItem', { ...menuItem });
   emit('item-clicked', menuItem);
 }
 

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuItem.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuItem.vue
@@ -1,6 +1,11 @@
 <template>
-  <li class="apos-context-menu__item">
+  <li
+    class="apos-context-menu__item"
+    :class="menuItem.separator ? 'apos-context-menu__item--separator' : null"
+  >
+    <hr v-if="menuItem.separator" class="apos-context-menu__separator" />
     <button
+      v-else
       class="apos-context-menu__button"
       :class="modifiers"
       :tabindex="tabindex"
@@ -87,7 +92,20 @@ export default {
 <style lang="scss" scoped>
 .apos-context-menu__item {
   display: flex;
+  align-items: center;
+}
 
+.apos-context-menu__item:not(.apos-context-menu__item--separator) {
+  min-height: 36px;
+}
+
+.apos-context-menu__separator {
+  box-sizing: border-box;
+  width: 100%;
+  margin: $spacing-half 0;
+  padding: 0;
+  border-color: var(--a-base-10);
+  border-style: solid;
 }
 
 .apos-context-menu__button {
@@ -98,27 +116,25 @@ export default {
     flex-grow: 1;
     align-items: center;
     width: 100%;
-    margin: 0 10px;
-    padding: 10px;
+    margin: 0 $spacing-three-quarters;
+    padding: $spacing-base;
     border: none;
-    color: var(--a-base-1);
+    font-size: var(--a-type-menu);
+    font-weight: 300;
     text-align: left;
-    border-radius: 3px;
+    border-radius: $spacing-half;
     background-color: var(--a-background-primary);
   }
 
   &:hover {
     cursor: pointer;
-    color: var(--a-text-primary);
+    background-color: var(--a-primary-transparent-05);
   }
 
-  &:focus {
-    outline: none;
-    color: var(--a-text-primary);
-  }
-
+  &:focus,
   &:active {
-    color: var(--a-base-1);
+    outline: 1px solid var(--a-primary-transparent-25);
+    background-color: var(--a-primary-transparent-05);
   }
 
   &--danger {
@@ -128,8 +144,15 @@ export default {
       color: var(--a-danger-button-hover);
     }
 
+    &:hover,
     &:focus,
     &:active {
+      background-color: var(--a-danger-button-background);
+    }
+
+    &:focus,
+    &:active {
+      outline: 1px solid var(--a-danger);
       color: var(--a-danger-button-active);
     }
   }
@@ -141,17 +164,29 @@ export default {
     &:focus,
     &:active {
       color: var(--a-primary);
+      background-color: var(--a-primary-transparent-15);
+    }
+
+    &:focus,
+    &:active {
+      outline: 1px solid var(--a-primary-transparent-25);
     }
   }
 
   &--disabled {
-    color: var(--a-base-5);
+    color: var(--a-base-3);
+
+    &:focus,
+    &:active {
+      outline: 1px solid var(--a-base-8);
+    }
 
     &:hover,
     &:focus,
     &:active {
       cursor: not-allowed;
       color: var(--a-base-5);
+      background-color: var(--a-base-9);
     }
   }
 
@@ -161,6 +196,6 @@ export default {
 }
 
 .apos-context-menu__active {
-  background-color: var(--a-base-10)
+  background-color: var(--a-base-10);
 }
 </style>

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuItem.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuItem.vue
@@ -78,9 +78,7 @@ export default {
   },
   methods: {
     click() {
-      console.log('AposContextMenuItem this.menuItem', { ...this.menuItem });
       this.$emit('clicked', this.menuItem);
-      // this.$emit('clicked', this.menuItem.action);
     }
   }
 };

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuItem.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuItem.vue
@@ -78,7 +78,9 @@ export default {
   },
   methods: {
     click() {
+      console.log('AposContextMenuItem this.menuItem', { ...this.menuItem });
       this.$emit('clicked', this.menuItem);
+      // this.$emit('clicked', this.menuItem.action);
     }
   }
 };

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuItem.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenuItem.vue
@@ -78,7 +78,7 @@ export default {
   },
   methods: {
     click() {
-      this.$emit('clicked', this.menuItem.action);
+      this.$emit('clicked', this.menuItem);
     }
   }
 };

--- a/modules/@apostrophecms/ui/ui/apos/components/AposFilterMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposFilterMenu.vue
@@ -138,24 +138,29 @@ export default {
   min-width: 140px;
 
   :deep(.apos-input--select) {
-    padding-top: 10px;
-    padding-bottom: 10px;
+    padding-top: $spacing-base;
+    padding-bottom: $spacing-base;
     background-color: var(--a-base-10);
     font-style: italic;
+  }
+
+  :deep(.apos-choice-label) {
+    padding-right: $spacing-half;
+    padding-left: $spacing-half;
   }
 }
 
 .apos-filters-menu :deep(.apos-field__label) {
   display: block;
   width: 100%;
-  margin-bottom: 10px;
-  padding-bottom: 10px;
+  margin-bottom: $spacing-base + $spacing-half;
+  padding-bottom: $spacing-half;
   border-bottom: 1px solid var(--a-base-9);
-  color: var(--a-base-3);
+  color: var(--a-base-2);
 }
 
 .apos-filters-menu__set {
-  margin-bottom: 30px;
+  margin: 0 0 $spacing-double + $spacing-half;
 
   &:last-child {
     margin-bottom: 0;

--- a/modules/@apostrophecms/ui/ui/apos/scss/global/_theme.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/global/_theme.scss
@@ -12,6 +12,7 @@
   --a-danger-button-hover: #c00717;
   --a-danger-button-active: #a10000;
   --a-danger-button-disabled: #ff9d98;
+  --a-danger-button-background: #eb443b0a;
   --a-sensitive: #643810;
   --a-sensitive-medium: #e2c7b9;
   --a-sensitive-light: #fff3e7;
@@ -77,6 +78,7 @@
   --a-type-base: 12px;
   --a-type-label: 13px;
   --a-type-large: 14px;
+  --a-type-menu: 14px;
   --a-type-heading: 22px;
   --a-type-display: 32px;
 

--- a/modules/@apostrophecms/ui/ui/apos/scss/mixins/_theme_mixins.scss
+++ b/modules/@apostrophecms/ui/ui/apos/scss/mixins/_theme_mixins.scss
@@ -24,6 +24,7 @@ $input-color-disabled: var(--a-base-4);
   --a-primary-transparent-50: #{color.adjust($color, $alpha: -0.5)};
   --a-primary-transparent-15: #{color.adjust($color, $alpha: -0.85)};
   --a-primary-transparent-10: #{color.adjust($color, $alpha: -0.9)};
+  --a-primary-transparent-05: #{color.adjust($color, $alpha: -0.95)};
   --a-primary-dark-10: #{color.mix(#000, $color, 10%)};
   --a-primary-dark-15: #{color.mix(#000, $color, 15%)};
   --a-primary-light-40: #{color.mix(#fff, $color, 40%)};

--- a/modules/@apostrophecms/widget-type/index.js
+++ b/modules/@apostrophecms/widget-type/index.js
@@ -393,6 +393,13 @@ module.exports = {
           The getWidgetClasses method is deprecated and will be removed in the next major
           version. The method in 3.x simply returns an empty array.`);
         return [];
+      },
+
+      addWidgetOperation(operation) {
+        self.apos.area.addWidgetOperation({
+          ...operation,
+          type: self.__meta.name
+        });
       }
 
     };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "dependencies": {
     "@apostrophecms/emulate-mongo-3-driver": "^1.0.6",
-    "@apostrophecms/vue-material-design-icons": "github:apostrophecms/vue-material-design-icons#pro-7247-widget-operations",
+    "@apostrophecms/vue-material-design-icons": "^1.0.0",
     "@ctrl/tinycolor": "^4.1.0",
     "@floating-ui/dom": "^1.5.3",
     "@opentelemetry/api": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "dependencies": {
     "@apostrophecms/emulate-mongo-3-driver": "^1.0.6",
-    "@apostrophecms/vue-material-design-icons": "^1.0.0",
+    "@apostrophecms/vue-material-design-icons": "github:apostrophecms/vue-material-design-icons#pro-7247-widget-operations",
     "@ctrl/tinycolor": "^4.1.0",
     "@floating-ui/dom": "^1.5.3",
     "@opentelemetry/api": "^1.0.4",

--- a/test/areas.js
+++ b/test/areas.js
@@ -427,6 +427,7 @@ describe('Areas', function() {
     const initialOperations = [ ...apos.area.widgetOperations ];
 
     const operation = {
+      name: 'someAction',
       modal: 'AposSomeModal',
       label: 'Some label',
       icon: 'some-icon',
@@ -447,13 +448,13 @@ describe('Areas', function() {
   });
 
   it('should throw an error when adding a widget operation that lacks required properties', function() {
-    const message = /requires label and modal/;
+    const message = /requires name, label and modal/;
 
     assert.throws(
       () => {
         apos.area.addWidgetOperation({
           label: 'Some label',
-          icon: 'some-icon'
+          modal: 'AposSomeModal'
         });
       },
       { message }
@@ -462,33 +463,64 @@ describe('Areas', function() {
     assert.throws(
       () => {
         apos.area.addWidgetOperation({
-          modal: 'AposSomeModal',
-          icon: 'some-icon'
+          name: 'someAction',
+          modal: 'AposSomeModal'
+        });
+      },
+      { message }
+    );
+
+    assert.throws(
+      () => {
+        apos.area.addWidgetOperation({
+          name: 'someAction',
+          label: 'Some label'
         });
       },
       { message }
     );
   });
 
-  it('should replace an existing widget operation', function() {
+  it('should replace an existing widget operation based on the name', function() {
     const initialOperations = [ ...apos.area.widgetOperations ];
     const operation = {
-      modal: 'AposSomeModal',
-      label: 'New label',
-      icon: 'new-icon'
+      name: 'nameA',
+      modal: 'modalA-2',
+      label: 'Label A-2',
+      icon: 'icon-a-2'
     };
 
     apos.area.widgetOperations = [
       {
-        modal: 'AposSomeModal',
-        label: 'Some label',
-        icon: 'sone-icon'
+        name: 'nameA',
+        modal: 'modalA-1',
+        label: 'Label A-1',
+        icon: 'icon-a-1'
+      },
+      {
+        name: 'nameB',
+        modal: 'modalB',
+        label: 'Label B',
+        icon: 'icon-b'
       }
     ];
     apos.area.addWidgetOperation(operation);
 
-    assert.strictEqual(apos.area.widgetOperations.length, 1);
-    assert.deepStrictEqual(apos.area.widgetOperations, [ { ...operation } ]);
+    assert.strictEqual(apos.area.widgetOperations.length, 2);
+    assert.deepStrictEqual(apos.area.widgetOperations, [
+      {
+        name: 'nameB',
+        modal: 'modalB',
+        label: 'Label B',
+        icon: 'icon-b'
+      },
+      {
+        name: 'nameA',
+        modal: 'modalA-2',
+        label: 'Label A-2',
+        icon: 'icon-a-2'
+      }
+    ]);
 
     apos.area.widgetOperations = initialOperations;
   });
@@ -496,6 +528,7 @@ describe('Areas', function() {
   it('should handle widget operations with custom permissions', function() {
     const initialOperations = [ ...apos.area.widgetOperations ];
     const operation = {
+      name: 'someAction',
       modal: 'AposSomeModal',
       label: 'Some label',
       icon: 'sone-icon',

--- a/test/areas.js
+++ b/test/areas.js
@@ -72,6 +72,10 @@ describe('Areas', function() {
     return t.destroy(apos);
   });
 
+  beforeEach(function() {
+    apos.area.widgetOperations = [];
+  });
+
   it('can get widgets from groups', function() {
     const options = {
       groups: {
@@ -424,8 +428,6 @@ describe('Areas', function() {
   });
 
   it('should support custom widget operations', function() {
-    const initialOperations = [ ...apos.area.widgetOperations ];
-
     const operation = {
       name: 'someAction',
       modal: 'AposSomeModal',
@@ -443,8 +445,6 @@ describe('Areas', function() {
 
     assert.strictEqual(apos.area.widgetOperations.length, 1);
     assert.deepStrictEqual(apos.area.widgetOperations, [ { ...operation } ]);
-
-    apos.area.widgetOperations = initialOperations;
   });
 
   it('should throw an error when adding a widget operation that lacks required properties', function() {
@@ -454,7 +454,8 @@ describe('Areas', function() {
       () => {
         apos.area.addWidgetOperation({
           label: 'Some label',
-          modal: 'AposSomeModal'
+          modal: 'AposSomeModal',
+          icon: 'some-icon'
         });
       },
       { message }
@@ -464,7 +465,8 @@ describe('Areas', function() {
       () => {
         apos.area.addWidgetOperation({
           name: 'someAction',
-          modal: 'AposSomeModal'
+          modal: 'AposSomeModal',
+          icon: 'some-icon'
         });
       },
       { message }
@@ -474,15 +476,34 @@ describe('Areas', function() {
       () => {
         apos.area.addWidgetOperation({
           name: 'someAction',
-          label: 'Some label'
+          label: 'Some label',
+          icon: 'some-icon'
         });
       },
       { message }
     );
+
+    assert.throws(
+      () => {
+        apos.area.addWidgetOperation({
+          name: 'someAction',
+          label: 'Some label',
+          modal: 'AposSomeModal'
+        });
+      },
+      { message: /requires the icon property at primary level/ }
+    );
+
+    // This ensures that the icon is not required at secondary level:
+    apos.area.addWidgetOperation({
+      name: 'someAction',
+      label: 'Some label',
+      modal: 'AposSomeModal',
+      secondaryLevel: true
+    });
   });
 
   it('should replace an existing widget operation based on the name', function() {
-    const initialOperations = [ ...apos.area.widgetOperations ];
     const operation = {
       name: 'nameA',
       modal: 'modalA-2',
@@ -521,12 +542,9 @@ describe('Areas', function() {
         icon: 'icon-a-2'
       }
     ]);
-
-    apos.area.widgetOperations = initialOperations;
   });
 
   it('should handle widget operations with custom permissions', function() {
-    const initialOperations = [ ...apos.area.widgetOperations ];
     const operation = {
       name: 'someAction',
       modal: 'AposSomeModal',
@@ -549,8 +567,6 @@ describe('Areas', function() {
       const browserData = apos.area.getBrowserData(apos.task.getContributorReq());
       assert.deepStrictEqual(browserData.widgetOperations, []);
     }
-
-    apos.area.widgetOperations = initialOperations;
   });
 });
 

--- a/test/areas.js
+++ b/test/areas.js
@@ -440,11 +440,32 @@ describe('Areas', function() {
       }
     };
 
-    apos.area.widgetOperations = [];
     apos.area.addWidgetOperation(operation);
 
     assert.strictEqual(apos.area.widgetOperations.length, 1);
     assert.deepStrictEqual(apos.area.widgetOperations, [ { ...operation } ]);
+  });
+
+  it('should support custom widget operations added via a widget module', function() {
+    const operation = {
+      name: 'someAction',
+      modal: 'AposSomeModal',
+      label: 'Some label',
+      icon: 'some-icon',
+      secondaryLevel: true,
+      permission: {
+        action: 'create',
+        type: 'article'
+      }
+    };
+
+    apos.modules['@apostrophecms/image-widget'].addWidgetOperation(operation);
+
+    assert.strictEqual(apos.area.widgetOperations.length, 1);
+    assert.deepStrictEqual(apos.area.widgetOperations, [ {
+      ...operation,
+      type: '@apostrophecms/image-widget'
+    } ]);
   });
 
   it('should throw an error when adding a widget operation that lacks required properties', function() {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

~TODO: check that other modules have not been broken with the `menuItemClicked` changed to pass an item object and not just `item.action`~ ✅ 

Related to https://github.com/apostrophecms/testbed/pull/343

## Summary

- Implement the new `apos.area.addWidgetOperation` method to:
  - Add widget operations at first level
  - Add widget operations at secondary level (via 3-dots menu)
- Add wrapper to the `@apostrophecms/widget-type` module to register operations only for widgets that match the type of the module where the wrapper is invoked.
- Handle permission in `apos.area.getBrowserData`
- Dynamically loop through widget operations
- Update widget operation icons
- Display secondary widget operations, by re-using `AposContextMenu.vue`
  - Adapt `AposContextMenu.vue` to make it emit the whole clicked item, not only its `action` property, in order to access the `modal` property.
  - Adapt this change everywhere (`action` -> `item.action`)
- ~Lot's of eslint `max-len` warnings fixed (marked as "linter" in the PR comments)~ (done in #4923)

## What are the specific steps to test this change?

**- Primary level**

```js
    apos.area.addWidgetOperation({
      name: 'openSettings',
      modal: 'AposSettingsManager',
      label: 'Create Section',
      icon: 'group-icon'
    });
```

<img width="244" alt="image" src="https://github.com/user-attachments/assets/c7c1919f-ca4a-4ed1-9c60-9d54b0b1838e" />

**- Secondary level**

```js
    apos.area.addWidgetOperation({
      name: 'createSections',
      modal: 'AposSettingsManager',
      label: 'Create Section',
      icon: 'group-icon',
      secondaryLevel: true
    });
```

<img width="290" alt="image" src="https://github.com/user-attachments/assets/4c3f82bd-58cc-4b35-a107-599badc0955a" />

**- Specific widget type**

```js
    // in `modules/@apostrophecms/image-widget/index.js`
    self.addWidgetOperation({
      name: 'adjustImage',
      modal: 'AposImageRelationshipEditor',
      label: 'Adjust Image',
      icon: 'image-edit-outline',
      permission: {
        action: 'edit',
        type: '@apostrophecms/image'
      }
    });
```

| image | rich text |
|--------|--------|
| <img width="255" alt="image" src="https://github.com/user-attachments/assets/0230a52f-f6a5-4354-8d3d-0c4eb30a8a17" /> | <img width="184" alt="image" src="https://github.com/user-attachments/assets/b707a288-4e87-4224-b683-3cd6f39a640f" /> | 

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
