### PR TITLE
Fix lock file check regression for in-process watchers

### DIFF
--- a/.changeset/asset-lock-check-once-per-process.md
+++ b/.changeset/asset-lock-check-once-per-process.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": patch
+---
+
+The lock file dependency check that forces a full rebuild now runs once per process. Watcher-triggered rebuilds stay scoped to the detected changes instead of rebuilding everything on every file change when the lock file changed or is absent. This bug was in effect only for projects missing a lock file in their `npmRoot` (e.g. npm monorepos). 

--- a/packages/apostrophe/modules/@apostrophecms/asset/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/asset/index.js
@@ -123,6 +123,9 @@ module.exports = {
     self.externalBuildModuleConfig = {};
 
     self.restartId = self.apos.util.generateId();
+    // Set to `true` once a build in this process has run the lock file
+    // dependency check and succeeded. See `checkLockFile()`.
+    self.lockFileChecked = false;
     self.iconMap = {
       ...globalIcons
     };
@@ -254,14 +257,15 @@ module.exports = {
         afterModuleInit: true,
         async task(argv = {}) {
           self.inBuildTask = true;
-          // If the lock file changed since the last build, force a full
-          // rebuild (and clear the build module cache) so a stale admin UI is
-          // never served after a dependency change (npm install/update).
-          const lockFileHash = await self.getLockFileHash();
-          const lockChanged = await self.checkLockFileChanged(lockFileHash);
+          // If the lock file changed since the last successful build, force a
+          // full rebuild (and clear the build module cache) so a stale admin
+          // UI is never served after a dependency change (npm install/update).
+          // The check runs once per process, so watcher-triggered rebuilds
+          // stay scoped to the detected changes.
+          const lockCheck = await self.checkLockFile();
           argv = {
             ...argv,
-            lockChanged
+            lockChanged: lockCheck.changed
           };
           let result;
           if (self.hasBuildModule()) {
@@ -279,8 +283,8 @@ module.exports = {
             });
             result = await webpackBuild.task(argv);
           }
-          // Record the lock file hash now that the build has succeeded.
-          await self.saveLockFileHash(lockFileHash);
+          // Record the check now that the build has succeeded.
+          await self.commitLockFileCheck(lockCheck);
           return result;
         }
       },
@@ -971,6 +975,39 @@ module.exports = {
         }
         await self.clearBuildModuleCache();
         return true;
+      },
+
+      // Run the dependency (lock file) check that drives the `lockChanged`
+      // build option, once per process. The first build performs the real
+      // comparison; later invocations (e.g. watcher-triggered rebuilds)
+      // report no change, because a dependency change while the process is
+      // running requires a restart anyway. The result must be handed back
+      // to `commitLockFileCheck()` after the build succeeds.
+      async checkLockFile() {
+        if (self.lockFileChecked) {
+          return {
+            committed: true,
+            changed: false,
+            hash: null
+          };
+        }
+        const hash = await self.getLockFileHash();
+        const changed = await self.checkLockFileChanged(hash);
+        return {
+          committed: false,
+          changed,
+          hash
+        };
+      },
+
+      // Persist the result of `checkLockFile()`. Called only after a
+      // successful build, so a failed build repeats the forced rebuild.
+      async commitLockFileCheck({ committed, hash }) {
+        if (committed) {
+          return;
+        }
+        await self.saveLockFileHash(hash);
+        self.lockFileChecked = true;
       },
 
       // Override to set externally a build watcher (a `chokidar` instance).

--- a/packages/apostrophe/test/asset-lock-cache.js
+++ b/packages/apostrophe/test/asset-lock-cache.js
@@ -35,6 +35,11 @@ describe('Assets - lock file cache invalidation', function() {
     await fs.writeFile(lockPath, lockSnapshot);
   });
 
+  beforeEach(function() {
+    // Each test starts as if the process had just booted.
+    apos.asset.lockFileChecked = false;
+  });
+
   function mutateLock(key) {
     const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
     lock[key] = (lock[key] || 0) + 1;
@@ -85,6 +90,39 @@ describe('Assets - lock file cache invalidation', function() {
     assert.strictEqual(changed, true);
   });
 
+  it('runs the lock check once per process', async function() {
+    await apos.asset.saveLockFileHash('an-old-hash');
+    const first = await apos.asset.checkLockFile();
+    assert.strictEqual(first.committed, false);
+    assert.strictEqual(first.changed, true);
+    await apos.asset.commitLockFileCheck(first);
+
+    // A watcher-triggered rebuild in the same process reports no change,
+    // even if the lock content mutated meanwhile.
+    mutateLock('__test-memo');
+    const again = await apos.asset.checkLockFile();
+    assert.strictEqual(again.committed, true);
+    assert.strictEqual(again.changed, false);
+  });
+
+  it('reports no change on rebuilds when there is no lock file', async function() {
+    const original = apos.asset.getLockFileHash;
+    apos.asset.getLockFileHash = async () => null;
+    try {
+      // No lock file: the first build of the process is forced...
+      const first = await apos.asset.checkLockFile();
+      assert.strictEqual(first.changed, true);
+      assert.strictEqual(first.hash, null);
+      await apos.asset.commitLockFileCheck(first);
+      // ...but watcher-triggered rebuilds are not.
+      const again = await apos.asset.checkLockFile();
+      assert.strictEqual(again.committed, true);
+      assert.strictEqual(again.changed, false);
+    } finally {
+      apos.asset.getLockFileHash = original;
+    }
+  });
+
   it('forces a rebuild when content changed but the lock mtime is older', async function() {
     const tsFile = path.join(
       apos.asset.getBundleRootDir(), 'apos-build-timestamp.txt'
@@ -100,6 +138,8 @@ describe('Assets - lock file cache invalidation', function() {
 
     // Dependency change: the lock content changes, but its mtime is OLDER than
     // the freshly built artifacts (fresh checkout / restored build cache).
+    // This happens across process starts, so reset the per-process check.
+    apos.asset.lockFileChecked = false;
     mutateLock('__test2');
     const older = new Date(Date.now() - 5 * 60 * 1000);
     await fs.utimes(lockPath, older, older);


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:

*Check one*
- [x] main
- [x] latest
- [x] stable
- [ ] Check if this PR will be resubmitted against another branch

## Summary

The lock file dependency check that forces a full rebuild now runs once per process. Watcher-triggered rebuilds stay scoped to the detected changes instead of rebuilding everything on every file change when the lock file changed or is absent. This bug was in effect only for projects missing a lock file in their `npmRoot` (e.g. npm monorepos). 

## What are the specific steps to test this change?

*For example:*

File change on projects not having a lock file in their `npmRoot` doesn't trigger full rebuild.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
