### PR TITLE
Literal content automatic registration

### DIFF
--- a/.changeset/apos-literal-content.md
+++ b/.changeset/apos-literal-content.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": minor
+---
+
+Added support for modules to declare *literal content* routes - URLs that serve non-page files such as `robots.txt`, `sitemap.xml`, or `llms.txt` rather than rendered pages. External front-end integrations (such as the Astro integration) can now read these routes and serve such files correctly instead of attempting to render them as pages. Custom modules can contribute their own routes by handling the new `@apostrophecms/url:getLiteralContentRoutes` event.

--- a/.changeset/astro-literal-content.md
+++ b/.changeset/astro-literal-content.md
@@ -1,0 +1,5 @@
+---
+"@apostrophecms/apostrophe-astro": minor
+---
+
+In SSR mode, the integration now automatically serves *literal content* files declared by Apostrophe modules - such as `robots.txt`, `sitemap.xml`, and `llms.txt` - by proxying them directly to Apostrophe instead of rendering them as pages. These files no longer need to be listed individually in the `proxyRoutes` option, which continues to work as before for any additional routes you wish to proxy.

--- a/.changeset/seo-literal-content.md
+++ b/.changeset/seo-literal-content.md
@@ -1,0 +1,5 @@
+---
+"@apostrophecms/seo": minor
+---
+
+The generated `robots.txt` and `llms.txt` files are now declared as *literal content* routes, so external front-end integrations (such as the Astro integration) serve them correctly in SSR mode automatically, with no per-route configuration. Requires a compatible version of Apostrophe core.

--- a/.changeset/sitemap-literal-content.md
+++ b/.changeset/sitemap-literal-content.md
@@ -1,0 +1,5 @@
+---
+"@apostrophecms/sitemap": minor
+---
+
+The generated `sitemap.xml` (or per-locale sitemaps) is now declared as a *literal content* route, so external front-end integrations (such as the Astro integration) serve it correctly in SSR mode automatically, with no per-route configuration. Requires a compatible version of Apostrophe core.

--- a/packages/apostrophe-astro/index.js
+++ b/packages/apostrophe-astro/index.js
@@ -94,7 +94,7 @@ export default function apostropheIntegration(options) {
   return {
     name: 'apostrophe-integration',
     hooks: {
-      "astro:config:setup": async ({ config, injectRoute, updateConfig, injectScript }) => {
+      "astro:config:setup": async ({ config, injectRoute, addMiddleware, updateConfig, injectScript }) => {
         isStaticBuild = config.output === 'static';
         if (!options.widgetsMapping || !options.templatesMapping) {
           throw new Error('Missing required options')
@@ -166,6 +166,13 @@ export default function apostropheIntegration(options) {
         if (isStaticBuild) {
           return;
         }
+        // Runtime literal-content routing: a per-request middleware sends
+        // module-declared literal URLs (robots.txt, sitemap.xml, …) to the raw
+        // proxy instead of the page renderer. Additive to `proxyRoutes` below.
+        addMiddleware({
+          order: 'pre',
+          entrypoint: '@apostrophecms/apostrophe-astro/lib/aposLiteralContentMiddleware.js'
+        });
         const inject = [
           '/apos-frontend/[...slug]',
           '/api/v1/[...slug]',

--- a/packages/apostrophe-astro/lib/aposLiteralContentMiddleware.js
+++ b/packages/apostrophe-astro/lib/aposLiteralContentMiddleware.js
@@ -1,0 +1,100 @@
+// Astro SSR middleware that routes module-declared "literal content" URLs
+// (robots.txt, sitemap.xml, llms.txt, …) straight to Apostrophe via the raw
+// proxy, bypassing the catch-all page renderer - which would `JSON.parse` the
+// non-HTML body and 500.
+//
+// This is the SSR counterpart to the static build's literal-content handling.
+// It is additive: the config-time `proxyRoutes` option is unaffected and keeps
+// working alongside this. Because the decision is made per request, the route
+// list can come from the running backend (unknown at config/startup time).
+//
+// The pattern list is the manifest served by the backend at
+// `/api/v1/@apostrophecms/url/literal-routes` (the
+// `@apostrophecms/url:getLiteralContentRoutes` event). It is fetched lazily on
+// the first request and cached with a TTL, so a newly declared route appears
+// without a frontend restart.
+import { defineMiddleware } from 'astro:middleware';
+import config from 'virtual:apostrophe-config';
+import aposResponse from './aposResponse.js';
+
+// Cache the compiled manifest for this long before refetching.
+// TODO: expose as a config option.
+const TTL_MS = 5 * 60 * 1000;
+// Shorter retry window when a fetch fails, so a briefly-unavailable backend
+// is not hammered on every request.
+const ERROR_TTL_MS = 15 * 1000;
+
+const EXTERNAL_FRONT_KEY = process.env.APOS_EXTERNAL_FRONT_KEY;
+
+let cache = null; // { matchers, expires }
+let inflight = null;
+
+// Compile a prefix-free path pattern to a RegExp.
+// `*` matches within a path segment; `**` matches across segments.
+// A trailing slash is tolerated.
+function toRegExp(pattern) {
+  const source = pattern
+    .replace(/[.+?^${}()|[\]\\]/g, '\\$&') // escape regex metachars
+    .replace(/\*\*/g, ' ') // placeholder for **
+    .replace(/\*/g, '[^/]*') // * stays within a segment
+    .replace(/ /g, '.*'); // ** spans segments
+  return new RegExp(`^${source}/?$`);
+}
+
+async function fetchManifest() {
+  const url = new URL(
+    (config.aposPrefix || '') + '/api/v1/@apostrophecms/url/literal-routes',
+    config.aposHost
+  );
+  const res = await fetch(url, {
+    headers: {
+      'x-requested-with': 'AposExternalFront',
+      'apos-external-front-key': EXTERNAL_FRONT_KEY
+    }
+  });
+  if (!res.ok) {
+    throw new Error(`literal-routes manifest fetch failed (${res.status})`);
+  }
+  const { patterns } = await res.json();
+  return (patterns || []).map(toRegExp);
+}
+
+function getMatchers() {
+  if (cache && cache.expires > Date.now()) {
+    return Promise.resolve(cache.matchers);
+  }
+  if (!inflight) {
+    inflight = fetchManifest()
+      .then((matchers) => {
+        cache = { matchers, expires: Date.now() + TTL_MS };
+        return matchers;
+      })
+      .catch((err) => {
+        // Fail open: no interception until the next retry window. Literal
+        // routes 500 in this state, but normal pages are unaffected.
+        console.error('[apostrophe-astro] literal-content middleware:', err.message);
+        cache = { matchers: [], expires: Date.now() + ERROR_TTL_MS };
+        return cache.matchers;
+      })
+      .finally(() => {
+        inflight = null;
+      });
+  }
+  return inflight;
+}
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  const matchers = await getMatchers();
+  if (matchers.length) {
+    // Patterns are prefix-free; strip Astro `base` / aposPrefix before matching.
+    const prefix = config.aposPrefix || '';
+    let pathname = context.url.pathname;
+    if (prefix && pathname.startsWith(prefix)) {
+      pathname = pathname.slice(prefix.length) || '/';
+    }
+    if (matchers.some((re) => re.test(pathname))) {
+      return aposResponse(context.request);
+    }
+  }
+  return next();
+});

--- a/packages/apostrophe-astro/lib/aposLiteralContentMiddleware.js
+++ b/packages/apostrophe-astro/lib/aposLiteralContentMiddleware.js
@@ -11,23 +11,26 @@
 // The pattern list is the manifest served by the backend at
 // `/api/v1/@apostrophecms/url/literal-routes` (the
 // `@apostrophecms/url:getLiteralContentRoutes` event). It is fetched lazily on
-// the first request and cached with a TTL, so a newly declared route appears
-// without a frontend restart.
+// the first request and kept for the lifetime of the process — the route list
+// is static once the backend is up. A failed fetch is not cached, so it is
+// retried on the next request; this gracefully handles any boot racing conditions.
 import { defineMiddleware } from 'astro:middleware';
 import config from 'virtual:apostrophe-config';
 import aposResponse from './aposResponse.js';
 
-// Cache the compiled manifest for this long before refetching.
-// TODO: expose as a config option.
-const TTL_MS = 5 * 60 * 1000;
-// Shorter retry window when a fetch fails, so a briefly-unavailable backend
-// is not hammered on every request.
-const ERROR_TTL_MS = 15 * 1000;
-
 const EXTERNAL_FRONT_KEY = process.env.APOS_EXTERNAL_FRONT_KEY;
 
-let cache = null; // { matchers, expires }
+// After this many consecutive 404s the endpoint is assumed absent (an
+// Apostrophe version without literal-content support) and the feature is
+// disabled for the lifetime of the process rather than probed on every request.
+const MAX_NOT_FOUND = 5;
+
+// Compiled matchers, fetched once and kept for the lifetime of the process.
+// Stays null until the first successful fetch, so a failed fetch is retried
+// on the next request.
+let cached = null;
 let inflight = null;
+let notFoundCount = 0;
 
 // Compile a prefix-free path pattern to a RegExp.
 // `*` matches within a path segment; `**` matches across segments.
@@ -52,6 +55,11 @@ async function fetchManifest() {
       'apos-external-front-key': EXTERNAL_FRONT_KEY
     }
   });
+  if (res.status === 404) {
+    const err = new Error('literal-routes endpoint not found (404)');
+    err.notFound = true;
+    throw err;
+  }
   if (!res.ok) {
     throw new Error(`literal-routes manifest fetch failed (${res.status})`);
   }
@@ -60,21 +68,32 @@ async function fetchManifest() {
 }
 
 function getMatchers() {
-  if (cache && cache.expires > Date.now()) {
-    return Promise.resolve(cache.matchers);
+  if (cached) {
+    return Promise.resolve(cached);
   }
   if (!inflight) {
     inflight = fetchManifest()
       .then((matchers) => {
-        cache = { matchers, expires: Date.now() + TTL_MS };
+        cached = matchers;
+        notFoundCount = 0;
         return matchers;
       })
       .catch((err) => {
-        // Fail open: no interception until the next retry window. Literal
-        // routes 500 in this state, but normal pages are unaffected.
-        console.error('[apostrophe-astro] literal-content middleware:', err.message);
-        cache = { matchers: [], expires: Date.now() + ERROR_TTL_MS };
-        return cache.matchers;
+        if (err.notFound) {
+          // Disable permanently (until restart).
+          if (++notFoundCount >= MAX_NOT_FOUND) {
+            cached = [];
+            console.error(
+              '[apostrophe-astro] literal-content: endpoint not found after ' +
+              `${notFoundCount} attempts; disabling. Please upgrade your Apostrophe version.`
+            );
+            return cached;
+          }
+        } else {
+          notFoundCount = 0;
+          console.error('[apostrophe-astro] literal-content middleware:', err.message);
+        }
+        return [];
       })
       .finally(() => {
         inflight = null;

--- a/packages/apostrophe/modules/@apostrophecms/url/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/url/index.js
@@ -58,6 +58,25 @@ module.exports = {
     };
   },
 
+  apiRoutes(self) {
+    return {
+      get: {
+        // GET /api/v1/@apostrophecms/url/literal-routes
+        //
+        // Returns `{ patterns: [ ... ] }`.
+        // See the `getLiteralContentRoutes` method.
+        'literal-routes': async (req) => {
+          if (!self.isExternalFront(req)) {
+            throw self.apos.error('forbidden');
+          }
+          return {
+            patterns: await self.getLiteralContentRoutes(req)
+          };
+        }
+      }
+    };
+  },
+
   handlers(self) {
     return {
       '@apostrophecms/page:beforeSend': {
@@ -92,6 +111,41 @@ module.exports = {
       // directly.
       isExternalFront(req) {
         return !!req.aposExternalFront;
+      },
+
+      // Returns the list of "literal content" route patterns declared by
+      // modules — URLs that serve non-page content (e.g. `/robots.txt`,
+      // `/sitemap.xml`, `/sitemaps/*`) and must be proxied raw by an external
+      // front rather than routed through its page renderer.
+      //
+      // Emits `@apostrophecms/url:getLiteralContentRoutes`; handlers in any
+      // module push prefix-free path patterns onto the `patterns` array
+      // (exact like `/robots.txt`, or glob like `/sitemaps/*`). Patterns are
+      // declared unconditionally and independent of `req`: the consumer only
+      // needs to know "this path is literal content", and a pattern that 404s
+      // is harmless. This differs from `getAllUrlMetadata`, which enumerates
+      // exact, existing URLs per locale for static builds and sitemaps.
+      //
+      // Example module level implementation:
+      // ```js
+      // handlers(self) {
+      //   return {
+      //     '@apostrophecms/url:getLiteralContentRoutes': {
+      //       addSitemapRoutes(req, patterns) {
+      //         patterns.push('/sitemap.xml');
+      //         if (self.options.perLocale) {
+      //           patterns.push('/sitemaps/*');
+      //         }
+      //       }
+      //     }
+      //   };
+      // }
+      // ```
+      //
+      async getLiteralContentRoutes(req) {
+        const patterns = [];
+        await self.emit('getLiteralContentRoutes', req, patterns);
+        return [ ...new Set(patterns) ];
       },
 
       // Returns the effective base URL for the given request.

--- a/packages/seo/modules/@apostrophecms/seo-fields-global/index.js
+++ b/packages/seo/modules/@apostrophecms/seo-fields-global/index.js
@@ -413,6 +413,12 @@ module.exports = {
             });
           }
         }
+      },
+      '@apostrophecms/url:getLiteralContentRoutes': {
+        addSeoRoutes(req, patterns) {
+          patterns.push('/robots.txt');
+          patterns.push('/llms.txt');
+        }
       }
     };
   },

--- a/packages/sitemap/index.js
+++ b/packages/sitemap/index.js
@@ -115,6 +115,12 @@ module.exports = {
             });
           }
         }
+      },
+      '@apostrophecms/url:getLiteralContentRoutes': {
+        addSitemapRoutes(req, patterns) {
+          patterns.push('/sitemap.xml');
+          patterns.push('/sitemaps/*');
+        }
       }
     };
   },


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:
*Check one*

- [x] main
- [x] latest
- [ ] stable

- [ ] Check if this PR will be resubmitted against another branch
## Summary

Allow literal content routes like `/robots.txt` to be exposed by their respective owning modules and auto-registered and handled in Apostrophe Astro. 

## What are the specific steps to test this change?

URLs like `/sitemap.xml`, `/robots.txt` are properly resolved (when their respective modules are enabled in the backend) without any project level configuration. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
