### PR TITLE
Pro 7547 locale switcher

### DIFF
--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -9,8 +9,8 @@ const { klona } = require('klona');
 // The `getManager` method should be used to obtain a reference to the module
 // that manages a particular doc type, so that you can benefit from behavior
 // specific to that module. One method of this module that you may sometimes use directly
-// is `apos.doc.find()`, which returns a query[query](server-@apostrophecms/query.html) for
-// fetching documents of all types. This is useful when implementing something
+// is `apos.doc.find()`, which returns a query[query](server-@apostrophecms/query.html)
+// for fetching documents of all types. This is useful when implementing something
 // like the [@apostrophecms/search](../@apostrophecms/search/index.html) module.
 //
 // ## Options
@@ -71,7 +71,12 @@ module.exports = {
           if (_id) {
             criteria._id = { $ne: _id };
           }
-          const doc = await self.find(req, criteria).permission(false).archived(null).project({ slug: 1 }).toObject();
+          const doc = await self
+            .find(req, criteria)
+            .permission(false)
+            .archived(null)
+            .project({ slug: 1 })
+            .toObject();
           if (doc) {
             throw self.apos.error('conflict');
           } else {
@@ -344,7 +349,8 @@ module.exports = {
       async changeDocIds(pairs, { keep, skipReplace = false } = {}) {
         let renamed = 0;
         let kept = 0;
-        // Get page paths up front so we can avoid multiple queries when working on path changes
+        // Get page paths up front so we can avoid multiple queries when working
+        // on path changes
         const pages = await self.apos.doc.db.find({
           path: { $exists: 1 },
           slug: /^\//
@@ -354,7 +360,8 @@ module.exports = {
         for (const pair of pairs) {
           const [ from, to ] = pair;
           const oldAposDocId = from.split(':')[0];
-          const existing = await self.apos.doc.db.findOne({ _id: skipReplace ? to : from });
+          const existing = await self.apos.doc.db
+            .findOne({ _id: skipReplace ? to : from });
           if (!existing) {
             throw self.apos.error('notfound');
           }
@@ -371,7 +378,10 @@ module.exports = {
           }
           const isPage = self.apos.page.isPage(existing);
           if (isPage) {
-            replacement.path = existing.path.replace(existing.aposDocId, replacement.aposDocId);
+            replacement.path = existing.path.replace(
+              existing.aposDocId,
+              replacement.aposDocId
+            );
           }
           try {
             if (!skipReplace) {
@@ -385,7 +395,8 @@ module.exports = {
               // We cannot fix this error
               throw e;
             }
-            const existingReplacement = await self.apos.doc.db.findOne({ _id: replacement._id });
+            const existingReplacement = await self.apos.doc.db
+              .findOne({ _id: replacement._id });
             if (!existingReplacement) {
               // We don't know the cause of this error
               throw e;
@@ -582,7 +593,8 @@ module.exports = {
       // await apos.doc.find(req, { type: 'foobar' }).toArray()
 
       find(req, criteria = {}, options = {}) {
-        return self.apos.modules['@apostrophecms/any-doc-type'].find(req, criteria, options);
+        return self.apos.modules['@apostrophecms/any-doc-type']
+          .find(req, criteria, options);
       },
 
       // **Most often you will insert or update docs via the
@@ -632,7 +644,9 @@ module.exports = {
 
             await telemetry.startActiveSpan(`db:${doc.type}:insert`, async (spanInsert) => {
               spanInsert.setAttribute(SemanticAttributes.CODE_FUNCTION, 'insertBody');
-              spanInsert.setAttribute(SemanticAttributes.CODE_NAMESPACE, self.__meta.name);
+              spanInsert.setAttribute(
+                SemanticAttributes.CODE_NAMESPACE, self.__meta.name
+              );
               spanInsert.setAttribute(telemetry.Attributes.TARGET_NAMESPACE, doc.type);
               spanInsert.setAttribute(telemetry.Attributes.TARGET_FUNCTION, 'insert');
               try {
@@ -701,7 +715,9 @@ module.exports = {
 
             await telemetry.startActiveSpan(`db:${doc.type}:update`, async (spanUpdate) => {
               spanUpdate.setAttribute(SemanticAttributes.CODE_FUNCTION, 'updateBody');
-              spanUpdate.setAttribute(SemanticAttributes.CODE_NAMESPACE, self.__meta.name);
+              spanUpdate.setAttribute(
+                SemanticAttributes.CODE_NAMESPACE, self.__meta.name
+              );
               spanUpdate.setAttribute(telemetry.Attributes.TARGET_NAMESPACE, doc.type);
               spanUpdate.setAttribute(telemetry.Attributes.TARGET_FUNCTION, 'update');
               try {
@@ -876,8 +892,8 @@ module.exports = {
           }
         }
       },
-      // Called by an `@apostrophecms/doc-type:insert` event handler to confirm that the user
-      // has the appropriate permissions for the doc's type and content.
+      // Called by an `@apostrophecms/doc-type:insert` event handler to confirm that
+      // the user has the appropriate permissions for the doc's type and content.
       testInsertPermissions(req, doc, options) {
         if (options.permissions !== false) {
           if (!self.apos.permission.can(req, 'create', doc)) {
@@ -999,9 +1015,17 @@ module.exports = {
       //
       // - Set value of a top-level meta property of an object field (can be
       //   further nested):
-      // `apos.doc.setMeta(doc, 'my-module', 'address', 'city', 'myMetaKey', 'myMetaValue');`
+      // `apos.doc.setMeta(
+      // doc,
+      // 'my-module',
+      // 'address',
+      // 'city',
+      // 'myMetaKey',
+      // 'myMetaValue'
+      // );`
       //
       // - Set value of a meta property of a field inside of an array field type:
+      // eslint-disable-next-line max-len
       // `apos.doc.setMeta(doc, 'my-module', arrayItemObject, 'city', 'myMetaKey', 'myMetaValue');`
       //
       // - Set value of a meta property of a rich text widget
@@ -1009,7 +1033,9 @@ module.exports = {
       //
       // - Dots in the `key` are treated as part of the key, dots in `pathComponents`
       //   are treated as dot-path and are not altered:
+      // eslint-disable-next-line max-len
       // `apos.doc.setMeta(doc, 'my-module', 'address', 'city.name', 'myMetaKey.with.dots', 'myMetaValue');`
+      // eslint-disable-next-line max-len
       //  will set `doc.aposMeta.address.aposMeta.city.name['my-module:myMetaKey.with.dots']: 'myMetaValue'`.
       setMeta(doc, namespace, ...pathArgsWithKeyAndValue) {
         if (!_.isPlainObject(doc) || !namespace) {
@@ -1150,7 +1176,8 @@ module.exports = {
       // Get the meta path for a given field.
       // Signature:
       // `apos.doc.getMetaPath([subobject,] ...pathComponents);`
-      // See `setMeta` for more information about `subobject` and `pathComponents` arguments.
+      // See `setMeta` for more information about `subobject` and
+      // `pathComponents` arguments.
       //
       // Returns the path to the meta property withouth the namespace and key.
       // The returned path can be directly used to access or modify the meta property.
@@ -1231,7 +1258,10 @@ module.exports = {
         if (!err) {
           return false;
         }
-        return err.code === 13596 || err.code === 13596 || err.code === 11000 || err.code === 11001;
+        return err.code === 13596 ||
+          err.code === 13596 ||
+          err.code === 11000 ||
+          err.code === 11001;
       },
       // Set the manager object corresponding
       // to a given doc type. Typically `manager`
@@ -1451,8 +1481,8 @@ module.exports = {
       // it will be inferred from the `type` of the document in context, with all page
       // types using the page module (not their type-specific module). This is almost
       // always correct, therefore it only makes sense to pass an explicit
-      // `moduleName` option here if the action API should be invoked on a different module
-      // than expected.
+      // `moduleName` option here if the action API should be invoked on a different
+      // module than expected.
       //
       // An additional optional `modifiers` property is supported - button modifiers
       // as supported by `AposContextMenu` (e.g. modifiers: [ 'danger' ]).
@@ -1461,7 +1491,8 @@ module.exports = {
       // the menu will be shown only for docs which have `autopublish: false` and
       // `localized: true` options.
       //
-      // `conditions` defines the circumstances under which the opetion should be displayed.
+      // `conditions` defines the circumstances under which the opetion should be
+      // displayed.
       // If all `conditions` are not met, the item is not displayed for this particular
       // document.
       //
@@ -1578,9 +1609,13 @@ module.exports = {
                 forSchema(field.schema, value);
               }
             } else if (field.type === 'relationship') {
-              doc[field.idsStorage] = (doc[field.idsStorage] || []).map(self.apos.doc.toAposDocId);
+              doc[field.idsStorage] = (doc[field.idsStorage] || [])
+                .map(self.apos.doc.toAposDocId);
               if (field.fieldsStorage) {
-                doc[field.fieldsStorage] = Object.fromEntries(Object.entries(doc[field.fieldsStorage] || {}).map(([ key, value ]) => [ self.apos.doc.toAposDocId(key), value ]));
+                doc[field.fieldsStorage] = Object.fromEntries(
+                  Object.entries(doc[field.fieldsStorage] || {})
+                    .map(([ key, value ]) => [ self.apos.doc.toAposDocId(key), value ])
+                );
               }
               needed = true;
             }
@@ -1647,7 +1682,8 @@ module.exports = {
           });
         }
         self.replicateReached = true;
-        // Include the criteria array in the event so that more entries can be pushed to it
+        // Include the criteria array in the event so that more entries
+        // can be pushed to it
         await self.emit('beforeReplicate', criteria);
         // We can skip the core work of this method if there is only one locale,
         // but the events should always be emitted as the guarantee is still there
@@ -1779,7 +1815,8 @@ module.exports = {
       },
 
       async bestAposDocId(criteria) {
-        const existing = await self.apos.doc.db.findOne(criteria, { projection: { aposDocId: 1 } });
+        const existing = await self.apos.doc.db
+          .findOne(criteria, { projection: { aposDocId: 1 } });
         return existing?.aposDocId || self.apos.util.generateId();
       },
 

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -415,14 +415,11 @@ module.exports = {
             locale: sanitizedLocale
           });
           if (_id) {
-            doc = await self.apos.doc.find(localeReq, {
-              aposDocId: _id.split(':')[0]
-            }).toObject();
-            if (!doc) {
-              const publishedLocaleReq = localeReq.clone({ mode: 'draft' });
-              doc = await self.apos.doc.find(publishedLocaleReq, {
-                aposDocId: _id.split(':')[0]
-              }).toObject();
+            const aposDocId = _id.split(':')[0];
+            doc = await self.apos.doc.find(localeReq, { aposDocId }).toObject();
+            if (!doc._url) {
+              const draftLocaleReq = localeReq.clone({ mode: 'draft' });
+              doc = await self.apos.doc.find(draftLocaleReq, { aposDocId }).toObject();
             }
           }
           if (!sanitizedLocale) {

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -1,9 +1,11 @@
 // This module makes an instance of the [i18next](https://npmjs.org/package/i18next) npm module available
-// in Nunjucks templates via the `__t()` helper function. That function is also available on `req` objects
-// as `req.t()`. Any options passed to this module are passed on to `i18next`.
+// in Nunjucks templates via the `__t()` helper function. That function is also
+// available on `req` objects as `req.t()`. Any options passed to this module are passed
+// on to `i18next`.
 //
-// `apos.i18n.i18next` can be used to directly access the `i18next` npm module instance if necessary.
-// It usually is not necessary. Use `req.t` if you need to localize in a route.
+// `apos.i18n.i18next` can be used to directly access the `i18next` npm module instance
+// if necessary. It usually is not necessary. Use `req.t` if you need to localize
+// in a route.
 //
 // ## Options
 //
@@ -110,7 +112,11 @@ module.exports = {
     if (self.defaultAdminLocale && typeof self.defaultAdminLocale !== 'string') {
       throw self.apos.error('invalid', 'The "defaultAdminLocale" option must be a string.');
     }
-    if (self.defaultAdminLocale && self.adminLocales.length && !self.adminLocales.some(al => al.value === self.defaultAdminLocale)) {
+    if (
+      self.defaultAdminLocale &&
+      self.adminLocales.length &&
+      !self.adminLocales.some(al => al.value === self.defaultAdminLocale)
+    ) {
       throw self.apos.error('invalid', `The value of "defaultAdminLocale" "${self.defaultAdminLocale}" doesn't match any of the existing "adminLocales" values.`);
     }
     const fallbackLng = [ self.defaultLocale ];
@@ -244,8 +250,12 @@ module.exports = {
         // from the Apostrophe Express module to ensure that user
         // defined cookie settings are respected.
         const aposExpressModule = self.apos.modules['@apostrophecms/express'];
-        req.session.cookie = new ExpressSessionCookie(aposExpressModule.sessionOptions.cookie);
-        return res.redirect(self.apos.url.build(req.url, { aposCrossDomainSessionToken: null }));
+        req.session.cookie = new ExpressSessionCookie(
+          aposExpressModule.sessionOptions.cookie
+        );
+        return res.redirect(
+          self.apos.url.build(req.url, { aposCrossDomainSessionToken: null })
+        );
       },
       // If the `redirectToFirstLocale` option is enabled
       // and the homepage is requested,
@@ -283,7 +293,8 @@ module.exports = {
           return next();
         }
 
-        // Add / for home page and to avoid being redirected again in the `locale` middleware:
+        // Add / for home page and to avoid being redirected again in
+        // the `locale` middleware:
         const redirectUrl = `${localesToCheck[0].prefix}/`;
 
         return res.redirect(redirectUrl);
@@ -425,7 +436,10 @@ module.exports = {
             // with the appropriate prefix
             result.redirectTo = localeReq.prefix;
           };
-          if (self.locales[localeReq.locale].hostname !== self.locales[req.locale].hostname) {
+          if (
+            self.locales[localeReq.locale].hostname !==
+            self.locales[req.locale].hostname
+          ) {
             const crossDomainSessionToken = self.apos.util.generateId();
             const session = {
               ...req.session,
@@ -489,15 +503,17 @@ module.exports = {
         self.addDefaultResourcesForModule(module);
         self.addNamespacedResourcesForModule(module);
       },
-      // Automatically adds any localizations found in .json files in the main `i18n` subdirectory
-      // of a module.
+      // Automatically adds any localizations found in .json files in
+      // the main `i18n` subdirectory of a module.
       //
-      // These are added to the `default` namespace, unless the legacy `i18n.ns` option is set
-      // for the module (not the preferred way, use namespace subdirectories in new projects).
+      // These are added to the `default` namespace, unless the legacy `i18n.ns` option
+      // is set for the module (not the preferred way, use namespace subdirectories in
+      // new projects).
       addDefaultResourcesForModule(module) {
         const ns = (module.options.i18n && module.options.i18n.ns) || 'default';
         self.namespaces[ns] = self.namespaces[ns] || {};
-        self.namespaces[ns].browser = self.namespaces[ns].browser || (module.options.i18n && module.options.i18n.browser);
+        self.namespaces[ns].browser = self.namespaces[ns].browser ||
+          (module.options.i18n && module.options.i18n.browser);
         for (const entry of module.__meta.chain) {
           const localizationsDir = path.join(entry.dirname, 'i18n');
           if (!self.defaultLocalizationsDirsAdded.has(localizationsDir)) {
@@ -510,7 +526,9 @@ module.exports = {
                 // Likely a namespace subdirectory
                 continue;
               }
-              const data = JSON.parse(fs.readFileSync(path.join(localizationsDir, localizationFile)));
+              const data = JSON.parse(
+                fs.readFileSync(path.join(localizationsDir, localizationFile))
+              );
               const locale = localizationFile.replace('.json', '');
               self.i18next.addResourceBundle(locale, ns, data, true, true);
             }
@@ -544,7 +562,8 @@ module.exports = {
               }
               for (const localizationFile of fs.readdirSync(namespaceDir)) {
                 if (!localizationFile.endsWith('.json')) {
-                  // Exclude parsing of non-JSON files, like hidden files, in the namespace directory
+                  // Exclude parsing of non-JSON files, like hidden files,
+                  // in the namespace directory
                   continue;
                 }
                 const fullLocalizationFile = path.join(namespaceDir, localizationFile);
@@ -737,7 +756,8 @@ module.exports = {
         const host = (process.env.NODE_ENV === 'production') ? req.hostname : req.get('Host');
         const fallbackBaseUrl = `${req.protocol}://${host}`;
         if (self.hostnamesInUse) {
-          req.baseUrl = (self.apos.page && self.apos.page.getBaseUrl(req)) || fallbackBaseUrl;
+          req.baseUrl = (self.apos.page && self.apos.page.getBaseUrl(req)) ||
+            fallbackBaseUrl;
         } else {
           req.baseUrl = self.apos.page && self.apos.page.getBaseUrl(req);
         }

--- a/modules/@apostrophecms/piece-page-type/index.js
+++ b/modules/@apostrophecms/piece-page-type/index.js
@@ -244,10 +244,16 @@ module.exports = {
           if (!req.aposParentPageCache) {
             req.aposParentPageCache = {};
           }
-          req.aposParentPageCache[pieceName] = pages;
+          if (pages?.length) {
+            req.aposParentPageCache[pieceName] = pages;
+          }
         }
         results.forEach(function (piece) {
-          const parentPage = self.chooseParentPage(req.aposParentPageCache[pieceName], piece);
+          const parentPage = self.chooseParentPage(
+            req.aposParentPageCache[pieceName] || [],
+            piece
+          );
+
           if (parentPage) {
             piece._url = self.buildUrl(req, parentPage, piece);
             piece._parent = self.pruneParent(parentPage);

--- a/modules/@apostrophecms/piece-page-type/index.js
+++ b/modules/@apostrophecms/piece-page-type/index.js
@@ -238,15 +238,13 @@ module.exports = {
       // Aliased as the `addUrls` method of [@apostrophecms/piece-type](../@apostrophecms/piece-type/index.html).
 
       async addUrlsToPieces(req, results) {
-        const pieceName = self.pieces.name;
+        const pieceName = `${self.pieces.name}:${req.mode}`;
         if (!(req.aposParentPageCache && req.aposParentPageCache[pieceName])) {
           const pages = await self.findForAddUrlsToPieces(req).toArray();
           if (!req.aposParentPageCache) {
             req.aposParentPageCache = {};
           }
-          if (pages?.length) {
-            req.aposParentPageCache[pieceName] = pages;
-          }
+          req.aposParentPageCache[pieceName] = pages;
         }
         results.forEach(function (piece) {
           const parentPage = self.chooseParentPage(


### PR DESCRIPTION
[PRO-7547](https://linear.app/apostrophecms/issue/PRO-7547/locale-switcher-does-not-work-for-pieces-if-the-piece-page-exists-but)

## Summary

See ticket:
Fix switch locale from piece to piece when the index page in the target locale is draft only.
⚠️ Most of the changes are linter only. I added two comments where the important code is located with some explanations.

## What are the specific steps to test this change?

* Create a piece in two locales
* Create an index page for these pieces in both locale
* In the target locale make the index page only draft
* Switch locale when on the piece page on the initial locale to the target locale
* It should find the target locale piece, even if its parent page is draft only


## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated