### PR TITLE
release 4.26.1

### DIFF
--- a/packages/apostrophe/CHANGELOG.md
+++ b/packages/apostrophe/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.26.1
+
+### Fixes
+
+- No changes. Published to reset the `latest` tag in `npm`, which inadvertently pointed to an alpha release for a brief period of time.
+
 ## 4.26.0
 
 ### Adds

--- a/packages/apostrophe/package.json
+++ b/packages/apostrophe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "4.26.0",
+  "version": "4.26.1",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
No changes at all, just resetting `latest` in npm.