### PR TITLE
Prepare for npm v12 - npm only modules

### DIFF
--- a/.changeset/grumpy-beers-beam.md
+++ b/.changeset/grumpy-beers-beam.md
@@ -1,0 +1,5 @@
+---
+"@apostrophecms/import-export-xlsx": minor
+---
+
+Replaced the off-registry SheetJS `xlsx` tarball dependency with the registry-published `@e965/xlsx` mirror, which exposes the same SheetJS Community Edition API. The module now installs entirely from the npm registry, avoiding install failures on networks restricted to the registry and the npm v12 restriction on non-registry (remote tarball) sources.

--- a/packages/import-export-xlsx/README.md
+++ b/packages/import-export-xlsx/README.md
@@ -17,9 +17,9 @@
 
 This module improves [@apostrophecms/import-export](https://github.com/apostrophecms/import-export) by adding the `xlsx` format.
 
-> Why does this specific format lies in another module?
+> Why does this specific format live in another module?
 
-Because it relies on a [dependency that is not hosted on NPM](https://github.com/SheetJS/sheetjs/issues/2667), which could lead to installation issues on networks that limit connections to NPM repository only.
+Historically because it relied on a [dependency that was not hosted on NPM](https://github.com/SheetJS/sheetjs/issues/2667). It now depends on [`@e965/xlsx`](https://www.npmjs.com/package/@e965/xlsx), a registry-published mirror of SheetJS Community Edition with the same API, so it installs from the npm registry like any other module. The format remains in its own module for backwards compatibility.
 
 ## Requirement
 

--- a/packages/import-export-xlsx/lib/xlsx.js
+++ b/packages/import-export-xlsx/lib/xlsx.js
@@ -1,4 +1,4 @@
-const XLSX = require('xlsx');
+const XLSX = require('@e965/xlsx');
 
 module.exports = {
   label: 'XLSX',

--- a/packages/import-export-xlsx/package.json
+++ b/packages/import-export-xlsx/package.json
@@ -24,6 +24,6 @@
     "stylelint-config-apostrophe": "workspace:^"
   },
   "dependencies": {
-    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
+    "@e965/xlsx": "^0.20.3"
   }
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:

- [x] main
- [x] latest
- [ ] stable
- [ ] Check if this PR will be resubmitted against another branch

## Summary

Replaced the off-registry SheetJS `xlsx` tarball dependency with the registry-published `@e965/xlsx` mirror, which exposes the same SheetJS Community Edition API. The module now installs entirely from the npm registry, avoiding install failures on networks restricted to the registry and the npm v12 restriction on non-registry (remote tarball) sources.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [x] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
