### PR TITLE
fix: treat col as a self-closing tag

### DIFF
--- a/.changeset/sixty-hats-kneel.md
+++ b/.changeset/sixty-hats-kneel.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": patch
+---
+
+Fix invalid HTML output for <col> elements in sanitize-html (treat void elements correctly)

--- a/packages/sanitize-html/index.js
+++ b/packages/sanitize-html/index.js
@@ -953,7 +953,7 @@ sanitizeHtml.defaults = {
     'alt'
   ],
   // Lots of these won't come up by default because we don't allow them
-  selfClosing: [ 'img', 'br', 'hr', 'area', 'base', 'basefont', 'input', 'link', 'meta' ],
+  selfClosing: [ 'img', 'br', 'hr', 'area', 'base', 'basefont', 'input', 'link', 'meta', 'col' ],
   // URL schemes we permit
   allowedSchemes: [ 'http', 'https', 'ftp', 'mailto', 'tel' ],
   allowedSchemesByTag: {},

--- a/packages/sanitize-html/test/test.js
+++ b/packages/sanitize-html/test/test.js
@@ -23,6 +23,18 @@ describe('sanitizeHtml', function() {
   it('should pass through simple, well-formed markup', function() {
     assert.equal(sanitizeHtml('<div><p>Hello <b>there</b></p></div>'), '<div><p>Hello <b>there</b></p></div>');
   });
+  it('should preserve col as a self closing tag', function() {
+    assert.equal(
+      sanitizeHtml(
+        '<table><colgroup><col span="2"></colgroup></table>',
+        {
+          allowedTags: false,
+          allowedAttributes: false
+        }
+      ),
+      '<table><colgroup><col span="2" /></colgroup></table>'
+    );
+  });
   it('should not pass through any text outside html tag boundary since html tag is found and option is ON', function() {
     assert.equal(sanitizeHtml('Text before html tag<html><div><p>Hello <b>there</b></p></div></html>Text after html tag!P�X��[<p>paragraph after closing html</p>', {
       enforceHtmlBoundary: true


### PR DESCRIPTION
## Summary

Fixes #5443 by adding `col` to the `selfClosing` tag list.

`<col>` is a void HTML element and should not be serialized with a closing tag. Previously, sanitize-html could output invalid HTML by converting a `<col>` element into `<col></col>`.

### Changes

* Added `col` to the default `selfClosing` tag list.
* Added a regression test covering this behavior.

### Testing

* Added a test that reproduces the issue.
* Verified the test passes after the fix.
* Ran the sanitize-html test suite.
