### PR TITLE
PRO-9688: prevent crash due to double defineProperty, but I have deja vu

### DIFF
--- a/.changeset/emulate-idempotent-patch.md
+++ b/.changeset/emulate-idempotent-patch.md
@@ -1,0 +1,5 @@
+---
+"@apostrophecms/emulate-mongo-3-driver": patch
+---
+
+Patching the `mongodb-legacy` classes is now idempotent. When two copies of this package are loaded against the same `mongodb-legacy` instance (for example, a version or source skew between a direct and a transitive dependency), the second copy no longer throws `TypeError: Cannot redefine property: Symbol(@@mdb.callbacks.toEmulate)`. The emulation method is defined only once and is now `configurable`, so any mix of patched and unpatched copies can load in either order without error.

--- a/packages/emulate-mongo-3-driver/collection.js
+++ b/packages/emulate-mongo-3-driver/collection.js
@@ -276,16 +276,26 @@ module.exports = function (baseClass) {
     // }
   }
 
-  Object.defineProperty(
-    baseClass.prototype,
-    toEmulate,
-    {
-      enumerable: false,
-      value: function () {
-        return Object.setPrototypeOf(this, EmulateCollection.prototype);
+  // `toEmulate` is a global `Symbol.for()` key, so every copy of this module
+  // shares it. When more than one copy is loaded against the same
+  // `mongodb-legacy` classes (e.g. a version/source skew between a direct and a
+  // transitive dependency), each copy tries to patch the same shared prototype.
+  // Patch only once, and use `configurable: true` so that an older, unguarded
+  // copy loading afterwards can still redefine it instead of throwing
+  // "Cannot redefine property: Symbol(@@mdb.callbacks.toEmulate)".
+  if (!Object.prototype.hasOwnProperty.call(baseClass.prototype, toEmulate)) {
+    Object.defineProperty(
+      baseClass.prototype,
+      toEmulate,
+      {
+        enumerable: false,
+        configurable: true,
+        value: function () {
+          return Object.setPrototypeOf(this, EmulateCollection.prototype);
+        }
       }
-    }
-  );
+    );
+  }
 
   return EmulateCollection;
 };

--- a/packages/emulate-mongo-3-driver/db.js
+++ b/packages/emulate-mongo-3-driver/db.js
@@ -80,16 +80,22 @@ module.exports = function (baseClass) {
     }
   }
 
-  Object.defineProperty(
-    baseClass.prototype,
-    toEmulate,
-    {
-      enumerable: false,
-      value: function () {
-        return Object.setPrototypeOf(this, EmulateDb.prototype);
+  // See collection.js for why this is guarded and `configurable`: multiple
+  // copies of this module may patch the same shared `mongodb-legacy` prototype
+  // via the global `Symbol.for()` key.
+  if (!Object.prototype.hasOwnProperty.call(baseClass.prototype, toEmulate)) {
+    Object.defineProperty(
+      baseClass.prototype,
+      toEmulate,
+      {
+        enumerable: false,
+        configurable: true,
+        value: function () {
+          return Object.setPrototypeOf(this, EmulateDb.prototype);
+        }
       }
-    }
-  );
+    );
+  }
 
   return EmulateDb;
 };

--- a/packages/emulate-mongo-3-driver/find-cursor.js
+++ b/packages/emulate-mongo-3-driver/find-cursor.js
@@ -27,17 +27,23 @@ module.exports = function (baseClass) {
     }
   }
 
-  Object.defineProperty(
-    baseClass.prototype,
-    toEmulate,
-    {
-      enumerable: false,
-      value: function () {
-        Object.setPrototypeOf(this, EmulateFindCursor.prototype);
-        return this;
+  // See collection.js for why this is guarded and `configurable`: multiple
+  // copies of this module may patch the same shared `mongodb-legacy` prototype
+  // via the global `Symbol.for()` key.
+  if (!Object.prototype.hasOwnProperty.call(baseClass.prototype, toEmulate)) {
+    Object.defineProperty(
+      baseClass.prototype,
+      toEmulate,
+      {
+        enumerable: false,
+        configurable: true,
+        value: function () {
+          Object.setPrototypeOf(this, EmulateFindCursor.prototype);
+          return this;
+        }
       }
-    }
-  );
+    );
+  }
 
   return EmulateFindCursor;
 };


### PR DESCRIPTION
This seems to be why those asset builds fail in the deploy, Claude sorted it out quickly from the error

But I recognized it

Didn't we do this before?