### PR TITLE
PRO-9072: fix open link in new tab not being cleared

### DIFF
--- a/.changeset/proud-feet-clean.md
+++ b/.changeset/proud-feet-clean.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": minor
+---
+
+Fix a bug when rich text link open in new tab checkbox can't be cleared

--- a/packages/apostrophe/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposImageControlDialog.vue
+++ b/packages/apostrophe/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposImageControlDialog.vue
@@ -191,6 +191,7 @@ export default {
         ...this.schemaHtmlAttributes.reduce((acc, field) => {
           const value = this.docFields.data[field.name];
           if (field.type === 'checkboxes' && !value?.[0]) {
+            acc[field.htmlAttribute] = null;
             return acc;
           }
           if (field.type === 'boolean') {

--- a/packages/apostrophe/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
+++ b/packages/apostrophe/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapLink.vue
@@ -179,6 +179,7 @@ export default {
       const attrs = this.schemaHtmlAttributes.reduce((acc, field) => {
         const value = this.docFields.data[field.name];
         if (field.type === 'checkboxes' && !value?.[0]) {
+          acc[field.htmlAttribute] = null;
           return acc;
         }
         if (field.type === 'boolean') {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Rich text link open in new tab checkbox can't be cleared once it's checked.

This patch fixes that.