### PR TITLE
PRO-7518: Fix children count and expand button refresh

### DIFF
--- a/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTree.vue
@@ -145,7 +145,8 @@ export default {
         });
       });
       // Place that largest value on that key of the spacingRow object.
-      // Put that array in the DOM, and generate styles to be passed down based on its layout. Give the first column any leftover space.
+      // Put that array in the DOM, and generate styles to be passed down based
+      // on its layout. Give the first column any leftover space.
       const finalRow = [];
       this.headers.forEach(col => {
         let obj;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

- Due to page manager optimization (no server request, in-place state updates), the `row._children` length becomes stale
- The reason for that is `sortable` (plugin) takes over manages the actual ordering. We only keep track of "important" data changes as level, rank, slug, etc. 
- The `sortable` code is not interested in a deep data as `row._children` so it's never touched.
- We are only interested in the children length in order to know if we should introduce a toggle feature.
- This problem is hard and would require either to again request relevant data from the server and update the entire tree (and re-render it - nullifies our optimization) or perform a very complex computation to sync our tree (the item children) with the changes reported by `sortable`
- There is a third option, that is now implemented. We use global signals for "atomic incrementing or decrementing" (correcting) the children count of affected parent pages. 
- The price to pay is 2 event handlers per tree row component. It's a small price compared to the eventual computation processor time required with the other scenarios (and much less options for bugs - the solution is simple). 

## What are the specific steps to test this change?

- When moving a page under another page that has no children, a toggle button should appear.
- When moving out the last child of a parent page, the toggle button should disappear. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
