### PR TITLE
PRO-8268: do the URL encoding work before Astro.redirect sees the URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Custom operations registered with `addCreateWidgetOperation` can now specify an `ifTypesIntersect` property containing an array of widget type names. If the area in question allows at least one, the operation is offered.
 
+### Changes
+
+* Redirects to URLs containing accent marks and other non-ascii characters now behave as expected with Astro. Pre-encoding the URLs exactly the way `res.redirect` would before passing them to Astro prevents an error in Astro and allows the redirect to succeed.
+
 ## 4.21.0 (2025-09-03)
 
 ### Adds

--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaContextualMenu.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaContextualMenu.vue
@@ -202,7 +202,10 @@ export default {
         return [];
       }
       const menu = [ ...this.contextMenuOptions.menu ];
-      const createWidgetOperations = filterCreateWidgetOperations(this.moduleOptions, this.options);
+      const createWidgetOperations = filterCreateWidgetOperations(
+        this.moduleOptions,
+        this.options
+      );
       for (const createWidgetOperation of createWidgetOperations) {
         menu.unshift({
           type: 'operation',

--- a/modules/@apostrophecms/express/index.js
+++ b/modules/@apostrophecms/express/index.js
@@ -159,6 +159,7 @@ const expressBearerToken = require('express-bearer-token');
 const cors = require('cors');
 const Promise = require('bluebird');
 const expressCacheOnDemand = require('express-cache-on-demand');
+const encodeUrl = require('encodeurl');
 
 module.exports = {
   async init(self) {
@@ -275,7 +276,11 @@ module.exports = {
           // not us
           // Per Express handling of 1 arg versus 2
           const status = args.length > 1 ? args[0] : 302;
-          const url = args[args.length - 1];
+          let url = args[args.length - 1];
+          // The URL needs to be encoded exactly as Express would do it,
+          // so that frontends like Astro (which don't do it for us) don't bomb
+          // attempting to issue the redirect
+          url = encodeUrl(url);
           return res.send({
             redirect: true,
             url,

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "csv-parse": "^5.6.0",
     "dayjs": "^1.9.8",
     "dompurify": "^3.2.5",
+    "encodeurl": "^2.0.0",
     "express": "^4.16.4",
     "express-bearer-token": "^3.0.0",
     "express-cache-on-demand": "^1.0.3",


### PR DESCRIPTION
We do it with `encodeurl` because that is what Express does (I checked the source). That module drives defensively, it doesn't re-encode what is already encoded, so I don't want to do the naive thing and just call `encodeURI` instead.