### PR TITLE
Bump undici and fix a leak

### DIFF
--- a/.changeset/old-seals-accept.md
+++ b/.changeset/old-seals-accept.md
@@ -1,0 +1,5 @@
+---
+"@apostrophecms/apostrophe-astro": minor
+---
+
+Upgraded the `undici` HTTP client from v6 to v8, which requires Node.js 22.19 or newer, and fixed a connection leak in the Astro proxy where responses that are not streamed on to the browser — redirects (301/302/307/308) and bodyless responses (204/304) — now release their backend response body immediately instead of leaving it for garbage collection, which under load could hold connections open and exhaust the connection pool.

--- a/packages/apostrophe-astro/lib/aposResponse.js
+++ b/packages/apostrophe-astro/lib/aposResponse.js
@@ -76,8 +76,12 @@ export default async function aposResponse(req) {
 
     const { headers, statusCode, ...rest } = res;
 
-    // Handle empty responses (status codes that should not have bodies)
-    if ([204, 304].includes(statusCode)) {
+    // Statuses whose body we never send to the client: 204/304 carry none,
+    // and redirects (301/302/307/308) become a fresh Astro redirect built
+    // from the Location header in aposProxy. Dump the undici body so its
+    // socket returns to the pool instead of being held open until GC.
+    if ([204, 304, 301, 302, 307, 308].includes(statusCode)) {
+      await res.body.dump().catch(() => {});
       return new Response(null, { ...rest, status: statusCode, headers: responseHeaders });
     }
 

--- a/packages/apostrophe-astro/package.json
+++ b/packages/apostrophe-astro/package.json
@@ -15,6 +15,6 @@
   "dependencies": {
     "lodash.deburr": "^4.1.0",
     "sluggo": "^1.0.0",
-    "undici": "^6.24.0"
+    "undici": "^8.5.0"
   }
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:
*Check one*

- [x] main
- [x] latest
- [x] stable

- [ ] Check if this PR will be resubmitted against another branch
## Summary

Upgraded the `undici` HTTP client from v6 to v8, which requires Node.js 22.19 or newer, and fixed a connection leak in the Astro proxy where responses that are not streamed on to the browser - redirects (301/302/307/308) and bodyless responses (204/304) - now release their backend response body immediately instead of leaving it for garbage collection, which under load could hold connections open and exhaust the connection pool.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
