### PR TITLE
PRO-7346: Add missing  error handling related with a previous patch

### DIFF
--- a/modules/@apostrophecms/i18n/i18n/en.json
+++ b/modules/@apostrophecms/i18n/i18n/en.json
@@ -593,6 +593,8 @@
   "uploaded": "Successfully uploaded a file",
   "uploadedMediaPlaceholder": "Uploaded media will appear here",
   "uploaded_plural": "Successfully uploaded {{ count }} files",
+  "uploadedError": "{{ count }} file failed to upload",
+  "uploadedError_plural": "{{ count }} files failed to upload",
   "uploading": "Uploading {{ name }}",
   "url": "URL",
   "user": "User",

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaUploader.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaUploader.vue
@@ -153,7 +153,7 @@ export default {
           }
         }
 
-        if (errorCount) {
+        if (errorCount > 0) {
           await apos.notify('apostrophe:uploadedError', {
             type: 'danger',
             icon: 'alert-circle-icon',

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaUploader.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaUploader.vue
@@ -157,7 +157,9 @@ export default {
           await apos.notify('apostrophe:uploadedError', {
             type: 'danger',
             icon: 'alert-circle-icon',
-            dismiss: true,
+            // Let it stick, we have too many server side notifications now
+            // (1 per failure).
+            dismiss: false,
             interpolate: {
               count: errorCount
             }

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaUploader.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaUploader.vue
@@ -120,6 +120,7 @@ export default {
         this.$emit('upload-started');
         const files = event.dataTransfer ? event.dataTransfer.files : event.target.files;
         const fileCount = files.length;
+        let errorCount = 0;
 
         const emptyDoc = await apos.http.post(this.action, {
           busy: true,
@@ -141,6 +142,7 @@ export default {
               images.push(img);
             }
           } catch (e) {
+            errorCount++;
             const msg = e.body && e.body.message ? e.body.message : this.$t('apostrophe:uploadError');
             await apos.notify(msg, {
               type: 'danger',
@@ -148,17 +150,30 @@ export default {
               dismiss: true,
               localize: false
             });
-            return;
           }
         }
 
-        await apos.notify('apostrophe:uploaded', {
-          type: 'success',
-          dismiss: true,
-          interpolate: {
-            count: fileCount
-          }
-        });
+        if (errorCount) {
+          await apos.notify('apostrophe:uploadedError', {
+            type: 'danger',
+            icon: 'alert-circle-icon',
+            dismiss: true,
+            interpolate: {
+              count: errorCount
+            }
+          });
+        }
+
+        const successCount = fileCount - errorCount;
+        if (successCount > 0) {
+          await apos.notify('apostrophe:uploaded', {
+            type: 'success',
+            dismiss: true,
+            interpolate: {
+              count: successCount
+            }
+          });
+        }
 
         // When complete, refresh the image grid, with the new images at top.
         this.$emit('upload-complete', images);


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

> Note: no need of changelog, an issue introduced by unreleased changes.

Let the Media Manager emit the results and show the failed upload number. When not doing so, it breaks our improved flow (no server requests, handling properly the empty placeholders based on failed/succeeded uploads). 

## What are the specific steps to test this change?

Upload X files, having a forbidden extension (e.g. `.js`) among them. The succeeded files should show after upload, the failing upload placeholder should be removed, additional notification should be shown informing about the number of failed files. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
