### PR TITLE
Pro 7563 images checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Change reset password form button label to `Reset Password`.
 * Removed overly verbose logging of schema errors in the schema module itself. These are already logged appropriately if they become the actual result of an API call. With this change it becomes possible to catch and discard or mitigate these in some situations without excessive log output.
 * Bumps eslint-config-apostrophe, fix errors and a bunch of warnings.
+* Gets back checkboxes in the media manager.
 
 ### Fixes
 

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -88,9 +88,6 @@
             :module-options="moduleOptions"
             :max-reached="maxReached()"
             :is-last-page="isLastPage"
-            :options="{
-              hideCheckboxes: !relationshipField
-            }"
             :relationship-field="relationshipField"
             :is-scroll-loading="isScrollLoading"
             @edit="updateEditing"

--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerDisplay.vue
@@ -115,7 +115,9 @@ export default {
     options: {
       type: Object,
       default() {
-        return {};
+        return {
+          hideCheckboxes: false
+        };
       }
     },
     accept: {
@@ -265,7 +267,8 @@ export default {
   }
 
   .apos-media-manager-display__cell:hover .apos-media-manager-display__checkbox,
-  .apos-media-manager-display__cell.apos-is-selected .apos-media-manager-display__checkbox {
+  .apos-media-manager-display__cell.apos-is-selected
+  .apos-media-manager-display__checkbox {
     opacity: 1;
   }
 

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposDocsManagerMixin.js
@@ -44,10 +44,16 @@ export default {
         // Treated as min for consistency with AposMinMaxCount
         return 'min';
       }
-      if (this.relationshipField.min && this.checked.length < this.relationshipField.min) {
+      if (
+        this.relationshipField.min &&
+        this.checked.length < this.relationshipField.min
+      ) {
         return 'min';
       }
-      if (this.relationshipField.max && this.checked.length > this.relationshipField.max) {
+      if (
+        this.relationshipField.max &&
+        this.checked.length > this.relationshipField.max
+      ) {
         return 'max';
       }
 


### PR DESCRIPTION
[PRO-7563](https://linear.app/apostrophecms/issue/PRO-7563/bring-back-the-code-that-hides-the-checkboxes-select-all-on-media)

## Summary

Gets back images checkboxes, do you see any place where we want to hide them now? Maybe we can just remove the option, or maybe not for BC.

## What are the specific steps to test this change?

Checkboxes are visible like before for batch operations.

[Cypress](https://github.com/apostrophecms/testbed/actions/runs/14449929568) 🟢 

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated