### PR TITLE
feat: clarify that permission settings apply across all locales

### DIFF
--- a/packages/apostrophe/modules/@apostrophecms/i18n/i18n/en.json
+++ b/packages/apostrophe/modules/@apostrophecms/i18n/i18n/en.json
@@ -387,7 +387,7 @@
   "mediaMB": "{{ size }}MB",
   "mediaManagerErrorRestoring": "Error Restoring",
   "mediaManagerErrorSaving": "Error Saving",
-  "mediaUploadViaDrop": "Drop ’em when you’re ready",
+  "mediaUploadViaDrop": "Drop 'em when you're ready",
   "mediaUploadViaExplorer": "Or click to open the file explorer",
   "mergeCells": "Merge Cells",
   "menu": "Menu",
@@ -430,8 +430,8 @@
   "notFoundPageMessage": "We can't seem to find the page you're looking for.",
   "notFoundPageStatusCode": "404",
   "notFoundPageTitle": "404 - Page not found",
-  "notInLocale": "The current page doesn’t exist in {{ label }}. Localize the version from {{ currentLocale }}?",
-  "notInLocaleDoc": "The current {{ docType }} doesn’t exist in {{ label }}. Localize the version from {{ currentLocale }}?",
+  "notInLocale": "The current page doesn't exist in {{ label }}. Localize the version from {{ currentLocale }}?",
+  "notInLocaleDoc": "The current {{ docType }} doesn't exist in {{ label }}. Localize the version from {{ currentLocale }}?",
   "notYetPublished": "This document hasn't been published yet.",
   "notificationClearEventError": "There was an error clearing a registered notification event.",
   "nudgeDown": "Nudge Down",
@@ -774,5 +774,6 @@
   "yesLocalizeAndSwitchLocales": "Yes, localize this page and switch locales",
   "yesLocalizeAndSwitchLocalesDoc": "Yes, localize this {{ docType }} and switch locales",
   "youTookControl": "You took control of this document in another tab or window. A document can only be edited in one place at a time.",
-  "yourDevice": "your device"
+  "yourDevice": "your device",
+  "permissionsApplyToAllLocales": "Note: Permission settings apply across all locales and cannot be set independently per locale."
 }

--- a/packages/apostrophe/modules/@apostrophecms/permission/ui/apos/components/AposPermissionGrid.vue
+++ b/packages/apostrophe/modules/@apostrophecms/permission/ui/apos/components/AposPermissionGrid.vue
@@ -1,5 +1,13 @@
 <template>
   <div class="apos-input__role__permission-grid">
+    <div class="apos-input__role__permission-grid__notice">
+      <AposIndicator
+        icon="information-icon"
+        :icon-size="14"
+        icon-color="var(--a-base-4)"
+      />
+      <span>{{ $t('apostrophe:permissionsApplyToAllLocales') }}</span>
+    </div>
     <div
       v-for="permissionSet in permissionSets"
       :key="permissionSet.name"
@@ -92,20 +100,11 @@ export default {
   watch: {
     apiParams: {
       async handler(newValue, oldValue) {
-        // The way we pass the props to this component as an object every
-        // means that everything gets flagged as a change every time the
-        // component is included in a render.
-        //
-        // So we need to compare the actual data, and this is a simple way
-        // to do that deeply for both regular and advanced permission.
         if (JSON.stringify(newValue) === JSON.stringify(oldValue)) {
           return;
         }
         this.permissionSets = await this.getPermissionSets();
       },
-      // Still in place in case we stop passing a new object
-      // every time, in which case this wouldn't fire
-      // without it. -Tom
       deep: true
     }
   },
@@ -156,6 +155,20 @@ export default {
       margin-top: $spacing-triple;
       grid-template-columns: repeat(auto-fit, minmax(50%, 1fr));
     }
+  }
+
+  .apos-input__role__permission-grid__notice {
+    display: flex;
+    align-items: center;
+    gap: $spacing-half;
+    grid-column: 1 / -1;
+    margin-bottom: $spacing-base;
+    padding: $spacing-half $spacing-base;
+    background-color: var(--a-base-10);
+    border-left: 3px solid var(--a-base-4);
+    border-radius: 3px;
+    color: var(--a-base-2);
+    font-size: var(--a-type-small);
   }
 
   .apos-input__role__permission-grid__row {


### PR DESCRIPTION
<!-- Please don't delete this template -->
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:
*Check one*

- [x] main
- [ ] latest
- [ ] stable
- [ ] Check if this PR will be resubmitted against another branch

## Summary

Closes #3452

Added a notice banner in the `AposPermissionGrid` component to clearly inform users that permission settings apply across all locales and cannot be set independently per locale. Also added the corresponding i18n translation key `permissionsApplyToAllLocales` to the English translation file.

## What are the specific steps to test this change?

> 1. Run the website and log in as an admin
> 2. Go to any page settings
> 3. Click on the Permissions tab
> 4. A notice banner will appear at the top informing the user that permission settings apply across all locales

## What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

**Other information:**
This change improves UX by making it clear to users that page permission settings are global across all locales, addressing the confusion reported in issue #3452.
