### PR TITLE
Resolved an issue affecting `withRelationships` with two or more steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 * Let the `@apostrophecms/page:unpark` task unpark all parked pages with the given slug, not just the first one.
 * Exclude unknown page types from the page manager.
+* Resolved an issue affecting `withRelationships` with two or more steps. This issue could cause a document to appear to be related to the same document more than once.
 
 ## 4.19.0 (2025-07-09)
 

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -26,8 +26,8 @@
         :class="labelsClasses"
       >
         <ol
-          @click="isSuppressingWidgetControls = false"
           class="apos-area-widget__breadcrumbs"
+          @click="isSuppressingWidgetControls = false"
         >
           <li
             class="

--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -159,7 +159,6 @@ module.exports = {
       post: {
         upload: [
           self.canUpload,
-          //In the existing code, we are reading the zeroth element from the files array object, which results in processing only a single file. Therefore, I am currently reading just one file from the Multer package.
           require('multer')({ dest: require('os').tmpdir() }).single('file'),
           async function (req) {
             try {
@@ -175,7 +174,6 @@ module.exports = {
 
               return attachment;
             } finally {
-              //Hence I am reading the single file from the upload and I am checking the condtion for the same
               if (req.file) {
                 try {
                   fs.unlinkSync(req.file.path);

--- a/modules/@apostrophecms/schema/lib/joinr.js
+++ b/modules/@apostrophecms/schema/lib/joinr.js
@@ -68,6 +68,14 @@ const joinr = module.exports = {
     getter,
     idMapper
   ) {
+    // This method never alters the items array itself, it alters
+    // the objects within it. So it is safe to reduce that array to
+    // its unique elements, and this simplifies calling code which does
+    // not have to guard against this situation.
+    // Note that we mean literal uniqueness (e.g. by reference), as this
+    // is the only time we need to avoid appending the same joined objects
+    // more than once.
+    items = [ ...new Set(items) ];
     let otherIds = [];
     const othersById = {};
     for (const item of items) {
@@ -167,6 +175,14 @@ const joinr = module.exports = {
     getter,
     idMapper
   ) {
+    // This method never alters the items array itself, it alters
+    // the objects within it. So it is safe to reduce that array to
+    // its unique elements, and this simplifies calling code which does
+    // not have to guard against this situation.
+    // Note that we mean literal uniqueness (e.g. by reference), as this
+    // is the only time we need to avoid appending the same joined objects
+    // more than once.
+    items = [ ...new Set(items) ];
     const itemIds = items.map(item => idMapper(item._id));
     for (const item of items) {
       if (!item[objectsField]) {


### PR DESCRIPTION
This issue could cause a document to appear to be related to the same document more than once. If several documents in the first step of the `withRelationships` path are related to the same document in the second step, then widgets containing relationships in the second step might populate with multiple copies of the same image.

In particular: [ 'articles', 'authors' ] in apollo, where 'authors' have an area containing an image widget, and the same author was attached to several articles.