### PR TITLE
Fix relationship select scrolling issue

### DIFF
--- a/.changeset/smart-kids-rest.md
+++ b/.changeset/smart-kids-rest.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": patch
+---
+
+Selecting an item in a relationship "browse" dialog no longer scrolls the title and Cancel/Select buttons out of view when the item is far down the list.

--- a/packages/apostrophe/modules/@apostrophecms/image/ui/apos/components/AposMediaUploader.vue
+++ b/packages/apostrophe/modules/@apostrophecms/image/ui/apos/components/AposMediaUploader.vue
@@ -252,6 +252,9 @@ export default {
     @include apos-transition();
 
     & {
+      // Contain the visually hidden (`.apos-sr-only`, position: absolute)
+      // file input so focusing it does not scroll a distant ancestor.
+      position: relative;
       display: flex;
       box-sizing: border-box;
       align-items: center;

--- a/packages/apostrophe/modules/@apostrophecms/ui/ui/apos/scss/global/_inputs.scss
+++ b/packages/apostrophe/modules/@apostrophecms/ui/ui/apos/scss/global/_inputs.scss
@@ -372,6 +372,8 @@
   @include type-base;
 
   & {
+    // Do not remove - it fixes unintended `sr-only` side effect.
+    position: relative;
     display: flex;
     align-items: center;
     color: var(--a-base-2);


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:
*Check one*

- [x] main
- [x] latest
- [x] stable

- [ ] Check if this PR will be resubmitted against another branch
## Summary

Fixes scrolling issue when choosing relationship that is out of the initial scroll view.

## What are the specific steps to test this change?

- create enough pieces so that there is a scroll in the manager modal
- use the piece in a relation, scroll down and select one
- the modal header should be in tact, no broken scroll issues

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
