### PR TITLE
Pro 7371 link pages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,1 +1,1 @@
-{ "extends": ["apostrophe"] }
+{ "extends": "apostrophe" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 ### Fixes
 
 * Fixes an edge case where reordering a page in the Page Manager might affect another locale.
+* Fixes chrome bug when pages manager checkboxes need a double click when coming from the rich text editor (because some text is selected).
+* Fixes the rich text insert menu image menu not being properly closed.
+* Fixes the rich text toolbar not closing sometimes when unfocusing the editor.
 
 ## 4.14.0 (2025-03-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Change user's email field type to `email`.
 * Improve media manager experience after uploading images. No additional server requests are made, no broken UI on error.
 * Change reset password form button label to `Reset Password`.
+* Bumps eslint-config-apostrophe, fix errors and a bunch of warnings.
 
 ### Fixes
 

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -32,6 +32,7 @@
             :tool="tools[item]"
             :options="editorOptions"
             :editor="editor"
+            @close="onCloseToolbarPopover"
           />
         </div>
       </AposContextMenuDialog>
@@ -186,7 +187,8 @@ export default {
       showPlaceholder: null,
       activeInsertMenuComponent: false,
       suppressInsertMenu: false,
-      insertMenuKey: null
+      insertMenuKey: null,
+      closeBubbleMenu: false
     };
   },
   computed: {
@@ -405,7 +407,28 @@ export default {
     apos.bus.$off('apos-refreshing', this.onAposRefreshing);
   },
   methods: {
+    shouldShowBubbleMenu({
+      editor, view, state, oldState, from, to
+    }) {
+      console.log('docuemnt.activeElement', document.activeElement);
+      // only show the bubble menu for images and links
+      const { selection } = state;
+      const { empty } = selection;
+
+      if (this.shouldCloseBubbleMenu) {
+        this.shouldCloseBubbleMenu = false;
+        return false;
+      }
+      if (this.isFocused && !empty) {
+        return true;
+      }
+      return false;
+    },
+    onCloseToolbarPopover() {
+      this.shouldCloseBubbleMenu = true;
+    },
     onBubbleHide() {
+      this.shouldCloseBubbleMenu = false;
       apos.bus.$emit('close-context-menus', 'richText');
     },
     generateKey() {

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -32,7 +32,7 @@
             :tool="tools[item]"
             :options="editorOptions"
             :editor="editor"
-            @close="onCloseToolbarPopover"
+            @close="closeToolbar"
           />
         </div>
       </AposContextMenuDialog>
@@ -187,8 +187,7 @@ export default {
       showPlaceholder: null,
       activeInsertMenuComponent: false,
       suppressInsertMenu: false,
-      insertMenuKey: null,
-      closeBubbleMenu: false
+      insertMenuKey: null
     };
   },
   computed: {
@@ -407,26 +406,6 @@ export default {
     apos.bus.$off('apos-refreshing', this.onAposRefreshing);
   },
   methods: {
-    shouldShowBubbleMenu({
-      editor, view, state, oldState, from, to
-    }) {
-      console.log('docuemnt.activeElement', document.activeElement);
-      // only show the bubble menu for images and links
-      const { selection } = state;
-      const { empty } = selection;
-
-      if (this.shouldCloseBubbleMenu) {
-        this.shouldCloseBubbleMenu = false;
-        return false;
-      }
-      if (this.isFocused && !empty) {
-        return true;
-      }
-      return false;
-    },
-    onCloseToolbarPopover() {
-      this.shouldCloseBubbleMenu = true;
-    },
     onBubbleHide() {
       this.shouldCloseBubbleMenu = false;
       apos.bus.$emit('close-context-menus', 'richText');
@@ -674,6 +653,11 @@ export default {
     },
     setActiveInsertMenu(isActive = true) {
       this.activeInsertMenuComponent = isActive;
+    },
+    closeToolbar() {
+      this.editor.chain().focus().run();
+      this.editor.commands.focus();
+      /* this.editor.commands.blur(); */ // Do we keep?
     }
   }
 };

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -318,9 +318,6 @@ export default {
     }
   },
   watch: {
-    /* openedPopover(val) { */
-    /*   console.log('opened popover: ', val); */
-    /* }, */
     isFocused(newVal) {
       if (!newVal) {
         if (this.pending) {

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -407,7 +407,6 @@ export default {
   },
   methods: {
     onBubbleHide() {
-      this.shouldCloseBubbleMenu = false;
       apos.bus.$emit('close-context-menus', 'richText');
     },
     generateKey() {
@@ -655,9 +654,11 @@ export default {
       this.activeInsertMenuComponent = isActive;
     },
     closeToolbar() {
-      this.editor.chain().focus().run();
+      // This is a workaround to force the toolbar to close on blur
+      // Related issue: https://github.com/ueberdosis/tiptap/issues/6210
       this.editor.commands.focus();
-      /* this.editor.commands.blur(); */ // Do we keep?
+      this.editor.commands.blur();
+      this.editor.chain().focus().run();
     }
   }
 };

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapAnchor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapAnchor.vue
@@ -145,6 +145,7 @@ export default {
     removeAnchor() {
       this.docFields.data = {};
       this.editor.commands.unsetAnchor();
+      this.editor.chain().focus().blur().run();
       this.close();
     },
     close() {
@@ -160,6 +161,7 @@ export default {
       this.editor.commands.setAnchor({
         id: this.docFields.data.anchor
       });
+      this.editor.chain().focus().blur().run();
       this.close();
     },
     keyboardHandler(e) {

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapAnchor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapAnchor.vue
@@ -72,6 +72,7 @@ export default {
       required: true
     }
   },
+  emits: [ 'close' ],
   data () {
     return {
       generation: 1,
@@ -148,7 +149,6 @@ export default {
     },
     close() {
       this.$refs.contextMenu.hide();
-      this.editor.chain().focus();
     },
     async save() {
       this.triggerValidation = true;
@@ -195,6 +195,7 @@ export default {
     },
     closePopover() {
       window.removeEventListener('keydown', this.keyboardHandler);
+      this.$emit('close');
     }
   }
 };

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapColor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapColor.vue
@@ -80,6 +80,7 @@ const props = defineProps({
     default: () => ({})
   }
 });
+const emit = defineEmits([ 'close' ]);
 
 const moduleOptions = window.apos.modules['@apostrophecms/rich-text-widget'];
 
@@ -120,6 +121,7 @@ function openPopover() {
 }
 function closePopover() {
   removeEventListener('keydown', keyboardHandler);
+  emit('close');
 }
 function keyboardHandler(e) {
   if ([ 'Escape', 'Enter' ].includes(e.key)) {

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapColor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapColor.vue
@@ -49,7 +49,7 @@
             type="primary"
             label="apostrophe:close"
             :modifiers="['small', 'margin-micro']"
-            @click="close"
+            @click.stop="close"
           />
         </footer>
       </div>
@@ -80,7 +80,7 @@ const props = defineProps({
     default: () => ({})
   }
 });
-const emit = defineEmits([ 'close' ]);
+const emit = defineEmits([ 'open-popover', 'close' ]);
 
 const moduleOptions = window.apos.modules['@apostrophecms/rich-text-widget'];
 
@@ -118,6 +118,7 @@ watch(
 
 function openPopover() {
   addEventListener('keydown', keyboardHandler);
+  emit('open-popover');
 }
 function closePopover() {
   removeEventListener('keydown', keyboardHandler);
@@ -131,6 +132,8 @@ function keyboardHandler(e) {
 
 function close() {
   if (contextMenu.value) {
+    props.editor.chain().focus().run();
+    props.editor.chain().blur().run();
     contextMenu.value.hide();
   }
 };

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapColor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapColor.vue
@@ -132,8 +132,7 @@ function keyboardHandler(e) {
 
 function close() {
   if (contextMenu.value) {
-    props.editor.chain().focus().run();
-    props.editor.chain().blur().run();
+    props.editor.chain().focus().blur().run();
     contextMenu.value.hide();
   }
 };

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapColor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapColor.vue
@@ -49,7 +49,7 @@
             type="primary"
             label="apostrophe:close"
             :modifiers="['small', 'margin-micro']"
-            @click.stop="close"
+            @click="close"
           />
         </footer>
       </div>

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapImage.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapImage.vue
@@ -5,6 +5,7 @@
       menu-placement="bottom-end"
       :button="button"
       :rich-text-menu="true"
+      @open="$emit('open-popover')"
       @close="$emit('close')"
     >
       <AposImageControlDialog
@@ -29,7 +30,7 @@ export default {
       required: true
     }
   },
-  emits: [ 'close' ],
+  emits: [ 'open-popover', 'close' ],
   computed: {
     button() {
       return {

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapImage.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapImage.vue
@@ -5,6 +5,7 @@
       menu-placement="bottom-end"
       :button="button"
       :rich-text-menu="true"
+      @close="closePopover"
     >
       <AposImageControlDialog
         :editor="editor"
@@ -28,6 +29,7 @@ export default {
       required: true
     }
   },
+  emits: [ 'close' ],
   computed: {
     button() {
       return {
@@ -70,6 +72,9 @@ export default {
     close() {
       this.$refs.contextMenu.hide();
       this.editor.chain().focus();
+    },
+    closePopover() {
+      this.$emit('close');
     }
   }
 };

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapImage.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapImage.vue
@@ -5,7 +5,7 @@
       menu-placement="bottom-end"
       :button="button"
       :rich-text-menu="true"
-      @close="closePopover"
+      @close="$emit('close')"
     >
       <AposImageControlDialog
         :editor="editor"
@@ -71,10 +71,6 @@ export default {
   methods: {
     close() {
       this.$refs.contextMenu.hide();
-      this.editor.chain().focus();
-    },
-    closePopover() {
-      this.$emit('close');
     }
   }
 };

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapInsertItem.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapInsertItem.vue
@@ -1,6 +1,7 @@
 <template>
   <AposContextMenu
     v-if="menuItem.component && !menuItem.noPopover"
+    ref="contextMenu"
     menu-placement="bottom-end"
     :rich-text-menu="true"
     @open="openPopover"
@@ -65,6 +66,7 @@ const props = defineProps({
 const emit = defineEmits([ 'set-active-insert-menu', 'done' ]);
 
 const isInlineComponentActive = ref(false);
+const contextMenu = ref(null);
 const isInlineComponentShowed = computed(() => {
   return Boolean(props.menuItem.noPopover &&
     props.menuItem.component &&
@@ -105,6 +107,9 @@ function closeInsertMenuItem() {
   removeSlash();
   emit('set-active-insert-menu', false);
   isInlineComponentActive.value = false;
+  if (contextMenu.value) {
+    contextMenu.value.hide();
+  }
 }
 
 function openPopover() {

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
@@ -260,9 +260,8 @@ export default {
       this.evaluateConditions();
     },
     closePopover() {
-      console.log('=====> focus commands <=====');
-      this.editor.commands.focus();
       window.removeEventListener('keydown', this.keyboardHandler);
+      this.$emit('close');
     }
   }
 };

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
@@ -73,6 +73,7 @@ export default {
       required: true
     }
   },
+  emits: [ 'close' ],
   data() {
     const moduleOptions = apos.modules['@apostrophecms/rich-text-widget'];
     return {
@@ -155,7 +156,6 @@ export default {
     },
     close() {
       this.$refs.contextMenu.hide();
-      this.editor.chain().focus();
     },
     async save() {
       this.triggerValidation = true;
@@ -260,6 +260,8 @@ export default {
       this.evaluateConditions();
     },
     closePopover() {
+      console.log('=====> focus commands <=====');
+      this.editor.commands.focus();
       window.removeEventListener('keydown', this.keyboardHandler);
     }
   }

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
@@ -152,6 +152,7 @@ export default {
     removeLink() {
       this.docFields.data = {};
       this.editor.commands.unsetLink();
+      this.editor.chain().focus().blur().run();
       this.close();
     },
     close() {
@@ -188,6 +189,7 @@ export default {
       attrs.href = this.docFields.data.href;
       this.editor.commands.setLink(attrs);
 
+      this.editor.chain().focus().blur().run();
       this.close();
     },
     keyboardHandler(e) {
@@ -208,7 +210,9 @@ export default {
         this.docFields.data = {};
         this.schema.forEach((item) => {
           if (item.htmlAttribute && item.type === 'checkboxes') {
-            this.docFields.data[item.name] = attrs[item.htmlAttribute] ? [ attrs[item.htmlAttribute] ] : [];
+            this.docFields.data[item.name] = attrs[item.htmlAttribute]
+              ? [ attrs[item.htmlAttribute] ]
+              : [];
             return;
           }
           if (item.htmlAttribute && item.type === 'boolean') {

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
@@ -73,7 +73,7 @@ export default {
       required: true
     }
   },
-  emits: [ 'close' ],
+  emits: [ 'open-popover', 'close' ],
   data() {
     const moduleOptions = apos.modules['@apostrophecms/rich-text-widget'];
     return {
@@ -258,6 +258,7 @@ export default {
       window.addEventListener('keydown', this.keyboardHandler);
       await this.populateFields();
       this.evaluateConditions();
+      this.$emit('open-popover');
     },
     closePopover() {
       window.removeEventListener('keydown', this.keyboardHandler);

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapMarks.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapMarks.vue
@@ -1,10 +1,12 @@
 <template>
   <div class="apos-marks-control">
     <AposContextMenu
+      ref="contextMenu"
       menu-placement="bottom-start"
       :button="button"
       :rich-text-menu="true"
       :center-on-icon="true"
+      @close="closePopover"
     >
       <div class="apos-popover apos-marks-control__dialog">
         <div class="apos-marks-control__content-wrapper">
@@ -62,6 +64,7 @@ export default {
       }
     }
   },
+  emits: [ 'close' ],
   data() {
     return {
       classes: this.options.marks.map(m => m.class)
@@ -139,10 +142,11 @@ export default {
     click() {
       this.toggleOpen();
     },
-    toggleOpen() {
-    },
     close() {
-      this.editor.chain().focus();
+      this.$refs.contextMenu.hide();
+    },
+    closePopover() {
+      this.$emit('close');
     }
   }
 };

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapMarks.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapMarks.vue
@@ -137,8 +137,7 @@ export default {
   methods: {
     toggleStyle(mark) {
       this.editor.commands[mark.command](mark.type, mark.options || {});
-      this.editor.chain().focus().run();
-      this.editor.chain().blur().run();
+      this.editor.chain().focus().blur().run();
       this.close();
     },
     click() {

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapMarks.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapMarks.vue
@@ -6,6 +6,7 @@
       :button="button"
       :rich-text-menu="true"
       :center-on-icon="true"
+      @open="openPopover"
       @close="closePopover"
     >
       <div class="apos-popover apos-marks-control__dialog">
@@ -64,7 +65,7 @@ export default {
       }
     }
   },
-  emits: [ 'close' ],
+  emits: [ 'open-popover', 'close' ],
   data() {
     return {
       classes: this.options.marks.map(m => m.class)
@@ -135,8 +136,9 @@ export default {
   },
   methods: {
     toggleStyle(mark) {
-      this.editor.commands.focus();
       this.editor.commands[mark.command](mark.type, mark.options || {});
+      this.editor.chain().focus().run();
+      this.editor.chain().blur().run();
       this.close();
     },
     click() {
@@ -144,6 +146,9 @@ export default {
     },
     close() {
       this.$refs.contextMenu.hide();
+    },
+    openPopover() {
+      this.$emit('open-popover');
     },
     closePopover() {
       this.$emit('close');

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapStyles.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapStyles.vue
@@ -17,6 +17,7 @@
       class="apos-tiptap-control apos-tiptap-control--select"
       :style="`width:${$t(nodeOptions[active].label).length * 6.5}px`"
       @change="setStyle"
+      @close="$emit('close')"
     >
       <option
         v-for="(style, i) in nodeOptions"
@@ -59,6 +60,7 @@ export default {
       }
     }
   },
+  emits: [ 'close' ],
   data() {
     return {
       multipleSelected: false
@@ -145,15 +147,16 @@ export default {
   methods: {
     setStyle($event) {
       const style = this.nodeOptions[$event.target.value];
-      this.editor.commands.focus();
       this.editor.commands[style.command](style.type, style.options || {});
+      this.$emit('close');
     }
   }
 };
 </script>
 
 <style lang="scss" scoped>
-  // If another select el is needed for the rich-text toolbar these styles should be made global
+  // If another select el is needed for the rich-text toolbar
+  // these styles should be made global
   .apos-tiptap-control--select {
     @include apos-button-reset();
     @include apos-transition();

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapStyles.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapStyles.vue
@@ -17,7 +17,6 @@
       class="apos-tiptap-control apos-tiptap-control--select"
       :style="`width:${$t(nodeOptions[active].label).length * 6.5}px`"
       @change="setStyle"
-      @close="$emit('close')"
     >
       <option
         v-for="(style, i) in nodeOptions"
@@ -148,6 +147,8 @@ export default {
     setStyle($event) {
       const style = this.nodeOptions[$event.target.value];
       this.editor.commands[style.command](style.type, style.options || {});
+      this.editor.chain().focus().run();
+      this.editor.chain().blur().run();
       this.$emit('close');
     }
   }

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapStyles.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapStyles.vue
@@ -147,8 +147,7 @@ export default {
     setStyle($event) {
       const style = this.nodeOptions[$event.target.value];
       this.editor.commands[style.command](style.type, style.options || {});
-      this.editor.chain().focus().run();
-      this.editor.chain().blur().run();
+      this.editor.chain().focus().blur().run();
       this.$emit('close');
     }
   }

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapTable.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapTable.vue
@@ -5,6 +5,7 @@
       v-model="current"
       class="apos-tiptap-control apos-tiptap-control--select"
       @change="takeAction"
+      @blur="$emit('close')"
     >
       <option
         v-for="action in actions"
@@ -46,6 +47,7 @@ export default {
       }
     }
   },
+  emits: [ 'close' ],
   data() {
     return {
       current: ''
@@ -124,26 +126,26 @@ export default {
   methods: {
     takeAction() {
       const action = this.current;
-      this.editor.commands.focus();
       if (action === 'insertTable') {
         // Reach into prosemirror for current selection,
         // then turn it into a cursor position only so we don't
         // delete the existing selection which would mean
         // you can only create a table by deleting some work
-        this.editor.commands.setTextSelection(this.editor.view.state.selection.$anchor.pos);
+        this.editor.commands.setTextSelection(
+          this.editor.view.state.selection.$anchor.pos
+        );
       }
       this.editor.commands[action]();
-      // We are using the select as a menu of one-time actions, it's not really a persisted value
+      // We are using the select as a menu of one-time actions,
+      // it's not really a persisted value
       this.current = '';
+      this.$emit('close');
     }
   }
 };
 </script>
 
 <style lang="scss" scoped>
-  // "If another select el is needed for the rich-text toolbar these styles should be made global."
-  // ... And here we are, but first let's see if we decide to rebuild this UI without the menu. -Tom
-
   .apos-tiptap-control--select {
     @include apos-button-reset();
     @include type-small;

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapTable.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapTable.vue
@@ -5,7 +5,6 @@
       v-model="current"
       class="apos-tiptap-control apos-tiptap-control--select"
       @change="takeAction"
-      @blur="$emit('close')"
     >
       <option
         v-for="action in actions"

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTreeRows.vue
@@ -81,6 +81,7 @@
                 readOnly: maxReached && !checked.includes(row._id)
               }"
               :choice="{ value: row._id }"
+              @pointerdown="pointerEvent"
             />
             <span class="apos-tree__cell__value">
               <AposIndicator
@@ -255,6 +256,11 @@ export default {
     });
   },
   methods: {
+    // Fix for chrome when some text is selected (needed double click to check the box)
+    // Comes from sortablejs, so we avoid the event to propagate to sortablejs listener
+    pointerEvent(event) {
+      event.stopPropagation();
+    },
     setHeights() {
       this.treeBranches.forEach(branch => {
         // Add padding to the max-height to avoid needing a `resize`

--- a/package.json
+++ b/package.json
@@ -132,8 +132,6 @@
     "xregexp": "^2.0.0"
   },
   "devDependencies": {
-    "@babel/eslint-parser": "^7.17.0",
-    "eslint": "^8.57.1",
     "eslint-config-apostrophe": "^5.0.0",
     "mocha": "^10.7.3",
     "nyc": "^15.1.0",


### PR DESCRIPTION
[PRO-7371](https://linear.app/apostrophecms/issue/PRO-7371/buggy-behavior-with-the-pages-manager-when-opening-it-from-a-link)
[PRO-7392](https://linear.app/apostrophecms/issue/PRO-7392/rich-text-widget-image-insertion-menu-not-working-correctly)
[PRO-7370](https://linear.app/apostrophecms/issue/PRO-7370/rich-text-toolbar-doesnt-close-automatically-when-i-save-link)

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*

## What are the specific steps to test this change?

* No more double click needed to select a page when coming from rich text
* Rich text toolbar doesn't get stuck (some workarounds)
* Fix bug of the insert menu for images (image menu not being properly closed)

[Cypress](https://github.com/apostrophecms/testbed/actions/runs/14223182226) 🟢 

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
