### PR TITLE
Fix asset URLs when a site prefix is configured

### DIFF
--- a/packages/apostrophe/modules/@apostrophecms/asset/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/asset/index.js
@@ -845,16 +845,17 @@ module.exports = {
       },
       getAssetBaseUrl() {
         const namespace = self.getNamespace();
+        const prefix = self.apos.prefix || '';
         if (self.isProductionMode()) {
           const releaseId = self.getReleaseId();
           const releaseDir = `/apos-frontend/releases/${releaseId}/${namespace}`;
           if (process.env.APOS_UPLOADFS_ASSETS) {
             return `${self.uploadfs.getUrl()}${releaseDir}`;
           } else {
-            return releaseDir;
+            return `${prefix}${releaseDir}`;
           }
         }
-        return `/apos-frontend/${namespace}`;
+        return `${prefix}/apos-frontend/${namespace}`;
       },
       getCacheBasePath() {
         return process.env.APOS_ASSET_CACHE ||

--- a/packages/apostrophe/test/assets.js
+++ b/packages/apostrophe/test/assets.js
@@ -171,6 +171,29 @@ describe('Assets', function() {
 
   this.timeout(5 * 60 * 1000);
 
+  it('should include the site prefix in asset URLs', async function() {
+    let prefixApos;
+
+    try {
+      prefixApos = await t.create({
+        root: module,
+        prefix: '/apos'
+      });
+
+      assert.equal(
+        prefixApos.asset.getAssetBaseUrl(),
+        '/apos/apos-frontend/default'
+      );
+
+      assert.equal(
+        prefixApos.asset.url('/modules/foo/bar.js'),
+        '/apos/apos-frontend/default/modules/foo/bar.js'
+      );
+    } finally {
+      await t.destroy(prefixApos);
+    }
+  });
+
   it('should exist on the apos object', async function() {
     apos = await t.create({
       root: module,


### PR DESCRIPTION
## Summary

Asset URLs generated by `apos.asset.getAssetBaseUrl()` do not include the configured site prefix.

For example, with:

```js
{
  prefix: '/apos'
}
```

the asset base URL currently resolves to:

```
/apos-frontend/default
```

instead of:

```
/apos/apos-frontend/default
```

## Changes

* Add `self.apos.prefix` support to `getAssetBaseUrl()`
* Leave the `APOS_UPLOADFS_ASSETS` branch unchanged because uploadfs already handles URL generation
* Add a regression test in `packages/apostrophe/test/assets.js`

## Example

Before:

```
/apos-frontend/default
```

After:

```
/apos/apos-frontend/default
```
