### PR TITLE
Remove stricting the engine for sanitize-html

### DIFF
--- a/packages/sanitize-html/package.json
+++ b/packages/sanitize-html/package.json
@@ -25,9 +25,6 @@
   ],
   "author": "Apostrophe Technologies, Inc.",
   "license": "MIT",
-  "engines": {
-    "node": ">=22.12.0"
-  },
   "dependencies": {
     "deepmerge": "^4.2.2",
     "escape-string-regexp": "^4.0.0",


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:

*Check one*
- [x] main
- [ ] latest
- [ ] stable
- [ ] Check if this PR will be resubmitted against another branch

## Summary

Not all projects are `node` based / server side rendering and so forcing the node version should not be done for a package which also can be used in the browser. Or atleast only be done via a new Major release, else existing pipelines, fail out of the box.

```
npm ERR! engine Not compatible with your version of node/npm: sanitize-html@2.17.6
npm ERR! notsup Not compatible with your version of node/npm: sanitize-html@2.17.6
npm ERR! notsup Required: {"node":">=22.12.0"}
npm ERR! notsup Actual:   {"npm":"9.9.4","node":"v20.19.2
```

## What are the specific steps to test this change?

npm install via node 20, npm 8, ... with strict engine flag active.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
