### PR TITLE
Fix new schema areas in existing documents (Astro)

### DIFF
--- a/.changeset/ripe-terms-happen.md
+++ b/.changeset/ripe-terms-happen.md
@@ -6,6 +6,6 @@
 Fixed adding or removing an area field from a schema breaking existing documents on an external front such as Astro.
 
 - `AposArea` now renders only schema-backed areas. A missing area no longer throws, and an area orphaned by removing its field from the schema (while its content remains in the document) renders nothing instead of breaking sibling areas in edit mode. Logged-in editors get a diagnostic message in place of an orphaned area; anonymous visitors see nothing.
-- Editable documents sent to an external front now materialize empty area objects for schema area fields added after the document was created, so they can be edited in context. This happens in memory, without writing to the database during a render.
+- Editable documents sent to an external front now materialize empty area objects for schema area fields added after the document was created, so they can be edited in context.
 - `apos.util.getManagerOf` accepts a `{ log }` option to suppress its error log when probing objects that may not have a manager.
 

--- a/.changeset/ripe-terms-happen.md
+++ b/.changeset/ripe-terms-happen.md
@@ -1,0 +1,11 @@
+---
+"@apostrophecms/apostrophe-astro": minor
+"apostrophe": minor
+---
+
+Fixed adding or removing an area field from a schema breaking existing documents on an external front such as Astro.
+
+- `AposArea` now renders only schema-backed areas. A missing area no longer throws, and an area orphaned by removing its field from the schema (while its content remains in the document) renders nothing instead of breaking sibling areas in edit mode. Logged-in editors get a diagnostic message in place of an orphaned area; anonymous visitors see nothing.
+- Editable documents sent to an external front now materialize empty area objects for schema area fields added after the document was created, so they can be edited in context. This happens in memory, without writing to the database during a render.
+- `apos.util.getManagerOf` accepts a `{ log }` option to suppress its error log when probing objects that may not have a manager.
+

--- a/packages/apostrophe-astro/components/AposArea.astro
+++ b/packages/apostrophe-astro/components/AposArea.astro
@@ -13,9 +13,13 @@ const {
 
 let attributes = {};
 
+// The backend sets `field` only on areas still in the schema; a missing or
+// orphaned area lacks it and renders nothing.
+const isArea = Boolean(area?.field);
+
 const widgets = area?.items || [];
 
-const isEdit = area?._edit && Astro.url.searchParams.get("aposEdit");
+const isEdit = isArea && area?._edit && Astro.url.searchParams.get("aposEdit");
 const forceWrapper = aposAttributes || aposStyle || aposClassName;
 
 const WidgetComponent = widgetComponent ?? AposWidget;
@@ -43,16 +47,16 @@ if (isEdit) {
   };
 }
 const Wrapper = isEdit || forceWrapper ? "div" : Fragment;
-const widgetOptions = getWidgetOptions(area.options);
+const widgetOptions = getWidgetOptions(area?.options);
 
-function getWidgetOptions(options) {
-  let widgets = options.widgets || {};
+function getWidgetOptions(options: any = {}) {
+  let widgets = { ...(options.widgets || {}) };
 
   if (options.groups) {
     for (const group of Object.keys(options.groups)) {
       widgets = {
         ...widgets,
-        ...options.groups[group].widgets,
+        ...(options.groups[group]?.widgets || {}),
       };
     }
   }
@@ -60,22 +64,45 @@ function getWidgetOptions(options) {
 }
 ---
 
-<Wrapper {...attributes}>
-  {
-    widgets?.map((item) => {
-      const options = {
-        ...item._options,
-        ...widgetOptions[item.type],
-      };
-      return (
-        <WidgetComponent
-          widget={item}
-          options={options}
-          area={area}
-          canEdit={isEdit}
-          {...props}
-        />
-      );
-    })
-  }
-</Wrapper>
+{
+  isArea ? (
+    <Wrapper {...attributes}>
+      {widgets.map((item) => {
+        const options = {
+          ...item._options,
+          ...widgetOptions[item.type],
+        };
+        return (
+          <WidgetComponent
+            widget={item}
+            options={options}
+            area={area}
+            canEdit={isEdit}
+            {...props}
+          />
+        );
+      })}
+    </Wrapper>
+  ) : (
+    // Orphaned area. Tell logged-in editors how to fix it; show nothing to
+    // anonymous visitors.
+    area?._edit &&
+    area?.metaType === "area" && (
+      <div
+        data-apos-area-error
+        role="alert"
+        style="margin:1rem 0;padding:0.75rem 1rem;border:2px solid #dc2626;border-radius:4px;background:#fff1f2;color:#991b1b;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:0.85rem;line-height:1.5;"
+      >
+        <strong>ApostropheCMS:</strong> an area passed to{" "}
+        <code>{"<AposArea />"}</code> is not defined in the schema, so it was
+        not rendered. Its field was likely removed from the schema while content
+        remains in the document. Restore the field in the schema, or remove the
+        matching <code>{"<AposArea />"}</code> from this template.
+        <br />
+        <small>
+          area _id: {area._id} — document: {area._docId}
+        </small>
+      </div>
+    )
+  )
+}

--- a/packages/apostrophe-astro/components/AposArea.astro
+++ b/packages/apostrophe-astro/components/AposArea.astro
@@ -17,7 +17,7 @@ let attributes = {};
 // orphaned area lacks it and renders nothing.
 const isArea = Boolean(area?.field);
 
-const widgets = area?.items || [];
+const widgets: Record<string, any>[] = area?.items || [];
 
 const isEdit = isArea && area?._edit && Astro.url.searchParams.get("aposEdit");
 const forceWrapper = aposAttributes || aposStyle || aposClassName;
@@ -84,9 +84,9 @@ function getWidgetOptions(options: any = {}) {
       })}
     </Wrapper>
   ) : (
-    // Orphaned area. Tell logged-in editors how to fix it; show nothing to
-    // anonymous visitors.
-    area?._edit &&
+    // Orphaned area. Dev-only diagnostic: `import.meta.env.DEV` is replaced
+    // with `false` in production, so this branch is dead-code eliminated.
+    (import.meta as any).env.DEV &&
     area?.metaType === "area" && (
       <div
         data-apos-area-error

--- a/packages/apostrophe/modules/@apostrophecms/area/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/area/index.js
@@ -285,6 +285,37 @@ module.exports = {
           self.missingWidgetTypes[name] = true;
         }
       },
+      // Build an empty area and attach it to `parent[name]`. When `parent`
+      // is doc-backed (has `_docId`, or is itself a doc) and `areaDotPath`
+      // is provided, also persist the area at that dot-path. The write is
+      // idempotent via `$eq: null`, so concurrent renders won't clobber each
+      // other. Returns the area.
+      //
+      // Used by the `{% area %}` tag and the external front annotator as a
+      // single source of truth for stubbing schema areas that have no value
+      // yet.
+      async addMissingArea(parent, name, areaDotPath) {
+        const area = {
+          metaType: 'area',
+          _id: self.apos.util.generateId(),
+          items: []
+        };
+        parent[name] = area;
+        const docId = parent._docId ??
+          (parent.metaType === 'doc' ? parent._id : null);
+        if (docId && areaDotPath) {
+          await self.apos.doc.db.updateOne(
+            {
+              _id: docId,
+              [areaDotPath]: { $eq: null }
+            },
+            {
+              $set: { [areaDotPath]: self.apos.util.clonePermanent(area) }
+            }
+          );
+        }
+        return area;
+      },
       prepForRender(area, context, fieldName) {
         const manager = self.apos.util.getManagerOf(context);
         const field = manager.schema.find(field => field.name === fieldName);
@@ -451,7 +482,10 @@ module.exports = {
         // Loop over the docs in the array passed in.
         for (const doc of within) {
           if (self.apos.externalFrontKey) {
-            self.apos.template.annotateDocForExternalFront(doc, { scene: req.scene });
+            await self.apos.template.annotateDocForExternalFront(
+              doc,
+              { scene: req.scene }
+            );
           }
 
           const rendered = [];

--- a/packages/apostrophe/modules/@apostrophecms/area/lib/custom-tags/area.js
+++ b/packages/apostrophe/modules/@apostrophecms/area/lib/custom-tags/area.js
@@ -63,15 +63,10 @@ module.exports = function(self) {
         // has a value, for instance the field could be new in the schema.
         // But we need an area _id. Stub it into the db on the fly
         // without race conditions
-        area = {
-          metaType: 'area',
-          _id: self.apos.util.generateId(),
-          items: []
-        };
-        doc[name] = area;
         const docId = doc._docId || ((doc.metaType === 'doc') ? doc._id : null);
+        let areaDotPath;
         if (docId) {
-          let mainDoc = await self.apos.doc.db.findOne({ _id: docId });
+          const mainDoc = await self.apos.doc.db.findOne({ _id: docId });
           if (!mainDoc) {
             throw self.apos.error('notfound');
           }
@@ -83,21 +78,14 @@ module.exports = function(self) {
             // Unlikely thanks to advisory locking
             throw self.apos.error('notfound');
           }
-          const areaDotPath = docDotPath ? `${docDotPath}.${name}` : name;
-          await self.apos.doc.db.updateOne({
-            _id: docId,
-            // Prevent race condition
-            [areaDotPath]: {
-              $eq: null
-            }
-          }, {
-            $set: {
-              [areaDotPath]: self.apos.util.clonePermanent(area)
-            }
-          });
-          mainDoc = await self.apos.doc.db.findOne({ _id: docId });
-          // Prevent race condition
-          area._id = self.apos.util.get(mainDoc, areaDotPath)._id;
+          areaDotPath = docDotPath ? `${docDotPath}.${name}` : name;
+        }
+        area = await self.apos.area.addMissingArea(doc, name, areaDotPath);
+        if (docId) {
+          // Race-safety: re-read the persisted _id in case another request
+          // wrote first (our $eq: null write was a no-op in that case).
+          const refreshed = await self.apos.doc.db.findOne({ _id: docId });
+          area._id = self.apos.util.get(refreshed, areaDotPath)._id;
         }
       }
       const manager = self.apos.util.getManagerOf(doc);

--- a/packages/apostrophe/modules/@apostrophecms/template/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/template/index.js
@@ -1231,7 +1231,7 @@ module.exports = {
       async annotateDataForExternalFront(req, template, data, moduleName) {
         const docs = self.getDocsForExternalFront(req, template, data, moduleName);
         for (const doc of docs) {
-          self.annotateDocForExternalFront(doc, { scene: req.scene });
+          await self.annotateDocForExternalFront(doc, { scene: req.scene });
         }
         data.aposBodyData = await self.getBodyData(req);
         // Already contains module name too
@@ -1283,14 +1283,18 @@ module.exports = {
         ].filter(doc => !!doc);
       },
 
-      annotateDocForExternalFront(doc, { scene } = {}) {
+      async annotateDocForExternalFront(doc, { scene } = {}) {
         const handled = new WeakSet();
         const missingAreas = [];
-        self.apos.doc.walk(doc, (o, k, v) => {
+        self.apos.doc.walk(doc, (o, k, v, __dotPath) => {
           if (o._edit === true && !handled.has(o)) {
             handled.add(o);
+            // `__dotPath` is the path to `v` (= o[k]); the container `o` lives
+            // one segment up — '' for the top-level doc.
+            const dot = __dotPath.lastIndexOf('.');
+            const containerDotPath = dot === -1 ? '' : __dotPath.substring(0, dot);
             for (const field of self.missingSchemaAreas(o)) {
-              missingAreas.push([ o, field ]);
+              missingAreas.push([ o, field, containerDotPath ]);
             }
           }
           if (v && v.metaType === 'area') {
@@ -1313,18 +1317,20 @@ module.exports = {
             return self.annotateAreaForExternalFront(field, v, { scene });
           }
         });
-        // Add the missing areas after the walk, so we never add keys to an
-        // object while it is being traversed. In memory only - unlike the
-        // `{% area %}` tag we never write to the database during a render.
-        for (const [ o, field ] of missingAreas) {
-          o[field.name] = {
-            metaType: 'area',
-            _id: self.apos.util.generateId(),
-            items: [],
-            _edit: true,
-            _docId: o._docId ?? (o.metaType === 'doc' ? o._id : null)
-          };
-          self.annotateAreaForExternalFront(field, o[field.name], { scene });
+        // Materialize every missing area, after the walk so we never add keys
+        // to an object while it is being traversed.
+        for (const [ o, field, containerDotPath ] of missingAreas) {
+          const areaDotPath = containerDotPath
+            ? `${containerDotPath}.${field.name}`
+            : field.name;
+          const area = await self.apos.area.addMissingArea(
+            o,
+            field.name,
+            areaDotPath
+          );
+          area._edit = true;
+          area._docId = o._docId ?? (o.metaType === 'doc' ? o._id : null);
+          self.annotateAreaForExternalFront(field, area, { scene });
         }
       },
 

--- a/packages/apostrophe/modules/@apostrophecms/template/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/template/index.js
@@ -1284,11 +1284,22 @@ module.exports = {
       },
 
       annotateDocForExternalFront(doc, { scene } = {}) {
+        const handled = new WeakSet();
+        const missingAreas = [];
         self.apos.doc.walk(doc, (o, k, v) => {
+          if (o._edit === true && !handled.has(o)) {
+            handled.add(o);
+            for (const field of self.missingSchemaAreas(o)) {
+              missingAreas.push([ o, field ]);
+            }
+          }
           if (v && v.metaType === 'area') {
             const manager = self.apos.util.getManagerOf(o);
             if (!manager) {
-              self.apos.util.warnDevOnce('noManagerForDocInExternalFront', `No manager for: ${o.metaType} ${o.type || ''}`);
+              self.apos.util.warnDevOnce(
+                'noManagerForDocInExternalFront',
+                `No manager for: ${o.metaType} ${o.type || ''}`
+              );
               return;
             }
             const field = manager.schema.find(f => f.name === k);
@@ -1302,6 +1313,19 @@ module.exports = {
             return self.annotateAreaForExternalFront(field, v, { scene });
           }
         });
+        // Add the missing areas after the walk, so we never add keys to an
+        // object while it is being traversed. In memory only - unlike the
+        // `{% area %}` tag we never write to the database during a render.
+        for (const [ o, field ] of missingAreas) {
+          o[field.name] = {
+            metaType: 'area',
+            _id: self.apos.util.generateId(),
+            items: [],
+            _edit: true,
+            _docId: o._docId ?? (o.metaType === 'doc' ? o._id : null)
+          };
+          self.annotateAreaForExternalFront(field, o[field.name], { scene });
+        }
       },
 
       // Annotate an area for easy rendering by an external front end
@@ -1343,6 +1367,13 @@ module.exports = {
             throw self.apos.error('invalid', 'Missing widget type');
           }
         }
+      },
+
+      // The schema area fields of `object` that have no value yet. Returns an
+      // empty array for anything without a schema manager.
+      missingSchemaAreas(object) {
+        const schema = self.apos.util.getManagerOf(object, { log: false })?.schema ?? [];
+        return schema.filter(field => field.type === 'area' && !object[field.name]);
       }
     };
   }

--- a/packages/apostrophe/modules/@apostrophecms/util/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/util/index.js
@@ -724,7 +724,7 @@ module.exports = {
       },
       // Given a widget or doc, return the appropriate manager module. If the manager
       // cannot be determined for any reason, undefined is returned.
-      getManagerOf(object) {
+      getManagerOf(object, { log = true } = {}) {
         if (object.metaType === 'doc') {
           return self.apos.doc.getManager(object.type);
         } else if (object.metaType === 'widget') {
@@ -733,10 +733,10 @@ module.exports = {
           return self.apos.schema.getArrayManager(object.scopedArrayName);
         } else if (object.metaType === 'object') {
           return self.apos.schema.getObjectManager(object.scopedObjectName);
-        } else {
+        } else if (log) {
           self.apos.util.error(`Unsupported metaType in getManagerOf: ${object.metaType}`);
-          return undefined;
         }
+        return undefined;
       },
       // fetch the value at the given path from the object or
       // array `o`. `path` supports dot notation like MongoDB, and

--- a/packages/apostrophe/test/external-front.js
+++ b/packages/apostrophe/test/external-front.js
@@ -17,10 +17,98 @@ describe('External Front', function() {
 
   it('apostrophe should initialize normally', async function() {
     apos = await t.create({
-      root: module
+      root: module,
+      modules: {
+        product: {
+          extend: '@apostrophecms/piece-type',
+          options: {
+            alias: 'product'
+          },
+          fields: {
+            add: {
+              main: {
+                type: 'area',
+                options: {
+                  widgets: {
+                    '@apostrophecms/rich-text': {}
+                  }
+                }
+              },
+              extra: {
+                type: 'area',
+                options: {
+                  widgets: {
+                    '@apostrophecms/rich-text': {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     });
 
     assert(apos.page.__meta.name === '@apostrophecms/page');
+  });
+
+  // A doc as it would look in memory, with `extra` simulating an area field
+  // added to the schema after the doc was created (so it has no value).
+  function productMissingExtra() {
+    const doc = apos.product.newInstance();
+    doc._id = 'product1:en:published';
+    doc.metaType = 'doc';
+    doc.title = 'Product 1';
+    doc.slug = 'product-1';
+    delete doc.extra;
+    return doc;
+  }
+
+  it('missingSchemaAreas returns unfilled area fields, ignores non-schema objects', function() {
+    const missing = apos.template.missingSchemaAreas(productMissingExtra());
+    assert.strictEqual(missing.length, 1);
+    assert.strictEqual(missing[0].name, 'extra');
+
+    // An area object carries `_edit` but has no schema manager: returns []
+    // quietly (getManagerOf called with log: false).
+    const area = {
+      metaType: 'area',
+      _edit: true
+    };
+    assert.deepStrictEqual(apos.template.missingSchemaAreas(area), []);
+  });
+
+  it('annotateDocForExternalFront materializes missing areas on an editable doc', function() {
+    const doc = productMissingExtra();
+    doc._edit = true;
+    // As loaded for an editor, existing areas carry _edit too
+    doc.main._edit = true;
+
+    apos.template.annotateDocForExternalFront(doc);
+
+    // Existing area still annotated, unchanged behavior
+    assert(doc.main.field && doc.main.field.name === 'main');
+    assert(doc.main.options);
+
+    // Missing area added as an empty, editable, annotated area
+    assert(doc.extra, 'extra area was materialized');
+    assert.strictEqual(doc.extra.metaType, 'area');
+    assert.deepStrictEqual(doc.extra.items, []);
+    assert.strictEqual(doc.extra._edit, true);
+    assert.strictEqual(doc.extra._docId, doc._id);
+    assert(doc.extra._id, 'has an id');
+    assert(doc.extra.field && doc.extra.field.name === 'extra');
+    assert(doc.extra.options, 'annotated with options');
+    assert(Array.isArray(doc.extra.choices));
+  });
+
+  it('annotateDocForExternalFront leaves missing areas alone on a non-editable doc', function() {
+    const doc = productMissingExtra();
+
+    apos.template.annotateDocForExternalFront(doc);
+
+    assert.strictEqual(doc.extra, undefined, 'extra not added for anonymous');
+    // Existing area annotated as before
+    assert(doc.main.field && doc.main.field.name === 'main');
   });
 
   it('fetch home with external front', async function() {

--- a/packages/apostrophe/test/external-front.js
+++ b/packages/apostrophe/test/external-front.js
@@ -77,13 +77,13 @@ describe('External Front', function() {
     assert.deepStrictEqual(apos.template.missingSchemaAreas(area), []);
   });
 
-  it('annotateDocForExternalFront materializes missing areas on an editable doc', function() {
+  it('annotateDocForExternalFront materializes missing areas on an editable doc', async function() {
     const doc = productMissingExtra();
     doc._edit = true;
     // As loaded for an editor, existing areas carry _edit too
     doc.main._edit = true;
 
-    apos.template.annotateDocForExternalFront(doc);
+    await apos.template.annotateDocForExternalFront(doc);
 
     // Existing area still annotated, unchanged behavior
     assert(doc.main.field && doc.main.field.name === 'main');
@@ -101,14 +101,72 @@ describe('External Front', function() {
     assert(Array.isArray(doc.extra.choices));
   });
 
-  it('annotateDocForExternalFront leaves missing areas alone on a non-editable doc', function() {
+  it('annotateDocForExternalFront leaves missing areas alone on a non-editable doc', async function() {
     const doc = productMissingExtra();
 
-    apos.template.annotateDocForExternalFront(doc);
+    await apos.template.annotateDocForExternalFront(doc);
 
     assert.strictEqual(doc.extra, undefined, 'extra not added for anonymous');
     // Existing area annotated as before
     assert(doc.main.field && doc.main.field.name === 'main');
+  });
+
+  it('annotateDocForExternalFront persists materialized areas at their schema path with the same _id sent to the UI', async function() {
+    // Insert a doc directly with only `main`, no `extra`, simulating a field
+    // added to the schema after the doc was created.
+    const docId = 'persist-test:en:draft';
+    await apos.doc.db.deleteOne({ _id: docId });
+    await apos.doc.db.insertOne({
+      _id: docId,
+      type: 'product',
+      metaType: 'doc',
+      aposMode: 'draft',
+      aposDocId: 'persist-test',
+      aposLocale: 'en:draft',
+      title: 'Persist Test',
+      slug: 'persist-test',
+      main: {
+        metaType: 'area',
+        _id: 'main-id-persist',
+        items: []
+      }
+    });
+
+    // Load the doc and mark editable (mirroring what doc-type load does)
+    const doc = await apos.doc.db.findOne({ _id: docId });
+    doc._edit = true;
+    doc.main._edit = true;
+
+    await apos.template.annotateDocForExternalFront(doc);
+
+    // In-memory: extra was materialized and annotated
+    assert(doc.extra && doc.extra._id, 'extra has an id in memory');
+    const inMemoryId = doc.extra._id;
+
+    // In the DB: extra was written at the schema path with the same _id, so a
+    // subsequent editor patch using @<inMemoryId>.items will resolve
+    const persisted = await apos.doc.db.findOne({ _id: docId });
+    assert(persisted.extra, 'extra was persisted');
+    assert.strictEqual(persisted.extra.metaType, 'area');
+    assert.deepStrictEqual(persisted.extra.items, []);
+    assert.strictEqual(
+      persisted.extra._id, inMemoryId,
+      'persisted _id matches the one sent to the UI'
+    );
+
+    // Idempotent: a second annotate keeps the same persisted _id (the
+    // $eq: null condition prevents overwrite)
+    const doc2 = await apos.doc.db.findOne({ _id: docId });
+    doc2._edit = true;
+    delete doc2.extra; // simulate the missing-area branch firing again
+    await apos.template.annotateDocForExternalFront(doc2);
+    const persistedAgain = await apos.doc.db.findOne({ _id: docId });
+    assert.strictEqual(
+      persistedAgain.extra._id, inMemoryId,
+      'persisted _id is unchanged on re-annotate'
+    );
+
+    await apos.doc.db.deleteOne({ _id: docId });
   });
 
   it('fetch home with external front', async function() {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:
*Check one*

- [x] main
- [x] latest
- [x] stable

- [x] Check if this PR will be resubmitted against another branch
## Summary

Adding area to a document schema now doesn't crash the existing documents. Improved reporting for orphan areas.

## What are the specific steps to test this change?

- Add new area to a page schema and add `AposArea` tag in the corresponding page template
- Refresh existing document that "doesn't know" about this schema change
- The new area should be in-context and operational
- Remove another area from the page (already saved on that page) and refresh the page
- A banner is shown only for editors only, hinting what the problem is and how to fix it. Annon view just renders nothing. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
