### PR TITLE
fix box field for rich-text

### DIFF
--- a/packages/apostrophe/modules/@apostrophecms/box-field/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/box-field/index.js
@@ -25,7 +25,7 @@ module.exports = {
 
             // All values to numbers or null
             defProps.forEach(side => {
-              const int = parseInt(data[field.name][side]);
+              const int = parseInt(data[field.name]?.[side]);
               if (int || int === 0) {
                 temp[side] = int;
               } else {


### PR DESCRIPTION
Some widget (probably the contextual ones?) don't contain the styles in the database, resulting in an error when trying to access their sub fields:

```
field.name margin
data[field.name] undefined
defProps [ 'top', 'right', 'bottom', 'left' ]
data {
  backgroundColor: null,
  _id: 'f49174ydzb9ksl8ddmv4aw4k',
  metaType: 'widget',
  type: '@apostrophecms/rich-text',
  aposPlaceholder: false,
  content: '<p>wfw f </p>',
  permalinkIds: [],
  imageIds: [],
  _edit: true,
  _docId: 'ma9daw9s5mbvjjt707yutzk1:en:draft'
}
```