### PR TITLE
PRO-9001: Global styles trigger visibility

### DIFF
--- a/packages/apostrophe/modules/@apostrophecms/styles/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/styles/index.js
@@ -70,15 +70,18 @@ module.exports = {
     self.stylesheetScopedRender = renderScopedStyles;
     self.styleCheckIfConditions = checkIfConditions;
 
-    self.apos.doc.addContextOperation({
-      action: 'reset-styles-position',
-      label: 'apostrophe:stylesResetPosition',
-      context: 'update',
-      type: 'event',
-      if: {
-        type: self.__meta.name
-      }
-    });
+    if (Object.keys(self.styles).length > 0) {
+      self.apos.doc.addContextOperation({
+        action: 'reset-styles-position',
+        label: 'apostrophe:stylesResetPosition',
+        context: 'update',
+        type: 'event',
+        if: {
+          type: self.__meta.name
+        }
+      });
+    }
+
     self.slug = options.slug || 'apostrophecms-styles';
     self.enableBrowserData();
     self.prependNodes('body', 'stylesheet');

--- a/packages/apostrophe/modules/@apostrophecms/styles/lib/methods.js
+++ b/packages/apostrophe/modules/@apostrophecms/styles/lib/methods.js
@@ -325,6 +325,9 @@ module.exports = (self, options) => {
       }
     },
     addToAdminBar() {
+      if (Object.keys(self.styles).length === 0) {
+        return;
+      }
       self.apos.adminBar.add(
         '@apostrophecms/styles',
         'apostrophe:stylesToggle',


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Don't show global styles trigger when no styles configuration.

## What are the specific steps to test this change?

No Global Styles when the module is not configured.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
