### PR TITLE
PRO-7633: Hotfix 4.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.15.2 (2025-04-28)
+
+### Security
+
+* Fixes a potential XSS attack vector, [https://github.com/advisories/GHSA-vhxf-7vqr-mrjg](CVE-2025-26791). While the risk was low, it was possible for one user with login and editing privileges to carry out an XSS attack on another by uploading a specially crafted SVG file. Normally this would not work because ApostropheCMS typically renders uploaded SVGs via an `img` tag, however if the second user downloaded the SVG file from the media library the exploit could work.
+
 ## 4.15.1 (2025-04-22)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Security
 
-* Fixes a potential XSS attack vector, [https://github.com/advisories/GHSA-vhxf-7vqr-mrjg](CVE-2025-26791). While the risk was low, it was possible for one user with login and editing privileges to carry out an XSS attack on another by uploading a specially crafted SVG file. Normally this would not work because ApostropheCMS typically renders uploaded SVGs via an `img` tag, however if the second user downloaded the SVG file from the media library the exploit could work.
+* Fixes a potential XSS attack vector, [CVE-2025-26791](https://github.com/advisories/GHSA-vhxf-7vqr-mrjg). While the risk was low, it was possible for one user with login and editing privileges to carry out an XSS attack on another by uploading a specially crafted SVG file. Normally this would not work because ApostropheCMS typically renders uploaded SVGs via an `img` tag, however if the second user downloaded the SVG file from the media library the exploit could work.
 
 ## 4.15.1 (2025-04-22)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "4.15.1",
+  "version": "4.15.2",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "css-loader": "^5.2.4",
     "csv-parse": "^5.6.0",
     "dayjs": "^1.9.8",
-    "dompurify": "^2.3.1",
+    "dompurify": "^3.2.5",
     "express": "^4.16.4",
     "express-bearer-token": "^3.0.0",
     "express-cache-on-demand": "^1.0.3",


### PR DESCRIPTION
hotfix for XSS issue.

The major version bump in dompurify is OK because all they did was remove IE support (not relevant in nodejs validation). I have verified that I can still upload SVG files to apostrophecms.