### PR TITLE
Fix media manager tags cap, dedup tags

### DIFF
--- a/.changeset/thick-ideas-arrive.md
+++ b/.changeset/thick-ideas-arrive.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": minor
+---
+
+Fixed the tag popover in the media library (used to apply tags to images in bulk) so it loads all image tags instead of only the first 50. Tags beyond the first 50 can now be found and applied, and creating a tag whose name already exists no longer produces a duplicate. The number of tags loaded into the popover is configurable via the new `tagPickerPerPage` option on the `@apostrophecms/image` module (default `400`).

--- a/packages/apostrophe/modules/@apostrophecms/image/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/image/index.js
@@ -22,6 +22,9 @@ module.exports = {
     pluralLabel: 'apostrophe:images',
     alias: 'image',
     perPage: 50,
+    // How many image tags to load into the batch-tag popover at once. Raise it
+    // for sites with an unusually large number of tags.
+    tagPickerPerPage: 400,
     sort: { createdAt: -1 },
     quickCreate: false,
     insertViaUpload: true,
@@ -333,15 +336,24 @@ module.exports = {
         });
 
         const imageTagManager = self.apos.doc.getManager('@apostrophecms/image-tag');
-        const tag = (operation === 'create')
-          ? await imageTagManager.insert(
-            req,
-            {
+        let tag;
+        if (operation === 'create') {
+          // Reuse an existing tag with the same slug instead of inserting a
+          // duplicate.
+          const desiredSlug = self.apos.util.slugify(title);
+          const lockName = `@apostrophecms/image-tag:create:${req.locale}:${desiredSlug}`;
+          tag = await self.apos.lock.withLock(lockName, async () => {
+            const existing = await imageTagManager
+              .find(req, { slug: desiredSlug })
+              .toObject();
+            return existing || imageTagManager.insert(req, {
               ...imageTagManager.newInstance(),
               title
-            }
-          )
-          : await imageTagManager.find(req, { slug }).toObject();
+            });
+          });
+        } else {
+          tag = await imageTagManager.find(req, { slug }).toObject();
+        }
 
         return self.apos.modules['@apostrophecms/job'].runBatch(
           req,
@@ -725,6 +737,7 @@ module.exports = {
       getBrowserData(_super, req) {
         const data = _super(req);
         data.components.managerModal = 'AposMediaManager';
+        data.tagPickerPerPage = self.options.tagPickerPerPage;
         return data;
       }
     };

--- a/packages/apostrophe/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
+++ b/packages/apostrophe/modules/@apostrophecms/image/ui/apos/components/AposMediaManager.vue
@@ -823,7 +823,8 @@ export default {
             qs: {
               sort: {
                 title: 1
-              }
+              },
+              perPage: this.moduleOptions.tagPickerPerPage
             }
           }
         );

--- a/packages/apostrophe/test/image-tags.js
+++ b/packages/apostrophe/test/image-tags.js
@@ -1,0 +1,103 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert/strict');
+
+describe('Image tags', function() {
+
+  let apos;
+  let jar;
+
+  this.timeout(t.timeout);
+
+  // Initialization, not a test: boot apostrophe and log in an admin, so any
+  // single test below can run in isolation (e.g. with `.only`).
+  before(async function() {
+    apos = await t.create({
+      root: module
+    });
+    assert(apos.image);
+    assert(apos.modules['@apostrophecms/image-tag']);
+
+    const user = apos.user.newInstance();
+    Object.assign(user, {
+      title: 'admin',
+      username: 'admin',
+      password: 'admin',
+      email: 'ad@min.com',
+      role: 'admin'
+    });
+    await apos.user.insert(apos.task.getReq(), user);
+    jar = await login('admin');
+  });
+
+  after(function() {
+    return t.destroy(apos);
+  });
+
+  it('should reuse an existing tag instead of creating a duplicate', async function() {
+    const manager = apos.modules['@apostrophecms/image-tag'];
+    // A tag the editor's popover would not necessarily have loaded.
+    const existing = await manager.insert(apos.task.getReq(), {
+      ...manager.newInstance(),
+      title: 'Reused Tag'
+    });
+
+    const response = await tagCreate('Reused Tag');
+    assert(response.jobId);
+
+    const ids = await distinctTagIds('Reused Tag');
+    assert.equal(ids.length, 1, 'exactly one image-tag for the title');
+    assert.equal(ids[0], existing.aposDocId, 'the existing tag was reused');
+  });
+
+  it('should not create duplicates under concurrent create requests', async function() {
+    const title = 'Concurrent Tag';
+
+    await Promise.all([
+      tagCreate(title),
+      tagCreate(title)
+    ]);
+
+    const ids = await distinctTagIds(title);
+    assert.equal(ids.length, 1, 'exactly one image-tag despite concurrent creates');
+  });
+
+  // The `tag` route runs the find-or-create before the (here empty) batch
+  // job, so no images are needed to exercise it.
+  async function tagCreate(title) {
+    return apos.http.post('/api/v1/@apostrophecms/image/tag', {
+      body: {
+        _ids: [],
+        operation: 'create',
+        title
+      },
+      jar
+    });
+  }
+
+  async function distinctTagIds(title) {
+    const docs = await apos.doc.db
+      .find({
+        type: '@apostrophecms/image-tag',
+        title
+      })
+      .toArray();
+    return [ ...new Set(docs.map(doc => doc.aposDocId)) ];
+  }
+
+  async function login(username, password = username) {
+    const loginJar = apos.http.jar();
+    let page = await apos.http.get('/', { jar: loginJar });
+    assert(page.match(/logged out/));
+    await apos.http.post('/api/v1/@apostrophecms/login/login', {
+      body: {
+        username,
+        password,
+        session: true
+      },
+      jar: loginJar
+    });
+    page = await apos.http.get('/', { jar: loginJar });
+    assert(page.match(/logged in/));
+    return loginJar;
+  }
+});


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:

*Check one*
- [x] main
- [x] latest
- [ ] stable
- [ ] Check if this PR will be resubmitted against another branch

> Note: Node 26 test failing is irrelevant to this change, it should be handled in a separate ticket/PR

## Summary

Remove the tag cap listed in the batch popover (Media Manager), 50 by default (pieces default). Create a new option `tagPickerPerPage` to let project devs decide the cap. Ensure tag-dedup by slug when creating one via server side locks - existing tags are silently reused.

A simple solution to avoid over engineering (server side search, infinite scrolling, etc).

## What are the specific steps to test this change?

- Create 50+ tags
- Open the tag batch operation in Media manager
- All tags are present and searchable
- Open new tab and add a tag
- Switch back to the original tab and attempt to create and assign the same named tag in the media manager batch operation popover
- No duplicates (the existing tag is used and assigned to the selected images)

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
