### PR TITLE
Fix: Edit button fails to open image editor for attachments not in visible page

### DIFF
--- a/modules/@apostrophecms/attachment/ui/components/ManagerModal.vue
+++ b/modules/@apostrophecms/attachment/ui/components/ManagerModal.vue
@@ -1,0 +1,17 @@
+<template>
+  <slot />
+</template>
+
+<script>
+export default {
+  name: 'ApostropheAttachmentManagerModalOverride',
+  methods: {
+    openImageEditor(image) {
+      const id = (image && image._id) ? image._id : image;
+      this.$emit('open-editor', 'apostrophe-attachment', id);
+    }
+  }
+};
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
## Summary
Fixes an issue where the “Edit” button in the media manager fails to open the
image editor if the selected image is not included in the currently loaded
page of results.

## Root Cause
The `openImageEditor` method was only executed when the image existed in the
`loadedImages` array. When the selected image was on page 2+ of the media
manager, this condition failed, preventing the editor dialog from opening.

## Fix
Override the module's UI component (`ManagerModal.vue`) and ensure that
`openImageEditor` always emits the `open-editor` event with the correct
attachment ID.

## Files Added