### PR TITLE
PRO-7308: Fix autocomplete sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ A `secondaryLevel: true` option is available to add operations to the widget's c
 
 ### Fixes
 
+* Fixes autocomplete and search sorting and as a consequence, fixes potential duplicates during pagination.
 * Fixes all eslint warnings.
 
 ## 4.15.2 (2025-04-28)

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -3293,7 +3293,10 @@ module.exports = {
             // we are using regex search
             if (!query.get('regexSearch')) {
               if ((!sort) || (sort === 'search')) {
-                sort = { textScore: { $meta: 'textScore' } };
+                sort = {
+                  textScore: { $meta: 'textScore' },
+                  _id: 1
+                };
               }
             }
           } else if (!sort) {

--- a/test/autocomplete.js
+++ b/test/autocomplete.js
@@ -1,0 +1,155 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert/strict');
+
+describe('Search', function () {
+  let apos;
+  let jar;
+
+  this.timeout(t.timeout);
+
+  before(async function () {
+    apos = await t.create({
+      root: module,
+      modules: {
+        blog: {
+          extend: '@apostrophecms/piece-type',
+          options: {
+            label: 'Blog',
+            alias: 'blog',
+            perPage: 10
+          }
+        }
+      }
+    });
+    await t.createAdmin(apos, 'admin', {
+      username: 'admin',
+      password: 'admin'
+    });
+    jar = await t.loginAs(apos, 'admin', 'admin');
+    await createManyPieces(apos, 20);
+  });
+
+  after(async function () {
+    await t.destroy(apos);
+    apos = null;
+  });
+
+  it('should return the same results for same search term (autocomplete)', async function () {
+    const searchTerm = 'test';
+    const response1 = await apos.http.get(apos.blog.action, {
+      qs: {
+        autocomplete: searchTerm,
+        page: 1
+      },
+      jar
+    });
+    const response2 = await apos.http.get(apos.blog.action, {
+      qs: {
+        autocomplete: searchTerm,
+        page: 1
+      },
+      jar
+    });
+
+    assert.equal(response1.results.length, 10);
+    assert.deepEqual(response1, response2);
+  });
+
+  it('should return the same results for same search term (search)', async function () {
+    const searchTerm = 'test';
+    const response1 = await apos.http.get(apos.blog.action, {
+      qs: {
+        search: searchTerm,
+        page: 1
+      },
+      jar
+    });
+    const response2 = await apos.http.get(apos.blog.action, {
+      qs: {
+        search: searchTerm,
+        page: 1
+      },
+      jar
+    });
+
+    assert.equal(response1.results.length, 10);
+    assert.deepEqual(response1, response2);
+  });
+
+  it('should not contain duplicates in the results between pages (autocomplete)', async function () {
+    const searchTerm = 'test';
+    const response1 = await apos.http.get(apos.blog.action, {
+      qs: {
+        autocomplete: searchTerm,
+        page: 1
+      },
+      jar
+    });
+    const response2 = await apos.http.get(apos.blog.action, {
+      qs: {
+        autocomplete: searchTerm,
+        page: 2
+      },
+      jar
+    });
+    assertNoDuplicates(response1, response2);
+  });
+
+  it('should not contain duplicates in the results between pages (search)', async function () {
+    const searchTerm = 'test';
+    const response1 = await apos.http.get(apos.blog.action, {
+      qs: {
+        search: searchTerm,
+        page: 1
+      },
+      jar
+    });
+    const response2 = await apos.http.get(apos.blog.action, {
+      qs: {
+        search: searchTerm,
+        page: 2
+      },
+      jar
+    });
+    assertNoDuplicates(response1, response2);
+  });
+});
+
+function assertNoDuplicates(response1, response2) {
+  const results1 = response1.results.map((result) => result._id);
+  const results1Unique = new Set(results1);
+
+  const results2 = response2.results.map((result) => result._id);
+  const results2Unique = new Set(results2);
+
+  const resultsTotal = results1.length + results2.length;
+  const resultsTotalUnique = new Set(
+    [ ...results1, ...results2 ]
+  );
+
+  const actual = {
+    results1: results1.length,
+    results2: results2.length,
+    total: resultsTotal
+  };
+
+  const expected = {
+    results1: results1Unique.size,
+    results2: results2Unique.size,
+    total: resultsTotalUnique.size
+  };
+
+  assert.deepEqual(actual, expected);
+}
+
+async function createManyPieces(apos, count) {
+  const req = apos.task.getReq();
+  for (let i = 0; i < count; i++) {
+    const piece = {
+      title: `Test${i}`,
+      type: 'blog',
+      slug: `test-${i}`
+    };
+    await apos.doc.getManager(piece.type).insert(req, piece);
+  }
+}


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Due to the lack of unique sort value, autocomplete and search (pieces/pages manager) can return randomly sorted results and duplicates during pagination. 

## What are the specific steps to test this change?

Search and autocomplete with the same phrase returns always the same result. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
