### PR TITLE
Pro 7831 dynamic filters

### DIFF
--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1589,17 +1589,16 @@ module.exports = {
       },
 
       composeFilters() {
-        self.filters = Object.keys(self.filters).map((key) => ({
-          name: key,
-          ...self.filters[key],
-          inputType: self.filters[key].inputType || 'select'
+        self.filters = Object.entries(self.filters).map(([ name, filter ]) => ({
+          name,
+          ...filter,
+          inputType: filter.inputType || 'select'
         }));
         // Add a null choice if not already added or set to `required`
         self.filters.forEach((filter) => {
-          if (filter.choices) {
+          if (Array.isArray(filter.choices)) {
             if (
               !filter.required &&
-              filter.choices &&
               !filter.choices.find((choice) => choice.value === null)
             ) {
               filter.def = null;

--- a/modules/@apostrophecms/modal/ui/apos/components/AposDocsManagerToolbar.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposDocsManagerToolbar.vue
@@ -60,6 +60,7 @@
         :filters="filters"
         :choices="filterChoices"
         :values="filterValues"
+        :module-name="moduleName"
         @input="filter"
       />
       <AposInputString

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -887,16 +887,17 @@ module.exports = {
         fieldModuleName,
         docId = null,
         optionalParenthesis = false,
-        following = {}
+        following = {},
+        featureType = 'field'
       ) {
         const [ methodDefinition, rest ] = methodKey.split('(');
         const hasParenthesis = rest !== undefined;
 
         if (!hasParenthesis && !optionalParenthesis) {
-          throw new Error(`The method "${methodDefinition}" defined in the "${fieldName}" field should be written with parenthesis: "${methodDefinition}()".`);
+          throw new Error(`The method "${methodDefinition}" defined in the "${fieldName}" ${featureType} should be written with parenthesis: "${methodDefinition}()".`);
         }
         if (hasParenthesis && !methodKey.endsWith('()')) {
-          self.apos.util.warn(`The method "${methodDefinition}" defined in the "${fieldName}" field should be written without argument: "${methodDefinition}()".`);
+          self.apos.util.warn(`The method "${methodDefinition}" defined in the "${fieldName}" ${featureType} should be written without argument: "${methodDefinition}()".`);
           methodKey = methodDefinition + '()';
         }
 
@@ -907,9 +908,9 @@ module.exports = {
         const module = self.apos.modules[moduleName];
 
         if (!module) {
-          throw new Error(`The "${moduleName}" module defined in the "${fieldName}" field does not exist.`);
+          throw new Error(`The "${moduleName}" module defined in the "${fieldName}" ${featureType} does not exist.`);
         } else if (!module[methodName]) {
-          throw new Error(`The "${methodName}" method from "${moduleName}" module defined in the "${fieldName}" field does not exist.`);
+          throw new Error(`The "${methodName}" method from "${moduleName}" module defined in the "${fieldName}" ${featureType} does not exist.`);
         }
 
         return module[methodName](req, { docId }, following);
@@ -2166,6 +2167,44 @@ module.exports = {
         });
       },
 
+      async choicesFilters(req) {
+        const moduleName = self.apos.launder.string(req.body.type);
+        const filterName = self.apos.launder.string(req.body.filterName);
+
+        const mod = self.apos.modules[moduleName];
+        if (!mod) {
+          throw self.apos.error('invalid', `Module "${moduleName}" not found.`);
+        }
+
+        const filter = mod.filters.find(f => f.name === filterName);
+        if (!filter) {
+          throw self.apos.error('invalid', `Filter "${filterName}" not found in module "${moduleName}".`);
+        }
+
+        try {
+          const choices = await self.evaluateMethod(
+            req,
+            filter.choices,
+            filter.name,
+            moduleName,
+            null,
+            true,
+            {},
+            'filter'
+          );
+
+          if (Array.isArray(choices)) {
+            return {
+              choices
+            };
+          } else {
+            throw self.apos.error('invalid', `The method ${filter.choices} from the module ${moduleName} did not return an array`);
+          }
+        } catch (error) {
+          throw self.apos.error('invalid', error.message);
+        }
+      },
+
       async choicesRoute(req) {
         const fieldId = self.apos.launder.string(req.query.fieldId);
         const docId = self.apos.launder.string(req.query.docId);
@@ -2231,7 +2270,11 @@ module.exports = {
     return {
       get: {
         async choices(req) {
-          return self.choicesRoute(req);
+          const featureType = self.apos.launder.string(req.body.featureType);
+
+          return featureType === 'filter'
+            ? self.choicesFilters(req)
+            : self.choicesRoute(req);
         },
         async evaluateExternalCondition(req) {
           const fieldId = self.apos.launder.string(req.query.fieldId);
@@ -2261,7 +2304,11 @@ module.exports = {
       },
       post: {
         async choices(req) {
-          return self.choicesRoute(req);
+          const featureType = self.apos.launder.string(req.body.featureType);
+
+          return featureType === 'filter'
+            ? self.choicesFilters(req)
+            : self.choicesRoute(req);
         }
       }
     };

--- a/modules/@apostrophecms/ui/ui/apos/components/AposFilterMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposFilterMenu.vue
@@ -56,11 +56,16 @@ export default {
           type: 'outline'
         };
       }
+    },
+    moduleName: {
+      type: String,
+      required: true
     }
   },
   emits: [ 'input' ],
   data() {
     return {
+      filterSets: [],
       map: {
         radio: 'AposInputRadio',
         checkbox: 'AposInputCheckboxes',
@@ -68,31 +73,6 @@ export default {
       },
       generation: 0
     };
-  },
-  computed: {
-    filterSets() {
-      const sets = [];
-      this.filters.forEach(filter => {
-        sets.push({
-          name: filter.name,
-          key: `${this.generation}:${filter.name}`,
-          field: {
-            name: filter.name,
-            type: filter.inputType || 'select',
-            label: filter.label || filter.name,
-            choices: this.addNullChoice(
-              filter,
-              this.choices[filter.name] || filter.choices
-            )
-          },
-          value: {
-            data: this.values[filter.name]
-          },
-          status: {}
-        });
-      });
-      return sets;
-    }
   },
   watch: {
     choices() {
@@ -102,7 +82,32 @@ export default {
       this.generation++;
     }
   },
+  mounted() {
+    this.setFilters();
+  },
   methods: {
+    async setFilters() {
+      const sets = [];
+      for (const filter of this.filters) {
+        const choices = await this.getChoices(filter);
+
+        sets.push({
+          name: filter.name,
+          key: `${this.generation}:${filter.name}`,
+          field: {
+            name: filter.name,
+            type: filter.inputType || 'select',
+            label: filter.label || filter.name,
+            choices: this.addNullChoice(filter, choices)
+          },
+          value: {
+            data: this.values[filter.name]
+          },
+          status: {}
+        });
+      }
+      this.filterSets = sets;
+    },
     input(value, filterName) {
       this.$emit('input', filterName, value);
     },
@@ -128,6 +133,27 @@ export default {
           value: null
         }
       ].concat(choices);
+    },
+    async getChoices(filter) {
+      if (typeof filter.choices === 'string') {
+        const action = apos.modules['@apostrophecms/schema'].action;
+
+        const response = await apos.http.post(
+          `${action}/choices`,
+          {
+            busy: true,
+            body: {
+              filterName: filter.name,
+              type: this.moduleName,
+              featureType: 'filter'
+            }
+          }
+        );
+
+        return response.choices || [];
+      }
+
+      return filter.choices;
     }
   }
 };


### PR DESCRIPTION
[PRO-7831](https://linear.app/apostrophecms/issue/PRO-7831/dynamic-choices-dont-work-with-filters)

## Summary

Makes dynamic choices work with filters.

## What are the specific steps to test this change?

You can configure filters with dynamic choices (like we do for fields), and it works:
```javascript
  filters: {
    add: {
      foo: {
        label: 'Foo',
        choices: 'getChoices()'
      }
    }
  }
```

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
