### PR TITLE
fixes widgetOptions not being used when passed from props (widget con…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Make conditional fields work in Image Editor.
 * Importing a custom icon from an npm module using a `~` path per the admin UI now works per the documentation, as long as the Vue component used for the icon is structured like those found in `@apostrophecms/vue-material-design-icons`.
 * The `button: true` flag works again for piece module utility operations. Previously the button appeared but did not trigger the desired operation.
+* Fix the fact that area options `minSize` and `aspectRatio` weren't passed to the image cropper when coming directly from the area and the widget controls (without passing through the widget editor).
 
 ### Changes
 

--- a/modules/@apostrophecms/image/ui/apos/components/AposImageRelationshipEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposImageRelationshipEditor.vue
@@ -159,7 +159,7 @@ export default {
       aspectRatioChoices,
       disableAspectRatio
     } = this.getAspectRatioData(widgetOptions);
-    const minSize = this.getMinSize(widgetOptions);
+    const minSize = this.widgetOptions.minSize || [];
     const image = this.getImage();
     const data = this.setDataValues(image);
 
@@ -441,9 +441,6 @@ export default {
     },
     switchPane(name) {
       this.currentTab = name;
-    },
-    getMinSize(widgetOptions = {}) {
-      return widgetOptions.minSize || [];
     },
     getAspectRatioData(widgetOptions = {}) {
       if (

--- a/modules/@apostrophecms/image/ui/apos/components/AposImageRelationshipEditor.vue
+++ b/modules/@apostrophecms/image/ui/apos/components/AposImageRelationshipEditor.vue
@@ -42,7 +42,7 @@
             </label>
             <AposSelect
               :selected="aspectRatio"
-              :choices="aspectRatios"
+              :choices="aspectRatioChoices"
               :disabled="disableAspectRatio"
               @change="updateAspectRatio"
             />
@@ -140,7 +140,11 @@ export default {
     },
     widgetSchema: {
       type: Array,
-      default: () => ([])
+      default: () => []
+    },
+    widgetOptions: {
+      type: Object,
+      default: null
     },
     item: {
       type: Object,
@@ -149,8 +153,13 @@ export default {
   },
   emits: [ 'modal-result' ],
   data() {
-    const { aspectRatio, disableAspectRatio } = this.getAspectRatioFromConfig();
-    const minSize = this.getMinSize();
+    const widgetOptions = this.getWidgetOptions();
+    const {
+      aspectRatio,
+      aspectRatioChoices,
+      disableAspectRatio
+    } = this.getAspectRatioData(widgetOptions);
+    const minSize = this.getMinSize(widgetOptions);
     const image = this.getImage();
     const data = this.setDataValues(image);
 
@@ -173,7 +182,7 @@ export default {
       },
       currentTab: null,
       aspectRatio,
-      aspectRatios: getAspectRatios(this.$t('apostrophe:aspectRatioFree')),
+      aspectRatioChoices,
       disableAspectRatio,
       minSize,
       correctingSizes: false,
@@ -201,6 +210,14 @@ export default {
     this.computeMinSizes();
   },
   methods: {
+    getWidgetOptions() {
+      if (this.widgetOptions) {
+        return this.widgetOptions;
+      }
+
+      const [ widgetOptions = {} ] = apos.area.widgetOptions || [];
+      return widgetOptions;
+    },
     getImage() {
       return this.item || this.widget?._image?.[0];
     },
@@ -254,8 +271,8 @@ export default {
         return;
       }
 
-      // If ratio wants a square, we simply take the higher min size of the
-      // image
+      // If ratio wants a square,
+      // we simply take the higher min size of the image
       if (this.aspectRatio === 1) {
         const higherValue = minWidth > minHeight ? minWidth : minHeight;
         this.minWidth = higherValue;
@@ -425,28 +442,36 @@ export default {
     switchPane(name) {
       this.currentTab = name;
     },
-    getAspectRatioFromConfig() {
-      const [ widgetOptions = {} ] = apos.area.widgetOptions || [];
-
-      return widgetOptions.aspectRatio && widgetOptions.aspectRatio.length === 2
-        ? {
-          aspectRatio: widgetOptions.aspectRatio[0] / widgetOptions.aspectRatio[1],
-          disableAspectRatio: true
-        }
-        : {
+    getMinSize(widgetOptions = {}) {
+      return widgetOptions.minSize || [];
+    },
+    getAspectRatioData(widgetOptions = {}) {
+      if (
+        !Array.isArray(widgetOptions.aspectRatio) ||
+        widgetOptions.aspectRatio.length !== 2
+      ) {
+        return {
           aspectRatio: null,
-          disableAspectRatio: false
+          disableAspectRatio: false,
+          aspectRatioChoices: getAspectRatios(this.$t('apostrophe:aspectRatioFree'))
         };
+      }
+
+      const [ x, y ] = widgetOptions.aspectRatio;
+      const aspectRatio = x / y;
+      return {
+        aspectRatio,
+        disableAspectRatio: true,
+        aspectRatioChoices: [ {
+          label: `${x}:${y}`,
+          value: aspectRatio
+        } ]
+      };
     },
     updateAspectRatio(value) {
       this.aspectRatio = value;
       this.computeMaxSizes();
       this.computeMinSizes();
-    },
-    getMinSize() {
-      const [ widgetOptions = {} ] = apos.area.widgetOptions;
-
-      return widgetOptions.minSize || [];
     },
     computeAspectRatio(value, name) {
       if (!this.aspectRatio) {


### PR DESCRIPTION
[PRO-8237](https://linear.app/apostrophecms/issue/PRO-8237/fix-aspect-ratio-not-being-taken-into-account-when-cropping-from-page)

## Summary

Fix image cropper when coming from page and widget controls (not from widget editor), where area config wasn't taken into account (minSize, aspectRatio):
```
            '@apostrophecms/image': {
              aspectRatio: [ 2, 1 ],
              minSize: [ 1000, 500 ]
            }
```

Also fixes aspect ratio being stuck on `free` when configured from the area, it know takes the configured value:
<img width="267" height="100" alt="image" src="https://github.com/user-attachments/assets/da1b529a-6316-487f-ac17-2ab2d239bac9" />

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
