### PR TITLE
Add placeholder flag when image widget has empty _image array

### DIFF
--- a/packages/apostrophe/CHANGELOG.md
+++ b/packages/apostrophe/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+- Fixes an issue where an image widget could fail to display its placeholder after the selected image is archived, leaving an empty `_image` relationship.
+
 ## 4.28.0
 
 ### Adds

--- a/packages/apostrophe/modules/@apostrophecms/image-widget/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/image-widget/index.js
@@ -189,6 +189,25 @@ module.exports = {
   },
   extendMethods(self) {
     return {
+      async sanitize(_super, req, input, options, convertOptions) {
+        // If the widget has no image and is not already a placeholder,
+        // mark it as a placeholder before validation so the required
+        // _image field check is skipped (aposPlaceholder widgets bypass
+        // schema conversion entirely). Without this, the required field
+        // error crashes ApostropheCMS's handleConvertErrors due to an
+        // upstream bug with numeric error paths.
+
+        // NOTE: This function only runs during the render-widget API call
+        // (the admin editor's widget validation/rendering endpoint)
+        if (
+          input.aposPlaceholder === false &&
+          Array.isArray(input.imageIds) &&
+          input.imageIds.length === 0
+        ) {
+          input.aposPlaceholder = true;
+        }
+        return _super(req, input, options, convertOptions);
+      },
       getBrowserData(_super, req) {
         return {
           ..._super(req),


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Summary

Fixes an issue where the image widget fails to display its placeholder after a previously selected image is archived, leaving the widget in a broken state with an empty `_image` relationship.

The fix extends `sanitize` to set `aposPlaceholder = true` before validation when the widget has an empty `imageIds` array. This is necessary because `aposPlaceholder` widgets bypass schema conversion entirely — without marking the widget as a placeholder early, the required `_image` field triggers an error that crashes ApostropheCMS's `handleConvertErrors` due to an upstream bug with numeric error paths.

## What are the specific steps to test this change?

1. Run the website and log in as an admin.
2. Create a page with an image widget and select an image.
3. Archive the selected image (so the widget's `_image` relationship becomes empty).
4. Re-open the page editor containing the image widget.
5. Confirm the image widget displays the placeholder (and does not behave as if an image is still selected).

## What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated