### PR TITLE
Ensure install of the project root for astro projects

### DIFF
--- a/packages/create-apostrophe/src/core/steps/install.js
+++ b/packages/create-apostrophe/src/core/steps/install.js
@@ -1,6 +1,9 @@
 // Step: install dependencies with npm. Standalone installs once in the app
-// root; an external-frontend project installs in backend/ and frontend/.
-// A non-npm manager is rejected up front. Failure → 'dependency_install'.
+// root; an external-frontend project installs in backend/ and frontend/, and
+// — if the project root ships its own package.json — also at the root (some
+// Astro kits put orchestration deps like `concurrently` there to power a
+// single `npm run dev`). A non-npm manager is rejected up front. Failure →
+// 'dependency_install'.
 
 import { join } from 'node:path';
 import { existsSync } from 'node:fs';
@@ -40,6 +43,9 @@ export async function install(
     const frontendDir = join(projectDir, 'frontend');
     if (existsSync(frontendDir)) {
       dirs.push(frontendDir);
+    }
+    if (existsSync(join(projectDir, 'package.json'))) {
+      dirs.push(projectDir);
     }
   }
 

--- a/packages/create-apostrophe/test/core/install.test.js
+++ b/packages/create-apostrophe/test/core/install.test.js
@@ -88,6 +88,36 @@ describe('core/steps/install', function () {
     ]);
   });
 
+  it('external frontend + root package.json: backend → frontend → root', async function () {
+    // Newer Astro kits ship a root package.json with orchestration deps
+    // (concurrently) so a single `npm run dev` runs both apps. Without
+    // installing the root, `npm run dev` fails with "concurrently: not found".
+    const projectDir = join(dir, 'proj');
+    const appRoot = join(projectDir, 'backend');
+    mkdirSync(appRoot, { recursive: true });
+    mkdirSync(join(projectDir, 'frontend'), { recursive: true });
+    writeFileSync(join(projectDir, 'package.json'), '{}');
+
+    const calls = [];
+    await install(
+      {
+        projectDir,
+        appRoot,
+        frontend: 'astro',
+        packageManager: 'npm'
+      },
+      { run: fakeRunFactory(calls) }
+    );
+
+    // Root install runs LAST so its (potentially redundant) recursion into
+    // workspaces hits an already-warm cache.
+    assert.deepEqual(calls.map((c) => [ c.command, c.cwd ]), [
+      [ 'npm', appRoot ],
+      [ 'npm', join(projectDir, 'frontend') ],
+      [ 'npm', projectDir ]
+    ]);
+  });
+
   it('unknown pm runs npm, reports \'unknown\'', async function () {
     const projectDir = join(dir, 'proj');
     mkdirSync(projectDir, { recursive: true });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

Astro project may have (and it currently has) root level dev dependencies. We now run root npm install as well. 
