### PR TITLE
do not cache error pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Changes
+
+* Set the `Cache-Control` header to `no-store` for error pages in order to prevent the risk of serving stale error pages to users.
+
 ## 4.17.1 (2025-05-16)
 
 ### Fixes

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -529,6 +529,11 @@ module.exports = {
           return false;
         }
 
+        if (req.res.statusCode >= 400) {
+          // Don't cache errors
+          return false;
+        }
+
         return Object.entries(req.session).every(([ key, val ]) =>
           key === 'cookie' || (
             (key === 'flash' || key === 'passport') && _.isEmpty(val)


### PR DESCRIPTION
* Set the `Cache-Control` header to `no-store` for error pages in order to prevent the risk of serving stale error pages to users.
