### PR TITLE
the moduleName passed to a doc type manager is the doc type, not the widget type you happen to be picking it for

### DIFF
--- a/modules/@apostrophecms/image-widget/ui/apos/components/AposImageWidget.vue
+++ b/modules/@apostrophecms/image-widget/ui/apos/components/AposImageWidget.vue
@@ -70,7 +70,7 @@ async function selectFromManager() {
 
   const [ selectedImg ] = (await apos.modal.execute(modalItem.componentName, {
     ...modalItem.props,
-    moduleName: props.type,
+    moduleName: '@apostrophecms/image',
     chosen: [],
     relationshipField: { max: 1 }
   })) || [];


### PR DESCRIPTION
One liner fixes ftw