### PR TITLE
Pro 8003 manage tags

### DIFF
--- a/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -374,19 +374,17 @@ export default {
           delete qs[prop];
         };
       }
-      const apiResponse = (await apos.http.get(
-        this.moduleOptions.action, {
-          qs,
-          draft: true
-        }
-      ));
+      const apiResponse = await apos.http.get(this.moduleOptions.action, {
+        qs,
+        draft: true
+      });
 
       if (options.tags) {
         if (filtered) {
           // We never filter the tag list because they are presented like
           // folders, and folders don't disappear when empty. So we need to make
           // a separate query for distinct tags if our first query was filtered
-          const apiResponse = (await apos.http.get(
+          const tagApiResponse = await apos.http.get(
             this.moduleOptions.action, {
               busy: true,
               qs: {
@@ -394,8 +392,8 @@ export default {
               },
               draft: true
             }
-          ));
-          result.tagList = apiResponse.choices._tags;
+          );
+          result.tagList = tagApiResponse.choices._tags;
         } else {
           result.tagList = apiResponse.choices ? apiResponse.choices._tags : [];
         }

--- a/modules/@apostrophecms/modal/ui/apos/components/AposDocsManagerToolbar.vue
+++ b/modules/@apostrophecms/modal/ui/apos/components/AposDocsManagerToolbar.vue
@@ -30,6 +30,7 @@
           @added="title => updateTag('create', { title })"
           @checked="slug => updateTag('add', { slug })"
           @unchecked="slug => updateTag('remove', { slug })"
+          @refresh-data="$emit('refresh-data')"
         />
         <AposButton
           v-else-if="!operations"
@@ -159,11 +160,12 @@ export default {
     }
   },
   emits: [
-    'select-click',
+    'batch',
     'filter',
-    'search',
     'page-change',
-    'batch'
+    'refresh-data',
+    'search',
+    'select-click'
   ],
   data() {
     return {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
@@ -205,6 +205,7 @@ const menuResizeObserver = new ResizeObserver((entries) => {
 
 defineExpose({
   hide,
+  show,
   setDropdownPosition
 });
 

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTagApply.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTagApply.vue
@@ -421,11 +421,15 @@ function getCheckedState(tag) {
   overflow-y: auto;
 }
 
+/* TODO: Fix UI when no tags found or none exist */
 .apos-apply-tag-menu__empty {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 50px 20px 60px;
+  justify-content: center;
+  height: 100%;
+  padding: 0 0 10px;
+  box-sizing: border-box;
 }
 
 .apos-apply-tag-menu__empty-message {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTagApply.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTagApply.vue
@@ -366,6 +366,7 @@ function getCheckedState(tag) {
   display: flex;
   flex-direction: column;
   width: 400px;
+  height: 450px;
   padding: 0;
 }
 
@@ -404,20 +405,20 @@ function getCheckedState(tag) {
 
 .apos-apply-tag-menu__tags {
   @include apos-list-reset();
-
-  & {
-    max-height: 315px;
-    overflow-y: auto;
-  }
 }
 
 .apos-apply-tag-menu__tag {
-  padding: $spacing-base $spacing-double;
+  padding: 11px 20px;
   border-top: 1px solid var(--a-base-9);
+
+  &:last-child {
+    border-bottom: 1px solid var(--a-base-9);
+  }
 }
 
 .apos-apply-tag-menu__search-body {
   flex: 1;
+  overflow-y: auto;
 }
 
 .apos-apply-tag-menu__empty {

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTagApply.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTagApply.vue
@@ -1,5 +1,6 @@
 <template>
   <AposContextMenu
+    ref="contextMenu"
     :menu-placement
     :button
     :disabled="isDisabled"
@@ -61,7 +62,7 @@
           type="quiet"
           :disabled="isTagFound"
           :disable-focus="!isOpen"
-          @click.stop="createOrManage"
+          @click.stop="createOrSearch"
         />
       </div>
     </div>
@@ -128,9 +129,10 @@ const props = defineProps({
   }
 });
 
-const emit = defineEmits([ 'added', 'checked', 'unchecked' ]);
+const emit = defineEmits([ 'added', 'checked', 'unchecked', 'refresh-data' ]);
 
 const textInputEl = useTemplateRef('textInput');
+const contextMenuEl = useTemplateRef('contextMenu');
 
 const isOpen = ref(false);
 const searchValue = ref({ data: '' });
@@ -259,7 +261,26 @@ function checkOrCreate() {
   create();
 };
 
-function createOrManage() {
+async function createOrManage() {
+  if (createUi.value) {
+    const imageTagMod = apos.modules['@apostrophecms/image-tag'];
+    await apos.modal.execute(imageTagMod.components.managerModal, {
+      moduleName: imageTagMod.name
+    });
+
+    emit('refresh-data');
+    contextMenuEl.value.show();
+    return;
+  }
+
+  if (searchValue.value.data) {
+    return create();
+  }
+
+  toggleCreateUi();
+}
+
+function createOrSearch() {
   if (!createUi.value && searchValue.value.data) {
     return create();
   }

--- a/modules/@apostrophecms/ui/ui/apos/components/AposTagApply.vue
+++ b/modules/@apostrophecms/ui/ui/apos/components/AposTagApply.vue
@@ -5,6 +5,7 @@
     :button
     :disabled="isDisabled"
     class="apos-apply-tag-menu"
+    :class="{ 'apos-apply-tag-menu--create-ui': createUi }"
     @open="isOpen = $event"
     @close="clearSearch"
   >
@@ -366,8 +367,12 @@ function getCheckedState(tag) {
   display: flex;
   flex-direction: column;
   width: 400px;
-  height: 450px;
   padding: 0;
+}
+
+.apos-apply-tag-menu:not(.apos-apply-tag-menu--create-ui)
+:deep(.apos-context-menu__pane) {
+  height: 450px;
 }
 
 .apos-apply-tag-menu__inner,
@@ -424,12 +429,12 @@ function getCheckedState(tag) {
 /* TODO: Fix UI when no tags found or none exist */
 .apos-apply-tag-menu__empty {
   display: flex;
+  box-sizing: border-box;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   height: 100%;
   padding: 0 0 10px;
-  box-sizing: border-box;
 }
 
 .apos-apply-tag-menu__empty-message {


### PR DESCRIPTION
[PRO-8007](https://linear.app/apostrophecms/issue/PRO-8007/batch-tagging-in-the-tag-list-view-the-dialogue-should-have-a-fixed)
[PRO-8003](https://linear.app/apostrophecms/issue/PRO-8003/batch-tagging-the-manage-tags-ui-should-open-the-image-tag-manager-not)

## Summary

* Batch tagging popover has a fixed height of 450px. 
* When clicking on `manage tags` we open the image-tags manager:
* When closing the images-tag manager, we refresh the `AposMediaManager` selected images and all tags to be sure changes saved are reflected in the UI.

## What are the specific steps to test this change?

* Check that the popover has a fixed height and that scroll is still working.
* Manager tags buy clicking `manager tags` and check changes are reflected in media manager and tags popover (which is closed and reopened).

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
