### PR TITLE
PRO-7932: Simplify field options and allow import image tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Adds keyboard shortcuts for manipulating widgets in areas. Includes Cut, Copy, Paste, Delete, and Duplicate.
 * Adds dynamic choices working with piece manager filters. 
+* Allow `import.imageTags` (array of image tag IDs) to be passed to the rich text widget when importing (see https://docs.apostrophecms.org/reference/api/rich-text.html#importing-inline-images).
 
 ### Changes
 

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -604,7 +604,7 @@ module.exports = {
           return {};
         }
         const schema = manager.schema;
-        const field = _.find(schema, 'name', name);
+        const field = schema?.find(field => field.name === name);
         if (!(field && field.options)) {
           return {};
         }

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -1070,7 +1070,8 @@ module.exports = {
                 });
                 const image = await self.apos.image.insert(req, {
                   title: name,
-                  attachment
+                  attachment,
+                  tagsIds: input.import.imageTags || []
                 });
                 const newSrc = `${self.apos.image.action}/${image.aposDocId}/src`;
                 $image.replaceWith(


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

- Removes lodash (questionable usage with find method not fitting the current documentation) and replaces it with a simple array `find`.
- Allow `import.imageTags` (array of image tag IDs) to be passed to the rich text widget when importing (see https://docs.apostrophecms.org/reference/api/rich-text.html#importing-inline-images).

## What are the specific steps to test this change?

Image tags can be assigned to imported images.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
