### PR TITLE
fix(apostrophe-astro): fix a bug where redirect responses drop headers

### DIFF
--- a/.changeset/late-comics-chew.md
+++ b/.changeset/late-comics-chew.md
@@ -3,3 +3,4 @@
 ---
 
 Fixed a bug where redirect responses proxied through `aposProxy.js` (e.g. OAuth login callbacks) lost every header except `Location`. This affected setups where Apostrophe is only reachable through the Astro proxy (e.g. a sidecar deployment), causing the session `Set-Cookie` header from an OAuth callback redirect to be silently dropped and the login to appear to fail.
+Included fix to `aposResponse.js` to remove entity headers describing the body when dropping the body (e.g. redirects) which may otherwise cause strict clients to hang waiting for bytes.

--- a/.changeset/late-comics-chew.md
+++ b/.changeset/late-comics-chew.md
@@ -1,0 +1,5 @@
+---
+"@apostrophecms/apostrophe-astro": patch
+---
+
+Fixed a bug where redirect responses proxied through `aposProxy.js` (e.g. OAuth login callbacks) lost every header except `Location`. This affected setups where Apostrophe is only reachable through the Astro proxy (e.g. a sidecar deployment), causing the session `Set-Cookie` header from an OAuth callback redirect to be silently dropped and the login to appear to fail.

--- a/packages/apostrophe-astro/endpoints/aposProxy.js
+++ b/packages/apostrophe-astro/endpoints/aposProxy.js
@@ -1,12 +1,8 @@
-import aposResponse from "../lib/aposResponse";
+import aposResponse from "../lib/aposResponse.js";
 
-export async function ALL({ params, request, redirect }) {
+export async function ALL({ request }) {
   try {
-    const response = await aposResponse(request);
-    if ([301, 302, 307, 308].includes(response.status)) {
-      return redirect(response.headers.get('location'), response.status);
-    }
-    return response;
+    return await aposResponse(request);
   } catch (e) {
     return new Response(e.message, { status: 500 });
   }

--- a/packages/apostrophe-astro/lib/aposResponse.js
+++ b/packages/apostrophe-astro/lib/aposResponse.js
@@ -83,12 +83,16 @@ export default async function aposResponse(req) {
 
     const { headers, statusCode, ...rest } = res;
 
-    // Statuses whose body we never send to the client: 204/304 carry none,
-    // and redirects (301/302/307/308) become a fresh Astro redirect built
-    // from the Location header in aposProxy. Dump the undici body so its
-    // socket returns to the pool instead of being held open until GC.
+    // Statuses we forward with no body: 204/304 carry none, and for
+    // redirects (301/302/307/308) Location + Set-Cookie are all the client
+    // needs. Dump the undici body so its socket returns to the pool, and
+    // strip the entity headers that described it - a stale Content-Length
+    // would make the client wait for bytes that never arrive.
     if ([204, 304, 301, 302, 307, 308].includes(statusCode)) {
       await res.body.dump().catch(() => {});
+      responseHeaders.delete('content-length');
+      responseHeaders.delete('content-encoding');
+      responseHeaders.delete('transfer-encoding');
       return new Response(null, { ...rest, status: statusCode, headers: responseHeaders });
     }
 

--- a/packages/apostrophe-astro/test/endpoints/aposProxy.test.js
+++ b/packages/apostrophe-astro/test/endpoints/aposProxy.test.js
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import esmock from 'esmock';
+
+async function loadAposProxy(mockResponse) {
+  return esmock('../../endpoints/aposProxy.js', {
+    '../../lib/aposResponse.js': {
+      default: async () => mockResponse
+    }
+  });
+}
+
+function makeRequest(url = 'http://localhost:4321/login/callback') {
+  return new Request(url);
+}
+
+describe('aposProxy', () => {
+  it('forwards redirect responses without dropping non-Location headers', async () => {
+    // Regression test: Astro's own `redirect()` helper only keeps the
+    // Location header, which silently drops the session Set-Cookie header
+    // an OAuth callback relies on to mark the browser as authenticated.
+    const headers = new Headers();
+    headers.set('location', '/dashboard');
+    headers.append('set-cookie', 'apos.sid=abc123; Path=/; HttpOnly');
+    headers.set('x-custom-auth', 'issued');
+    const mockResponse = new Response(null, { status: 302, headers });
+
+    const { ALL } = await loadAposProxy(mockResponse);
+    const res = await ALL({ request: makeRequest() });
+
+    assert.equal(res.status, 302);
+    assert.equal(res.headers.get('location'), '/dashboard');
+    assert.equal(res.headers.get('set-cookie'), 'apos.sid=abc123; Path=/; HttpOnly');
+    assert.equal(res.headers.get('x-custom-auth'), 'issued');
+  });
+
+  it('passes non-redirect responses through unchanged', async () => {
+    const mockResponse = new Response('{"ok":true}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' }
+    });
+
+    const { ALL } = await loadAposProxy(mockResponse);
+    const res = await ALL({ request: makeRequest() });
+
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), '{"ok":true}');
+  });
+
+  it('returns a 500 text response when aposResponse throws', async () => {
+    const { ALL } = await esmock('../../endpoints/aposProxy.js', {
+      '../../lib/aposResponse.js': {
+        default: async () => { throw new Error('boom'); }
+      }
+    });
+
+    const res = await ALL({ request: makeRequest() });
+    assert.equal(res.status, 500);
+    assert.equal(await res.text(), 'boom');
+  });
+});

--- a/packages/apostrophe-astro/test/lib/aposResponse.test.js
+++ b/packages/apostrophe-astro/test/lib/aposResponse.test.js
@@ -153,6 +153,28 @@ describe('aposResponse', () => {
         assert.equal(res.body, null);
       });
     }
+
+    for (const status of [ 204, 304, 301, 302, 307, 308 ]) {
+      it(`strips entity headers describing the dropped body for ${status}`, async () => {
+        const { default: aposResponse } = await loadAposResponse({}, async () => ({
+          statusCode: status,
+          headers: {
+            location: '/dashboard',
+            'set-cookie': 'apos.sid=abc123; Path=/; HttpOnly',
+            'content-length': '1234',
+            'content-encoding': 'gzip',
+            'transfer-encoding': 'chunked'
+          },
+          body: makeBody('')
+        }));
+        const res = await aposResponse(makeRequest());
+        assert.equal(res.status, status);
+        assert.equal(res.headers.get('set-cookie'), 'apos.sid=abc123; Path=/; HttpOnly');
+        assert.equal(res.headers.get('content-length'), null);
+        assert.equal(res.headers.get('content-encoding'), null);
+        assert.equal(res.headers.get('transfer-encoding'), null);
+      });
+    }
   });
 
   describe('normal response', () => {


### PR DESCRIPTION
## Please indicate which branch this PR should merge into:

*Check one*
- [x] main
- [x] latest
- [x] stable
- [ ] Check if this PR will be resubmitted against another branch

## Summary

When ApostropheCMS is deployed as a sidecar with no external network exposure (i.e. `APOS_HOST` is pointed at Astro such that all traffic to ApostropheCMS is routed through `aposProxy.js`), some logins (e.g. Google OAuth SSO with `@apostrophecms/passport-bridge`) fail to persist session cookies after the callback redirect.

This is caused by `aposProxy.js` rebuilding redirect responses using Astro's `redirect()` function which is hard-coded to drop all headers except for `Location` - e.g. dropping headers like `Set-Cookie` from the auth callback's redirect response.

**For example (Google auth):**

```mermaid
sequenceDiagram
    autonumber
    participant Browser
    participant Astro as Astro proxy (aposProxy.js)
    participant Apos as Apostrophe (passport-bridge)
    participant Google

    Browser->>Astro: GET /auth/google/login
    Astro->>Apos: proxy request
    Apos-->>Astro: 302 Location: accounts.google.com/...
    Astro-->>Browser: 302 (forwarded)

    Browser->>Google: GET /o/oauth2/auth
    Google-->>Browser: 302 Location: /auth/google/callback?code=...

    Browser->>Astro: GET /auth/google/callback?code=...
    Astro->>Apos: proxy request
    Apos-->>Astro: 302 Location: /<br/>Set-Cookie: apos.sid=...

    rect rgb(255, 220, 220)
    Note over Astro: BUG: aposProxy.js calls Astro's redirect()<br/>which drops the Set-Cookie header
    end
    Astro-->>Browser: 302 Location: / (no Set-Cookie)

```

### Fix

The `aposResponse()` function already builds complete working responses with all backend headers intact.

```diff
-export async function ALL({ params, request, redirect }) {
+export async function ALL({ request }) {
   try {
-    const response = await aposResponse(request);
-    if ([301, 302, 307, 308].includes(response.status)) {
-      return redirect(response.headers.get('location'), response.status);
-    }
-    return response;
+    return await aposResponse(request);
   } catch (e) {
     return new Response(e.message, { status: 500 });
   }
 };
```

This is consistent with existing behaviour: `aposResponse` forwards headers on backend responses.

### Cause

Traced back to [apostrophecms/apostrophe-astro@4cf1797](https://github.com/apostrophecms/apostrophe-astro/commit/4cf1797b1f26ffdf6fb08c145600ef0586337fa1).

Before that commit `aposProxy.js` always returned `aposResponse()` (no special case for redirects).

The bug this commit fixed was in `aposResponse.js` was real and fixed properly, but it also added a special case in `aposProxy.js` which excluded redirects from the fix.

It effectively bundled two changes:
1. Correctly building headers and passing statusCode, which fixed the described bug, and
2. An unnecessary branch in `aposProxy.js` rerouting redirects through Astro's `redirect()` causing the headers to drop.

NB: I have checked that my change does not regress the issue fixed by this change - i.e. visiting `/login` while already logged in.

## Follow up

When forwarding the response with `aposResponse.js` the response body may be dropped (on specific status, e.g. redirects) but the entity headers describing the body (e.g. content-length, content-encoding, transfer-encoding) were not removed .
A stale content-length may make strict clients (reverse proxies, non-browser HTTP clients) hang waiting for body bytes that will never arrive.

Fixed by removing the stale headers alongside removing the response body.

## What are the specific steps to test this change?

- Added `test/endpoints/aposProxy.test.js`. Redirect responses forward `Set-Cookie` and custom headers, non-redirect responses pass through unchanged.
-  Added a case to `test/lib/aposResponse.test.js`. For each of the impacted statuses 204/304/301/302/307/308, content-length, content-encoding, and transfer-encoding are stripped while set-cookie survives.
- Package test suite passes (`pnpm --filter @apostrophecms/apostrophe-astro run test`).
- Manual test: Google OAuth login with passport-bridge against a sidecar deployment (e.g. `APOS_HOST` set to the Astro origin).

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [x] Related tests have been updated
