### PR TITLE
PRO-7811: Rich text modified state not detected correctly by the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### Fixes
 
 * Add missing Pages manager shortcuts list helper.
+* Improve the `isEmpty` method of the rich text widget to take into account the HTML blocks (e.g. `<figure>` and `<table>`) that are not empty but do not contain any plain text.
+* Improve the "visually empty" check of the rich text widget to compare the current content to the default initial content.
 
 ## 4.18.0 (2025-06-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@
 ### Fixes
 
 * Add missing Pages manager shortcuts list helper.
-* Improve the `isEmpty` method of the rich text widget to take into account the HTML blocks (e.g. `<figure>` and `<table>`) that are not empty but do not contain any plain text.
-* Improve the "visually empty" check of the rich text widget to compare the current content to the default initial content.
+* Improve the `isEmpty` method of the rich text widget to take into account the HTML blocks (`<figure>` and `<table>`) that are not empty but do not contain any plain text.
 
 ## 4.18.0 (2025-06-11)
 

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -837,8 +837,11 @@ module.exports = {
       },
 
       isEmpty(widget) {
-        const html = (widget.content || '').trim();
-        return html.length === 0;
+        const content = (widget.content || '').trim();
+        const text = self.apos.util.htmlToPlaintext(content).trim();
+        return text.length === 0 &&
+          content.includes('<table') === false &&
+          content.includes('<figure') === false;
       },
 
       sanitizeHtml(html, options) {

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -837,8 +837,8 @@ module.exports = {
       },
 
       isEmpty(widget) {
-        const text = self.apos.util.htmlToPlaintext(widget.content || '');
-        return !text.trim().length;
+        const html = (widget.content || '').trim();
+        return html.length === 0;
       },
 
       sanitizeHtml(html, options) {

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -298,12 +298,7 @@ export default {
       // Only true for a new rich text widget
       return !this.modelValue.content.length;
     },
-    initialContent() {
-      const content = this.transformNamedAnchors(this.modelValue.content);
-      if (content.length) {
-        return content;
-      }
-
+    defaultContent() {
       // If we don't supply a valid instance of the first style, then
       // the text align control will not work until the user manually
       // applies a style or refreshes the page
@@ -314,8 +309,25 @@ export default {
             ? this.editorOptions.marks.find(style => style.def)
             : null;
 
+      // The above can be null or undefined, play safe.
+      if (defaultStyle) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'No default node found for the rich text widget, please check your configuration.'
+        );
+        return '<p></p>';
+      }
+
       const _class = defaultStyle.class ? ` class="${defaultStyle.class}"` : '';
       return `<${defaultStyle.tag}${_class}></${defaultStyle.tag}>`;
+    },
+    initialContent() {
+      const content = this.transformNamedAnchors(this.modelValue.content);
+      if (content.length) {
+        return content;
+      }
+
+      return this.defaultContent;
     },
     // Names of active toolbar items for this particular widget, as an array
     toolbar() {
@@ -335,16 +347,14 @@ export default {
     },
     isVisuallyEmpty() {
       const div = document.createElement('div');
-      let hasSomeContent = false;
+      let hasDefaultContent = false;
       div.innerHTML = this.modelValue.content?.trim();
       if (this.editor) {
-        const editorJSON = this.editor.getJSON();
-        // We are interested in different than the default `p` wrappers
-        // when the innerHTML is empty.
-        hasSomeContent = !!editorJSON?.content
-          .filter(c => ![ 'paragraph' ].includes(c.type)).length;
+        // We are interested in different than the default HTML content
+        // when the textContent is empty.
+        hasDefaultContent = this.editor.getHTML().trim() === this.defaultContent.trim();
       }
-      return (!div.textContent && !hasSomeContent);
+      return (!div.textContent && hasDefaultContent);
     },
     editorModifiers () {
       const classes = [];


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

The in-context editing relies on `modified` document property, returned by the backend, to enable the "Update" (publish) context bar button. However, the `isEmpty()` handler of the rich text "understands" only a plain text as non-empty state. This is wrong from some time (because we have pure HTML nodes as `figure` and `table`). We detect just a "string" now.

Additionally,  the visually empty check of the UI is improved to avoid (visual) confusion. 

## What are the specific steps to test this change?

The Update button in the in-context editing is enabled when rich text Image is inserted in an empty area.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
