### PR TITLE
Fix widget groups edge case

### DIFF
--- a/.changeset/dark-signs-mate.md
+++ b/.changeset/dark-signs-mate.md
@@ -2,4 +2,4 @@
 "apostrophe": minor
 ---
 
-Fix edge case where widgets having styles and fields at the same time would show "Ungrouped" tab. Add `hideSingleTab` option that can be enabled in any widget to hide tabs from the widget editor when there is only one tab containing fields. This option can be also enabeld globally in `@apostrophecms/widget-type` options.
+Fix edge case where widgets having styles and fields at the same time would show "Ungrouped" tab. Add `hideSingleTab` option that can be enabled in any widget to hide tabs from the widget editor when there is only one tab containing fields. This option can also be enabled globally in `@apostrophecms/widget-type` options.

--- a/.changeset/dark-signs-mate.md
+++ b/.changeset/dark-signs-mate.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": minor
+---
+
+Fix edge case where widgets having styles and fields at the same time would show "Ungrouped" tab. Add `hideSingleTab` option that can be enabled in any widget to hide tabs from the widget editor when there is only one tab containing fields. This option can be also enabeld globally in `@apostrophecms/widget-type` options.

--- a/packages/anchors/modules/@apostrophecms/anchors-layout-column-widget/index.js
+++ b/packages/anchors/modules/@apostrophecms/anchors-layout-column-widget/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  improve: '@apostrophecms/layout-column-widget',
+  options: {
+    anchors: false
+  }
+};

--- a/packages/apostrophe/modules/@apostrophecms/layout-widget/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/layout-widget/index.js
@@ -71,6 +71,11 @@ module.exports = {
             }
           }
         }
+      },
+      group: {
+        utility: {
+          fields: [ 'columns' ]
+        }
       }
     };
   },

--- a/packages/apostrophe/modules/@apostrophecms/widget-type/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/widget-type/index.js
@@ -174,7 +174,10 @@ module.exports = {
     origin: null,
     preview: true,
     // Set to false to opt out of the automatic styling wrapping of widget output
-    stylesWrapper: true
+    stylesWrapper: true,
+    // If set to true, the widget editor will hide tabs when there is only one,
+    // even if groups are defined. Defaults to false for backwards compatibility.
+    hideSingleTab: false
   },
   init(self) {
     self.isExplicitOrigin = self.options.origin !== null;
@@ -306,14 +309,20 @@ module.exports = {
           label: 'apostrophe:styles',
           fields: groupFields
         };
-        // Create a default group if none exist
+        // Create a default group if none exist.
+        // Ignore utility group if it's the only one, since it's now the way
+        // to hide fields (see layout column widget).
+        const visibleFields = Object.keys(self.fields)
+          .filter(
+            fieldName => !self.fieldsGroups.utility?.fields?.includes(fieldName)
+          );
         if (
-          !Object.keys(self.fieldsGroups).length &&
-          Object.keys(self.fields).length
+          !Object.keys(self.fieldsGroups).filter(g => g !== 'utility').length &&
+          visibleFields.length
         ) {
           self.fieldsGroups.basics = {
             label: 'apostrophe:basics',
-            fields: Object.keys(self.fields)
+            fields: visibleFields
           };
         }
         self.fieldsGroups.styles = stylesGroup;
@@ -778,7 +787,8 @@ module.exports = {
           preview: self.options.preview,
           isExplicitOrigin: self.isExplicitOrigin,
           widgetOperations: self.getWidgetOperations(req),
-          widgetBreadcrumbOperations: self.getWidgetBreadcrumbOperations(req)
+          widgetBreadcrumbOperations: self.getWidgetBreadcrumbOperations(req),
+          hideSingleTab: self.options.hideSingleTab
         });
         return result;
       }

--- a/packages/apostrophe/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
+++ b/packages/apostrophe/modules/@apostrophecms/widget-type/ui/apos/components/AposWidgetEditor.vue
@@ -56,7 +56,7 @@
         :items="breadcrumbs"
       />
       <AposWidgetModalTabs
-        v-if="tabs.length && tabs[0].name !== 'ungrouped'"
+        v-if="shouldShowTabs"
         :key="tabKey"
         :current="currentTab"
         :tabs="tabs"
@@ -225,6 +225,12 @@ export default {
     },
     moduleOptions() {
       return window.apos.modules[apos.area.widgetManagers[this.type]];
+    },
+    shouldShowTabs() {
+      if (this.moduleOptions.hideSingleTab) {
+        return this.tabs.length > 1;
+      }
+      return this.tabs.length && this.tabs[0].name !== 'ungrouped';
     },
     typeLabel() {
       return this.moduleOptions.label;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Fix edge case where widgets having styles and fields at the same time would show "Ungrouped" tab. Add `hideSingleTab` option that can be enabled in any widget to hide tabs from the widget editor when there is only one tab containing fields. This option can be also enabeld globally in `@apostrophecms/widget-type` options.

## What are the specific steps to test this change?

Groups for widget with styles are properly generated. `hideSingleTab: true` on a widget hides tabs in Widget editor when there is only one tab.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
