### PR TITLE
Process manually and inject CSS, fix manage layout CSS glitch

### DIFF
--- a/modules/@apostrophecms/layout-widget/index.js
+++ b/modules/@apostrophecms/layout-widget/index.js
@@ -228,20 +228,29 @@ module.exports = {
         try {
           const postcss = require('postcss');
           const cssnano = require('cssnano');
-          const mobilePreview = require('postcss-viewport-to-container-toggle');
+          const assetOptions = self.apos.asset.breakpointPreviewMode || {};
 
-          const resultApos = await postcss([
-            mobilePreview({
-              modifierAttr: 'data-breakpoint-preview-mode',
-              debug: self.apos.adminBar.breakpointPreviewMode?.debug === true,
-              transform: self.apos.adminBar.breakpointPreviewMode?.transform || null
-            }),
+          const resultPublic = await postcss([
             cssnano({
               preset: 'default'
             })
           ]).process(cssContent, { from: undefined });
 
-          const resultPublic = await postcss([
+          if (assetOptions.enable !== true) {
+            return {
+              apos: resultPublic.css,
+              public: resultPublic.css
+            };
+          }
+
+          const mobilePreview = require('postcss-viewport-to-container-toggle');
+
+          const resultApos = await postcss([
+            mobilePreview({
+              modifierAttr: 'data-breakpoint-preview-mode',
+              debug: assetOptions.debug === true,
+              transform: assetOptions.transform || null
+            }),
             cssnano({
               preset: 'default'
             })

--- a/modules/@apostrophecms/layout-widget/index.js
+++ b/modules/@apostrophecms/layout-widget/index.js
@@ -218,10 +218,12 @@ module.exports = {
         const mobileBreakpointPlus = mobileBreakpoint + 1;
         const tabletBreakpoint = self.options.tablet?.breakpoint || 1024;
         const tabletBreakpointPlus = tabletBreakpoint + 1;
-        cssContent = cssContent.replace(/\{\$mobile\}/g, mobileBreakpoint);
-        cssContent = cssContent.replace(/\{\$mobile-plus\}/g, mobileBreakpointPlus);
-        cssContent = cssContent.replace(/\{\$tablet\}/g, tabletBreakpoint);
-        cssContent = cssContent.replace(/\{\$tablet-plus\}/g, tabletBreakpointPlus);
+        cssContent = cssContent
+          .replace(/\{\$mobile\}/g, mobileBreakpoint)
+          .replace(/\{\$mobile-plus\}/g, mobileBreakpointPlus)
+          .replace(/\{\$tablet\}/g, tabletBreakpoint)
+          .replace(/\{\$tablet-plus\}/g, tabletBreakpointPlus);
+
         return self.processCss(cssContent);
       },
       async processCss(cssContent) {
@@ -250,18 +252,19 @@ module.exports = {
               modifierAttr: 'data-breakpoint-preview-mode',
               debug: assetOptions.debug === true,
               transform: assetOptions.transform || null
-            }),
-            cssnano({
-              preset: 'default'
             })
-          ]).process(cssContent, { from: undefined });
+          ]).process(resultPublic.css, { from: undefined });
 
           return {
             apos: resultApos.css,
             public: resultPublic.css
           };
         } catch (error) {
-          const errorTrace = error.stack ? error.stack.split('\n').slice(1).join('\n') : '';
+          const errorTrace = error.stack
+            ? error.stack
+              .split('\n')
+              .slice(1)
+            : [];
           self.logWarn('inline-css-minify-failed', error.message, {
             error: errorTrace
           });

--- a/modules/@apostrophecms/layout-widget/index.js
+++ b/modules/@apostrophecms/layout-widget/index.js
@@ -230,7 +230,7 @@ module.exports = {
         try {
           const postcss = require('postcss');
           const cssnano = require('cssnano');
-          const assetOptions = self.apos.asset.breakpointPreviewMode || {};
+          const options = self.apos.asset.breakpointPreviewMode || {};
 
           const resultPublic = await postcss([
             cssnano({
@@ -238,7 +238,7 @@ module.exports = {
             })
           ]).process(cssContent, { from: undefined });
 
-          if (assetOptions.enable !== true) {
+          if (options.enable !== true) {
             return {
               apos: resultPublic.css,
               public: resultPublic.css
@@ -250,8 +250,8 @@ module.exports = {
           const resultApos = await postcss([
             mobilePreview({
               modifierAttr: 'data-breakpoint-preview-mode',
-              debug: assetOptions.debug === true,
-              transform: assetOptions.transform || null
+              debug: options.debug === true,
+              transform: options.transform || null
             })
           ]).process(resultPublic.css, { from: undefined });
 

--- a/modules/@apostrophecms/layout-widget/ui/apos/components/AposAreaLayoutEditor.vue
+++ b/modules/@apostrophecms/layout-widget/ui/apos/components/AposAreaLayoutEditor.vue
@@ -2,6 +2,7 @@
   <div
     v-click-outside-element="resetFocusedArea"
     :data-apos-area="areaId"
+    data-tablet-full="true"
     class="apos-area"
     :class="themeClass"
     :style="{

--- a/modules/@apostrophecms/layout-widget/ui/src/_breakpoints.scss
+++ b/modules/@apostrophecms/layout-widget/ui/src/_breakpoints.scss
@@ -1,4 +1,0 @@
-/* Breakpoint configuration for the layout widget. Override by overriding 
-this file on a project level. */
-$layout-breakpoint-mobile: 600px !default;
-$layout-breakpoint-tablet: 1024px !default;

--- a/modules/@apostrophecms/layout-widget/ui/src/layout.css
+++ b/modules/@apostrophecms/layout-widget/ui/src/layout.css
@@ -1,11 +1,3 @@
-// Breakpoints (Sass, build-time). CSS custom properties cannot be used in
-// @media/@container conditions at runtime, so expose !default Sass vars.
-// Variables live in a separate file to allow clean overrides upstream.
-@import './breakpoints';
-// Height-based breakpoints intentionally omitted due to stylelint policy and
-// limited real-world usage. Add if your config allows and you truly need them.
-
-// Do not use `place-self`, justify/align-self are more widely supported
 .layout-widget {
   display: grid;
   grid-template-columns: repeat(var(--grid-columns, 12), 1fr);
@@ -14,21 +6,21 @@
   justify-items: var(--justify-items);
   /* stylelint-disable-next-line declaration-block-no-redundant-longhand-properties */
   align-items: var(--align-items);
-
-  & > div {
-    grid-column: var(--colstart, auto) / span var(--colspan, 1);
-    grid-row: var(--rowstart, auto) / span var(--rowspan, 1);
-    justify-self: var(--justify);
-    /* stylelint-disable-next-line declaration-block-no-redundant-longhand-properties */
-    align-self: var(--align);
-    order: var(--order, 0);
-  }
 }
 
-// Tablet rules. Override $layout-breakpoint-tablet to change.
+.layout-widget > div {
+  grid-column: var(--colstart, auto) / span var(--colspan, 1);
+  grid-row: var(--rowstart, auto) / span var(--rowspan, 1);
+  justify-self: var(--justify);
+  /* stylelint-disable-next-line declaration-block-no-redundant-longhand-properties */
+  align-self: var(--align);
+  order: var(--order, 0);
+}
+
+/* Tablet rules. Override $layout-breakpoint-tablet to change. */
 /* stylelint-disable-next-line media-feature-name-allowed-list */
-@media screen and (min-width: $layout-breakpoint-mobile + 1px) and (max-width: $layout-breakpoint-tablet) {
-    /* Auto mode: ignore device vars, just 2 per row */
+@media screen and (min-width: {$mobile-plus}px) and (max-width: {$tablet}px) {
+  /* Auto mode: ignore device vars, just 2 per row */
   .layout-widget[data-tablet-auto="true"] {
     grid-template-columns: repeat(2, 1fr);
 
@@ -45,7 +37,7 @@
     The backend should mark last odd items as full width to avoid
     weird spacing at the end of rows.
   */
-  .layout-widget[data-tablet-auto="true"] > [data-full-tablet="true"] { 
+  .layout-widget[data-tablet-auto="true"] > [data-tablet-full="true"] { 
     grid-column: 1 / span 2; 
   }
 
@@ -69,9 +61,9 @@
   }
 }
 
-// Mobile rules. Override $layout-breakpoint-mobile to change.
+/* Mobile rules. Override $layout-breakpoint-mobile to change. */
 /* stylelint-disable-next-line media-feature-name-allowed-list */
-@media screen and (max-width: $layout-breakpoint-mobile) {
+@media screen and (max-width: {$mobile}px) {
   .layout-widget {
     grid-template-columns: 1fr;
 
@@ -102,4 +94,4 @@
   .layout-widget > [data-visible-mobile="false"] { 
     display: none; 
   }
-} 
+}

--- a/modules/@apostrophecms/layout-widget/views/column.html
+++ b/modules/@apostrophecms/layout-widget/views/column.html
@@ -6,7 +6,7 @@ The area related `data.*` is available plus `item` and `widgetOptions`. #}
   {% if data.canEdit %} data-apos-widget="{{ item._id }}"{% endif %}
   data-visible-tablet="{{ item.tablet.show }}"
   data-visible-mobile="{{ item.mobile.show }}"
-  {% if lastId and item._id === lastId %}data-full-tablet="true"{% endif %}
+  {% if lastId and item._id === lastId %}data-tablet-full="true"{% endif %}
   style="
     --colstart: {{ item.desktop.colstart }}; 
     --colspan: {{ item.desktop.colspan }}; 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "css-loader": "^5.2.4",
+    "cssnano": "^7.1.1",
     "csv-parse": "^5.6.0",
     "dayjs": "^1.9.8",
     "dompurify": "^3.2.5",


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

- Load and preprocess the public styles on init
- Inject the appropriate style on runtime
- Remove the public sass
- Fix a glitch when manage UI is not properly shown when mobile preview is active

Closes PRO-8322