### PR TITLE
Migrate node-fetch to built-in fetch (undici)

### DIFF
--- a/.changeset/pro-9597-fetch-apostrophe.md
+++ b/.changeset/pro-9597-fetch-apostrophe.md
@@ -4,6 +4,8 @@
 
 The server-side HTTP client (`apos.http`) now uses Node's built-in `fetch` instead of `node-fetch`.
 
+`node-fetch` is no longer maintained, and Node's built-in `fetch` is its standard, actively maintained successor, available in every Node.js version Apostrophe supports - so this is the right time to adopt it. We do not consider this a breaking change: common `apos.http.*` usage is unchanged, and we deliberately preserved compatibility where it mattered - `form-data` request bodies, cookie jars, the `timeout` option (now backed by an `AbortSignal`), and absolute redirect `Location` headers all behave as before.
+
 Most code that calls `apos.http.get()`, `apos.http.post()`, etc. needs no changes. A few things to be aware of if you use advanced options or read raw responses:
 
 - The `agent` option is no longer supported (the built-in `fetch` has no equivalent). Pass an undici `dispatcher` instead; `apos.http` throws if `agent` is given.

--- a/.changeset/pro-9597-fetch-apostrophe.md
+++ b/.changeset/pro-9597-fetch-apostrophe.md
@@ -1,0 +1,17 @@
+---
+"apostrophe": minor
+---
+
+The server-side HTTP client (`apos.http`) now uses Node's built-in `fetch` instead of `node-fetch`.
+
+Most code that calls `apos.http.get()`, `apos.http.post()`, etc. needs no changes. A few things to be aware of if you use advanced options or read raw responses:
+
+- The `agent` option is no longer supported (the built-in `fetch` has no equivalent). Pass an undici `dispatcher` instead; `apos.http` throws if `agent` is given.
+- A `Host` request header can no longer be set (it is disallowed by the fetch standard and is silently ignored).
+- `originalResponse: true` now resolves with the built-in `fetch` `Response`. Its `body` is a web `ReadableStream` (use `require('node:stream').Readable.fromWeb()` to read it as a Node stream), and node-fetch-only helpers such as `.buffer()` are no longer available.
+- Requests that send a conditional header (`If-None-Match` / `If-Modified-Since`) now also send `Cache-Control: no-cache`, as required by the fetch standard. An endpoint that returns `304 Not Modified` based on those headers may return `200` to such a request.
+
+New capabilities:
+
+- The `timeout` option (in milliseconds) and the standard `signal` (`AbortSignal`) and undici `dispatcher` options are supported.
+- A request `body` may be a native `FormData`, in addition to a `form-data` package instance.

--- a/.changeset/pro-9597-fetch-oembetter.md
+++ b/.changeset/pro-9597-fetch-oembetter.md
@@ -1,0 +1,5 @@
+---
+"oembetter": patch
+---
+
+Replaced the `node-fetch` dependency with Node's built-in `fetch`. This is an internal change with no effect on the public API.

--- a/.changeset/yummy-buckets-fly.md
+++ b/.changeset/yummy-buckets-fly.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": patch
+---
+
+Batch jobs now reliably record their total item count, so completion notifications no longer occasionally report a null total.

--- a/packages/apostrophe/modules/@apostrophecms/http/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/http/index.js
@@ -1,9 +1,9 @@
 const _ = require('lodash');
 const qs = require('qs');
-const fetch = require('node-fetch');
 const tough = require('tough-cookie');
 const escapeHost = require('../../../lib/escape-host.js');
 const util = require('util');
+const { PassThrough } = require('node:stream');
 
 module.exports = {
   options: {
@@ -53,160 +53,151 @@ module.exports = {
         self.errors[name] = code;
       },
 
-      // Fetch the given URL and return the response body. Accepts the
-      // following options:
-      //
-      // `qs` (builds a query string with qs)
-      // `jar` (pass in a cookie jar obtained from apos.http.jar())
-      // `parse` (can be 'json` to always parse the response body as JSON,
-      // otherwise the response body is parsed as JSON only if the content-type
-      // is application/json) `headers` (an object containing header names and
-      // values) `fullResponse` (if true, return an object with `status`,
-      // `headers` and `body` properties, rather than returning the body
-      // directly; the individual `headers` are canonicalized to lowercase
-      // names. If a header appears multiple times an array is returned for it)
-      //
-      // If the status code is >= 400 an error is thrown. The error object will
-      // be similar to a `fullResponse` object, with a `status` property.
-      //
-      // If the URL is site-relative (starts with /) it will be requested from
-      // the apostrophe site itself.
+      /**
+       * Options accepted by the `apos.http.*` request methods. Any additional
+       * properties are passed through to the built-in `fetch` as-is (e.g.
+       * `redirect`, `signal`).
+       *
+       * @typedef {object} AposHttpOptions
+       * @property {object} [qs] Query-string parameters, serialized with `qs`
+       *   and appended to the URL.
+       * @property {object} [jar] A cookie jar from `apos.http.jar()`. Its
+       *   cookies are sent with the request, and any `Set-Cookie` in the
+       *   response is stored back into the jar.
+       * @property {'json'|'form'} [send] Force body encoding: `'json'` sends
+       *   `body` JSON-encoded, `'form'` sends it URL-encoded.
+       * @property {*} [body] Request body. A plain object or array is sent as
+       *   JSON; a `FormData` (the global or a `form-data` instance) is sent as
+       *   multipart; otherwise sent as-is. See `send` to force encoding.
+       * @property {'json'} [parse] Always parse the response body as JSON.
+       *   Without it, the body is parsed as JSON only when the response
+       *   content-type is `application/json`.
+       * @property {Object<string, string>} [headers] Request header names and
+       *   values. Per the fetch standard a `Host` header cannot be set.
+       * @property {boolean} [fullResponse] Resolve with `{ status, headers,
+       *   body }` instead of the body alone. Header names are lowercased; a
+       *   header seen multiple times is comma-joined.
+       * @property {boolean} [originalResponse] Resolve with the raw built-in
+       *   fetch `Response`. Its `body` is a WHATWG `ReadableStream` (use
+       *   `Readable.fromWeb()` to consume it as a Node stream).
+       * @property {number} [timeout] Per-request timeout in milliseconds,
+       *   applied via `AbortSignal.timeout`. A falsy value means no timeout.
+       * @property {AbortSignal} [signal] Abort signal; combined with `timeout`
+       *   when both are given.
+       * @property {object} [dispatcher] An undici `Dispatcher` (e.g. a proxy or
+       *   custom-TLS agent). Replaces the former node-fetch `agent` option.
+       */
 
+      /**
+       * Make a GET request and resolve with the response body.
+       *
+       * If the URL is site-relative (starts with `/`) it is requested from the
+       * apostrophe site itself. Throws if the status code is >= 400; the error
+       * resembles a `fullResponse` object with a `status` property.
+       *
+       * @param {string} url
+       * @param {AposHttpOptions} [options]
+       * @returns {Promise<*>} The response body, or a `fullResponse` /
+       *   `originalResponse` object when those options are set.
+       */
       async get(url, options) {
         return self.remote('GET', url, options);
       },
 
-      // Make a HEAD request for the given URL and return the response object,
-      // which will include a `status` property as well as `headers`.
-      //
-      // Options:
-      //
-      // `qs` (builds a query string with qs)
-      // `jar` (pass in a cookie jar obtained from apos.http.jar())
-      // `headers` (an object containing header names and values)
-      //
-      // If the status code is >= 400 an error is thrown. The error object
-      // will have a `status` property.
-      //
-      // If the URL is site-relative (starts with /) it will be requested from
-      // the apostrophe site itself.
-
+      /**
+       * Make a HEAD request. Resolves with the (empty) response body; pass
+       * `fullResponse: true` to read the `status` and `headers`.
+       *
+       * If the URL is site-relative (starts with `/`) it is requested from the
+       * apostrophe site itself. Throws if the status code is >= 400.
+       *
+       * @param {string} url
+       * @param {AposHttpOptions} [options]
+       * @returns {Promise<*>}
+       */
       async head(url, options) {
         return self.remote('HEAD', url, options);
       },
 
-      // Send a POST request to the given URL and return the response body.
-      // Accepts the following options:
-      //
-      // `qs` (pass object; builds a query string with qs)
-      // `jar` (pass in a cookie jar obtained from apos.http.jar())
-      // `send` (can be 'json' to always send `options.body` JSON encoded, or
-      // 'form' to send it URL-encoded) `body` (request body; if an object or
-      // array, sent as JSON, otherwise sent as-is, unless the `send` option is
-      // set) `parse` (can be 'json` to always parse the response body as JSON,
-      // otherwise the response body is parsed as JSON only if the content-type
-      // is application/json) `headers` (an object containing header names and
-      // values) `fullResponse` (if true, return an object with `status`,
-      // `headers` and `body` properties, rather than returning the body
-      // directly; the individual `headers` are canonicalized to lowercase
-      // names. If a header appears multiple times an array is returned for it)
-      //
-      // If the status code is >= 400 an error is thrown. The error object will
-      // be similar to a `fullResponse` object, with a `status` property.
-      //
-      // If the URL is site-relative (starts with /) it will be requested from
-      // the apostrophe site itself.
-
+      /**
+       * Send a POST request and resolve with the response body.
+       *
+       * If the URL is site-relative (starts with `/`) it is requested from the
+       * apostrophe site itself. Throws if the status code is >= 400; the error
+       * resembles a `fullResponse` object with a `status` property.
+       *
+       * @param {string} url
+       * @param {AposHttpOptions} [options]
+       * @returns {Promise<*>} The response body, or a `fullResponse` /
+       *   `originalResponse` object when those options are set.
+       */
       async post(url, options) {
         return self.remote('POST', url, options);
       },
 
-      // Send a DELETE request to the given URL and return the response body.
-      // Accepts the following options:
-      //
-      // `qs` (pass object; builds a query string with qs)
-      // `jar` (pass in a cookie jar obtained from apos.http.jar())
-      // `send` (can be 'json' to always send `options.body` JSON encoded, or
-      // 'form' to send it URL-encoded) `body` (request body; if an object or
-      // array, sent as JSON, otherwise sent as-is, unless the `send` option is
-      // set) `parse` (can be 'json` to always parse the response body as JSON,
-      // otherwise the response body is parsed as JSON only if the content-type
-      // is application/json) `headers` (an object containing header names and
-      // values) `fullResponse` (if true, return an object with `status`,
-      // `headers` and `body` properties, rather than returning the body
-      // directly; the individual `headers` are canonicalized to lowercase
-      // names. If a header appears multiple times an array is returned for it)
-      //
-      // If the status code is >= 400 an error is thrown. The error object will
-      // be similar to a `fullResponse` object, with a `status` property.
-      //
-      // If the URL is site-relative (starts with /) it will be requested from
-      // the apostrophe site itself.
-
+      /**
+       * Send a DELETE request and resolve with the response body.
+       *
+       * If the URL is site-relative (starts with `/`) it is requested from the
+       * apostrophe site itself. Throws if the status code is >= 400; the error
+       * resembles a `fullResponse` object with a `status` property.
+       *
+       * @param {string} url
+       * @param {AposHttpOptions} [options]
+       * @returns {Promise<*>} The response body, or a `fullResponse` /
+       *   `originalResponse` object when those options are set.
+       */
       async delete(url, options) {
         return self.remote('DELETE', url, options);
       },
 
-      // Send a PUT request to the given URL and return the response body.
-      // Accepts the following options:
-      //
-      // `qs` (pass object; builds a query string with qs)
-      // `jar` (pass in a cookie jar obtained from apos.http.jar())
-      // `send` (can be 'json' to always send `options.body` JSON encoded, or
-      // 'form' to send it URL-encoded) `body` (request body; if an object or
-      // array, sent as JSON, otherwise sent as-is, unless the `send` option is
-      // set) `parse` (can be 'json` to always parse the response body as JSON,
-      // otherwise the response body is parsed as JSON only if the content-type
-      // is application/json) `headers` (an object containing header names and
-      // values) `fullResponse` (if true, return an object with `status`,
-      // `headers` and `body` properties, rather than returning the body
-      // directly; the individual `headers` are canonicalized to lowercase
-      // names. If a header appears multiple times an array is returned for it)
-      //
-      // If the status code is >= 400 an error is thrown. The error object will
-      // be similar to a `fullResponse` object, with a `status` property.
-      //
-      // If the URL is site-relative (starts with /) it will be requested from
-      // the apostrophe site itself.
-
+      /**
+       * Send a PUT request and resolve with the response body.
+       *
+       * If the URL is site-relative (starts with `/`) it is requested from the
+       * apostrophe site itself. Throws if the status code is >= 400; the error
+       * resembles a `fullResponse` object with a `status` property.
+       *
+       * @param {string} url
+       * @param {AposHttpOptions} [options]
+       * @returns {Promise<*>} The response body, or a `fullResponse` /
+       *   `originalResponse` object when those options are set.
+       */
       async put(url, options) {
         return self.remote('PUT', url, options);
       },
 
-      // Send a PATCH request to the given URL and return the response body.
-      // Accepts the following options:
-      //
-      // `qs` (pass object; builds a query string with qs)
-      // `jar` (pass in a cookie jar obtained from apos.http.jar())
-      // `send` (can be 'json' to always send `options.body` JSON encoded, or
-      // 'form' to send it URL-encoded) `body` (request body; if an object or
-      // array, sent as JSON, otherwise sent as-is, unless the `send` option is
-      // set) `parse` (can be 'json` to always parse the response body as JSON,
-      // otherwise the response body is parsed as JSON only if the content-type
-      // is application/json) `headers` (an object containing header names and
-      // values) `fullResponse` (if true, return an object with `status`,
-      // `headers` and `body` properties, rather than returning the body
-      // directly; the individual `headers` are canonicalized to lowercase
-      // names. If a header appears multiple times an array is returned for it)
-      // `originalResponse` (if true, return the response object exactly as it
-      // is returned by node-fetch)
-      //
-      // If the status code is >= 400 an error is thrown. The error object will
-      // be similar to a `fullResponse` object, with a `status` property.
-      //
-      // If the URL is site-relative (starts with /) it will be requested from
-      // the apostrophe site itself.
-
+      /**
+       * Send a PATCH request and resolve with the response body.
+       *
+       * If the URL is site-relative (starts with `/`) it is requested from the
+       * apostrophe site itself. Throws if the status code is >= 400; the error
+       * resembles a `fullResponse` object with a `status` property.
+       *
+       * @param {string} url
+       * @param {AposHttpOptions} [options]
+       * @returns {Promise<*>} The response body, or a `fullResponse` /
+       *   `originalResponse` object when those options are set.
+       */
       async patch(url, options) {
         return self.remote('PATCH', url, options);
       },
 
-      // Invoke a remote HTTP API with the named method. Use .get, .post, etc.
-      // This is an implementation method invoked by these
-      //
-      // If the URL is site-relative (starts with /) it will be requested from
-      // the apostrophe site itself.
-
+      /**
+       * Invoke a remote HTTP API with the given method. The implementation
+       * behind `get`, `post`, `put`, `patch`, `delete` and `head` — prefer
+       * those.
+       *
+       * If the URL is site-relative (starts with `/`) it is requested from the
+       * apostrophe site itself. Throws if the status code is >= 400; the error
+       * resembles a `fullResponse` object with a `status` property.
+       *
+       * @param {string} method HTTP method, e.g. `'GET'`.
+       * @param {string} url
+       * @param {AposHttpOptions} [options]
+       * @returns {Promise<*>} The response body, or a `fullResponse` /
+       *   `originalResponse` object when those options are set.
+       */
       async remote(method, url, options) {
         let awaitedBody = false;
         if (!options) {
@@ -216,6 +207,24 @@ module.exports = {
           ...options,
           method
         };
+        // `agent` was a node-fetch option with no equivalent in the built-in
+        // fetch: an http.Agent is not an undici Dispatcher. Fail loudly rather
+        // than silently ignore a proxy/TLS/keep-alive intention. Power users
+        // can pass an undici `dispatcher` instead, which fetch accepts as-is.
+        if (options.agent) {
+          throw new Error('apos.http no longer supports the `agent` option (the built-in fetch has no equivalent). Pass an undici `dispatcher` instead.');
+        }
+        // `timeout` was a node-fetch option; the built-in fetch uses an
+        // AbortSignal. Translate it to preserve the behavior, combining it with
+        // any caller-supplied signal. As with node-fetch, a falsy timeout (0,
+        // undefined) means "no timeout".
+        if (options.timeout) {
+          const timeoutSignal = AbortSignal.timeout(options.timeout);
+          options.signal = options.signal
+            ? AbortSignal.any([ options.signal, timeoutSignal ])
+            : timeoutSignal;
+          delete options.timeout;
+        }
         if (url.match(/^\//)) {
           url = `${self.getBase()}${url}`;
         }
@@ -228,14 +237,35 @@ module.exports = {
           options.headers = options.headers || {};
           options.headers.cookie = cookies.join('; ');
         }
-        if (options.body && options.body.constructor && (options.body.constructor.name === 'FormData')) {
-          // If we don't do this multiparty will not parse it properly
+        if (
+          options.body &&
+          (typeof options.body.getHeaders === 'function') &&
+          (typeof options.body.pipe === 'function')
+        ) {
+          // A `form-data` package instance. The built-in fetch does not
+          // recognize it (passed directly it is coerced to a useless string
+          // body), so we adapt it ourselves: take its multipart Content-Type
+          // (with boundary) from getHeaders(), set Content-Length so multiparty
+          // can parse it, and stream it through a PassThrough, which the
+          // built-in fetch does accept as a request body.
+          const form = options.body;
           const contentLength = await util.promisify((callback) => {
-            return options.body.getLength(callback);
+            return form.getLength(callback);
           })();
-          options.headers = options.headers || {};
-          options.headers['Content-Length'] = contentLength;
-          // node-fetch will set the Content-Type
+          options.headers = {
+            ...form.getHeaders(),
+            ...options.headers,
+            'Content-Length': contentLength
+          };
+          const pass = new PassThrough();
+          form.pipe(pass);
+          options.body = pass;
+          // Required by the built-in fetch when the body is a stream.
+          options.duplex = 'half';
+        } else if (options.body instanceof FormData) {
+          // A native (WHATWG) FormData: the built-in fetch sets the multipart
+          // Content-Type (with boundary) and streams it. Nothing to do here,
+          // and we must not fall through to the JSON branch below.
         } else if (((options.body != null) && ((typeof options.body) === 'object')) || (options.send === 'json')) {
           options.body = JSON.stringify(options.body);
           options.headers = options.headers || {};
@@ -248,9 +278,9 @@ module.exports = {
         const res = await fetch(url, options);
         let body;
         if (options.jar) {
-          // This is node-fetch specific, browsers limit what JS can see about
-          // this header
-          (res.headers.raw()['set-cookie'] || []).forEach(cookie => {
+          // getSetCookie() returns each Set-Cookie value separately; browsers
+          // limit what JS can see about this header
+          res.headers.getSetCookie().forEach(cookie => {
             options.jar.setCookieSync(cookie, url);
           });
         }
@@ -279,6 +309,12 @@ module.exports = {
             // Usually just a source of bugs
             headers[name] = value;
           });
+          // node-fetch resolved a redirect's Location to an absolute URL; the
+          // built-in fetch returns it as sent (often relative). Resolve it
+          // against the request URL to preserve the absolute form callers expect.
+          if ((res.status >= 300) && (res.status < 400) && headers.location) {
+            headers.location = new URL(headers.location, url).href;
+          }
           return {
             status: res.status,
             headers,

--- a/packages/apostrophe/modules/@apostrophecms/job/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/job/index.js
@@ -110,7 +110,9 @@ module.exports = {
           // sends a response with a jobId to the browser
           job = await self.start(options);
 
-          self.setTotal(job, ids.length);
+          // Persist the total before work begins so the completed notification
+          // and job document always report it, even if processing finishes fast.
+          await self.setTotal(job, ids.length);
           // Runs after response is already sent
           run();
 

--- a/packages/apostrophe/package.json
+++ b/packages/apostrophe/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/apostrophecms/apostrophe/tree/main/packages/apostrophe",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=22.0.0"
   },
   "keywords": [
     "apostrophe",
@@ -102,7 +102,6 @@
     "minimatch": "^3.1.4",
     "mkdirp": "^0.5.5",
     "multer": "^2.1.1",
-    "node-fetch": "^2.6.1",
     "nodemailer": "^8.0.5",
     "nunjucks": "^3.2.1",
     "oembetter": "workspace:^",

--- a/packages/apostrophe/test-lib/test.js
+++ b/packages/apostrophe/test-lib/test.js
@@ -1,5 +1,6 @@
 const fs = require('fs-extra');
 const path = require('path');
+const http = require('node:http');
 
 const setupPackages = ({ folder = 'test' }) => {
   const testNodeModules = path.join(__dirname, '../', folder, 'node_modules/');
@@ -57,5 +58,37 @@ const setupPackages = ({ folder = 'test' }) => {
 };
 setupPackages({ folder: 'test' });
 
+// Performs a GET via the raw node:http client, sending `headers` to the server
+// verbatim. Use this in tests that must control headers the built-in fetch
+// (used by apos.http) would otherwise refuse or rewrite: e.g. a forbidden
+// `Host` header, or the `Cache-Control: no-cache` it adds to any request that
+// carries a conditional header (If-None-Match / If-Modified-Since). `url` may
+// be absolute or site-relative (resolved against `apos.http.getBase()`).
+// Resolves with a fullResponse-shaped { status, headers, body }.
+const rawGet = (apos, url, headers = {}) => {
+  const target = url.startsWith('/') ? `${apos.http.getBase()}${url}` : url;
+  const parsed = new URL(target);
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      hostname: parsed.hostname,
+      port: parsed.port,
+      path: parsed.pathname + parsed.search,
+      method: 'GET',
+      headers
+    }, (res) => {
+      const chunks = [];
+      res.on('data', (chunk) => chunks.push(chunk));
+      res.on('end', () => resolve({
+        status: res.statusCode,
+        headers: res.headers,
+        body: Buffer.concat(chunks).toString()
+      }));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+};
+
 module.exports = require('./util.js');
 module.exports.setupPackages = setupPackages;
+module.exports.rawGet = rawGet;

--- a/packages/apostrophe/test-lib/test.js
+++ b/packages/apostrophe/test-lib/test.js
@@ -67,12 +67,11 @@ setupPackages({ folder: 'test' });
 // Resolves with a fullResponse-shaped { status, headers, body }.
 const rawGet = (apos, url, headers = {}) => {
   const target = url.startsWith('/') ? `${apos.http.getBase()}${url}` : url;
-  const parsed = new URL(target);
   return new Promise((resolve, reject) => {
-    const req = http.request({
-      hostname: parsed.hostname,
-      port: parsed.port,
-      path: parsed.pathname + parsed.search,
+    // Pass the URL string (rather than a split hostname/port) so an IPv6 base
+    // such as `http://[::1]:3000` from getBase() is handled correctly; a
+    // bracketed hostname passed on its own is treated as a name to DNS-resolve.
+    const req = http.request(target, {
       method: 'GET',
       headers
     }, (res) => {

--- a/packages/apostrophe/test/files.js
+++ b/packages/apostrophe/test/files.js
@@ -1,6 +1,9 @@
 const t = require('../test-lib/test.js');
 const assert = require('assert/strict');
 const fs = require('fs');
+// rawGet (raw node:http) lets this suite send a spoofed `Host` header, which
+// the built-in fetch used by apos.http would drop as a forbidden header.
+const { rawGet } = t;
 
 describe('Files', function() {
 
@@ -142,17 +145,13 @@ describe('Files', function() {
       const attachment = apos.attachment.first(file);
       const url = apos.attachment.url(attachment);
       assert(url);
-      // Send an attacker-controlled Host header (e.g. the cloud metadata
-      // address from the advisory). The upstream fetch must be resolved
-      // against the server-trusted baseUrl, not this header, so the
-      // legitimate content is still served and the request is never
-      // steered at the spoofed host.
-      const response = await apos.http.get(url, {
-        headers: {
-          Host: '169.254.169.254'
-        },
-        fullResponse: true
-      });
+      // Spoof the Host header (the cloud-metadata address from the advisory)
+      // over a raw request: apos.http uses the built-in fetch, which drops a
+      // forbidden `Host` header and so cannot deliver the spoof. The server
+      // must resolve the upstream fetch against its trusted baseUrl, not this
+      // header, so the legitimate content is still served and the request is
+      // never steered at the spoofed host.
+      const response = await rawGet(apos, url, { Host: '169.254.169.254' });
       assert.strictEqual(response.status, 200);
       assert.strictEqual(response.body, attachment.data);
     } finally {

--- a/packages/apostrophe/test/pages.js
+++ b/packages/apostrophe/test/pages.js
@@ -1,6 +1,12 @@
 const t = require('../test-lib/test.js');
 const assert = require('assert');
 const _ = require('lodash');
+// The REST API etag tests below issue their conditional request via rawGet
+// (raw node:http): the built-in fetch used by apos.http adds Cache-Control:
+// no-cache to any request carrying a conditional header (Fetch standard), which
+// would suppress the asserted 304s. The page-serving etag tests stay on
+// apos.http (those routes set 304 explicitly).
+const { rawGet } = t;
 
 describe('Pages', function() {
   let apos;
@@ -1087,11 +1093,8 @@ describe('Pages', function() {
     };
 
     const response1 = await apos.http.get(`/api/v1/@apostrophecms/page/${homeId}`, { fullResponse: true });
-    const response2 = await apos.http.get(`/api/v1/@apostrophecms/page/${homeId}`, {
-      fullResponse: true,
-      headers: {
-        'if-none-match': response1.headers.etag
-      }
+    const response2 = await rawGet(apos, `/api/v1/@apostrophecms/page/${homeId}`, {
+      'if-none-match': response1.headers.etag
     });
 
     assert(response1.status === 200);
@@ -1125,11 +1128,8 @@ describe('Pages', function() {
     // so requesting it again should not return a 304 status code
     const pageUpdateResponse = await apos.doc.update(apos.task.getReq(), pageDoc);
 
-    const response2 = await apos.http.get(`/api/v1/@apostrophecms/page/${homeId}`, {
-      fullResponse: true,
-      headers: {
-        'if-none-match': response1.headers.etag
-      }
+    const response2 = await rawGet(apos, `/api/v1/@apostrophecms/page/${homeId}`, {
+      'if-none-match': response1.headers.etag
     });
 
     const eTag1Parts = response1.headers.etag.split(':');
@@ -1165,11 +1165,8 @@ describe('Pages', function() {
     outOfDateETagParts[2] = Number(outOfDateETagParts[2]) -
       (4444 + 1) * 1000; // 1s outdated
 
-    const response2 = await apos.http.get(`/api/v1/@apostrophecms/page/${homeId}`, {
-      fullResponse: true,
-      headers: {
-        'if-none-match': outOfDateETagParts.join(':')
-      }
+    const response2 = await rawGet(apos, `/api/v1/@apostrophecms/page/${homeId}`, {
+      'if-none-match': outOfDateETagParts.join(':')
     });
 
     const eTag1Parts = response1.headers.etag.split(':');

--- a/packages/apostrophe/test/pieces.js
+++ b/packages/apostrophe/test/pieces.js
@@ -6,6 +6,12 @@ const _ = require('lodash');
 const FormData = require('form-data');
 const t = require('../test-lib/test.js');
 
+// The etag tests below issue their conditional request via rawGet (raw
+// node:http): the built-in fetch used by apos.http adds Cache-Control: no-cache
+// to any request carrying a conditional header (Fetch standard), which would
+// suppress the asserted 304s.
+const { rawGet } = t;
+
 describe('Pieces', function() {
 
   let apos;
@@ -1807,11 +1813,8 @@ describe('Pieces', function() {
     };
 
     const response1 = await apos.http.get('/api/v1/thing/testThing:en:published', { fullResponse: true });
-    const response2 = await apos.http.get('/api/v1/thing/testThing:en:published', {
-      fullResponse: true,
-      headers: {
-        'if-none-match': response1.headers.etag
-      }
+    const response2 = await rawGet(apos, '/api/v1/thing/testThing:en:published', {
+      'if-none-match': response1.headers.etag
     });
 
     assert(response1.status === 200);
@@ -1845,11 +1848,8 @@ describe('Pieces', function() {
     // so requesting it again should not return a 304 status code
     const pieceUpdateResponse = await apos.doc.update(apos.task.getReq(), pieceDoc);
 
-    const response2 = await apos.http.get('/api/v1/thing/testThing:en:published', {
-      fullResponse: true,
-      headers: {
-        'if-none-match': response1.headers.etag
-      }
+    const response2 = await rawGet(apos, '/api/v1/thing/testThing:en:published', {
+      'if-none-match': response1.headers.etag
     });
 
     const eTag1Parts = response1.headers.etag.split(':');
@@ -1885,11 +1885,8 @@ describe('Pieces', function() {
     outOfDateETagParts[2] = Number(outOfDateETagParts[2]) -
       (4444 + 1) * 1000; // 1s outdated
 
-    const response2 = await apos.http.get('/api/v1/thing/testThing:en:published', {
-      fullResponse: true,
-      headers: {
-        'if-none-match': outOfDateETagParts.join(':')
-      }
+    const response2 = await rawGet(apos, '/api/v1/thing/testThing:en:published', {
+      'if-none-match': outOfDateETagParts.join(':')
     });
 
     const eTag1Parts = response1.headers.etag.split(':');

--- a/packages/oembetter/oembed.js
+++ b/packages/oembetter/oembed.js
@@ -1,4 +1,3 @@
-const fetch = require('node-fetch');
 const { XMLParser } = require('fast-xml-parser');
 
 const cheerio = require('cheerio');

--- a/packages/oembetter/package.json
+++ b/packages/oembetter/package.json
@@ -30,7 +30,6 @@
     "async": "^0.9.0",
     "cheerio": "^1.1.0",
     "fast-xml-parser": "^5.7.0",
-    "node-fetch": "^2.6.7",
     "urls": "0.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:


- [x] main
- [x] latest
- [ ] stable

## Summary

Migrate node-fetch to built-in fetch (undici), remove the node-fetch dep. Full details in the changelog. 
This is required due to the fact `node-fetch` is a deprecated and not following node standards. A better long term contract. 

## What are the specific steps to test this change?

No internal BC break. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
