### PR TITLE
PRO-9175: fix regression that broke on-page, in-context area editing for certain areas

### DIFF
--- a/.changeset/moody-icons-invent.md
+++ b/.changeset/moody-icons-invent.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": patch
+---
+
+Fixed a regression introduced in 4.26.0 that could cause some areas on the page not to be editable outside of the page or piece settings dialog.

--- a/packages/apostrophe/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
+++ b/packages/apostrophe/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
@@ -49,11 +49,17 @@ export default function() {
     els.filter(el => depth(el) === lowest).forEach(el => createAreaApp(el));
   }
 
+  // Determine how deeply it is nested in other areas. We don't care about
+  // non-area levels
   function depth(el) {
     let depth = 0;
     while (el) {
       el = el.parentNode;
-      depth++;
+      if (el?.hasAttribute) {
+        if (el.hasAttribute('data-apos-area-newly-editable') || el.hasAttribute('data-apos-area-editable')) {
+          depth++;
+        }
+      }
     }
     return depth;
   }
@@ -97,6 +103,7 @@ export default function() {
       }
     }
     el.removeAttribute('data-apos-area-newly-editable');
+    el.setAttribute('data-apos-area-editable', true);
 
     let created = false;
     let observer;


### PR DESCRIPTION
To verify this fix, you can edit your page template so that it has at least two separate area fields, and one of the `{% area... %}` calls is nested in a div, while the other is not.

Without the fix, the one nested in a div is not editable on-page.

With the fix, they are both editable on-page.

The fix has also been verified on the Wissahickon Charter School site.