### PR TITLE
Pro 8087 aspect ratio image widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 * Importing a custom icon from an npm module using a `~` path per the admin UI now works per the documentation, as long as the Vue component used for the icon is structured like those found in `@apostrophecms/vue-material-design-icons`.
 * The `button: true` flag works again for piece module utility operations. Previously the button appeared but did not trigger the desired operation.
 * Fixes the widget data being cloned to be saved before the `postprocess` method being called, which leads to a loss of data in `AposWidgetEditor` (like the autocrop data).
+* Fixes autocropping not working when uploading or selecting images from the new quick image upload UI.
+* In editors like `AposWidgetEditor` relationships are now post processed after they are updated in `AposInputRelationship` only for the relationship that has been updated. 
+It allows live preview to work well with it, it also avoids complexity and fixes updated data not being properly synced between the editor and the `AposSchema`.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Make conditional fields work in Image Editor.
 * Importing a custom icon from an npm module using a `~` path per the admin UI now works per the documentation, as long as the Vue component used for the icon is structured like those found in `@apostrophecms/vue-material-design-icons`.
 * The `button: true` flag works again for piece module utility operations. Previously the button appeared but did not trigger the desired operation.
+* Fixes the widget data being cloned to be saved before the `postprocess` method being called, which leads to a loss of data in `AposWidgetEditor` (like the autocrop data).
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * `apos.doc.edit` now accepts an optional `values` object as the final parameter, containing initial values for some or all fields. This is supported only when editing existing documents.
 * When specifying a modal name to be executed, developers may now register "transformers" to be invoked first, using pipe syntax. For example, the modal name `aposSectionTemplateLibraryWidgetToDoc|AposDocEditor` will invoke the transformer `aposSectionTemplateLibraryWidgetToDoc` with the original props, and pass the returned result to `AposDocEditor`. Note that transformers are awaited. Transformers are registered in frontend admin UI code by passing a name and a function to `apos.ui.addTransformer`.
 * Adds quick image upload UI to `@apostrophecms/image-widget`.
+* Makes autocropping work when uploading or selecting images from the new quick image upload UI.
 
 ### Fixes
 
@@ -17,7 +18,6 @@
 * Importing a custom icon from an npm module using a `~` path per the admin UI now works per the documentation, as long as the Vue component used for the icon is structured like those found in `@apostrophecms/vue-material-design-icons`.
 * The `button: true` flag works again for piece module utility operations. Previously the button appeared but did not trigger the desired operation.
 * Fixes the widget data being cloned to be saved before the `postprocess` method being called, which leads to a loss of data in `AposWidgetEditor` (like the autocrop data).
-* Fixes autocropping not working when uploading or selecting images from the new quick image upload UI.
 * In editors like `AposWidgetEditor` relationships are now post processed after they are updated in `AposInputRelationship` only for the relationship that has been updated. 
 It allows live preview to work well with it, it also avoids complexity and fixes updated data not being properly synced between the editor and the `AposSchema`.
 

--- a/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
+++ b/modules/@apostrophecms/doc-type/ui/apos/components/AposDocEditor.vue
@@ -637,7 +637,6 @@ export default {
 
       let doc;
       try {
-        await this.postprocess();
         doc = await requestMethod(route, {
           busy: true,
           body,

--- a/modules/@apostrophecms/image-widget/ui/apos/components/AposImageWidget.vue
+++ b/modules/@apostrophecms/image-widget/ui/apos/components/AposImageWidget.vue
@@ -26,7 +26,7 @@ import {
 } from 'vue';
 import { useAposWidget } from 'Modules/@apostrophecms/widget-type/composables/AposWidget.js';
 import aposWidgetProps from 'Modules/@apostrophecms/widget-type/composables/AposWidgetProps.js';
-import { _postprocess } from 'Modules/@apostrophecms/modal/composables/AposEditor.js';
+import { postprocessRelationships } from 'Modules/@apostrophecms/piece-type/lib/postprocessRelationships.js';
 
 const props = defineProps(aposWidgetProps);
 const imgModuleOptions = apos.modules['@apostrophecms/image'];
@@ -83,7 +83,7 @@ async function selectFromManager() {
       ...props.modelValue,
       _image: [ selectedImg ]
     };
-    await _postprocess(widgetModuleOptions.schema, widgetData, props.options);
+    await postprocessRelationships(widgetModuleOptions.schema, widgetData, props.options);
 
     emit('update', widgetData);
   }
@@ -195,7 +195,7 @@ async function upload(files = []) {
       ...props.modelValue,
       _image: [ imgPiece ]
     };
-    await _postprocess(widgetModuleOptions.schema, widgetData, props.options);
+    await postprocessRelationships(widgetModuleOptions.schema, widgetData, props.options);
 
     emit('update', widgetData);
   } catch (e) {

--- a/modules/@apostrophecms/image-widget/ui/apos/components/AposImageWidget.vue
+++ b/modules/@apostrophecms/image-widget/ui/apos/components/AposImageWidget.vue
@@ -174,7 +174,7 @@ async function upload(files = []) {
       },
       draft: true
     });
-    const formData = new window.FormData();
+    const formData = new FormData();
     formData.append('file', file);
 
     // Make an async request to upload the image.

--- a/modules/@apostrophecms/modal/ui/apos/composables/AposEditor.js
+++ b/modules/@apostrophecms/modal/ui/apos/composables/AposEditor.js
@@ -1,0 +1,57 @@
+// For now just moving postprocess logic here,
+// if needed we might move more from AposEditorMixin.js
+
+// Perform any postprocessing required by direct or nested schema fields
+// before the object can be saved
+export async function _postprocess(schema, data, widgetOptions) {
+  // Relationship fields may have postprocessors (e.g. autocropping)
+  const relationships = findRelationships(schema, data);
+
+  for (const relationship of relationships) {
+    if (!(relationship.value && relationship.field.postprocessor)) {
+      continue;
+    }
+    const withType = relationship.field.withType;
+    const mod = apos.modules[withType];
+    const response = await apos.http.post(`${mod.action}/${relationship.field.postprocessor}`, {
+      qs: {
+        aposMode: 'draft'
+      },
+      body: {
+        relationship: relationship.value,
+        // Pass the options of the widget currently being edited, some
+        // postprocessors need these
+        // (e.g. autocropping cares about widget aspectRatio)
+        widgetOptions
+      },
+      busy: true
+    });
+    relationship.context[relationship.field.name] = response.relationship;
+  }
+}
+
+function findRelationships(schema, object) {
+  let relationships = [];
+  for (const field of schema) {
+    if (field.type === 'relationship') {
+      relationships.push({
+        context: object,
+        field,
+        value: object[field.name]
+      });
+    } else if (field.type === 'array') {
+      for (const value of (object[field.name] || [])) {
+        relationships = [
+          ...relationships,
+          findRelationships(field.schema, value)
+        ];
+      }
+    } else if (field.type === 'object') {
+      relationships = [
+        ...relationships,
+        findRelationships(field.schema, object[field.name] || {})
+      ];
+    }
+  }
+  return relationships;
+}

--- a/modules/@apostrophecms/modal/ui/apos/composables/AposEditor.js
+++ b/modules/@apostrophecms/modal/ui/apos/composables/AposEditor.js
@@ -3,9 +3,9 @@
 
 // Perform any postprocessing required by direct or nested schema fields
 // before the object can be saved
-export async function _postprocess(schema, data, widgetOptions/* , oldData */) {
+export async function _postprocess(schema, data, widgetOptions, fieldIds) {
   // Relationship fields may have postprocessors (e.g. autocropping)
-  const relationships = findRelationships(schema, data);
+  const relationships = findRelationships(schema, data, fieldIds);
 
   for (const relationship of relationships) {
     if (!(relationship.value && relationship.field.postprocessor)) {
@@ -26,16 +26,15 @@ export async function _postprocess(schema, data, widgetOptions/* , oldData */) {
       },
       busy: true
     });
-    console.log('response.relationship', response.relationship);
     relationship.context[relationship.field.name] = response.relationship;
   }
 }
 
-function findRelationships(schema, object, oldObject) {
+function findRelationships(schema, object, ids) {
   let relationships = [];
-  const oldRelationships = [];
   for (const field of schema) {
-    if (field.type === 'relationship') {
+    if (field.type === 'relationship' && ids.has(field._id)) {
+      console.log('field._id', ids, field._id);
       relationships.push({
         context: object,
         field,
@@ -55,5 +54,5 @@ function findRelationships(schema, object, oldObject) {
       ];
     }
   }
-  return [ relationships, oldRelationships ];
+  return relationships;
 }

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -220,13 +220,6 @@ export default {
         this.triggerValidation = false;
       });
     },
-    async postprocess(fieldIds) {
-      await _postprocess(
-        this.schema,
-        this.docFields.data,
-        apos.area.widgetOptions[0],
-        fieldIds
-      );
-    }
+    async postprocess() {}
   }
 };

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -229,8 +229,8 @@ export default {
           continue;
         }
         const withType = relationship.field.withType;
-        const module = apos.modules[withType];
-        relationship.context[relationship.field.name] = (await apos.http.post(`${module.action}/${relationship.field.postprocessor}`, {
+        const mod = apos.modules[withType];
+        const response = await apos.http.post(`${mod.action}/${relationship.field.postprocessor}`, {
           qs: {
             aposMode: 'draft'
           },
@@ -242,7 +242,8 @@ export default {
             widgetOptions: apos.area.widgetOptions[0]
           },
           busy: true
-        })).relationship;
+        });
+        relationship.context[relationship.field.name] = response.relationship;
       }
       function findRelationships(schema, object) {
         let relationships = [];

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -224,8 +224,7 @@ export default {
       await _postprocess(
         this.schema,
         this.docFields.data,
-        apos.area.widgetOptions[0],
-        oldData
+        apos.area.widgetOptions[0]
       );
     }
   }

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -220,11 +220,12 @@ export default {
         this.triggerValidation = false;
       });
     },
-    async postprocess(oldData) {
+    async postprocess(fieldIds) {
       await _postprocess(
         this.schema,
         this.docFields.data,
-        apos.area.widgetOptions[0]
+        apos.area.widgetOptions[0],
+        fieldIds
       );
     }
   }

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -215,7 +215,7 @@ export default {
     },
     triggerValidate() {
       this.triggerValidation = true;
-      this.$nextTick(async () => {
+      this.$nextTick(() => {
         this.triggerValidation = false;
       });
     },

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -18,7 +18,6 @@ import { klona } from 'klona';
 import {
   evaluateExternalConditions, getConditionalFields, getConditionTypesObject
 } from 'Modules/@apostrophecms/schema/lib/conditionalFields.js';
-import { _postprocess } from '../composables/AposEditor.js';
 
 export default {
   props: {

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -219,6 +219,11 @@ export default {
         this.triggerValidation = false;
       });
     },
-    async postprocess() {}
+    async postprocess() {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'The function postprocess from AposEditorMixin does not do anything anymore.\nRelationship postprocessing is made at input level in AposInputRelationship and in some cases globally like in AposImageWidget.'
+      );
+    }
   }
 };

--- a/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
+++ b/modules/@apostrophecms/modal/ui/apos/mixins/AposEditorMixin.js
@@ -220,11 +220,12 @@ export default {
         this.triggerValidation = false;
       });
     },
-    async postprocess() {
+    async postprocess(oldData) {
       await _postprocess(
         this.schema,
         this.docFields.data,
-        apos.area.widgetOptions[0]
+        apos.area.widgetOptions[0],
+        oldData
       );
     }
   }

--- a/modules/@apostrophecms/piece-type/ui/apos/lib/postprocessRelationships.js
+++ b/modules/@apostrophecms/piece-type/ui/apos/lib/postprocessRelationships.js
@@ -1,16 +1,13 @@
-// For now just moving postprocess logic here,
-// if needed we might move more from AposEditorMixin.js
-
 // Perform any postprocessing required by direct or nested schema fields
 // before the object can be saved
-export async function _postprocess(schema, data, widgetOptions) {
+export async function postprocessRelationships(schema, data, widgetOptions) {
   // Relationship fields may have postprocessors (e.g. autocropping)
-  const relationships = _findRelationships(schema, data);
+  const relationships = findRelationships(schema, data);
 
   for (const {
     value, field, context
   } of relationships) {
-    context[field.name] = await _getPostprocessedRelationship(
+    context[field.name] = await getPostprocessedRelationship(
       value,
       field,
       widgetOptions
@@ -18,7 +15,7 @@ export async function _postprocess(schema, data, widgetOptions) {
   }
 }
 
-export async function _getPostprocessedRelationship(
+export async function getPostprocessedRelationship(
   value,
   field,
   widgetOptions
@@ -44,7 +41,7 @@ export async function _getPostprocessedRelationship(
   return response.relationship;
 }
 
-function _findRelationships(schema, object) {
+function findRelationships(schema, object) {
   let relationships = [];
   for (const field of schema) {
     if (field.type === 'relationship') {
@@ -57,13 +54,13 @@ function _findRelationships(schema, object) {
       for (const value of (object[field.name] || [])) {
         relationships = [
           ...relationships,
-          _findRelationships(field.schema, value)
+          findRelationships(field.schema, value)
         ];
       }
     } else if (field.type === 'object') {
       relationships = [
         ...relationships,
-        _findRelationships(field.schema, object[field.name] || {})
+        findRelationships(field.schema, object[field.name] || {})
       ];
     }
   }

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposInputRelationship.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposInputRelationship.js
@@ -117,8 +117,6 @@ export default {
   },
   watch: {
     next(after, before) {
-      console.log('after', after);
-      console.log('before', before);
       for (const doc of before) {
         this.subfields[doc._id] = doc._fields;
       }

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposInputRelationship.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposInputRelationship.js
@@ -1,7 +1,7 @@
 import { klona } from 'klona';
 import AposInputMixin from 'Modules/@apostrophecms/schema/mixins/AposInputMixin';
 import newInstance from 'apostrophe/modules/@apostrophecms/schema/lib/newInstance.js';
-import { _getPostprocessedRelationship } from 'Modules/@apostrophecms/modal/composables/AposEditor.js';
+import { getPostprocessedRelationship } from 'Modules/@apostrophecms/piece-type/lib/postprocessRelationships.js';
 
 export default {
   name: 'AposInputRelationship',
@@ -157,7 +157,7 @@ export default {
       this.disabled = !!this.limitReached;
     },
     async updateSelected(items) {
-      this.next = await _getPostprocessedRelationship(
+      this.next = await getPostprocessedRelationship(
         items,
         this.field,
         this.widgetOptions
@@ -303,7 +303,7 @@ export default {
           : rel;
       });
 
-      this.next = await _getPostprocessedRelationship(
+      this.next = await getPostprocessedRelationship(
         updatedItems,
         this.field,
         this.widgetOptions

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposSchema.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposSchema.js
@@ -265,11 +265,14 @@ export default {
         this.$emit('reset');
       });
     },
-    updateNextAndEmit() {
+    async updateNextAndEmit() {
       if (!this.schemaReady) {
         return;
       }
+      // This fixes the issue of error validation arriving after input values change
+      await this.$nextTick();
       const oldHasErrors = this.next.hasErrors;
+      // destructure these for non-linked comparison
       let changeFound = false;
 
       this.next.hasErrors = false;

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposSchema.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposSchema.js
@@ -275,6 +275,7 @@ export default {
       const newFieldState = { ...this.fieldState };
 
       let changeFound = false;
+      const changedTypes = new Set();
 
       this.next.hasErrors = false;
       this.next.fieldState = { ...this.fieldState };
@@ -296,22 +297,25 @@ export default {
             )
           ) {
             changeFound = true;
+            changedTypes.add(field.type);
+
             this.next.data[field.name] = this.fieldState[field.name].data;
           } else {
             this.next.data[field.name] = this.modelValue.data[field.name];
           }
         });
       if (
-        oldHasErrors !== this.next.hasErrors ||
-        oldFieldState !== newFieldState
+        oldHasErrors !== this.next.hasErrors
+        /* oldFieldState !== newFieldState */
       ) {
+        console.log('=====> weird change found <=====');
         // Otherwise the save button may never unlock
         changeFound = true;
       }
 
       if (changeFound) {
         // ... removes need for deep watch at parent level
-        this.$emit('update:model-value', { ...this.next });
+        this.$emit('update:model-value', { ...this.next }, { changedTypes });
       }
     },
     displayComponent({ name, hidden = false }) {

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposSchema.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposSchema.js
@@ -270,12 +270,8 @@ export default {
         return;
       }
       const oldHasErrors = this.next.hasErrors;
-      // destructure these for non-linked comparison
-      const oldFieldState = { ...this.next.fieldState };
-      const newFieldState = { ...this.fieldState };
-
       let changeFound = false;
-      const changedTypes = new Set();
+      const changedFieldIds = new Set();
 
       this.next.hasErrors = false;
       this.next.fieldState = { ...this.fieldState };
@@ -297,25 +293,23 @@ export default {
             )
           ) {
             changeFound = true;
-            changedTypes.add(field.type);
+            changedFieldIds.add(field._id);
 
+            // fieldState never gets the relationships postprocessed data
+            // that's why it gets seen as different than next all the time
             this.next.data[field.name] = this.fieldState[field.name].data;
           } else {
             this.next.data[field.name] = this.modelValue.data[field.name];
           }
         });
-      if (
-        oldHasErrors !== this.next.hasErrors
-        /* oldFieldState !== newFieldState */
-      ) {
-        console.log('=====> weird change found <=====');
+      if (oldHasErrors !== this.next.hasErrors) {
         // Otherwise the save button may never unlock
         changeFound = true;
       }
 
       if (changeFound) {
         // ... removes need for deep watch at parent level
-        this.$emit('update:model-value', { ...this.next }, { changedTypes });
+        this.$emit('update:model-value', { ...this.next }, { changedFieldIds });
       }
     },
     displayComponent({ name, hidden = false }) {

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposSchema.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposSchema.js
@@ -271,7 +271,6 @@ export default {
       }
       const oldHasErrors = this.next.hasErrors;
       let changeFound = false;
-      const changedFieldIds = new Set();
 
       this.next.hasErrors = false;
       this.next.fieldState = { ...this.fieldState };
@@ -293,7 +292,6 @@ export default {
             )
           ) {
             changeFound = true;
-            changedFieldIds.add(field._id);
 
             // fieldState never gets the relationships postprocessed data
             // that's why it gets seen as different than next all the time
@@ -309,7 +307,7 @@ export default {
 
       if (changeFound) {
         // ... removes need for deep watch at parent level
-        this.$emit('update:model-value', { ...this.next }, { changedFieldIds });
+        this.$emit('update:model-value', { ...this.next });
       }
     },
     displayComponent({ name, hidden = false }) {

--- a/modules/@apostrophecms/schema/ui/apos/logic/AposSchema.js
+++ b/modules/@apostrophecms/schema/ui/apos/logic/AposSchema.js
@@ -269,10 +269,11 @@ export default {
       if (!this.schemaReady) {
         return;
       }
-      // This fixes the issue of error validation arriving after input values change
-      await this.$nextTick();
       const oldHasErrors = this.next.hasErrors;
       // destructure these for non-linked comparison
+      const oldFieldState = { ...this.next.fieldState };
+      const newFieldState = { ...this.fieldState };
+
       let changeFound = false;
 
       this.next.hasErrors = false;
@@ -303,7 +304,10 @@ export default {
             this.next.data[field.name] = this.modelValue.data[field.name];
           }
         });
-      if (oldHasErrors !== this.next.hasErrors) {
+      if (
+        oldHasErrors !== this.next.hasErrors ||
+        oldFieldState !== newFieldState
+      ) {
         // Otherwise the save button may never unlock
         changeFound = true;
       }

--- a/modules/@apostrophecms/ui/ui/apos/composables/AposTheme.js
+++ b/modules/@apostrophecms/ui/ui/apos/composables/AposTheme.js
@@ -1,11 +1,12 @@
 import { computed } from 'vue';
 
-export function useAposTheme () {
-  const themeClass = computed(() => {
-    const classes = [];
-    classes.push(`apos-theme--primary-${window.apos.ui.theme.primary}`);
-    return classes;
-  });
-
+export function useAposTheme() {
+  const themeClass = computed(_themeClass);
   return { themeClass };
 };
+
+export function _themeClass() {
+  const classes = [];
+  classes.push(`apos-theme--primary-${window.apos.ui.theme.primary}`);
+  return classes;
+}

--- a/modules/@apostrophecms/ui/ui/apos/mixins/AposThemeMixin.js
+++ b/modules/@apostrophecms/ui/ui/apos/mixins/AposThemeMixin.js
@@ -1,12 +1,11 @@
+import { _themeClass } from '../composables/AposTheme.js';
+
 // Provides computed classes for decorating top-level Apos vue apps with a UI
 // theme
-
 export default {
   computed: {
     themeClass() {
-      const classes = [];
-      classes.push(`apos-theme--primary-${window.apos.ui.theme.primary}`);
-      return classes;
+      return _themeClass();
     }
   }
 };

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -229,7 +229,7 @@ export default {
     this.initPreview();
   },
   methods: {
-    async updateDocFields(value) {
+    updateDocFields(value) {
       this.updateFieldErrors(value.fieldState);
       this.docFields.data = {
         ...this.docFields.data,

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -229,22 +229,25 @@ export default {
     this.initPreview();
   },
   methods: {
-    async updateDocFields(value) {
+    async updateDocFields(value, { changedTypes = new Set() } = {}) {
       this.updateFieldErrors(value.fieldState);
-      const oldDocFields = klona(this.docFields.data);
       this.docFields.data = {
         ...this.docFields.data,
         ...value.data
       };
+      console.log('changedTypes', changedTypes);
+      if (changedTypes.has('relationship')) {
+        try {
+          console.log('this.docFields.data', JSON.stringify(this.docFields.data?._image));
+          await this.postprocess();
+        } catch (e) {
+          await this.handleSaveError(e, {
+            fallback: 'An error occurred updating the widget.'
+          });
+        }
+      }
       this.evaluateConditions();
       this.updatePreview();
-      try {
-        await this.postprocess(oldDocFields);
-      } catch (e) {
-        await this.handleSaveError(e, {
-          fallback: 'An error occurred updating the widget.'
-        });
-      }
     },
     initPreview() {
       if (!this.preview) {

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -229,14 +229,22 @@ export default {
     this.initPreview();
   },
   methods: {
-    updateDocFields(value) {
+    async updateDocFields(value) {
       this.updateFieldErrors(value.fieldState);
+      const oldDocFields = klona(this.docFields.data);
       this.docFields.data = {
         ...this.docFields.data,
         ...value.data
       };
       this.evaluateConditions();
       this.updatePreview();
+      try {
+        await this.postprocess(oldDocFields);
+      } catch (e) {
+        await this.handleSaveError(e, {
+          fallback: 'An error occurred updating the widget.'
+        });
+      }
     },
     initPreview() {
       if (!this.preview) {
@@ -302,15 +310,6 @@ export default {
             return;
           }
         }
-        try {
-          await this.postprocess();
-        } catch (e) {
-          await this.handleSaveError(e, {
-            fallback: 'An error occurred saving the widget.'
-          });
-          return;
-        }
-
         const widget = this.getWidgetObject();
         this.saving = true;
         this.$emit('modal-result', widget);

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -229,19 +229,12 @@ export default {
     this.initPreview();
   },
   methods: {
-    async updateDocFields(value, { changedFieldIds = new Set() } = {}) {
+    async updateDocFields(value) {
       this.updateFieldErrors(value.fieldState);
       this.docFields.data = {
         ...this.docFields.data,
         ...value.data
       };
-      try {
-        await this.postprocess(changedFieldIds);
-      } catch (e) {
-        await this.handleSaveError(e, {
-          fallback: 'An error occurred updating the widget.'
-        });
-      }
       this.evaluateConditions();
       this.updatePreview();
     },

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -231,6 +231,8 @@ export default {
   methods: {
     updateDocFields(value) {
       this.updateFieldErrors(value.fieldState);
+      this.logData('doc fields', this.docFields.data);
+      this.logData('value data', value.data);
       this.docFields.data = {
         ...this.docFields.data,
         ...value.data
@@ -282,7 +284,6 @@ export default {
     async save() {
       this.triggerValidation = true;
       this.$nextTick(async () => {
-        const widget = this.getWidgetObject();
         if (this.errorCount > 0) {
           this.triggerValidation = false;
           await apos.notify('apostrophe:resolveErrorsBeforeSaving', {
@@ -311,6 +312,8 @@ export default {
           });
           return;
         }
+
+        const widget = this.getWidgetObject();
         this.saving = true;
         this.$emit('modal-result', widget);
         this.modal.showModal = false;
@@ -333,14 +336,21 @@ export default {
           }
       );
     },
+    logData(msg, data) {
+      console.log(msg || data, data?._image?.[0]?._fields);
+    },
     getWidgetObject(props = {}) {
+      this.logData('getting', this.docFields.data);
       const widget = klona(this.docFields.data);
       widget._id = this.id || this.newId;
       widget.type = this.type;
-      return {
+      const res = {
         ...widget,
         ...props
       };
+
+      this.logData('after', res);
+      return res;
     },
     getPreviewWidgetObject() {
       if (!this.previewWidgetId) {

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -231,8 +231,6 @@ export default {
   methods: {
     updateDocFields(value) {
       this.updateFieldErrors(value.fieldState);
-      this.logData('doc fields', this.docFields.data);
-      this.logData('value data', value.data);
       this.docFields.data = {
         ...this.docFields.data,
         ...value.data
@@ -336,21 +334,14 @@ export default {
           }
       );
     },
-    logData(msg, data) {
-      console.log(msg || data, data?._image?.[0]?._fields);
-    },
     getWidgetObject(props = {}) {
-      this.logData('getting', this.docFields.data);
       const widget = klona(this.docFields.data);
       widget._id = this.id || this.newId;
       widget.type = this.type;
-      const res = {
+      return {
         ...widget,
         ...props
       };
-
-      this.logData('after', res);
-      return res;
     },
     getPreviewWidgetObject() {
       if (!this.previewWidgetId) {

--- a/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -229,22 +229,18 @@ export default {
     this.initPreview();
   },
   methods: {
-    async updateDocFields(value, { changedTypes = new Set() } = {}) {
+    async updateDocFields(value, { changedFieldIds = new Set() } = {}) {
       this.updateFieldErrors(value.fieldState);
       this.docFields.data = {
         ...this.docFields.data,
         ...value.data
       };
-      console.log('changedTypes', changedTypes);
-      if (changedTypes.has('relationship')) {
-        try {
-          console.log('this.docFields.data', JSON.stringify(this.docFields.data?._image));
-          await this.postprocess();
-        } catch (e) {
-          await this.handleSaveError(e, {
-            fallback: 'An error occurred updating the widget.'
-          });
-        }
+      try {
+        await this.postprocess(changedFieldIds);
+      } catch (e) {
+        await this.handleSaveError(e, {
+          fallback: 'An error occurred updating the widget.'
+        });
       }
       this.evaluateConditions();
       this.updatePreview();

--- a/modules/@apostrophecms/widget-type/ui/apos/composables/AposWidget.js
+++ b/modules/@apostrophecms/widget-type/ui/apos/composables/AposWidget.js
@@ -3,7 +3,7 @@ import {
   ref, unref, computed, nextTick
 } from 'vue';
 
-// When modifyin this file, verify that `AposWidgetMixin.js` still works
+// When modifying this file, verify that `AposWidgetMixin.js` still works
 export function useAposWidget(props) {
   const rendered = ref('...');
 


### PR DESCRIPTION
[PRO-8087](https://linear.app/apostrophecms/issue/PRO-8087/autocrop-doesnt-work-for-image-widgets)

## Summary

Fix autocrop in `image-widget`.

## What are the specific steps to test this change?

[Cypress tests](https://github.com/apostrophecms/testbed/actions/runs/17261371871) 🟢 

[Cypress PR](https://github.com/apostrophecms/testbed/pull/372).

Autocrop should work for:
* Quick image upload from media manager
* Drag and drop
* Quick image upload from your device
* Old school widget editor selection

Also it now works with live preview properly without slowing everything up.
It fixes a problem of updated data not being properly synced between the editor `docFields.data` and `AposSchema` `fieldState` / `next`. It's better that data updates come from inputs / schema and not from above to avoid bugs / confusion.

I moved the postprocess relationship logic into its own file, and in the context of the editors, it's made when a relationship field is upaded (inside the field itself when it changes). This way no need to create more complexity by comparing documents and stuff.
Works well, never triggered except if a relationship changed. for that specific relationship. So works nicely with widget preview.

## What kind of change does this PR introduce?

- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
