### PR TITLE
PRO-7943: Fix wrapper class when no base class is set

### DIFF
--- a/modules/@apostrophecms/image-widget/views/fragment.html
+++ b/modules/@apostrophecms/image-widget/views/fragment.html
@@ -8,7 +8,7 @@
     />
   {%- elif attachment -%}
       {%- set className = options.className or manager.options.className -%}
-<figure class="{{ className + "__wrapper" }}" style="{{ _figureStyle(options, manager) | trim }}">
+<figure{% if className %} class="{{ className + "__wrapper" }}"{% endif %} style="{{ _figureStyle(options, manager) | trim }}">
   {{ _imageWithLink(widget, attachment, options, manager, contextOptions) -}}
   {% if widget.caption -%}<figcaption class="{{ className + "__caption" }}">
     {{ widget.caption }}
@@ -30,7 +30,7 @@
   {%- set dimensionAttrs = options.dimensionAttrs or manager.options.dimensionAttrs -%}
   {%- set loadingType = options.loadingType or manager.options.loadingType -%}
   {%- set size = options.size or manager.options.size or 'full' -%}
-<img {% if className %} class="{{ className }}"{% endif %}
+<img{% if className %} class="{{ className }}"{% endif %}
   {% if loadingType %} loading="{{ loadingType }}"{% endif %}
   data-apos-test="image-widget"
   srcset="{{ apos.image.srcset(attachment) }}"


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

A tiny bug, when no `options.className` is set (or no context option with the same name), the figure class is set to `false_wrapper`. This patch just removes the class attribute in that case.

## What are the specific steps to test this change?

No `false_wrapper` class is set. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
