### PR TITLE
Initial focus trap issue in modals

### DIFF
--- a/packages/apostrophe/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
+++ b/packages/apostrophe/modules/@apostrophecms/modal/ui/apos/components/AposModal.vue
@@ -510,7 +510,12 @@ function onKeydownTab(event) {
   if (event.target?.nodeName?.toLowerCase() === 'textarea') {
     return;
   }
-  const elements = getFocusableElements(modalEl.value);
+  // Skip visually hidden elements when cycling — but only here, not in
+  // trapFocus. Initial focus runs while `renderingElements` is still true,
+  // which puts the content under display:none and makes every candidate's
+  // offsetParent null.
+  const elements = getFocusableElements(modalEl.value)
+    .filter(el => el.offsetParent !== null);
   // Keep the store snapshot consistent for other consumers.
   store.updateModalData(props.modalData.id, { elementsToFocus: elements });
   cycleElementsToFocus(event, elements);
@@ -556,11 +561,7 @@ function getFocusableElements(rootEl) {
   if (!rootEl) {
     return [];
   }
-  return [ ...rootEl.querySelectorAll(focusableSelector) ]
-    // a cheap "visible and in the DOM" condition,
-    // false positive expected for position: fixed and
-    // visually hidden elements (visible: hidden, opacity: 0, etc.)
-    .filter(el => el.offsetParent !== null);
+  return [ ...rootEl.querySelectorAll(focusableSelector) ];
 }
 
 async function trapFocus() {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Fix initial focus trap issue, introduced with recent changes. No need of changelog as this is a fix of a fix (already has changelog). 

## What are the specific steps to test this change?

When opening area widget group (the modal), the focus is properly trapped by that modal.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
