### PR TITLE
PRO-9146: Do not commit or npm publish our personal AI agent code settings

### DIFF
--- a/packages/ai-helper/.gitignore
+++ b/packages/ai-helper/.gitignore
@@ -3,3 +3,5 @@ npm-debug.log
 .DS_Store
 package-lock.json
 .claude
+.gemini
+.codex

--- a/packages/anchors/.gitignore
+++ b/packages/anchors/.gitignore
@@ -10,3 +10,5 @@ node_modules
 # vim swp files
 .*.sw*
 .claude
+.gemini
+.codex

--- a/packages/apostrophe-astro/.gitignore
+++ b/packages/apostrophe-astro/.gitignore
@@ -1,3 +1,5 @@
 /node_modules
 .DS_Store
 .claude
+.gemini
+.codex

--- a/packages/apostrophe/.gitignore
+++ b/packages/apostrophe/.gitignore
@@ -43,3 +43,5 @@ test/public/uploads
 # vim swp files
 .*.sw*
 .claude
+.gemini
+.codex

--- a/packages/apostrophe/test/data/.gitignore
+++ b/packages/apostrophe/test/data/.gitignore
@@ -1,2 +1,4 @@
 temp
 .claude
+.gemini
+.codex

--- a/packages/apostrophecms-openapi/.gitignore
+++ b/packages/apostrophecms-openapi/.gitignore
@@ -62,3 +62,5 @@ Thumbs.db
 ehthumbs.db
 Desktop.ini
 .claude
+.gemini
+.codex

--- a/packages/apostrophecms-openapi/examples/typescript/.gitignore
+++ b/packages/apostrophecms-openapi/examples/typescript/.gitignore
@@ -3,3 +3,5 @@ node_modules
 typings
 dist
 .claude
+.gemini
+.codex

--- a/packages/blog/.gitignore
+++ b/packages/blog/.gitignore
@@ -10,3 +10,5 @@ node_modules
 # vim swp files
 .*.sw*
 .claude
+.gemini
+.codex

--- a/packages/boring/.gitignore
+++ b/packages/boring/.gitignore
@@ -5,3 +5,5 @@ node_modules
 # We do not commit CSS, only LESS
 public/css/*.css
 .claude
+.gemini
+.codex

--- a/packages/broadband/.gitignore
+++ b/packages/broadband/.gitignore
@@ -3,3 +3,5 @@ npm-debug.log
 *.DS_Store
 node_modules
 .claude
+.gemini
+.codex

--- a/packages/cache-on-demand/.gitignore
+++ b/packages/cache-on-demand/.gitignore
@@ -4,3 +4,5 @@ node_modules
 # We do not commit CSS, only LESS
 public/css/*.css
 .claude
+.gemini
+.codex

--- a/packages/cache-redis/.gitignore
+++ b/packages/cache-redis/.gitignore
@@ -10,3 +10,5 @@ node_modules
 # vim swp files
 .*.sw*
 .claude
+.gemini
+.codex

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .vscode
 .claude
+.gemini
+.codex

--- a/packages/csv-to-zone-file/.gitignore
+++ b/packages/csv-to-zone-file/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .claude
+.gemini
+.codex

--- a/packages/csv-to-zone-file/bin/.gitignore
+++ b/packages/csv-to-zone-file/bin/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .claude
+.gemini
+.codex

--- a/packages/emulate-mongo-3-driver/.gitignore
+++ b/packages/emulate-mongo-3-driver/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .claude
+.gemini
+.codex

--- a/packages/eslint-config-apostrophe/.gitignore
+++ b/packages/eslint-config-apostrophe/.gitignore
@@ -2,3 +2,5 @@ package-lock.json
 .vscode
 node_modules
 .claude
+.gemini
+.codex

--- a/packages/event/.gitignore
+++ b/packages/event/.gitignore
@@ -10,3 +10,5 @@ node_modules
 # vim swp files
 .*.sw*
 .claude
+.gemini
+.codex

--- a/packages/express-cache-on-demand/.gitignore
+++ b/packages/express-cache-on-demand/.gitignore
@@ -4,3 +4,5 @@ node_modules
 # We do not commit CSS, only LESS
 public/css/*.css
 .claude
+.gemini
+.codex

--- a/packages/favicon/.gitignore
+++ b/packages/favicon/.gitignore
@@ -10,3 +10,5 @@ node_modules
 # vim swp files
 .*.sw*
 .claude
+.gemini
+.codex

--- a/packages/form-submission-google/.gitignore
+++ b/packages/form-submission-google/.gitignore
@@ -10,3 +10,5 @@ node_modules
 # vim swp files
 .*.sw*
 .claude
+.gemini
+.codex

--- a/packages/form/.gitignore
+++ b/packages/form/.gitignore
@@ -14,3 +14,5 @@ node_modules
 # Test files
 test/public/uploads
 .claude
+.gemini
+.codex

--- a/packages/i18n-static/.gitignore
+++ b/packages/i18n-static/.gitignore
@@ -3,3 +3,5 @@ node_modules
 package-lock.json
 npm-debug.log
 .claude
+.gemini
+.codex

--- a/packages/import-export-xlsx/.gitignore
+++ b/packages/import-export-xlsx/.gitignore
@@ -10,3 +10,5 @@ node_modules
 # vim swp files
 .*.sw*
 .claude
+.gemini
+.codex

--- a/packages/import-export/.gitignore
+++ b/packages/import-export/.gitignore
@@ -20,3 +20,5 @@ test/public/css/master-*.less
 /test/public/exports
 /test/public/uploads
 .claude
+.gemini
+.codex

--- a/packages/launder/.gitignore
+++ b/packages/launder/.gitignore
@@ -5,3 +5,5 @@ node_modules
 # We do not commit CSS, only LESS
 public/css/*.css
 .claude
+.gemini
+.codex

--- a/packages/login-hcaptcha/.gitignore
+++ b/packages/login-hcaptcha/.gitignore
@@ -14,3 +14,5 @@ node_modules
 test/data
 test/public
 .claude
+.gemini
+.codex

--- a/packages/login-recaptcha/.gitignore
+++ b/packages/login-recaptcha/.gitignore
@@ -13,3 +13,5 @@ node_modules
 test/data
 test/public
 .claude
+.gemini
+.codex

--- a/packages/login-totp/.gitignore
+++ b/packages/login-totp/.gitignore
@@ -13,3 +13,5 @@ node_modules
 test/data
 test/public
 .claude
+.gemini
+.codex

--- a/packages/mongodb-snapshot/.gitignore
+++ b/packages/mongodb-snapshot/.gitignore
@@ -2,3 +2,5 @@
 /package-lock.json
 /test/test.snapshot
 .claude
+.gemini
+.codex

--- a/packages/moog-require/.gitignore
+++ b/packages/moog-require/.gitignore
@@ -5,3 +5,5 @@ npm-debug.log
 # We do not commit CSS, only LESS
 public/css/*.css
 .claude
+.gemini
+.codex

--- a/packages/oembetter/.gitignore
+++ b/packages/oembetter/.gitignore
@@ -4,3 +4,5 @@ npm-debug.log
 *.DS_Store
 node_modules
 .claude
+.gemini
+.codex

--- a/packages/open-graph/.gitignore
+++ b/packages/open-graph/.gitignore
@@ -7,3 +7,5 @@ node_modules
 # vim swp files
 .*.sw*
 .claude
+.gemini
+.codex

--- a/packages/openapi-generator/.gitignore
+++ b/packages/openapi-generator/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 .DS_Store
 .DS_Store?
 .claude
+.gemini
+.codex

--- a/packages/passport-bridge/.gitignore
+++ b/packages/passport-bridge/.gitignore
@@ -10,3 +10,5 @@ node_modules
 # vim swp files
 .*.sw*
 .claude
+.gemini
+.codex

--- a/packages/postcss-viewport-to-container-toggle/.gitignore
+++ b/packages/postcss-viewport-to-container-toggle/.gitignore
@@ -19,3 +19,5 @@ test/public/css/master-*.less
 /test/public/exports
 /test/public/uploads
 .claude
+.gemini
+.codex

--- a/packages/random-words/.gitignore
+++ b/packages/random-words/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 package-lock.json
 .claude
+.gemini
+.codex

--- a/packages/redirect/.gitignore
+++ b/packages/redirect/.gitignore
@@ -7,3 +7,5 @@ node_modules
 # vim swp files
 .*.sw*
 .claude
+.gemini
+.codex

--- a/packages/sanitize-html/.gitignore
+++ b/packages/sanitize-html/.gitignore
@@ -6,3 +6,5 @@ node_modules
 # We do not commit CSS, only LESS
 public/css/*.css
 .claude
+.gemini
+.codex

--- a/packages/scheduled-publishing/.gitignore
+++ b/packages/scheduled-publishing/.gitignore
@@ -10,3 +10,5 @@ node_modules
 # vim swp files
 .*.sw*
 .claude
+.gemini
+.codex

--- a/packages/security-headers/.gitignore
+++ b/packages/security-headers/.gitignore
@@ -10,3 +10,5 @@ node_modules
 # vim swp files
 .*.sw*
 .claude
+.gemini
+.codex

--- a/packages/seo/.gitignore
+++ b/packages/seo/.gitignore
@@ -7,3 +7,5 @@ node_modules
 # vim swp files
 .*.sw*
 .claude
+.gemini
+.codex

--- a/packages/sitemap/.gitignore
+++ b/packages/sitemap/.gitignore
@@ -12,3 +12,5 @@ node_modules
 /test/public
 /test/locales
 .claude
+.gemini
+.codex

--- a/packages/sluggo/.gitignore
+++ b/packages/sluggo/.gitignore
@@ -3,3 +3,5 @@ npm-debug.log
 node_modules
 package-lock.json
 .claude
+.gemini
+.codex

--- a/packages/stylelint-config-apostrophe/.gitignore
+++ b/packages/stylelint-config-apostrophe/.gitignore
@@ -4,3 +4,5 @@
 node_modules
 package-lock.json
 .claude
+.gemini
+.codex

--- a/packages/stylelint-no-mixed-decls/.gitignore
+++ b/packages/stylelint-no-mixed-decls/.gitignore
@@ -2,3 +2,5 @@ node_modules
 package-lock.json
 .nyc_output
 .claude
+.gemini
+.codex

--- a/packages/svg-sprite/.gitignore
+++ b/packages/svg-sprite/.gitignore
@@ -10,3 +10,5 @@ node_modules
 # vim swp files
 .*.sw*
 .claude
+.gemini
+.codex

--- a/packages/uploadfs/.gitignore
+++ b/packages/uploadfs/.gitignore
@@ -14,3 +14,5 @@ package-lock.json
 # an extra local test in my checkout
 test-jimp.js
 .claude
+.gemini
+.codex

--- a/packages/vite/.gitignore
+++ b/packages/vite/.gitignore
@@ -14,3 +14,5 @@ test/data
 # vim swp files
 .*.sw*
 .claude
+.gemini
+.codex


### PR DESCRIPTION
Ignore the dotfile folder names used by the three majors to keep personal settings regarding a project so they don't leak potentially sensitive information. Typically there would be none, but these do reveal stuff like what commands you allow the agents to run without approval etc., which is a personal decision that shouldn't come from git, and also it could conceivably extend to something more revealing.