### PR TITLE
PRO-8218: fix the use of vue icons from npm modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * The `?render-areas=1` API feature now correctly disregards areas in separate documents loaded via relationship fields. Formerly their presence resulted in an error, not a rendering.
 * Make conditional fields work in Image Editor.
+* Importing a custom icon from an npm module using a `~` path per the admin UI now works per the documentation, as long as the Vue component used for the icon is structured like those found in `@apostrophecms/vue-material-design-icons`.
 
 ### Changes
 

--- a/modules/@apostrophecms/asset/lib/build/external-module-api.js
+++ b/modules/@apostrophecms/asset/lib/build/external-module-api.js
@@ -717,16 +717,18 @@ function invoke() {
 
       const importIndex = [];
       for (const [ registerAs, importFrom ] of Object.entries(self.iconMap)) {
+        let importName = importFrom;
         if (!importIndex.includes(importFrom)) {
           if (importFrom.substring(0, 1) === '~') {
-            output.importCode += `import ${importFrom}Icon from '${importFrom.substring(1)}';\n`;
+            importName = self.apos.util.slugify(importFrom).replaceAll('-', '');
+            output.importCode += `import ${importName}Icon from '${importFrom.substring(1)}';\n`;
           } else {
             output.importCode +=
-                `import ${importFrom}Icon from '@apostrophecms/vue-material-design-icons/${importFrom}.vue';\n`;
+                `import ${importName}Icon from '@apostrophecms/vue-material-design-icons/${importFrom}.vue';\n`;
           }
           importIndex.push(importFrom);
         }
-        output.registerCode += `window.apos.iconComponents['${registerAs}'] = ${importFrom}Icon;\n`;
+        output.registerCode += `window.apos.iconComponents['${registerAs}'] = ${importName}Icon;\n`;
       }
 
       return output;

--- a/modules/@apostrophecms/asset/lib/build/task.js
+++ b/modules/@apostrophecms/asset/lib/build/task.js
@@ -484,15 +484,17 @@ module.exports = (self) => ({
 
       const importIndex = [];
       for (const [ registerAs, importFrom ] of Object.entries(self.iconMap)) {
+        let importName = importFrom;
         if (!importIndex.includes(importFrom)) {
           if (importFrom.substring(0, 1) === '~') {
-            output.importCode += `import ${importFrom}Icon from '${importFrom.substring(1)}';\n`;
+            importName = self.apos.util.slugify(importFrom).replaceAll('-', '');
+            output.importCode += `import ${importName}Icon from '${importFrom.substring(1)}';\n`;
           } else {
-            output.importCode += `import ${importFrom}Icon from '@apostrophecms/vue-material-design-icons/${importFrom}.vue';\n`;
+            output.importCode += `import ${importName}Icon from '@apostrophecms/vue-material-design-icons/${importFrom}.vue';\n`;
           }
           importIndex.push(importFrom);
         }
-        output.registerCode += `window.apos.iconComponents['${registerAs}'] = ${importFrom}Icon;\n`;
+        output.registerCode += `window.apos.iconComponents['${registerAs}'] = ${importName}Icon;\n`;
       }
 
       return output;

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -1183,9 +1183,9 @@ module.exports = (self) => {
         }
         destination[field.name] = actualDocs;
       }
-      // "min" and "required" are not enforced server-side for relationships because it is always possible
-      // for the related document to be removed independently at some point. This leads to too many
-      // edge cases and knock-on effects if enforced
+      // "min" and "required" are not enforced server-side for relationships because
+      // it is always possible for the related document to be removed independently
+      // at some point. This leads to too many edge cases and knock-on effects if enforced
       if (field.max && field.max < destination[field.name].length) {
         throw self.apos.error('max', `Maximum ${field.withType} required reached.`);
       }


### PR DESCRIPTION
It looks like this could never have worked as written, because the variable name associated with the import would have a `~` in it.

Fixed it by slugifying. Makes a long import name, but only the import file cares, in the end the developer gets the name they wanted.

I hand-verified that the changes in task.js and external-output-api.js are identical, and also tested both `testbed` and `starter-kit-essentials`.