### PR TITLE
Bump deprecated deps

### DIFF
--- a/.changeset/pro-9620-npm12.md
+++ b/.changeset/pro-9620-npm12.md
@@ -1,0 +1,6 @@
+---
+"apostrophe": patch
+"uploadfs": patch
+---
+
+Bumped `glob` to `^13` (core) and `rimraf` to `^6` (uploadfs) to clear the deprecated `glob@10` warning shown on every install. The old `glob@10` arrived both directly from core and transitively through `uploadfs` → `rimraf@5`; both now resolve to the current, supported `glob@13` (`rimraf@6` depends on `glob@13` as well). No API or behavior changes.

--- a/packages/apostrophe/package.json
+++ b/packages/apostrophe/package.json
@@ -87,7 +87,7 @@
     "express-cache-on-demand": "workspace:^",
     "express-session": "^1.18.2",
     "fs-extra": "^7.0.1",
-    "glob": "^10.4.5",
+    "glob": "^13.0.0",
     "he": "^1.2.0",
     "html-to-text": "^9.0.5",
     "i18next": "^20.3.2",

--- a/packages/uploadfs/package.json
+++ b/packages/uploadfs/package.json
@@ -31,7 +31,7 @@
     "fs-extra": "^5.0.0",
     "gzipme": "^0.1.1",
     "lodash": "^4.18.1",
-    "rimraf": "^5.0.7"
+    "rimraf": "^6.0.0"
   },
   "optionalDependencies": {
     "@aws-sdk/client-s3": "^3.908.0",


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:

- [x] main
- [x] latest
- [ ] stable
- [ ] Check if this PR will be resubmitted against another branch

## Summary

Bumped `glob` to `^13` (core) and `rimraf` to `^6` (uploadfs) to clear the deprecated `glob@10` warning shown on every install. The old `glob@10` arrived both directly from core and transitively through `uploadfs` → `rimraf@5`; both now resolve to the current, supported `glob@13` (`rimraf@6` depends on `glob@13` as well). No API or behavior changes.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [x] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
