### PR TITLE
PRO-8370: Prevent double click edit when edit is disabled

### DIFF
--- a/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -74,7 +74,7 @@
               :modifiers="['no-motion']"
               :disable-focus="!(isHovered || isFocused)"
               @click="foreign ? $emit('edit', i) : null"
-              @dblclick="(!foreign && !isContextual) ? $emit('edit', i) : null"
+              @dblclick="(!foreign && !isContextual && !shouldSkipEdit) ? $emit('edit', i) : null"
             />
           </li>
         </ol>
@@ -376,6 +376,9 @@ export default {
     },
     widgetBreadcrumbOperations() {
       return (this.widgetModuleOptions.widgetBreadcrumbOperations || []);
+    },
+    shouldSkipEdit() {
+      return this.widgetModuleOptions.skipOperations?.includes('edit') ?? false;
     },
     isFocused() {
       return this.focusedWidget === this.widget._id;

--- a/modules/@apostrophecms/layout-widget/ui/apos/components/AposAreaLayoutEditor.vue
+++ b/modules/@apostrophecms/layout-widget/ui/apos/components/AposAreaLayoutEditor.vue
@@ -69,6 +69,7 @@
       >
         <template #item="{ item: widget }">
           <AposAreaWidget
+            :key="widget._id"
             :area-id="areaId"
             :widget="widget"
             :meta="meta[widget._id]"


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Disallow the double click when the edit widget operation is disabled. 