### PR TITLE
Prepare for npm v12 - create apostrophe

### DIFF
--- a/.changeset/pro-9620-npm12-apos-create.md
+++ b/.changeset/pro-9620-npm12-apos-create.md
@@ -1,0 +1,5 @@
+---
+"create-apostrophe": minor
+---
+
+Fixed `npm create apostrophe` with the SQLite database option under npm v12 (and when run from a global `@apostrophecms/cli` install). The installer now performs its post-install database work using the newly generated project's own `better-sqlite3`, rather than the installer's bundled copy.

--- a/packages/create-apostrophe/src/core/create-project.js
+++ b/packages/create-apostrophe/src/core/create-project.js
@@ -6,7 +6,13 @@
 import { getKit } from './kits.js';
 import { detectPackageManager, assertSupportedPackageManager } from './pm.js';
 import { StageError, UnsupportedPackageManagerError } from './errors.js';
-import { checkConnection, dropDatabase } from './db.js';
+import {
+  checkConnection,
+  dropDatabase,
+  clearDatabase as clearDb,
+  restore as restoreDb,
+  loadProjectDbConnect
+} from './db.js';
 import { clone as realClone } from './steps/clone.js';
 import { scaffold as realScaffold } from './steps/scaffold.js';
 import { install as realInstall } from './steps/install.js';
@@ -115,20 +121,24 @@ export function makeCreateProject({
           shortName: options.shortName,
           dbReset: options.dbReset
         }, {
-          verifyConnection: checkConnection,
+          verifyConnection: options.dbChoice === 'sqlite' ? undefined : checkConnection,
           dropDatabase
         }));
 
       // Runs before admin-user so the admin reconciles against the restored
       // dump. Renders its own tasks, so it is not wrapped in step().
       if (kit.seedData) {
+        const projectDbConnect = loadProjectDbConnect(appRoot);
         await importSampleData({
           appRoot,
           dbChoice: options.dbChoice,
           dbUri: options.dbUri,
           shortName: options.shortName
         }, {
-          task: (label, taskOpts) => logger.task(label, taskOpts)
+          task: (label, taskOpts) => logger.task(label, taskOpts),
+          clearDatabase: (uri) => clearDb(uri, { connect: projectDbConnect }),
+          restore: (uri, source) =>
+            restoreDb(uri, source, { restore: projectDbConnect.restore })
         });
       }
 

--- a/packages/create-apostrophe/src/core/db.js
+++ b/packages/create-apostrophe/src/core/db.js
@@ -9,6 +9,7 @@
 // (enforced by test/boundary.test.js).
 
 import path from 'node:path';
+import { createRequire } from 'node:module';
 import dbConnect from '@apostrophecms/db-connect';
 import { assertSafeShortName } from './validate.js';
 
@@ -49,6 +50,38 @@ export function resolveDbUri({
     throw new TypeError(`resolveDbUri: ${dbChoice} requires a dbUri.`);
   }
   return dbUri;
+}
+
+/**
+ * The freshly-installed project's own `@apostrophecms/db-connect`, so any
+ * post-install sqlite work runs against the same driver the app will use —
+ * i.e. the `better-sqlite3` the project's `allowScripts` block actually built.
+ * create-apostrophe's own `better-sqlite3` is never built in npx / global
+ * installs (no project root → `allowScripts` doesn't apply), so its bundled
+ * copy must never construct a sqlite database.
+ *
+ * db-connect is resolved the way the project's Apostrophe resolves it
+ * (Apostrophe depends on it directly), so it is found whether npm hoisted it
+ * to the project root or nested it under `apostrophe`. All sqlite operations
+ * in this installer happen *after* the project install, so the module is
+ * always present by the time this is called.
+ *
+ * Returns `fallback` (the bundled copy) when the project module can't be
+ * resolved.
+ *
+ * @param {string} appRoot  Installed app root (where node_modules/apostrophe lives).
+ * @param {{ fallback?: typeof dbConnect }} [opts]
+ * @returns {typeof dbConnect}
+ */
+export function loadProjectDbConnect(appRoot, { fallback = dbConnect } = {}) {
+  try {
+    const requireFromApp = createRequire(path.join(appRoot, 'package.json'));
+    const apostropheEntry = requireFromApp.resolve('apostrophe');
+    const requireFromApostrophe = createRequire(apostropheEntry);
+    return requireFromApostrophe('@apostrophecms/db-connect');
+  } catch {
+    return fallback;
+  }
 }
 
 /**

--- a/packages/create-apostrophe/test/core/db.test.js
+++ b/packages/create-apostrophe/test/core/db.test.js
@@ -1,12 +1,13 @@
 import assert from 'node:assert/strict';
 import {
-  mkdtempSync, rmSync, existsSync
+  mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import dbConnect from '@apostrophecms/db-connect';
 import {
-  resolveDbUri, inspect, checkConnection, dropDatabase, clearDatabase, restore
+  resolveDbUri, inspect, checkConnection, dropDatabase, clearDatabase, restore,
+  loadProjectDbConnect
 } from '../../src/core/db.js';
 
 // A fake db-connect client whose db() exposes just the surface db.js uses.
@@ -357,5 +358,74 @@ describe('core/db — restore (via injected impl)', function () {
     await restore('mongodb://h/db', 'the-source', { restore: restoreImpl });
     assert.equal(seen.uri, 'mongodb://h/db');
     assert.equal(seen.source, 'the-source');
+  });
+});
+
+describe('core/db — loadProjectDbConnect', function () {
+  let appRoot;
+
+  // Materialize a fake CJS package on disk under <root>/node_modules.
+  // `body` is appended after `module.exports = ...;`.
+  function fakePackage(root, name, exportsExpr, body = '') {
+    const dir = join(root, 'node_modules', ...name.split('/'));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({
+        name,
+        version: '0.0.0',
+        main: 'index.js'
+      })
+    );
+    writeFileSync(join(dir, 'index.js'), `module.exports = ${exportsExpr};\n${body}`);
+    return dir;
+  }
+
+  beforeEach(function () {
+    appRoot = mkdtempSync(join(tmpdir(), 'ca-pdc-'));
+    writeFileSync(join(appRoot, 'package.json'), JSON.stringify({ name: 'proj' }));
+  });
+
+  afterEach(function () {
+    rmSync(appRoot, {
+      recursive: true,
+      force: true
+    });
+  });
+
+  it('returns the project copy when db-connect is hoisted to the project root', function () {
+    fakePackage(appRoot, 'apostrophe', '{}');
+    fakePackage(
+      appRoot,
+      '@apostrophecms/db-connect',
+      'function connect() {}',
+      'module.exports.SENTINEL = "hoisted";\nmodule.exports.restore = function () {};\n'
+    );
+    const dbc = loadProjectDbConnect(appRoot);
+    assert.equal(dbc.SENTINEL, 'hoisted');
+    assert.notEqual(dbc, dbConnect, 'must not be the bundled copy');
+  });
+
+  it('finds db-connect nested under apostrophe (resolved the way Apostrophe does)', function () {
+    const aposDir = fakePackage(appRoot, 'apostrophe', '{}');
+    // No top-level db-connect — only nested inside apostrophe's node_modules.
+    fakePackage(
+      aposDir,
+      '@apostrophecms/db-connect',
+      'function connect() {}',
+      'module.exports.SENTINEL = "nested";\nmodule.exports.restore = function () {};\n'
+    );
+    const dbc = loadProjectDbConnect(appRoot);
+    assert.equal(dbc.SENTINEL, 'nested');
+  });
+
+  it('falls back to the bundled copy when apostrophe is not installed', function () {
+    // appRoot has package.json but no node_modules/apostrophe.
+    const fallback = { SENTINEL: 'fallback' };
+    assert.equal(loadProjectDbConnect(appRoot, { fallback }), fallback);
+  });
+
+  it('falls back to the bundled db-connect by default', function () {
+    assert.equal(loadProjectDbConnect(appRoot), dbConnect);
   });
 });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:

- [x] main
- [x] latest
- [ ] stable

## Summary

Fixed `npm create apostrophe` with the SQLite database option under npm v12 (and when run from a global `@apostrophecms/cli` install). The installer now performs its post-install database work using the newly generated project's own `better-sqlite3`, rather than the installer's bundled copy.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [x] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
