### PR TITLE
AposAreaWidget: fixes z-index of controls over + button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ A `secondaryLevel: true` option is available to add operations to the widget's c
 * Widget live preview is now attempting to auto-position the Widget Editor modal only if no explicit widget configuration (`options.origin`) is provided.
 * `required` is now implemented on the server side as well for `relationship` fields. It behaves like `min: 1`. It was always implemented on the front end. However, note that a relationship can still become empty if the related document is archived or deleted.
 * Image widgets, and others with a placeholder when empty, now restore their placeholder view when canceling the widget editor in live preview mode.
+* Fixes `z-index` of widget controls, going above the controls add button.
 
 ### Changes
 

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -1,4 +1,3 @@
-
 <template>
   <div
     ref="widget"
@@ -76,8 +75,8 @@
       <div
         class="
           apos-area-widget-controls
-          apos-area-widget-controls--add--top
-          apos-area-widget-controls--add
+          apos-area-widget-controls__add--top
+          apos-area-widget-controls__add
         "
         :class="addClasses"
       >
@@ -101,7 +100,7 @@
         :class="{'apos-is-disabled': isFocused}"
       />
       <div
-        class="apos-area-widget-controls apos-area-widget-controls--modify"
+        class="apos-area-widget-controls apos-area-widget-controls__modify"
         :class="controlsClasses"
       >
         <AposWidgetControls
@@ -155,8 +154,9 @@
       />
       <div
         class="
-          apos-area-widget-controls apos-area-widget-controls--add
-          apos-area-widget-controls--add--bottom
+          apos-area-widget-controls
+          apos-area-widget-controls__add
+          apos-area-widget-controls__add--bottom
         "
         :class="addClasses"
       >
@@ -632,7 +632,7 @@ export default {
     }
 
     &.apos-is-ui-adjusted {
-      .apos-area-widget-controls--modify {
+      .apos-area-widget-controls__modify {
         top: 0;
         transform: translate3d(-10px, 50px, 0);
       }
@@ -690,7 +690,8 @@ export default {
     }
   }
 
-  .apos-area-widget-controls--modify {
+  .apos-area-widget-controls__modify {
+    z-index: $z-index-widget-focused-controls;
     top: 50%;
     right: 0;
     transform: translate3d(-10px, -50%, 0);
@@ -728,20 +729,20 @@ export default {
     }
   }
 
-  .apos-area-widget-controls--add {
+  .apos-area-widget-controls__add {
     top: 0;
     left: 50%;
     transform: translate(-50%, -50%);
 
-    &.apos-area-widget-controls--add--top.apos-is-open--menu-top,
-    &.apos-area-widget-controls--add--bottom.apos-is-open--menu-bottom {
+    &.apos-area-widget-controls__add--top.apos-is-open--menu-top,
+    &.apos-area-widget-controls__add--bottom.apos-is-open--menu-bottom {
       z-index: $z-index-area-schema-ui;
     }
   }
 
-  .apos-area-widget-controls--add {
-    &.apos-area-widget-controls--add--top.apos-is-open--menu-top,
-    &.apos-area-widget-controls--add--bottom.apos-is-open--menu-bottom {
+  .apos-area-widget-controls__add {
+    &.apos-area-widget-controls__add--top.apos-is-open--menu-top,
+    &.apos-area-widget-controls__add--bottom.apos-is-open--menu-bottom {
 
       /* stylelint-disable-next-line max-nesting-depth */
       :deep(.apos-button__wrapper .apos-button:not([disabled])) {
@@ -750,7 +751,7 @@ export default {
     }
   }
 
-  .apos-area-widget-controls--add {
+  .apos-area-widget-controls__add {
     :deep(.apos-button__wrapper) {
       padding: 8px;
 
@@ -791,7 +792,7 @@ export default {
     }
   }
 
-  .apos-area-widget-controls--add--bottom {
+  .apos-area-widget-controls__add--bottom {
     top: auto;
     bottom: 0;
     transform: translate(-50%, 50%);

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -75,8 +75,8 @@
       <div
         class="
           apos-area-widget-controls
-          apos-area-widget-controls__add--top
-          apos-area-widget-controls__add
+          apos-area-widget-controls--add--top
+          apos-area-widget-controls--add
         "
         :class="addClasses"
       >
@@ -100,7 +100,7 @@
         :class="{'apos-is-disabled': isFocused}"
       />
       <div
-        class="apos-area-widget-controls apos-area-widget-controls__modify"
+        class="apos-area-widget-controls apos-area-widget-controls--modify"
         :class="controlsClasses"
       >
         <AposWidgetControls
@@ -155,8 +155,8 @@
       <div
         class="
           apos-area-widget-controls
-          apos-area-widget-controls__add
-          apos-area-widget-controls__add--bottom
+          apos-area-widget-controls--add
+          apos-area-widget-controls--add--bottom
         "
         :class="addClasses"
       >
@@ -632,7 +632,7 @@ export default {
     }
 
     &.apos-is-ui-adjusted {
-      .apos-area-widget-controls__modify {
+      .apos-area-widget-controls--modify {
         top: 0;
         transform: translate3d(-10px, 50px, 0);
       }
@@ -690,7 +690,7 @@ export default {
     }
   }
 
-  .apos-area-widget-controls__modify {
+  .apos-area-widget-controls--modify {
     z-index: $z-index-widget-focused-controls;
     top: 50%;
     right: 0;
@@ -729,20 +729,20 @@ export default {
     }
   }
 
-  .apos-area-widget-controls__add {
+  .apos-area-widget-controls--add {
     top: 0;
     left: 50%;
     transform: translate(-50%, -50%);
 
-    &.apos-area-widget-controls__add--top.apos-is-open--menu-top,
-    &.apos-area-widget-controls__add--bottom.apos-is-open--menu-bottom {
+    &.apos-area-widget-controls--add--top.apos-is-open--menu-top,
+    &.apos-area-widget-controls--add--bottom.apos-is-open--menu-bottom {
       z-index: $z-index-area-schema-ui;
     }
   }
 
-  .apos-area-widget-controls__add {
-    &.apos-area-widget-controls__add--top.apos-is-open--menu-top,
-    &.apos-area-widget-controls__add--bottom.apos-is-open--menu-bottom {
+  .apos-area-widget-controls--add {
+    &.apos-area-widget-controls--add--top.apos-is-open--menu-top,
+    &.apos-area-widget-controls--add--bottom.apos-is-open--menu-bottom {
 
       /* stylelint-disable-next-line max-nesting-depth */
       :deep(.apos-button__wrapper .apos-button:not([disabled])) {
@@ -751,7 +751,7 @@ export default {
     }
   }
 
-  .apos-area-widget-controls__add {
+  .apos-area-widget-controls--add {
     :deep(.apos-button__wrapper) {
       padding: 8px;
 
@@ -792,7 +792,7 @@ export default {
     }
   }
 
-  .apos-area-widget-controls__add--bottom {
+  .apos-area-widget-controls--add--bottom {
     top: auto;
     bottom: 0;
     transform: translate(-50%, 50%);


### PR DESCRIPTION
[PRO-7664](https://linear.app/apostrophecms/issue/PRO-7664/yet-another-widget-z-index-issue)

## Summary
Fix the second level controls being under the `+` button
![image](https://github.com/user-attachments/assets/90f24e7f-895f-4f3f-abc3-a4fb13eecf44)

## What are the specific steps to test this change?

See above.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
