### PR TITLE
Log aposResponse errors

### DIFF
--- a/.changeset/wild-lies-film.md
+++ b/.changeset/wild-lies-film.md
@@ -1,0 +1,5 @@
+---
+"@apostrophecms/apostrophe-astro": minor
+---
+
+Log aposResponse errors

--- a/packages/apostrophe-astro/lib/aposResponse.js
+++ b/packages/apostrophe-astro/lib/aposResponse.js
@@ -49,7 +49,7 @@ export default async function aposResponse(req) {
 
     const aposUrl = new URL(aposHost + pathname);
     aposUrl.search = url.search;
- 
+
     // Prepare headers, excluding any specified in config
     const requestHeaders = {};
     for (const [name, value] of req.headers) {
@@ -111,6 +111,7 @@ export default async function aposResponse(req) {
           }
           // Skip unknown encodings silently
         } catch (decompressError) {
+          console.error(decompressError);
           // If decompression fails, return original response
           return new Response(new Uint8Array(bodyArrayBuffer), {
             ...rest,
@@ -133,10 +134,12 @@ export default async function aposResponse(req) {
         headers: responseHeaders
       });
     } catch (bodyError) {
+      console.error(bodyError);
       // If we can't process the body, fall back to the original response
       return new Response(res.body, { ...rest, status: statusCode, headers: responseHeaders });
     }
   } catch (error) {
+    console.error(error);
     // Handle any unexpected errors
     return new Response(`Server error: ${error.message}`, { status: 500 });
   }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Log aposResponse errors

## What are the specific steps to test this change?

When aposResponse catches an error, it will return the response as a string

Later on in the stack, something will log the following

```
error: SyntaxError: Unexpected token 'S', "Server err"... is not valid JSON
    at JSON.parse (<anonymous>)
    at parseJSONFromBytes (node:internal/deps/undici/undici:4255:19)
    at successSteps (node:internal/deps/undici/undici:6902:27)
    at readAllBytes (node:internal/deps/undici/undici:5825:13)
Error fetching aposPage {
  urlDetails: URL {
    href: 'https://localhost/',
    origin: 'https://localhost',
    protocol: 'https:',
    username: '',
    password: '',
    host: 'localhost',
    hostname: 'localhost',
    port: '',
    pathname: '/',
    search: '',
    searchParams: URLSearchParams {},
    hash: ''
  }
}
No template found for {
  template: undefined,
  module: undefined,
  type: 'apos-fetch-error',
  url: 'https://localhost'
}
```

The root cause of the issue is unknown because there is a component somewhere that will try to `JSON.parse` the string response `return new Response(res.body, { ...rest, status: statusCode, headers: responseHeaders });`

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
