### PR TITLE
PRO-7367: Add missing notifications and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixes
 
+* Adds missing notifications and error handling in media manager and save notification for auto-published pieces.
 * Update `uploadfs` to `1.24.3`.
 * Fixes an edge case where reordering a page in the Page Manager might affect another locale.
 * Fixes chrome bug when pages manager checkboxes need a double click when coming from the rich text editor (because some text is selected).

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -644,13 +644,12 @@ export default {
         if (this.isLockedError(e)) {
           await this.showLockedError(e);
           this.modal.showModal = false;
-          return;
         } else {
           await this.handleSaveError(e, {
             fallback: 'An error occurred saving the document.'
           });
-          return;
         }
+        return;
       }
       if (!keepOpen) {
         this.$emit('modal-result', doc);
@@ -658,6 +657,12 @@ export default {
       }
       if (draft) {
         await apos.notify('apostrophe:draftSaved', {
+          type: 'success',
+          dismiss: true,
+          icon: 'file-document-icon'
+        });
+      } else if (!andPublish && this.moduleOptions.autopublish) {
+        await apos.notify('apostrophe:changesPublished', {
           type: 'success',
           dismiss: true,
           icon: 'file-document-icon'

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -287,19 +287,32 @@ export default {
         return;
       }
       const route = `${this.moduleOptions.action}/${this.activeMedia._id}`;
-      const patched = await apos.http.patch(route, {
-        busy: true,
-        body: {
-          archived: true
-        },
-        draft: true
-        // Autopublish will take care of the published side
-      });
-      apos.bus.$emit('content-changed', {
-        doc: patched,
-        action: 'archive'
-      });
-      await this.cancel();
+      try {
+        const patched = await apos.http.patch(route, {
+          busy: true,
+          body: {
+            archived: true
+          },
+          draft: true
+          // Autopublish will take care of the published side
+        });
+        apos.bus.$emit('content-changed', {
+          doc: patched,
+          action: 'archive'
+        });
+        await apos.notify('apostrophe:contentArchived', {
+          type: 'success',
+          icon: 'archive-arrow-down-icon',
+          dismiss: true
+        });
+        await this.cancel();
+      } catch (e) {
+        await apos.notify('apostrophe:errorWhileArchiving', {
+          type: 'danger',
+          icon: 'alert-circle-icon',
+          dismiss: true
+        });
+      }
     },
     async save() {
       this.triggerValidation = true;
@@ -338,6 +351,13 @@ export default {
           action: this.restoreOnly ? 'restore' : 'update'
         });
         this.original = klona(this.docFields.data);
+        const successEvent = this.restoreOnly
+          ? 'apostrophe:contentRestored'
+          : 'apostrophe:updated';
+        apos.notify(successEvent, {
+          type: 'success',
+          dismiss: true
+        });
       } catch (e) {
         if (this.isLockedError(e)) {
           await this.showLockedError(e);
@@ -353,7 +373,6 @@ export default {
         }
       } finally {
         this.showReplace = false;
-
       }
     },
     generateLipKey() {

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -353,7 +353,7 @@ export default {
         this.original = klona(this.docFields.data);
         const successEvent = this.restoreOnly
           ? 'apostrophe:contentRestored'
-          : 'apostrophe:updated';
+          : 'apostrophe:changesPublished';
         apos.notify(successEvent, {
           type: 'success',
           dismiss: true


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Adds missing notifications and error handling in media manager and save notification for auto-published pieces.

## What are the specific steps to test this change?

Notifications are shown for archive, restore and update in media manager, and save for autopublished pieces. Archive errors in media manager are handled correctly. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
