### PR TITLE
PRO-8023: editor component

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
+++ b/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
@@ -3,8 +3,6 @@ import createApp from 'Modules/@apostrophecms/ui/lib/vue';
 
 export default function() {
 
-  const component = apos.vueComponents.AposAreaEditor;
-
   let widgetsRendering = 0;
 
   apos.area.widgetOptions = [];
@@ -72,6 +70,14 @@ export default function() {
     const choices = JSON.parse(el.getAttribute('data-choices'));
     const renderings = {};
     const _docId = data._docId;
+
+    let componentName = options.editorComponent;
+    if (!apos.vueComponents[componentName]) {
+      // eslint-disable-next-line no-console
+      console.error(`Area Editor component "${componentName}" not found. Switching to default.`);
+      componentName = 'AposAreaEditor';
+    }
+    const component = apos.vueComponents[componentName];
 
     for (const widgetEl of el.querySelectorAll('[data-apos-widget]')) {
       const _id = widgetEl.getAttribute('data-apos-widget');

--- a/modules/@apostrophecms/area/ui/apos/logic/AposAreaEditor.js
+++ b/modules/@apostrophecms/area/ui/apos/logic/AposAreaEditor.js
@@ -1,0 +1,717 @@
+import { createId } from '@paralleldrive/cuid2';
+import { klona } from 'klona';
+import AposThemeMixin from 'Modules/@apostrophecms/ui/mixins/AposThemeMixin';
+import newInstance from 'apostrophe/modules/@apostrophecms/schema/lib/newInstance.js';
+
+export default {
+  mixins: [ AposThemeMixin ],
+  props: {
+    docId: {
+      type: String,
+      default: null
+    },
+    docType: {
+      type: String,
+      default: null
+    },
+    id: {
+      type: String,
+      required: true
+    },
+    field: {
+      type: Object,
+      default() {
+        return {};
+      }
+    },
+    fieldId: {
+      type: String,
+      required: true
+    },
+    options: {
+      type: Object,
+      default() {
+        return {};
+      }
+    },
+    items: {
+      type: Array,
+      default() {
+        return [];
+      }
+    },
+    meta: {
+      type: Object,
+      default() {
+        return {};
+      }
+    },
+    followingValues: {
+      type: Object,
+      default() {
+        return {};
+      }
+    },
+    choices: {
+      type: Array,
+      required: true
+    },
+    renderings: {
+      type: Object,
+      default() {
+        return {};
+      }
+    },
+    generation: {
+      type: Number,
+      required: false,
+      default() {
+        return null;
+      }
+    }
+  },
+  emits: [ 'changed' ],
+  data() {
+    return {
+      addWidgetEditor: null,
+      addWidgetOptions: null,
+      addWidgetType: null,
+      areaId: createId(),
+      next: this.getValidItems(),
+      hoveredWidget: null,
+      hoveredNonForeignWidget: null,
+      focusedWidget: null,
+      contextMenuOptions: {
+        menu: this.choices
+      },
+      edited: {},
+      widgets: {}
+    };
+  },
+  computed: {
+    isEmptySingleton() {
+      return this.next.length === 0 &&
+        this.options.widgets &&
+        Object.keys(this.options.widgets).length === 1 &&
+        (this.options.max || this.field.max) &&
+        (this.options.max === 1 || this.field.max === 1);
+    },
+    icon() {
+      let icon = null;
+      if (
+        this.isEmptySingleton &&
+        this.contextMenuOptions.menu[0] &&
+        this.contextMenuOptions.menu[0].icon
+      ) {
+        icon = this.contextMenuOptions.menu[0].icon;
+      }
+      return icon;
+    },
+    moduleOptions() {
+      return window.apos.area;
+    },
+    types() {
+      return Object.keys(this.widgets);
+    },
+    maxReached() {
+      return this.options.max && this.next.length >= this.options.max;
+    },
+    foreign() {
+      // Cast to boolean is necessary to satisfy prop typing
+      return !!(this.docId && (window.apos.adminBar.contextId !== this.docId));
+    },
+    focusedWidgetIndex() {
+      if (!this.focusedWidget) {
+        return -1;
+      }
+
+      return this.next.findIndex(widget => widget._id === window.apos.focusedWidget);
+    }
+  },
+  watch: {
+    // Note: please don't make this a deep watcher as that could cause
+    // issues with live widget preview and also performance, the top level
+    // array will change in situations where a patch API call is actually
+    // needed at this level
+    next() {
+      if (!this.docId) {
+        // For the benefit of AposInputArea which is the
+        // direct parent when we are not editing on-page
+        this.$emit('changed', {
+          items: this.next
+        });
+      }
+      // For the benefit of all other area editors on-page
+      // which may have this one as a sub-area in some way, and
+      // mistakenly think they know its contents have not changed
+      apos.bus.$emit('area-updated', {
+        _id: this.id,
+        items: this.next
+      });
+    },
+    generation() {
+      this.next = this.getValidItems();
+    }
+  },
+  created() {
+    if (this.options.groups) {
+      for (const group of Object.keys(this.options.groups)) {
+        this.widgets = {
+          ...this.options.groups[group].widgets,
+          ...this.widgets
+        };
+      }
+    }
+  },
+  mounted() {
+    this.bindEventListeners();
+  },
+  beforeUnmount() {
+    this.unbindEventListeners();
+  },
+  methods: {
+    bindEventListeners() {
+      apos.bus.$on('area-updated', this.areaUpdatedHandler);
+      apos.bus.$on('widget-hover', this.updateWidgetHovered);
+      apos.bus.$on('widget-focus', this.updateWidgetFocused);
+      apos.bus.$on('command-menu-area-copy-widget', this.handleCopy);
+      apos.bus.$on('command-menu-area-cut-widget', this.handleCut);
+      apos.bus.$on('command-menu-area-duplicate-widget', this.handleDuplicate);
+      apos.bus.$on('command-menu-area-paste-widget', this.handlePaste);
+      apos.bus.$on('command-menu-area-remove-widget', this.handleRemove);
+      window.addEventListener('keydown', this.focusParentEvent);
+    },
+    unbindEventListeners() {
+      apos.bus.$off('area-updated', this.areaUpdatedHandler);
+      apos.bus.$off('widget-hover', this.updateWidgetHovered);
+      apos.bus.$off('widget-focus', this.updateWidgetFocused);
+      apos.bus.$off('command-menu-area-copy-widget', this.handleCopy);
+      apos.bus.$off('command-menu-area-cut-widget', this.handleCut);
+      apos.bus.$off('command-menu-area-duplicate-widget', this.handleDuplicate);
+      apos.bus.$off('command-menu-area-paste-widget', this.handlePaste);
+      apos.bus.$off('command-menu-area-remove-widget', this.handleRemove);
+      window.removeEventListener('keydown', this.focusParentEvent);
+    },
+    isInsideContentEditable() {
+      return document.activeElement.closest('[contenteditable]') !== null;
+    },
+    isInsideFocusedArea() {
+      return window.apos.focusedArea === this.areaId;
+    },
+    resetFocusedArea() {
+      if (window.apos.focusedArea !== this.areaId) {
+        return;
+      }
+
+      this.setFocusedArea(null, null);
+    },
+    setFocusedArea(areaId, event) {
+      if (event) {
+        // prevent parent areas from changing the focusedArea
+        event.stopPropagation();
+      }
+
+      window.apos.focusedArea = areaId;
+    },
+    handleCopy() {
+      if (
+        !this.isInsideFocusedArea() ||
+        this.isInsideContentEditable() ||
+        this.focusedWidgetIndex === -1
+      ) {
+        return;
+      }
+
+      this.copy(this.focusedWidgetIndex);
+    },
+    handleCut() {
+      if (
+        !this.isInsideFocusedArea() ||
+        this.isInsideContentEditable() ||
+        this.focusedWidgetIndex === -1
+      ) {
+        return;
+      }
+
+      this.cut(this.focusedWidgetIndex);
+    },
+    handleDuplicate() {
+      if (
+        !this.isInsideFocusedArea() ||
+        this.isInsideContentEditable() ||
+        this.focusedWidgetIndex === -1
+      ) {
+        return;
+      }
+
+      this.clone(this.focusedWidgetIndex);
+    },
+    handlePaste() {
+      if (
+        !this.isInsideFocusedArea() ||
+        this.isInsideContentEditable() ||
+        (this.focusedWidgetIndex === -1 && this.next.length > 0)
+      ) {
+        return;
+      }
+
+      this.paste(Math.max(this.focusedWidgetIndex, 0));
+    },
+    handleRemove() {
+      if (
+        !this.isInsideFocusedArea() ||
+        this.isInsideContentEditable() ||
+        this.focusedWidgetIndex === -1
+      ) {
+        return;
+      }
+
+      this.remove(this.focusedWidgetIndex);
+    },
+    areaUpdatedHandler(area) {
+      for (const item of this.next) {
+        if (this.patchSubobject(item, area)) {
+          break;
+        }
+      }
+    },
+    focusParentEvent(event) {
+      if (event.metaKey && event.keyCode === 8) {
+        // meta + backspace
+        apos.bus.$emit('widget-focus-parent', this.focusedWidget);
+      }
+    },
+    updateWidgetHovered({ _id, nonForeignId }) {
+      this.hoveredWidget = _id;
+      this.hoveredNonForeignWidget = nonForeignId;
+    },
+    updateWidgetFocused({ _id, scrollIntoView = false }) {
+      this.focusedWidget = _id;
+      // Attached to window so that modals can see the area is active
+      window.apos.focusedWidget = _id;
+
+      // We want what's next to run only once
+      // for the area containing the focusedWidget
+      // and not for all areas present on the page
+      if (this.focusedWidgetIndex === -1) {
+        return;
+      }
+
+      this.setFocusedArea(this.areaId, null);
+
+      if (scrollIntoView) {
+        this.$nextTick(() => {
+          const $el = document.querySelector(`[data-apos-widget-id="${_id}"]`);
+          if (!$el) {
+            return;
+          }
+
+          const headerHeight = window.apos.adminBar.height;
+          const bufferSpace = 40;
+          const targetTop = $el.getBoundingClientRect().top;
+          const scrollPos = targetTop - headerHeight - bufferSpace;
+
+          window.scrollBy({
+            top: scrollPos,
+            behavior: 'smooth'
+          });
+
+          $el.focus({
+            preventScroll: true
+          });
+        });
+      }
+    },
+    async up(i) {
+      if (this.docId === window.apos.adminBar.contextId) {
+        apos.bus.$emit('context-edited', {
+          $move: {
+            [`@${this.id}.items`]: {
+              $item: this.next[i]._id,
+              $before: this.next[i - 1]._id
+            }
+          }
+        });
+      }
+      this.next = [
+        ...this.next.slice(0, i - 1),
+        this.next[i],
+        this.next[i - 1],
+        ...this.next.slice(i + 1)
+      ];
+    },
+    async down(i) {
+      if (this.docId === window.apos.adminBar.contextId) {
+        apos.bus.$emit('context-edited', {
+          $move: {
+            [`@${this.id}.items`]: {
+              $item: this.next[i]._id,
+              $after: this.next[i + 1]._id
+            }
+          }
+        });
+      }
+      this.next = [
+        ...this.next.slice(0, i),
+        this.next[i + 1],
+        this.next[i],
+        ...this.next.slice(i + 2)
+      ];
+    },
+    async remove(i, { autosave = true } = {}) {
+      if (autosave && (this.docId === window.apos.adminBar.contextId)) {
+        apos.bus.$emit('context-edited', {
+          $pullAllById: {
+            [`@${this.id}.items`]: [ this.next[i]._id ]
+          }
+        });
+      }
+      this.next = [
+        ...this.next.slice(0, i),
+        ...this.next.slice(i + 1)
+      ];
+      const focusNext = this.next[i - 1] || this.next[i];
+
+      if (focusNext) {
+        apos.bus.$emit('widget-focus', {
+          _id: focusNext._id,
+          scrollIntoView: true
+        });
+      }
+
+    },
+    async cut(i) {
+      apos.area.widgetClipboard.set(this.next[i]);
+      await this.remove(i);
+      apos.notify('Widget cut to clipboard', {
+        type: 'success',
+        icon: 'content-cut-icon',
+        dismiss: true
+      });
+    },
+    async copy(i) {
+      apos.area.widgetClipboard.set(this.next[i]);
+      apos.notify('Widget copied to clipboard', {
+        type: 'success',
+        icon: 'content-copy-icon',
+        dismiss: true
+      });
+    },
+    async edit(i) {
+      if (this.foreign) {
+        try {
+          const doc = await apos.http.get(
+            `${window.apos.doc.action}/${this.docId}`,
+            {
+              busy: true
+            }
+          );
+          if (doc._url) {
+            const contextTitle = window.apos.adminBar.context.title;
+            if (await apos.confirm({
+              heading: this.$t('apostrophe:leavePageHeading', {
+                oldTitle: contextTitle,
+                newTitle: doc.title
+              }),
+              description: this.$t('apostrophe:leavePageDescription', {
+                oldTitle: contextTitle
+              }),
+              localize: false
+            })) {
+              location.assign(doc._url);
+            }
+          } else {
+            apos.bus.$emit('admin-menu-click', {
+              itemName: `${doc.type}:editor`,
+              props: {
+                docId: doc._id
+              }
+            });
+          }
+          return;
+        } catch (e) {
+          if (e.status === 404) {
+            apos.notify('apostrophe:notFound', { type: 'error' });
+            return;
+          } else {
+            throw e;
+          }
+        }
+      }
+
+      const widget = this.next[i];
+
+      if (!this.widgetIsContextual(widget.type)) {
+        const componentName = this.widgetEditorComponent(widget.type);
+        apos.area.activeEditor = this;
+        apos.bus.$on('apos-refreshing', cancelRefresh);
+        const preview = this.widgetPreview(widget.type, i, false);
+        const result = await apos.modal.execute(componentName, {
+          modelValue: widget,
+          options: this.widgetOptionsByType(widget.type),
+          type: widget.type,
+          docId: this.docId,
+          parentFollowingValues: this.followingValues,
+          areaFieldId: this.fieldId,
+          meta: this.meta[widget._id]?.aposMeta,
+          preview
+        });
+        apos.area.activeEditor = null;
+        apos.bus.$off('apos-refreshing', cancelRefresh);
+        if (result) {
+          return this.update(result);
+        }
+      }
+    },
+    clone(index) {
+      const widget = klona(this.next[index]);
+      delete widget._id;
+      this.regenerateIds(
+        apos.modules[apos.area.widgetManagers[widget.type]].schema,
+        widget
+      );
+      this.insert({
+        widget,
+        index: index + 1
+      });
+    },
+    async paste(index) {
+      const clipboard = apos.area.widgetClipboard.get();
+      if (clipboard) {
+        const widget = clipboard;
+        const allowed = this.contextMenuOptions.menu.find(
+          option => option.name === widget.type
+        );
+        if (allowed) {
+          this.add({
+            index,
+            clipboard
+          });
+        }
+      }
+    },
+    // Regenerate all array item, area, object and widget ids so they are considered
+    // new. Useful when copying a widget with nested content.
+    regenerateIds(schema, object) {
+      object._id = createId();
+      for (const field of schema) {
+        if (field.type === 'array') {
+          for (const item of (object[field.name] || [])) {
+            this.regenerateIds(field.schema, item);
+          }
+        } else if (field.type === 'object') {
+          this.regenerateIds(field.schema, object[field.name] || {});
+        } else if (field.type === 'area') {
+          if (object[field.name]) {
+            object[field.name]._id = createId();
+            for (const item of (object[field.name].items || [])) {
+              const schema = apos.modules[apos.area.widgetManagers[item.type]].schema;
+              this.regenerateIds(schema, item);
+            }
+          }
+        }
+        // We don't want to regenerate attachment ids. They correspond to
+        // actual files, and the reference count will update automatically
+      }
+    },
+    async update(updated, { autosave = true, reverting = false } = {}) {
+      if (!reverting) {
+        updated.aposPlaceholder = false;
+      }
+      if (!updated.metaType) {
+        updated.metaType = 'widget';
+      }
+      if (autosave && (this.docId === window.apos.adminBar.contextId)) {
+        apos.bus.$emit('context-edited', {
+          [`@${updated._id}`]: updated
+        });
+      }
+      this.next = this.next.map((widget) => {
+        if (widget._id === updated._id) {
+          return updated;
+        }
+        return widget;
+      });
+      this.edited[updated._id] = true;
+    },
+    // Add a widget into an area.
+    async add({
+      index,
+      name,
+      clipboard
+    }) {
+      if (clipboard) {
+        this.regenerateIds(
+          apos.modules[apos.area.widgetManagers[clipboard.type]].schema,
+          clipboard
+        );
+        return this.insert({
+          widget: clipboard,
+          index
+        });
+      } else if (this.widgetIsContextual(name)) {
+        return this.insert({
+          widget: {
+            type: name,
+            ...this.contextualWidgetDefaultData(name),
+            aposPlaceholder: this.widgetHasPlaceholder(name)
+          },
+          index
+        });
+      } else if (!this.widgetHasInitialModal(name)) {
+        const widget = this.newWidget(name);
+        return this.insert({
+          widget: {
+            ...widget,
+            aposPlaceholder: this.widgetHasPlaceholder(name)
+          },
+          index
+        });
+      } else {
+        const componentName = this.widgetEditorComponent(name);
+        apos.area.activeEditor = this;
+        const preview = this.widgetPreview(name, index, true);
+        const widget = await apos.modal.execute(componentName, {
+          modelValue: null,
+          options: this.widgetOptionsByType(name),
+          type: name,
+          docId: this.docId,
+          areaFieldId: this.fieldId,
+          parentFollowingValues: this.followingValues,
+          preview
+        });
+        apos.area.activeEditor = null;
+        if (widget) {
+          return this.insert({
+            widget,
+            index
+          });
+        }
+      }
+    },
+    widgetOptionsByType(name) {
+      if (this.options.widgets) {
+        return this.options.widgets[name];
+      } else if (this.options.expanded) {
+        for (const info of Object.values(this.options.groups || {})) {
+          if (info?.widgets?.[name]) {
+            return info.widgets[name];
+          }
+        }
+      }
+      return null;
+    },
+    contextualWidgetDefaultData(type) {
+      return this.moduleOptions.contextualWidgetDefaultData[type];
+    },
+    async insert({
+      index, widget, autosave = true
+    } = {}) {
+      if (!widget._id) {
+        widget._id = createId();
+      }
+      if (!widget.metaType) {
+        widget.metaType = 'widget';
+      }
+      if (autosave && (this.docId === window.apos.adminBar.contextId)) {
+        const push = {
+          $each: [ widget ]
+        };
+        if (index < this.next.length) {
+          push.$before = this.next[index]._id;
+        }
+        apos.bus.$emit('context-edited', {
+          $push: {
+            [`@${this.id}.items`]: push
+          }
+        });
+      }
+      this.next = [
+        ...this.next.slice(0, index),
+        widget,
+        ...this.next.slice(index)
+      ];
+      if (this.widgetIsContextual(widget.type)) {
+        this.edit(index);
+      }
+      apos.bus.$emit('widget-focus', {
+        _id: widget._id,
+        scrollIntoView: true
+      });
+    },
+    widgetIsContextual(type) {
+      return this.moduleOptions.widgetIsContextual[type];
+    },
+    widgetHasPlaceholder(type) {
+      return this.moduleOptions.widgetHasPlaceholder[type];
+    },
+    widgetHasInitialModal(type) {
+      return this.moduleOptions.widgetHasInitialModal[type];
+    },
+    widgetEditorComponent(type) {
+      return this.moduleOptions.components.widgetEditors[type];
+    },
+    widgetPreview(type, index, create) {
+      return this.moduleOptions.widgetPreview[type]
+        ? {
+          area: this,
+          index,
+          create
+        }
+        : null;
+    },
+    // Recursively seek `subObject` within `object`, based on whether
+    // its _id matches that of a sub-object of `object`. If found,
+    // replace that sub-object with `subObject` and return `true`.
+    patchSubobject(object, subObject) {
+      let result;
+      for (const [ key, val ] of Object.entries(object)) {
+        if (key.charAt(0) === '_') {
+          // Patch only the thing itself, not a relationship that also contains
+          // a copy
+          continue;
+        }
+        if (val && typeof val === 'object') {
+          if (val._id === subObject._id) {
+            object[key] = subObject;
+            return true;
+          }
+          result = this.patchSubobject(val, subObject);
+          if (result) {
+            return result;
+          }
+        }
+      }
+    },
+    rendering(widget) {
+      if (this.edited[widget._id]) {
+        return null;
+      } else {
+        return this.renderings[widget._id];
+      }
+    },
+    getValidItems() {
+      return this.items.filter(item => {
+        if (!window.apos.modules[`${item.type}-widget`]) {
+          // eslint-disable-next-line no-console
+          console.warn(`The widget type ${item.type} exists in the content but is not configured.`);
+        }
+        return window.apos.modules[`${item.type}-widget`];
+      });
+    },
+    // Return a new widget object in which defaults are fully populated,
+    // especially valid sub-area objects, so that nested edits work on the page
+    newWidget(type) {
+      const schema = apos.modules[apos.area.widgetManagers[type]].schema;
+      const widget = {
+        ...newInstance(schema),
+        type
+      };
+      return widget;
+    }
+  }
+};
+
+function cancelRefresh(refreshOptions) {
+  refreshOptions.refresh = false;
+}

--- a/modules/@apostrophecms/area/views/area.html
+++ b/modules/@apostrophecms/area/views/area.html
@@ -1,15 +1,19 @@
 {# area needs its own copy of the widget options as #}
 {# JSON, for adding new widgets #}
 
-<div class="apos-area" {%- if data.canEdit %} data-apos-area-newly-editable data-doc-id='{{ data.area._docId | jsonAttribute({ single: true }) }}' data-field-id='{{ data.field._id | jsonAttribute({ single: true }) }}' data-options='{{ apos.util.omit(data.options, 'area') | jsonAttribute({ single: true }) }}' data='{{ data.area | jsonAttribute({ single: true }) }}' data-choices='{{ data.choices | jsonAttribute({ single: true }) }}'{% endif %}>
+<div class="apos-area {{ data._with.className }}" {%- if data.canEdit %} data-apos-area-newly-editable data-doc-id='{{ data.area._docId | jsonAttribute({ single: true }) }}' data-field-id='{{ data.field._id | jsonAttribute({ single: true }) }}' data-options='{{ apos.util.omit(data.options, 'area') | jsonAttribute({ single: true }) }}' data='{{ data.area | jsonAttribute({ single: true }) }}' data-choices='{{ data.choices | jsonAttribute({ single: true }) }}'{% endif %} {%- if data._with.style %} style="{{ data._with.style }}"{% endif %}>
   {%- for item in data.area.items -%}
     {%- set widgetOptions = data.options.widgets[item.type] or {} -%}
-    {%- if data.canEdit -%}
-      <div data-apos-widget="{{ item._id }}">
-    {%- endif -%}
-    {% widget item, widgetOptions with data._with %}
-    {%- if data.canEdit -%}
-      </div>
-    {%- endif -%}
+    {% if data.options.widgetTemplate %}
+      {% include data.options.widgetTemplate %}
+    {% else %}
+      {%- if data.canEdit -%}
+        <div data-apos-widget="{{ item._id }}">
+      {%- endif -%}
+      {% widget item, widgetOptions with data._with %}
+      {%- if data.canEdit -%}
+        </div>
+      {%- endif -%}
+    {% endif %}
   {%- endfor -%}
 </div>

--- a/modules/@apostrophecms/layout-widget/index.js
+++ b/modules/@apostrophecms/layout-widget/index.js
@@ -19,6 +19,7 @@ module.exports = {
         type: 'area',
         options: {
           editorComponent: 'AposAreaLayoutEditor',
+          widgetTemplate: '@apostrophecms/layout-widget:item.html',
           widgets: {
             '@apostrophecms/layout-column': {}
           }

--- a/modules/@apostrophecms/layout-widget/ui/apos/components/AposAreaLayoutEditor.vue
+++ b/modules/@apostrophecms/layout-widget/ui/apos/components/AposAreaLayoutEditor.vue
@@ -6,6 +6,7 @@
     :class="themeClass"
     @click="setFocusedArea(areaId, $event)"
   >
+    <h5>A message from the Layout Area Editor</h5>
     <div
       v-if="next.length === 0 && !foreign"
       class="apos-empty-area"
@@ -79,10 +80,10 @@
 </template>
 
 <script>
-import AposAreaEditorLogic from '../logic/AposAreaEditor.js';
+import AposAreaEditorLogic from 'Modules/@apostrophecms/area/logic/AposAreaEditor.js';
 
 export default {
-  name: 'AposAreaEditor',
+  name: 'AposAreaLayoutEditor',
   mixins: [ AposAreaEditorLogic ]
 };
 </script>

--- a/modules/@apostrophecms/layout-widget/views/item.html
+++ b/modules/@apostrophecms/layout-widget/views/item.html
@@ -1,0 +1,12 @@
+{# Included directly from the `area.html` template.
+The area related `data.*` is available pluis `item` and `widgetOptions`. #}
+<div
+  {% if data.canEdit %}data-apos-widget="{{ item._id }}"{% endif %}
+  style="
+    --column-start: {{ item.start }}; 
+    --column-span: {{ item.span }}; 
+    --justify: {{ item.justify }};
+    --align: {{ item.align }};
+">
+  {% area item, 'content' %}
+</div>

--- a/modules/@apostrophecms/layout-widget/views/widget.html
+++ b/modules/@apostrophecms/layout-widget/views/widget.html
@@ -1,20 +1,4 @@
-{% if data.widget.columns.items.length %}
-  <section 
-    class="layout-widget" 
-    style="--grid-columns: {{ data.options.steps }}"
-  >
-      {% for item in data.widget.columns.items %}
-        <div 
-          style="
-            --column-start: {{ item.start }}; 
-            --column-span: {{ item.span }}; 
-            --justify: {{ item.justify }};
-            --align: {{ item.align }};
-        ">
-          {% area item, 'content' %}
-        </div>
-      {% endfor %}
-  </section>
-{% else %}
-  {% area data.widget, 'columns' %}
-{% endif %}
+{% area data.widget, 'columns' with { 
+  style: '--grid-columns: ' + data.options.steps + ';', 
+  className: 'layout-widget' 
+} %}


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

- Allow control over area backend rendering via combination of schema and contextual (an object passed `with` custom tag keyword) options. This includes class name and style for the area wrapper, per widget item custom template, custom editor component. 
- Refactor Area Editor, extracting its logic
- Create a copy of Area Editor (Area Layout Editor) that reuses that logic and renders a development message to prove it's in use
- Use the custom Area Layout Editor with our new layout widget.

**The Result** 

The strategy "almost" works so far. This change allows the grid to be rendered in preview and public mode, but fails in edit mode. This is expected! In the next step we need the combination of the new area editor AND a custom widget component (probably inline) to handle the editing experience, while the rest should stay unchanged. 

Why not working? Because the Widget Editor also does its own thing (adding wrappers and number of dom enhancements) by default. But most importantly, it requests the widget contents directly, thus bypassing our new feature. This is fine! We'll handle this case manually in the next iteration.  