### PR TITLE
Fix subtle bug in AposPermissionGrid that caused unrelated clicks to be "swallowed" due to a race condition at low network speeds

### DIFF
--- a/.changeset/some-cougars-pay.md
+++ b/.changeset/some-cougars-pay.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": patch
+---
+
+Fix subtle bug in AposPermissionGrid that caused unrelated clicks to be "swallowed" due to a race condition at low network speeds

--- a/packages/apostrophe/modules/@apostrophecms/permission/ui/apos/components/AposPermissionGrid.vue
+++ b/packages/apostrophe/modules/@apostrophecms/permission/ui/apos/components/AposPermissionGrid.vue
@@ -91,9 +91,21 @@ export default {
   },
   watch: {
     apiParams: {
-      async handler() {
+      async handler(newValue, oldValue) {
+        // The way we pass the props to this component as an object every
+        // means that everything gets flagged as a change every time the
+        // component is included in a render.
+        //
+        // So we need to compare the actual data, and this is a simple way
+        // to do that deeply for both regular and advanced permission.
+        if (JSON.stringify(newValue) === JSON.stringify(oldValue)) {
+          return;
+        }
         this.permissionSets = await this.getPermissionSets();
       },
+      // Still in place in case we stop passing a new object
+      // every time, in which case this wouldn't fire
+      // without it. -Tom
       deep: true
     }
   },


### PR DESCRIPTION
This is a follow-up to PRO-9158. We were wasting quite a lot of time and network activity, resulting in extra unnecessary "purple time," on almost every interaction involving editing a user. That's because AposPermissionGrid takes its parameters as an object. Watching an object, deeply or not, will trigger 100% of the time if the object itself is a new object, and building the object in the `<template>` itself always has that effect (every re-render of the parent component guarantees the watcher is triggered).

My workaround is to compare the JSON representations of the old and new values in the watcher and bail if they are the same. This is lower-risk than overhauling both the apostrophe module and the advanced permission module.

I tested this in my checkout of the CU customer project and verified that it solves the "have to double-click the browse sites button" problem for them.