### PR TITLE
fix(schema): launder email field value before validating and storing

### DIFF
--- a/.changeset/email-field-trim-whitespace.md
+++ b/.changeset/email-field-trim-whitespace.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": patch
+---
+
+The `email` schema field now validates and stores the laundered value, so surrounding whitespace is trimmed rather than causing a valid address to be rejected as invalid. Non-string input (for example a number sent through the REST API) is now coerced by the launder step instead of throwing an uncaught error.

--- a/packages/apostrophe/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/packages/apostrophe/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -569,18 +569,17 @@ module.exports = (self) => {
     vueComponent: 'AposInputString',
     convert: function (req, field, data, destination) {
       destination[field.name] = self.apos.launder.string(data[field.name]);
-      if (!data[field.name]) {
+      if (!destination[field.name]) {
         if (field.required) {
           throw self.apos.error('required');
         }
       } else {
         // regex source: https://emailregex.com/
-        const matches = data[field.name].match(/^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/);
+        const matches = destination[field.name].match(/^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/);
         if (!matches) {
           throw self.apos.error('invalid');
         }
       }
-      destination[field.name] = data[field.name];
     },
     validate(field, options, warn, fail) {
       if (field.direction && !_.includes([ 'ltr', 'rtl' ], field.direction)) {

--- a/packages/apostrophe/test/schemas.js
+++ b/packages/apostrophe/test/schemas.js
@@ -593,6 +593,27 @@ describe('Schemas', function() {
     assert(result.name === 'Apost');
   });
 
+  it('should trim surrounding whitespace from a valid value for an email field type', async function() {
+    const schema = apos.schema.compose({
+      addFields: [
+        {
+          type: 'email',
+          name: 'authorEmail',
+          label: 'Author Email'
+        }
+      ]
+    });
+    assert(schema.length === 1);
+    const input = {
+      authorEmail: '  test@example.com  '
+    };
+    const req = apos.task.getReq();
+    const result = {};
+    await apos.schema.convert(req, schema, input, result);
+    assert(_.keys(result).length === 1);
+    assert(result.authorEmail === 'test@example.com');
+  });
+
   it('should allow saving a 0 value provided as a number if a field is required for an integer field type', async function() {
     const schema = apos.schema.compose({
       addFields: [


### PR DESCRIPTION
## Bug

The `email` schema field's `convert` launders the submitted value into `destination[field.name]`, but then validates the **raw** `data[field.name]` and overwrites the destination with that raw value, discarding the laundered result.

Two consequences:

1. A valid address with surrounding whitespace is rejected. The validation regex is anchored (`^…$`) and excludes whitespace, so `"  test@example.com  "` fails to match and throws `invalid` — even though the first line already computed the trimmed value that was meant to be stored.
2. Non-string input (e.g. a number sent through the REST API) throws an uncaught `TypeError` (`data[field.name].match is not a function`) instead of failing validation gracefully. Every other string-based field type launders first and so coerces such input.

## Repro

```js
const schema = apos.schema.compose({
  addFields: [ { type: 'email', name: 'authorEmail', label: 'Author Email' } ]
});
const result = {};
await apos.schema.convert(apos.task.getReq(), schema, { authorEmail: '  test@example.com  ' }, result);
// expected: result.authorEmail === 'test@example.com'
// actual:   throws [ 'invalid: invalid' ]
```

## Fix

Validate and store `destination[field.name]` (the laundered value) and drop the redundant final overwrite. This trims surrounding whitespace before validating, matches the behavior of the other string-based field types, and safely coerces non-string input via `launder.string`.

Adds a regression test in `test/schemas.js` and a changeset.
