### PR TITLE
PRO-8877: modal content direction

### DIFF
--- a/packages/apostrophe/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
+++ b/packages/apostrophe/modules/@apostrophecms/area/ui/apos/components/AposAreaWidget.vue
@@ -149,6 +149,7 @@
         :is="widgetEditorComponent(widget.type)"
         v-if="isContextual && !foreign"
         :key="generation"
+        :class="adminContentDirectionClass"
         :options="widgetOptions"
         :type="widget.type"
         :model-value="widget"
@@ -163,6 +164,7 @@
         v-else
         :id="widget._id"
         :key="`${generation}-preview`"
+        :class="adminContentDirectionClass"
         :options="widgetOptions"
         :type="widget.type"
         :area-field-id="fieldId"
@@ -209,6 +211,8 @@
 import { mapState, mapActions } from 'pinia';
 import { useWidgetStore } from 'Modules/@apostrophecms/ui/stores/widget';
 import { useBreakpointPreviewStore } from 'Modules/@apostrophecms/ui/stores/breakpointPreview.js';
+import { useModalStore } from 'Modules/@apostrophecms/ui/stores/modal.js';
+
 export default {
   name: 'AposAreaWidget',
   props: {
@@ -356,6 +360,9 @@ export default {
       'emphasizedWidgets'
     ]),
     ...mapState(useBreakpointPreviewStore, { breakpointPreviewMode: 'mode' }),
+    adminContentDirectionClass() {
+      return this.getAdminContentDirectionClass();
+    },
     // Passed only to the preview layer (custom preview components).
     followingValuesWithParent() {
       return Object.entries(this.followingValues || {})
@@ -440,7 +447,10 @@ export default {
     },
     labelsClasses() {
       return {
-        [this.classes.show]: this.isHovered || this.isFocused || this.isEmphasized
+        [this.classes.show]: this.isHovered || this.isFocused || this.isEmphasized,
+        // Force LTR for breadcrumbs for now so that nested AreaWidgets
+        // behave properly.
+        'apos-ltr': true
       };
     },
     addClasses() {
@@ -544,6 +554,7 @@ export default {
   },
   methods: {
     ...mapActions(useWidgetStore, [ 'setFocusedWidget', 'setHoveredWidget' ]),
+    ...mapActions(useModalStore, [ 'getAdminContentDirectionClass' ]),
     // Emits same actions as the native operations,
     // e.g ('edit', { index }), ('remove', { index }), etc.
     onOperation({ name, payload }) {

--- a/packages/apostrophe/modules/@apostrophecms/ui/ui/apos/stores/modal.js
+++ b/packages/apostrophe/modules/@apostrophecms/ui/ui/apos/stores/modal.js
@@ -37,9 +37,23 @@ export const useModalStore = defineStore('modal', () => {
     return activeModal.value?.locale || apos.i18n.locale;
   }
 
-  function getAdminDirectionClass() {
+  function getActiveDirection() {
     const locale = getActiveLocale();
-    const direction = apos.i18n.locales[locale]?.direction;
+    return apos.i18n.locales[locale]?.direction;
+  }
+
+  function getAdminContentDirectionClass() {
+    const direction = getActiveDirection();
+
+    if (direction === 'rtl') {
+      return 'apos-rtl';
+    }
+
+    return null;
+  }
+
+  function getAdminDirectionClass() {
+    const direction = getActiveDirection();
 
     if (direction === 'rtl') {
       return 'apos-ltr';
@@ -57,8 +71,7 @@ export const useModalStore = defineStore('modal', () => {
   // Only force RTL, the input fields are already LTR by default
   // (because the admin UI is always LTR)
   function getAdminFieldDirectionClass(overrideDirection) {
-    const locale = getActiveLocale();
-    const direction = apos.i18n.locales[locale]?.direction || 'ltr';
+    const direction = getActiveDirection() || 'ltr';
 
     if (overrideDirection) {
       return overrideDirection === 'rtl' ? 'apos-rtl' : null;
@@ -263,7 +276,9 @@ export const useModalStore = defineStore('modal', () => {
     activeModal,
     hasChooserModal,
     getActiveLocale,
+    getActiveDirection,
     getAdminDirectionClass,
+    getAdminContentDirectionClass,
     getAdminFieldDirectionClass,
     add,
     remove,


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Modal content  respects the current locale direction - all area widgets are shown RTL when edited in a modal and locale direction is RTL

