### PR TITLE
allow titlefield to be set to false

### DIFF
--- a/.changeset/tasty-ends-shout.md
+++ b/.changeset/tasty-ends-shout.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": patch
+---
+
+Array fields can set titleField to `false` to use numbered index labels

--- a/packages/apostrophe/modules/@apostrophecms/schema/ui/apos/logic/AposArrayEditor.js
+++ b/packages/apostrophe/modules/@apostrophecms/schema/ui/apos/logic/AposArrayEditor.js
@@ -306,7 +306,7 @@ export default {
           }
         }
 
-      } else if (this.schema.find(field => field.name === 'title') && (item.title !== undefined)) {
+      } else if ((this.field.titleField !== false) && this.schema.find(field => field.name === 'title') && (item.title !== undefined)) {
         candidate = item.title;
       }
       if ((candidate == null) || candidate === '') {

--- a/packages/apostrophe/modules/@apostrophecms/schema/ui/apos/logic/AposInputArray.js
+++ b/packages/apostrophe/modules/@apostrophecms/schema/ui/apos/logic/AposInputArray.js
@@ -399,7 +399,9 @@ export default {
       return newInstance(this.schema);
     },
     getLabel(id, index) {
-      const titleField = this.field.titleField || 'title';
+      const titleField = this.field.titleField === false
+        ? null
+        : (this.field.titleField || 'title');
       const item = this.items.find(item => item._id === id);
       return get(item.schemaInput.data, titleField) || `Item ${index + 1}`;
     },


### PR DESCRIPTION
Arrays default back to using `title` as the default `titleField` with no way to opt out. My `title` field was an object and using it as a string was obviously breaking UI