### PR TITLE
PRO-7309: Widget server validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Adds
 
+* Adds a server validation before adding a widget to an area. Introduces a new POST route `@apostrophecms/area/validate-widget`.
 * The new `apos.area.addWidgetOperation` method can be used to display custom operations for widgets.
 A wrapper is available in the `@apostrophecms/widget-type` module to register operations only for widgets that match the type of the module where the wrapper is invoked.
 For example, calling `self.addWidgetOperation` in the ``@apostrophecms/image-widget`` module will apply the operation exclusively to image widgets.

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -168,7 +168,7 @@ module.exports = {
         const type = self.apos.launder.string(req.body.type);
         const field = self.apos.schema.getFieldById(areaFieldId);
         if (!field) {
-          throw self.apos.error('invalid');
+          throw self.apos.error('invalid', 'Missing area field ID');
         }
 
         const widgets = self.getWidgets(field.options);
@@ -178,7 +178,7 @@ module.exports = {
         const manager = self.getWidgetManager(type);
         if (!manager) {
           self.warnMissingWidgetType(type);
-          throw self.apos.error('invalid');
+          throw self.apos.error('invalid', 'Missing widget type');
         }
         try {
           widget = await manager.sanitize(req, widget, options);

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -393,6 +393,7 @@ export default {
           type: widget.type,
           docId: this.docId,
           parentFollowingValues: this.followingValues,
+          areaFieldId: this.fieldId,
           meta: this.meta[widget._id]?.aposMeta,
           preview
         });

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaEditor.vue
@@ -501,6 +501,7 @@ export default {
           options: this.widgetOptionsByType(name),
           type: name,
           docId: this.docId,
+          areaFieldId: this.fieldId,
           parentFollowingValues: this.followingValues,
           preview
         });

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -192,7 +192,11 @@ export default {
           }
         }
       } else {
-        await apos.notify((e.body && e.body.message) || fallback, {
+        // As per the new standard, any message in `data.detail` is considered
+        // a human readable error message. If it is not present, we fall back to
+        // the message in `body.message` or the fallback.
+        const bodyMessage = e.body?.data?.detail || e.body?.message;
+        await apos.notify(bodyMessage || fallback, {
           type: 'danger',
           icon: 'alert-circle-icon',
           dismiss: true

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -117,6 +117,10 @@ export default {
       type: Object,
       default: null
       // if present, has "area", "index" and "create" properties
+    },
+    areaFieldId: {
+      type: String,
+      default: null
     }
   },
   emits: [ 'modal-result' ],
@@ -279,6 +283,16 @@ export default {
           });
           this.focusNextError();
           return;
+        } else {
+          try {
+            await this.serverValidate();
+          } catch (e) {
+            this.triggerValidation = false;
+            await this.handleSaveError(e, {
+              fallback: 'A validation error occurred while saving the widget.'
+            });
+            return;
+          }
         }
         try {
           await this.postprocess();
@@ -292,6 +306,23 @@ export default {
         this.$emit('modal-result', widget);
         this.modal.showModal = false;
       });
+    },
+    async serverValidate() {
+      await apos.http.post(
+          `${apos.area.action}/validate-widget`,
+          {
+            busy: true,
+            qs: {
+              aposEdit: '1',
+              aposMode: 'draft'
+            },
+            body: {
+              widget: this.docFields.data,
+              areaFieldId: this.areaFieldId,
+              type: this.type
+            }
+          }
+      );
     },
     getWidgetObject(props = {}) {
       const widget = klona(this.docFields.data);


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

- Introduces a new POST route `@apostrophecms/area/validate-widget`.
- Refactor the area API routes to avoid code duplication. 
- Adds a server validation before adding a widget to an area.
- Let the generic server error handler (UI) look for `data.details` as per latest standard.

## What are the specific steps to test this change?

Extend a widget's `sanitize` method and throw an error. Attempt to add that widget to some area - you should see the error message (the one from `{ details: xxx }` if you provide it) as notification. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
