### PR TITLE
Pro 7348

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 * Fixes the rich text insert menu image menu not being properly closed.
 * Fixes the rich text toolbar not closing sometimes when unfocusing the editor.
 * Fixes missing wording on images batch operations.
+* Fixes rich text toolbar width being limited to parent width.
+* Fixes rich text insert menu focused item text color easily overridable.
 
 ## 4.14.2 (2025-04-02)
 

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -753,6 +753,11 @@ function traverseNextNode(node) {
   $z-index-button-background: 1;
   $z-index-button-foreground: 2;
 
+  .bubble-menu {
+    width: max-content;
+    max-width: 95vw;
+  }
+
   .apos-rich-text-toolbar.editor-menu-bubble {
     z-index: $z-index-manager-toolbar;
     position: absolute;

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapInsertBtn.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapInsertBtn.vue
@@ -13,8 +13,12 @@
       />
     </div>
     <div class="apos-rich-text-insert-menu-label">
-      <h4>{{ $t(props.menuItem.label) }}</h4>
-      <p>{{ $t(props.menuItem.description) }}</p>
+      <h4 class="apos-rich-text-insert-menu-label__title">
+        {{ $t(props.menuItem.label) }}
+      </h4>
+      <p class="apos-rich-text-insert-menu-label__desc">
+        {{ $t(props.menuItem.description) }}
+      </p>
     </div>
   </button>
 </template>
@@ -59,7 +63,11 @@ const props = defineProps({
 
     &:active, &:focus {
       background-color: var(--a-primary);
-      color: var(--a-white);
+
+      .apos-rich-text-insert-menu-label__title,
+      .apos-rich-text-insert-menu-label__desc {
+        color: var(--a-white);
+      }
     }
   }
 


### PR DESCRIPTION
https://linear.app/apostrophecms/issue/PRO-7348/rich-text-toolbar-resize-weirdly-when-too-long
https://linear.app/apostrophecms/issue/PRO-7497/the-insert-image-title-becomes-invisible-in-blue-against-a-dark-purple

## Summary

* Fixes rich text toolbar size. Make it takes `max-content` to not be limited to parent width. But also a max-wdith to not go above screen width.
* Text color of insert menu focused element was easily overridable from other style like palette, I made it more precise so harder to override.

## What are the specific steps to test this change?

Check tickets.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
