### PR TITLE
Fix typo resulting in column styles not working sometimes

### DIFF
--- a/packages/apostrophe/modules/@apostrophecms/layout-widget/ui/apos/components/AposAreaLayoutEditor.vue
+++ b/packages/apostrophe/modules/@apostrophecms/layout-widget/ui/apos/components/AposAreaLayoutEditor.vue
@@ -250,7 +250,7 @@ export default {
   beforeUnmount() {
     apos.bus.$off('apos-switch-layout-mode', this.switchLayoutMode);
     apos.bus.$off('apos-layout-col-delete', this.onRemoveLayoutColumn);
-    apos.bus.$off('apos-edit-styles', this.edistStyles);
+    apos.bus.$off('apos-edit-styles', this.editStyles);
   },
   methods: {
     ...mapActions(useWidgetStore, [


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Column styles trigger is not working after Layout styles are applied. The problem is related to a listener cleanup typo. 

## What are the specific steps to test this change?

Column styles always trigger styles editor (showcased in Cypress tests).

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
