### PR TITLE
PRO-8187: render-areas should not crash when related docs with areas are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 * When specifying a modal name to be executed, developers may now register "transformers" to be invoked first, using pipe syntax. For example, the modal name `aposSectionTemplateLibraryWidgetToDoc|AposDocEditor` will invoke the transformer `aposSectionTemplateLibraryWidgetToDoc` with the original props, and pass the returned result to `AposDocEditor`. Note that transformers are awaited. Transformers are registered in frontend admin UI code by passing a name and a function to `apos.ui.addTransformer`.
 * Adds quick image upload UI to `@apostrophecms/image-widget`.
 
+### Fixes
+
+* The `?render-areas=1` API feature now correctly disregards areas in separate documents loaded via relationship fields. Formerly their presence resulted in an error, not a rendering.
+
 ## 4.20.0 (2025-08-06)
 
 ### Adds

--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -383,8 +383,8 @@ module.exports = {
               return;
             }
             // We're only rendering areas on the document, not ancestor or
-            // child page documents.
-            const regex = /^_(ancestors|children)|\._(ancestors|children)/;
+            // child page or related documents.
+            const regex = /^_|\._/;
             if (dotPath.match(regex)) {
               return;
             }


### PR DESCRIPTION
This is a blocker to get section template library working reliably for QA.