### PR TITLE
Fix rich text styles computation performance

### DIFF
--- a/packages/apostrophe/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/packages/apostrophe/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -150,6 +150,8 @@ import TableHeader from '@tiptap/extension-table-header';
 import TableRow from '@tiptap/extension-table-row';
 import Placeholder from '@tiptap/extension-placeholder';
 import { klona } from 'klona';
+import newInstance from 'apostrophe/modules/@apostrophecms/schema/lib/newInstance.js';
+import merge from 'lodash/merge';
 import { useAposStyles } from 'Modules/@apostrophecms/styles/composables/AposStyles.js';
 
 export default {
@@ -370,6 +372,12 @@ export default {
     }
   },
   mounted() {
+    const widgetInstance = newInstance(
+      this.moduleOptions.schema
+    );
+    merge(widgetInstance, this.docFields.data);
+    this.docFields.data = widgetInstance;
+
     this.getWidgetStyles(this.docFields.data, this.moduleOptions);
     this.instantiateEditor();
     apos.bus.$on('apos-refreshing', this.onAposRefreshing);


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

A simple patch that prevents style recomputation on every rich text keystroke.
Additionally, fix missing default values from the styles schema. 