### PR TITLE
PRO-9148: Add support for intlMapping

### DIFF
--- a/.changeset/hot-tools-fold.md
+++ b/.changeset/hot-tools-fold.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": minor
+---
+
+Adds the `intlMapping` option to locale configuration to map custom locale codes to standard ones for `Intl` usage. This property is available in `apos.i18n.locales` for project-level code.

--- a/packages/apostrophe/lib/locales.js
+++ b/packages/apostrophe/lib/locales.js
@@ -11,6 +11,14 @@ module.exports = {
       const prefix = options.prefix || '__none';
       const key = `${hostname}:${prefix}`;
       const direction = options.direction;
+      const intlMapping = options.intlMapping;
+
+      if (intlMapping && (typeof intlMapping !== 'string')) {
+        throw new Error(stripIndent`
+          The locale "${name}" has an invalid intlMapping option "${intlMapping}".
+          The intlMapping option must be a string.
+        `);
+      }
 
       // Note that default `ltr` directions should have been set
       // already by the `getLocales` method in the i18n module.

--- a/packages/apostrophe/modules/@apostrophecms/i18n/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/i18n/index.js
@@ -27,7 +27,7 @@
 // as the default value for the`adminLocale` user field. If it is not set,
 // but `adminLocales` is set, then the default is to display the admin UI
 // in the same language as the website content.
-// Example: `defaultLocale: 'fr'`.
+// Example: `defaultAdminLocale: 'fr'`.
 //
 // ### `encoding`
 //

--- a/packages/apostrophe/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
+++ b/packages/apostrophe/modules/@apostrophecms/image/ui/apos/components/AposMediaManagerEditor.vue
@@ -171,6 +171,14 @@ export default {
     moduleOptions() {
       return window.apos.modules[this.activeMedia.type] || {};
     },
+    intlLocale() {
+      const locale = window.apos.locale;
+      const locales = window.apos.i18n.locales;
+      if (locales?.[locale]?.intlMapping) {
+        return locales[locale].intlMapping;
+      }
+      return locale;
+    },
     canLocalize() {
       return this.moduleOptions.canLocalize && this.activeMedia._id;
     },
@@ -201,19 +209,31 @@ export default {
         return '';
       }
       const size = this.activeMedia.attachment.length;
-      const formatter = new Intl.NumberFormat(apos.locale, {
-        maximumFractionDigits: 2
-      });
-      if (size >= 1000000) {
-        const formatted = formatter.format(size / 1000000);
-        return this.$t('apostrophe:mediaMB', {
-          size: formatted
+      try {
+        const formatter = new Intl.NumberFormat(this.intlLocale, {
+          maximumFractionDigits: 2
         });
-      } else {
-        const formatted = formatter.format(size / 1000);
-        return this.$t('apostrophe:mediaKB', {
-          size: formatted
-        });
+        if (size >= 1000000) {
+          const formatted = formatter.format(size / 1000000);
+          return this.$t('apostrophe:mediaMB', {
+            size: formatted
+          });
+        } else {
+          const formatted = formatter.format(size / 1000);
+          return this.$t('apostrophe:mediaKB', {
+            size: formatted
+          });
+        }
+      } catch (e) {
+        if (size >= 1000000) {
+          return this.$t('apostrophe:mediaMB', {
+            size: (size / 1000000).toFixed(2)
+          });
+        } else {
+          return this.$t('apostrophe:mediaKB', {
+            size: (size / 1000).toFixed(2)
+          });
+        }
       }
     },
     createdDate() {

--- a/packages/apostrophe/test/i18n.js
+++ b/packages/apostrophe/test/i18n.js
@@ -17,7 +17,8 @@ describe('static i18n', function() {
             locales: {
               en: {},
               fr: {
-                prefix: '/fr'
+                prefix: '/fr',
+                intlMapping: 'fr-FR'
               },
               he: {
                 label: 'Hebrew',
@@ -63,6 +64,11 @@ describe('static i18n', function() {
   it('should should exist on the apos object', async function() {
     assert(apos.i18n);
     assert(apos.i18n.i18next);
+  });
+
+  it('should preserve intlMapping property on locales', async function() {
+    assert.equal(apos.i18n.locales.fr.intlMapping, 'fr-FR');
+    assert.equal(apos.i18n.locales.en.intlMapping, undefined);
   });
 
   it('should set the lang and dir attributes by default', async function() {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Adds the `intlMapping` option to locale configuration to map custom locale codes to standard ones for `Intl` usage. This property is available in `apos.i18n.locales` for project-level code.

## What are the specific steps to test this change?

Intl Mapping is correctly used in Media manager (image details when editing an image)

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
