### PR TITLE
use req with the corresponding right when using an api key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 * The Download links in the media library now immediately download the file as expected, rather than navigating to the image in the current tab. `AposButton` now supports the `:download="true"` prop as expected.
-* Using an API key with the editor, contributor or guest role now have a `req` object with the corresponding rights, which fixes content access issues.
+* Using an API key with the editor, contributor or guest role now have a `req` object with the corresponding rights. The old behavior gave non-admin API keys less access than expected.
 
 ## 4.17.1 (2025-05-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * The Download links in the media library now immediately download the file as expected, rather than navigating to the image in the current tab. `AposButton` now supports the `:download="true"` prop as expected.
+* Using an API key with the editor, contributor or guest role now have a `req` object with the corresponding rights, which fixes content access issues.
 
 ## 4.17.1 (2025-05-16)
 

--- a/modules/@apostrophecms/express/index.js
+++ b/modules/@apostrophecms/express/index.js
@@ -317,7 +317,7 @@ module.exports = {
             taskReq = self.apos.task.getReq();
           } else if (info.role === 'editor') {
             taskReq = self.apos.task.getEditorReq();
-          } else if (info.role === 'contriburor') {
+          } else if (info.role === 'contributor') {
             taskReq = self.apos.task.getContributorReq();
           } else if (info.role === 'guest') {
             taskReq = self.apos.task.getGuestReq();

--- a/modules/@apostrophecms/express/index.js
+++ b/modules/@apostrophecms/express/index.js
@@ -315,6 +315,12 @@ module.exports = {
           const info = self.options.apiKeys[key];
           if (info.role === 'admin') {
             taskReq = self.apos.task.getReq();
+          } else if (info.role === 'editor') {
+            taskReq = self.apos.task.getEditorReq();
+          } else if (info.role === 'contriburor') {
+            taskReq = self.apos.task.getContributorReq();
+          } else if (info.role === 'guest') {
+            taskReq = self.apos.task.getGuestReq();
           } else {
             taskReq = self.apos.task.getAnonReq();
           }

--- a/test/express.js
+++ b/test/express.js
@@ -2,7 +2,6 @@ const t = require('../test-lib/test.js');
 const assert = require('assert');
 
 describe('Express', function() {
-
   let jar;
   let apos;
 
@@ -169,6 +168,57 @@ describe('Express', function() {
     assert(req.absoluteUrl === 'https://example.com/subdir/test');
 
     // Last use of this apos object
+    await t.destroy(apos);
+  });
+
+  it('should find pages marked as "loginRequired" when using an API key with different roles', async function() {
+    apos = await t.create({
+      root: module,
+      modules: {
+        '@apostrophecms/express': {
+          options: {
+            apiKeys: {
+              adminKey: { role: 'admin' },
+              editorKey: { role: 'editor' },
+              contributorKey: { role: 'contributor' },
+              guestKey: { role: 'guest' }
+            }
+          }
+        },
+        '@apostrophecms/page': {
+          options: {
+            park: [
+              {
+                parkedId: 'child',
+                title: 'Child',
+                slug: '/child',
+                type: 'default-page',
+                visibility: 'loginRequired'
+              }
+            ]
+          }
+        },
+        'default-page': {}
+      }
+    });
+
+    const base = apos.http.getBase();
+    const keys = [
+      'adminKey',
+      'editorKey',
+      'contributorKey',
+      'guestKey'
+    ];
+
+    for (const key of keys) {
+      const response = await fetch(`${base}/child`, {
+        method: 'GET',
+        headers: new Headers({ Authorization: `ApiKey ${key}` })
+      });
+
+      assert.strictEqual(response.status, 200);
+    };
+
     await t.destroy(apos);
   });
 });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

* Using an API key with the editor, contributor or guest role now have a `req` object with the corresponding rights. The old behavior gave non-admin API keys less access than expected.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
