### PR TITLE
applying widget level styles in template

### DIFF
--- a/packages/apostrophe/modules/@apostrophecms/widget-type/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/widget-type/index.js
@@ -418,7 +418,9 @@ module.exports = {
           contextOptions: _with
         });
 
-        if (self.styles && self.options.stylesWrapper !== false) {
+        const hasStyles = Object.keys(self.styles || {}).length > 0;
+
+        if (hasStyles && self.options.stylesWrapper !== false) {
           const styles = self.apos.styles.prepareWidgetStyles(widget);
           const styleTag = self.apos.styles.getWidgetElements(styles);
           const wrapperAttrs = self.apos.styles.getWidgetAttributes(styles);


### PR DESCRIPTION
- ~fix box-type field to make it render valid css property~ --> separate PR: https://github.com/apostrophecms/apostrophe/pull/5227
  - ~we can now set a `border-%key%-width` property, for instance~ 
- render styles, using `self.apos.styles` methods