### PR TITLE
disable add content button when area max is reached

### DIFF
--- a/packages/apostrophe/CHANGELOG.md
+++ b/packages/apostrophe/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixes
 
 * Fixes an issue where the frontend was caching stale choices for `select`, `radio` and `checkboxes` fields that were saved but no longer valid (i.e removed from the schema).
+* When we reach the max in a widget area, the `Add Content` button is now disabled.
 
 ### Changes
 

--- a/packages/apostrophe/modules/@apostrophecms/area/ui/apos/logic/AposAreaEditor.js
+++ b/packages/apostrophe/modules/@apostrophecms/area/ui/apos/logic/AposAreaEditor.js
@@ -115,7 +115,8 @@ export default {
       return Object.keys(this.widgets);
     },
     maxReached() {
-      return this.options.max && this.next.length >= this.options.max;
+      const max = this.options.max || this.field.max;
+      return max && this.next.length >= max;
     },
     foreign() {
       // Cast to boolean is necessary to satisfy prop typing


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Disable `Add Content` buttons when the max is reached inside an area

## What are the specific steps to test this change?

1. Create an area with `max: 2` or any value
2. Check that when the max number of widgets is reached inside the area, the `Add Content` buttons are disabled

```javascript
      main: {
        type: 'area',
        max: 2,
        options: {
          widgets: {
            '@apostrophecms/image': {},
            '@apostrophecms/video': {},
            '@apostrophecms/rich-text': {}
          }
        }
      }
```

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
