### PR TITLE
PRO-8743: windows fix 2b: back off on the file:/// URLs for vite

### DIFF
--- a/modules/@apostrophecms/asset/lib/build/external-module-api.js
+++ b/modules/@apostrophecms/asset/lib/build/external-module-api.js
@@ -653,8 +653,8 @@ function invoke() {
             }
           }
         }
-        // You would think we should run pathToFileURL over realPath, but that actually breaks
-        // both Windows and Linux with Vite. -Tom
+        // You would think we should run pathToFileURL over realPath,
+        // but that actually breaks both Windows and Linux with Vite. -Tom
         const importPath = JSON.stringify(realPath);
         const name = self.getComponentNameByPath(
           component,


### PR DESCRIPTION
those URLs actually breaks both windows and linux under some circumstances. Probably a vite bug, but vite will happily eat file paths starting with C:\, so.