### PR TITLE
fix: remove potential XSS vector in anchors widget

### DIFF
--- a/packages/anchors/modules/@apostrophecms/anchors-widget-type/index.js
+++ b/packages/anchors/modules/@apostrophecms/anchors-widget-type/index.js
@@ -24,8 +24,15 @@ module.exports = {
 
         if (widget.anchorId && self.options.anchors !== false) {
           // Apply a wrapper div with the anchor attribute.
-          const attr = self.options.anchorAttribute || 'id';
-          const opener = `<div ${attr}=${widget.anchorId}>`;
+          // Sanitize attribute name to a whitelist
+          let attr = self.options.anchorAttribute || 'id';
+          if (![ 'id', 'name', 'data-anchor' ].includes(attr)) {
+            attr = 'id';
+          }
+
+          // Escape the anchorId to prevent XSS
+          const escapedId = self.apos.util.escapeHtml(widget.anchorId);
+          const opener = `<div ${attr}="${escapedId}">`;
 
           return opener + rendered + '</div>';
         } else {


### PR DESCRIPTION
The anchors widget output method was directly interpolating `widget.anchorId` into an HTML attribute without sanitization. If a user was able to control the `anchorId` value, they could inject arbitrary HTML attributes, leading to a cross-site scripting (XSS) vulnerability. The fix escapes the `widget.anchorId` value before inserting it into the `div` element, ensuring it is treated as a plain string. Additionally, the attribute name is now checked against a whitelist to prevent injection into the attribute name itself.