### PR TITLE
Fix focus trap on the last element in a modal

### DIFF
--- a/.changeset/moody-poems-speak.md
+++ b/.changeset/moody-poems-speak.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": minor
+---
+
+Fixed an issue where using the Tab key to navigate within modals could incorrectly jump focus to a wrong element instead of the next input field.

--- a/.changeset/moody-poems-speak.md
+++ b/.changeset/moody-poems-speak.md
@@ -3,3 +3,5 @@
 ---
 
 Fixed an issue where using the Tab key to navigate within modals could incorrectly jump focus to a wrong element instead of the next input field.
+
+Fixed Tab navigation escaping out of modals when the form contained hidden sections or elements that became disabled after editing.

--- a/packages/apostrophe/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/packages/apostrophe/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -16,7 +16,7 @@
       :data-apos-graph-key="props.graphKey || undefined"
       tabindex="0"
       @focus.capture="captureFocus"
-      @keyup.tab="onKeyup"
+      @keydown.tab="onKeydownTab"
       @keyup.esc="onKeyup"
     >
       <transition :name="transitionType">
@@ -476,13 +476,25 @@ onUnmounted(() => {
   }
 });
 
-function onKeyup(event) {
+// Handle Tab on keydown — before the browser moves focus.
+// Handling Tab on keyup is too late: the browser
+// has already moved focus, so the cycling logic sees the wrong
+// activeElement.
+function onKeydownTab(event) {
+  if (!shouldTrapFocus.value) {
+    return;
+  }
   if (!store.isOnTop(modalEl.value)) {
     return;
   }
+  if (event.target?.nodeName?.toLowerCase() === 'textarea') {
+    return;
+  }
+  cycleElementsToFocus(event, props.modalData.elementsToFocus);
+}
 
-  if (event.key === 'Tab') {
-    cycleElementsToFocus(event, props.modalData.elementsToFocus);
+function onKeyup(event) {
+  if (!store.isOnTop(modalEl.value)) {
     return;
   }
 

--- a/packages/apostrophe/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/packages/apostrophe/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -216,6 +216,22 @@ const nonDraggableElements = [
   '.apos-input-array-inline-table'
 ];
 
+// Selector for focusable elements inside the modal. Used both at trap setup
+// and on every Tab keydown to refresh the cycle list, so that elements that
+// became disabled/hidden (e.g. Save when validation fails) or newly visible
+// are reflected.
+const focusableSelector = [
+  '[tabindex]',
+  '[href]',
+  'input',
+  'select',
+  'textarea',
+  'button',
+  '[data-apos-focus-priority]'
+]
+  .map(s => `${s}:not([tabindex="-1"]):not([disabled]):not([type="hidden"]):not([aria-hidden]):not(.apos-sr-only)`)
+  .join(', ');
+
 const resizeSides = [
   {
     edge: 'top',
@@ -477,9 +493,11 @@ onUnmounted(() => {
 });
 
 // Handle Tab on keydown — before the browser moves focus.
-// Handling Tab on keyup is too late: the browser
-// has already moved focus, so the cycling logic sees the wrong
-// activeElement.
+// Handling Tab on keyup is too late: the browser has already moved focus,
+// so the cycling logic sees the wrong activeElement.
+//
+// We also recompute the focusable list here on every Tab, scoped to
+// modalEl, instead of relying on the snapshot taken at trapFocus() time.
 function onKeydownTab(event) {
   if (!shouldTrapFocus.value) {
     return;
@@ -490,7 +508,10 @@ function onKeydownTab(event) {
   if (event.target?.nodeName?.toLowerCase() === 'textarea') {
     return;
   }
-  cycleElementsToFocus(event, props.modalData.elementsToFocus);
+  const elements = getFocusableElements(modalEl.value);
+  // Keep the store snapshot consistent for other consumers.
+  store.updateModalData(props.modalData.id, { elementsToFocus: elements });
+  cycleElementsToFocus(event, elements);
 }
 
 function onKeyup(event) {
@@ -529,23 +550,20 @@ function captureFocus(e) {
   store.updateModalData(props.modalData.id, { focusedElement: e.target });
 }
 
+function getFocusableElements(rootEl) {
+  if (!rootEl) {
+    return [];
+  }
+  return [ ...rootEl.querySelectorAll(focusableSelector) ]
+    // a cheap "visible and in the DOM" condition,
+    // false positive expected for position: fixed and
+    // visually hidden elements (visible: hidden, opacity: 0, etc.)
+    .filter(el => el.offsetParent !== null);
+}
+
 async function trapFocus() {
   if (modalEl?.value) {
-    const elementSelectors = [
-      '[tabindex]',
-      '[href]',
-      'input',
-      'select',
-      'textarea',
-      'button',
-      '[data-apos-focus-priority]'
-    ];
-
-    const selector = elementSelectors
-      .map(addExcludingAttributes)
-      .join(', ');
-
-    const elementsToFocus = [ ...modalEl.value.querySelectorAll(selector) ];
+    const elementsToFocus = getFocusableElements(modalEl.value);
 
     store.updateModalData(props.modalData.id, { elementsToFocus });
 
@@ -567,10 +585,6 @@ async function trapFocus() {
     renderingElements.value = false;
     await nextTick();
     focusElement(props.modalData.focusedElement, firstElementToFocus);
-  }
-
-  function addExcludingAttributes(element) {
-    return `${element}:not([tabindex="-1"]):not([disabled]):not([type="hidden"]):not([aria-hidden]):not(.apos-sr-only)`;
   }
 }
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Fixed an issue where using the Tab key to navigate within modals could incorrectly jump focus to a wrong element instead of the next input field.

## What are the specific steps to test this change?

When cycling through a form in a modal, reaching the last form element won't jump to the first focusable element (usually the Cancel button). 

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
