### PR TITLE
PRO-8348: part of the hotfix for poor error handling if one site in a multisite project does not initialize properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 4.21.1 (2025-09-26)
+
+### Adds
+
+* The `exit` option to the main `apostrophe()` function now supports the new string value `exit: 'throw'`. If this value is specified and the apostrophe startup procedure fails with an error, the actual error is re-thrown for the benefit of the caller.
+* For backwards compatibility, the existing `exit: false` option to the main `apostrophe()` function is still supported, but now logs the error that took place before returning `undefined` as before. This is more useful than the previous behavior, but `exit: 'throw'` is the more logical choice if you need to avoid a process exit.
+* The default behavior is still to log the error and exit the process, which isthe only sensible move in most single-site projects.
+
 ## 4.21.0 (2025-09-03)
 
 ### Adds

--- a/index.js
+++ b/index.js
@@ -350,7 +350,16 @@ async function apostrophe(options, telemetry, rootSpan) {
 
     return self;
   } catch (e) {
-    if (options.exit !== false) {
+    if (options.exit === false) {
+      console.error('apostrophe: error occurred during startup, continuing:');
+      console.error(e);
+      // returns undefined, for legacy reasons
+    } else if (options.exit === 'throw') {
+      // A more sensible approach for those who want to do something
+      // if initialization fails
+      throw e;
+    } else {
+      // Longstanding default behavior
       console.error(e);
       await self._exit(1, e);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "4.21.0",
+  "version": "4.21.1",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The important part is that the multisite module just never asked apostrophe *not* to exit, which, fun fact, it does by default if initialization of the whole site fails.

Secondary is that I added better handling so multisite can decide how to log it via `exit: 'throw'`, and also added any logging at all if `exit: false` is used, way to go past Tom some real thorough thinking there 👀 