### PR TITLE
Hide rich text controls on interaction

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -440,7 +440,6 @@ export default {
   },
   methods: {
     suppressWidgetControls() {
-      console.log('hide those controls!!!');
       this.isSuppressingWidgetControls = true;
     },
     getFocusForMenu({ menuId, isOpen }) {

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -135,6 +135,7 @@
         :doc-id="docId"
         :focused="isFocused"
         @update="$emit('update', $event)"
+        @suppressWidgetControls="suppressWidgetControls"
       />
       <component
         :is="widgetComponent(widget.type)"
@@ -285,12 +286,14 @@ export default {
       mounted: false, // hack around needing DOM to be rendered for computed classes
       isSuppressed: false,
       menuOpen: null,
+      isSuppressingWidgetControls: false,
       classes: {
         show: 'apos-is-visible',
         open: 'apos-is-open',
         focus: 'apos-is-focused',
         highlight: 'apos-is-highlighted',
-        adjust: 'apos-is-ui-adjusted'
+        adjust: 'apos-is-ui-adjusted',
+        suppressWidgetControls: 'apos-is-suppressing-widget-controls'
       },
       breadcrumbs: {
         $lastEl: null,
@@ -362,7 +365,8 @@ export default {
     },
     controlsClasses() {
       return {
-        [this.classes.show]: this.isFocused
+        [this.classes.show]: this.isFocused,
+        [this.classes.suppressWidgetControls]: this.isSuppressingWidgetControls
       };
     },
     containerClasses() {
@@ -398,6 +402,7 @@ export default {
       } else {
         this.menuOpen = null;
         this.$refs.wrapper.removeEventListener('keydown', this.handleKeyboardUnfocus);
+        this.isSuppressingWidgetControls = false;
       }
     }
   },
@@ -434,6 +439,10 @@ export default {
     apos.bus.$off('widget-focus-parent', this.focusParent);
   },
   methods: {
+    suppressWidgetControls() {
+      console.log('hide those controls!!!');
+      this.isSuppressingWidgetControls = true;
+    },
     getFocusForMenu({ menuId, isOpen }) {
       if (
         (
@@ -881,7 +890,7 @@ export default {
     }
   }
 
-  .apos-is-visible,
+  .apos-is-visible:not(.apos-is-suppressing-widget-controls),
   .apos-is-focused {
     opacity: 1;
     pointer-events: auto;

--- a/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -216,11 +216,6 @@ export default {
     };
   },
   computed: {
-    selectionIsEmpty() {
-      if (this.editor) {
-        return this.editor.view.state.selection.empty;
-      } 
-    },
     tableOptions() {
       const options = this.moduleOptions.tableOptions || {};
 
@@ -385,9 +380,7 @@ export default {
   },
   watch: {
     suppressWidgetControls(newVal) {
-      console.log('suppressWidgetControls changed');
       if (newVal) {
-        console.log('emit suppress');
         this.$emit('suppressWidgetControls')
       } 
     },


### PR DESCRIPTION
## Summary

- Adds an event contextual widgets can emit that will signal to the widget wrapper to hide the widget controls
- Rich text signals to hide widget controls on typing
- Rich text signals to hide widget controls on text selection
