### PR TITLE
fix(sanitize-html): emit transformTags text on empty tags when textFilter is set

### DIFF
--- a/packages/sanitize-html/index.js
+++ b/packages/sanitize-html/index.js
@@ -540,8 +540,13 @@ function sanitizeHtml(html, options, _recursing) {
         result += ' />';
       } else {
         result += '>';
-        if (frame.innerText && !hasText && !options.textFilter) {
-          result += escapeHtml(frame.innerText);
+        if (frame.innerText && !hasText) {
+          const escaped = escapeHtml(frame.innerText);
+          if (options.textFilter) {
+            result += options.textFilter(escaped, name);
+          } else {
+            result += escaped;
+          }
           addedText = true;
         }
       }

--- a/packages/sanitize-html/test/test.js
+++ b/packages/sanitize-html/test/test.js
@@ -323,6 +323,24 @@ describe('sanitizeHtml', function() {
     }), '<a href="http://somelink">some new text</a>');
   });
 
+  it('should add new text to an empty tag when transforming function sets it and an identity textFilter is present', function () {
+    assert.equal(sanitizeHtml('<a></a>', {
+      allowedTags: [ 'a' ],
+      textFilter: function (text) {
+        return text;
+      },
+      transformTags: {
+        a: function (tagName, attribs) {
+          return {
+            tagName,
+            attribs,
+            text: 'some new text'
+          };
+        }
+      }
+    }), '<a>some new text</a>');
+  });
+
   it('should preserve text when initially set and replace attributes when they are changed by transforming function', function () {
     assert.equal(sanitizeHtml('<a href="http://somelink">some initial text</a>', {
       transformTags: {


### PR DESCRIPTION
## Summary

A `transformTags` handler that adds text to an allowed tag is silently dropped when the tag originally had no text content and an identity (no-op) `textFilter` is configured.

```js
sanitizeHtml('<a></a>', {
  allowedTags: ['a'],
  textFilter: (t) => t,
  transformTags: { a: (tn, at) => ({ tagName: tn, attribs: at, text: 'INJECTED' }) }
})
// actual:   "<a></a>"
// expected: "<a>INJECTED</a>"
```

The control without a `textFilter` already yields the expected output:

```js
sanitizeHtml('<a></a>', {
  allowedTags: ['a'],
  transformTags: { a: (tn, at) => ({ tagName: tn, attribs: at, text: 'INJECTED' }) }
})
// "<a>INJECTED</a>"
```

So the presence of an identity `textFilter` changes the result, which violates two documented contracts:

- `transformTags` `text`: documented to "add or modify the text contents of a tag" (already covered by a passing test for the no-`textFilter` case).
- `textFilter`: documented to "process all text content"; an identity filter is a no-op and must not change output.

This is a correctness bug, not a security bypass.

## Root cause

In `onopentag` (`packages/sanitize-html/index.js`), the branch that emits `frame.innerText` for an allowed tag was guarded by `!options.textFilter`:

```js
if (frame.innerText && !hasText && !options.textFilter) {
  result += escapeHtml(frame.innerText);
  addedText = true;
}
```

The `!options.textFilter` guard deferred emission to `ontext` so the filter could run there. But for an empty element `htmlparser2` never calls `ontext`, so the injected text was emitted by neither branch and was lost.

## Fix

Emit `frame.innerText` through `options.textFilter` here when one is set, mirroring the existing discard path that already filters `frame.innerText`:

```js
if (frame.innerText && !hasText) {
  const escaped = escapeHtml(frame.innerText);
  if (options.textFilter) {
    result += options.textFilter(escaped, name);
  } else {
    result += escaped;
  }
  addedText = true;
}
```

`addedText = true` keeps `ontext` from double-emitting on the non-empty path (where `htmlparser2` does fire `ontext`), so output for the existing non-empty cases is unchanged.

## Tests

Added one test to `packages/sanitize-html/test/test.js` for the empty-tag + identity-`textFilter` case. It fails on the unpatched code (`'<a></a>'` instead of `'<a>some new text</a>'`) and passes after the fix. The full package suite goes from 213 passing + 1 failing to 214 passing, with no regressions to the existing non-empty `transformTags` text + `textFilter` test.

Note: the standalone `apostrophecms/sanitize-html` repo was archived on 2026-02-26; this monorepo (`packages/sanitize-html`, v2.17.5) is the live home of the code.