### PR TITLE
make sure classes are stripped when styles are set without specifying…

### DIFF
--- a/.changeset/hungry-animals-joke.md
+++ b/.changeset/hungry-animals-joke.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": patch
+---
+
+if no class provided for a rt style set it to null to ensure removal

--- a/packages/apostrophe/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/packages/apostrophe/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -648,6 +648,8 @@ export default {
         // Handle custom attributes
         if (style.class) {
           style.options.class = style.class;
+        } else {
+          style.options.class = null;
         }
 
         if (!style.type) {


### PR DESCRIPTION
## Summary

If you have two of the same elements defined as part of a rich text style configuration and one has a class but the other doesn't, switching between them doesn't strip the class when moving from the classed selection to the unclassed selection.

This change ensures that if a style is configured without a class we explicit assign class to `null`

## Example RT config
```
{
  toolbar: [
    'styles'
  ],
  styles: [
    {
      tag: 'p',
      label: 'Regular Paragraph'
    },
    {
      class: 'large',
      tag: 'p',
      label: 'Large Paragraph'
    }
  ]
};
```