### PR TITLE
PRO-8223: be careful when assuming doc is an actual doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fixes the widget data being cloned to be saved before the `postprocess` method being called, which leads to a loss of data in `AposWidgetEditor` (like the autocrop data).
 * In editors like `AposWidgetEditor` relationships are now post processed after they are updated in `AposInputRelationship` only for the relationship that has been updated. 
 It allows live preview to work well with it, it also avoids complexity and fixes updated data not being properly synced between the editor and the `AposSchema`.
+* Deeply nested widgets can now be edited properly via the editor dialog box. This longstanding issue did not affect on-page editing.
 
 ### Changes
 

--- a/modules/@apostrophecms/area/lib/custom-tags/area.js
+++ b/modules/@apostrophecms/area/lib/custom-tags/area.js
@@ -69,7 +69,7 @@ module.exports = function(self) {
           items: []
         };
         doc[name] = area;
-        const docId = doc._docId || doc._id;
+        const docId = doc._docId || ((doc.metaType === 'doc') ? doc._id : null);
         if (docId) {
           let mainDoc = await self.apos.doc.db.findOne({ _id: docId });
           if (!mainDoc) {

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -2491,7 +2491,7 @@ module.exports = {
                     area._edit = true;
                   }
 
-                  area._docId = doc._id;
+                  area._docId = doc._docId || ((doc.metaType === 'doc') ? doc._id : null);
                   for (const item of area.items) {
                     if (area._edit) {
                       // Keep propagating ._edit so a widget can be passed
@@ -2499,7 +2499,7 @@ module.exports = {
                       // -Tom
                       item._edit = true;
                     }
-                    item._docId = doc._id;
+                    item._docId = area._docId;
                     if (!widgetsByType[item.type]) {
                       widgetsByType[item.type] = [];
                     }
@@ -2512,7 +2512,7 @@ module.exports = {
               // be edited in context
               for (const info of arrayItemsInfo) {
                 const arrayItem = info.arrayItem;
-                arrayItem._docId = doc._docId || doc._id;
+                arrayItem._docId = doc._docId || ((doc.metaType === 'doc') ? doc._id : null);
                 arrayItem._edit = doc._edit;
               }
             }

--- a/modules/@apostrophecms/schema/ui/apos/lib/detectChange.js
+++ b/modules/@apostrophecms/schema/ui/apos/lib/detectChange.js
@@ -64,7 +64,7 @@ export function detectFieldChange(field, v1, v2) {
       const newObject = {};
       for (const [ key, val ] of Object.entries(o)) {
         if (key === '_docId') {
-          newObject._docId = o._docId.replace(/:.*$/, '');
+          newObject._docId = (o._docId == null) ? null : o._docId.replace(/:.*$/, '');
         } else if (key === '_id') {
           // So draft and published can be compared
           newObject._id = o._id.replace(/:[\w-]+:[\w]+$/, '');


### PR DESCRIPTION
I tracked the issue to the render-widget route, which passes the widget to certain document loaders as if it were a document. Trouble occurs when the "areas" loader assumes the "doc" it has been given is a real doc and uses it to impute a value for docId.

This is problematic because docId is intentionally `null` in the editor dialog.

I corrected the issue by verifying the `metaType` of `doc` first.

I also added this check in a few other places.

Finally, one piece of frontend code assumed `docId` could not be null, so I had to fix that as well.