### PR TITLE
fix stylelint errors and upgrade @apostrophecms/stylelint-no-mixed-decls

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -4,7 +4,19 @@
     "@apostrophecms/stylelint-no-mixed-decls": [
       true,
       {
-        "contain-nested": [ "apos-transition" ]
+        "contain-nested": [
+          "type-base",
+          "type-help",
+          "type-small",
+          "type-label",
+          "type-large",
+          "type-title",
+          "type-display",
+          "apos-input",
+          "link-primary",
+          "apos-transition",
+          "apos-button-reset"
+        ]
       }
     ]
   }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Relies on https://github.com/apostrophecms/stylelint-no-mixed-decls/pull/2

- ~fix current sass error~ done in #5068
- use the new `@apostrophecms/stylelint-no-mixed-decls` plugin option to define external mixins known to contain nested rules

By adding `apos-transition` to the `contain-nested` option array, stylelint will complain, like sass.

```js
{
  "extends": "stylelint-config-apostrophe",
  "rules": {
    "@apostrophecms/stylelint-no-mixed-decls": [
      true,
      {
        "contain-nested": [ "apos-transition" ]
      }
    ]
  }
}
```

<img width="1168" height="515" alt="image" src="https://github.com/user-attachments/assets/043db19a-38a7-45b2-bfb2-6dbac30bf907" />