### PR TITLE
PRO-8220: "button: true" works again for piece module utility operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * The `?render-areas=1` API feature now correctly disregards areas in separate documents loaded via relationship fields. Formerly their presence resulted in an error, not a rendering.
 * Make conditional fields work in Image Editor.
 * Importing a custom icon from an npm module using a `~` path per the admin UI now works per the documentation, as long as the Vue component used for the icon is structured like those found in `@apostrophecms/vue-material-design-icons`.
+* The `button: true` flag works again for piece module utility operations. Previously the button appeared but did not trigger the desired operation.
 
 ### Changes
 

--- a/modules/@apostrophecms/piece-type/ui/apos/components/AposUtilityOperations.vue
+++ b/modules/@apostrophecms/piece-type/ui/apos/components/AposUtilityOperations.vue
@@ -8,9 +8,9 @@
       :key="button.action"
       type="default"
       :icon-only="button.iconOnly"
-      :icon="button.icon || false"
+      :icon="button.icon || null"
       :label="button.label"
-      @click="handleUtilityOperation(button.action)"
+      @click="handleUtilityOperation(button)"
     />
     <AposContextMenu
       v-if="utilityOperations.menu.length"


### PR DESCRIPTION
Regression: this got broken when we expanded the amount of information these operations can pass, between April and July. Impacts the ai helper module, but also new work like section template library that needs a utility operation not hidden away in a menu.