### PR TITLE
PRO-7797: Ensure defaultNode has highest priority

### DIFF
--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -435,6 +435,8 @@ export default {
       .filter(Boolean)
       .concat(this.aposTiptapExtensions());
 
+    this.ensureExtensionsPriority(extensions);
+
     this.editor = new Editor({
       content: this.initialContent,
       autofocus: this.autofocus,
@@ -669,6 +671,21 @@ export default {
           marks: this.editorOptions.marks.map(this.localizeStyle),
           types: this.tiptapTypes
         }));
+    },
+    // Find the `defaultNode` extension and ensure it's registered first.
+    // Any other priority related logic should be handled here.
+    // Why sorting is important?
+    // See https://github.com/ProseMirror/prosemirror/issues/1534#issuecomment-2984216986
+    // related with list item issues and `defaultNode`.
+    // NOTE: this handler mutates the input array for performance reasons.
+    ensureExtensionsPriority(extensions) {
+      const defaultNodeIndex = extensions.findIndex(ext => ext.name === 'defaultNode');
+      if (defaultNodeIndex > 0) {
+        const defaultNode = extensions.splice(defaultNodeIndex, 1)[0];
+        extensions.unshift(defaultNode);
+      }
+
+      return extensions;
     },
     showFloatingMenu({
       state, oldState

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@tiptap/extension-underline": "^2.0.3",
     "@tiptap/starter-kit": "^2.0.3",
     "@tiptap/vue-3": "^2.0.3",
-    "prosemirror-model": "1.25.0",
     "@vue/compiler-sfc": "^3.3.8",
     "autoprefixer": "^10.4.1",
     "bluebird": "^3.7.2",


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Unpin `prosemirror-model` and fix the underlying issue.

**The long story:**

We use custom extension named `defaultNode` in order to allow rich-text areas to have a "default style". A scenario - a configured by a developer rich text placed to produce `h1` on a page doesn't require the editor to switch the style manually to `h1`. 

The `defaultNode` can adapt and based on the configured style with `def: true`, become a simple extension of `paragraph`, `heading` or just a text node (`span`). The problem arising with this approach is how prosemirror handles parsing - it needs 1-to-1 mapping of a "nodeName" to a "nodeElement". When the DOM parser attempts to parse the tree and in our case - to validate a list, it matches the configured list item `content`, in our case `defaultNode`. However, when our `defaultNode` is just a `paragraph` extension (by default), the DOM parser matches the original `paragraph` node because it has a higher priority (it's registered first). The parser then don't recognize the node as the one configured for the list item content (it's `paragraph` and not `defaultNode`) and decides to "fix" the DOM by pulling it out of the list.

The current patch fixes that scenario with ensuring the right order - `defaultNode` is always registered first. This solves the problem at hand. We can collaborate on how to avoid prosemirror schema containing duplicate DOM representation in the future.

References:
- https://github.com/ProseMirror/prosemirror/issues/1534
- https://github.com/ueberdosis/tiptap/issues/6443

## What are the specific steps to test this change?

List should be properly parsed, UI tests should pass.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
