### PR TITLE
Ensure convert doesn't fail on its own

### DIFF
--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -753,7 +753,7 @@ module.exports = {
             ? error.path.split('.')
             : [ null, error.path ];
           const curDestination = destId
-            ? (destination.items || destination || []).find(({ _id }) => _id === destId)
+            ? (destination?.items || destination || []).find(({ _id }) => _id === destId)
             : destination;
 
           const errorPath = destinationPath


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

I tiny change to ensure a safe convert check.
