### PR TITLE
browser search shortcut in page manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixes
 
 * Resolve inline image URLs correctly when in edit mode and not in the default locale.
+* Using `CTRL+F` or `CMD+F` in the page manager now works.
 
 ### Changes
 

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -179,14 +179,15 @@ module.exports = {
           },
           shortcut: 'C'
         },
-        [`${self.__meta.name}:search`]: {
-          type: 'item',
-          label: 'apostrophe:commandMenuSearch',
-          action: {
-            type: 'command-menu-manager-focus-search'
-          },
-          shortcut: 'Ctrl+F Meta+F'
-        },
+        // NOTE: there is no search in the page manager
+        // [`${self.__meta.name}:search`]: {
+        //   type: 'item',
+        //   label: 'apostrophe:commandMenuSearch',
+        //   action: {
+        //     type: 'command-menu-manager-focus-search'
+        //   },
+        //   shortcut: 'Ctrl+F Meta+F'
+        // },
         [`${self.__meta.name}:select-all`]: {
           type: 'item',
           label: 'apostrophe:commandMenuSelectAll',


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Search shortcut in the pages manager is now working again

## What are the specific steps to test this change?

1. Open the pages manager
2. Use the search keyboard shortcut (`CTRL+F` or `META+F`)
3. The browser search feature should be in focus
4. Open the shortcuts list in the page manager should not show `Search`

Quick note: on a piece manager, using the search shortcut twice will trigger the browser search.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
