### PR TITLE
bump express-cache-on-demand to 1.0.4

### DIFF
--- a/packages/apostrophe/CHANGELOG.md
+++ b/packages/apostrophe/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Fixes an issue where the frontend was caching stale choices for `select`, `radio` and `checkboxes`
 fields that were saved but no longer valid (i.e removed from the schema).
+* Bumped dependency on `express-cache-on-demand` to guarantee installation of recent fixes for edge cases that could share a response between two locales of a single-site project, report errors without a process restart, and correctly handle `res.send('')` with an empty string.
 
 ## 4.24.0 (2025-11-25)
 

--- a/packages/apostrophe/package.json
+++ b/packages/apostrophe/package.json
@@ -81,7 +81,7 @@
     "encodeurl": "^2.0.0",
     "express": "^4.16.4",
     "express-bearer-token": "^3.0.0",
-    "express-cache-on-demand": "^1.0.3",
+    "express-cache-on-demand": "^1.0.4",
     "express-session": "^1.18.2",
     "fs-extra": "^7.0.1",
     "glob": "^10.4.5",


### PR DESCRIPTION
lookit me, pr-in' in the monorepos