### PR TITLE
PRO-8043: Opt-out from locale inferring when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@
 
 ### Adds
 
-- Adds any alt text found in an attribute to the media library attachment during import of rich text inline images by API
+* Adds any alt text found in an attribute to the media library attachment during import of rich text inline images by API
 
 ### Changes
 
-- Changes handling of `order` and `groups` in the `admin-bar` module to respect, rather that reverse, the order of items
+* Changes handling of `order` and `groups` in the `admin-bar` module to respect, rather that reverse, the order of items
 
 ### Fixes
+
+* Ensure relationship convert handler can handle properly some cases where the document and request modes are different.
 
 ## 4.19.0 (2025-07-09)
 

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -1117,6 +1117,10 @@ module.exports = (self) => {
           }
         }
       }
+      // PRO-8043: When dealing with ID's only, request based locale inference
+      // is not needed. `undefined` - default auto locale inference,
+      // `null` - no locale inference.
+      const inferLocale = titlesOrIds.length > 0 ? undefined : null;
       const clauses = [];
       if (titlesOrIds.length) {
         clauses.push({
@@ -1138,6 +1142,7 @@ module.exports = (self) => {
         const results = await manager
           .find(req, { $or: clauses })
           .relationships(false)
+          .locale(inferLocale)
           .toArray();
         // Must maintain input order. Also discard things not actually found in
         // the db


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Improve the resolving logic of the relationship type `convert` handler:
- Ignore the request locale when it know it works with `_id`'s to avoid false positives
- This makes sense of the context of validating data, because the handler should care about the document and shouldn't be involved in any related to `aposMode` related logic. 
- When related items provide `_id` we can opt-out of auto-locale inferring, because the `_id` is unique.
- In all other cases the old logic applies (infer locale and mode)  

## What are the specific steps to test this change?

Providing a `published` request and `draft` document should successfully validate the draft document (and ignore `published` mode). 

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
