### PR TITLE
AI engine foundation

### DIFF
--- a/packages/apostrophe/defaults.js
+++ b/packages/apostrophe/defaults.js
@@ -27,6 +27,7 @@ module.exports = {
     '@apostrophecms/login': {},
     '@apostrophecms/doc': {},
     '@apostrophecms/job': {},
+    '@apostrophecms/ai': {},
     '@apostrophecms/modal': {},
     '@apostrophecms/oembed': {},
     '@apostrophecms/pager': {},

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -1,0 +1,135 @@
+// This module provides `apos.ai`, the provider-agnostic AI engine. Feature
+// code talks only to this surface; provider adapters register here and
+// translate the normalized shapes to their service dialects.
+//
+// Providers are opt-in: the module ships no provider and no key. Configure
+// each provider under `options.providers[name]` and (with more than one)
+// name the default with `options.provider`.
+
+module.exports = {
+  options: {
+    alias: 'ai',
+    // providers: { name: { apiKey, baseUrl, adapter, models, effort, capabilities } }
+    providers: {},
+    // provider: the default provider name; inferred when only one is configured
+    // effort: { default, levels: { name: { provider, model, reasoning } } }
+    // image: { provider, model, aspect, quality }
+    // mock: (request) => assistant turn, consulted only under APOS_AI_MOCK
+    // Conservative agent-loop cap; any call may override it
+    maxSteps: 5
+  },
+  init(self) {
+    self.validateOptions(self.options);
+  },
+  methods(self) {
+    return {
+      // Validate the shape of the module options, throwing a clear error
+      // naming the offending entry. Checks that need the adapter registry
+      // (unknown adapters, dangling routing references, effort levels with
+      // no row) happen later, at activation.
+      validateOptions(options) {
+        const fail = (message) => {
+          throw new Error(message);
+        };
+        const isObject = (value) => value && typeof value === 'object' &&
+          !Array.isArray(value);
+        const checkString = (value, name) => {
+          if (value !== undefined && typeof value !== 'string') {
+            fail(`"${name}" must be a string`);
+          }
+        };
+        const checkEffortRow = (row, name, { provider = false } = {}) => {
+          if (!isObject(row)) {
+            fail(`"${name}" must be an object like { provider, model }`);
+          }
+          if (provider && typeof row.provider !== 'string') {
+            fail(`"${name}.provider" must be a string`);
+          }
+          if (typeof row.model !== 'string') {
+            fail(`"${name}.model" must be a string`);
+          }
+          checkString(row.reasoning, `${name}.reasoning`);
+        };
+
+        const {
+          providers, provider, effort, image, maxSteps, mock
+        } = options;
+
+        if (!isObject(providers)) {
+          fail('"providers" must be an object of provider entries');
+        }
+        for (const [ name, entry ] of Object.entries(providers)) {
+          if (!isObject(entry)) {
+            fail(`"providers.${name}" must be an object`);
+          }
+          checkString(entry.apiKey, `providers.${name}.apiKey`);
+          checkString(entry.baseUrl, `providers.${name}.baseUrl`);
+          checkString(entry.adapter, `providers.${name}.adapter`);
+          if (entry.models !== undefined) {
+            if (!isObject(entry.models)) {
+              fail(`"providers.${name}.models" must be an object of model entries`);
+            }
+            for (const [ model, info ] of Object.entries(entry.models)) {
+              if (!isObject(info)) {
+                fail(`"providers.${name}.models.${model}" must be an object`);
+              }
+            }
+          }
+          if (entry.effort !== undefined) {
+            if (!isObject(entry.effort)) {
+              fail(`"providers.${name}.effort" must be an object of effort rows`);
+            }
+            for (const [ level, row ] of Object.entries(entry.effort)) {
+              // The provider is implicit (the entry itself), rows carry model
+              checkEffortRow(row, `providers.${name}.effort.${level}`);
+            }
+          }
+          if (entry.capabilities !== undefined) {
+            if (!isObject(entry.capabilities)) {
+              fail(`"providers.${name}.capabilities" must be an object`);
+            }
+            for (const [ capability, value ] of Object.entries(entry.capabilities)) {
+              if (typeof value !== 'boolean') {
+                fail(`"providers.${name}.capabilities.${capability}" must be a boolean`);
+              }
+            }
+          }
+        }
+
+        checkString(provider, 'provider');
+        if (provider && !providers[provider]) {
+          fail(`"provider" names "${provider}" which is not a configured provider`);
+        }
+
+        if (effort !== undefined) {
+          if (!isObject(effort)) {
+            fail('"effort" must be an object like { default, levels }');
+          }
+          checkString(effort.default, 'effort.default');
+          if (effort.levels !== undefined) {
+            if (!isObject(effort.levels)) {
+              fail('"effort.levels" must be an object of routing entries');
+            }
+            for (const [ level, row ] of Object.entries(effort.levels)) {
+              checkEffortRow(row, `effort.levels.${level}`, { provider: true });
+            }
+          }
+        }
+
+        if (image !== undefined) {
+          checkEffortRow(image, 'image', { provider: true });
+          checkString(image.aspect, 'image.aspect');
+          checkString(image.quality, 'image.quality');
+        }
+
+        if (!Number.isInteger(maxSteps) || maxSteps < 1) {
+          fail('"maxSteps" must be a positive integer');
+        }
+
+        if (mock !== undefined && typeof mock !== 'function') {
+          fail('"mock" must be a function');
+        }
+      }
+    };
+  }
+};

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -19,18 +19,142 @@ module.exports = {
     maxSteps: 5
   },
   init(self) {
+    self.adapters = {};
+    self.providers = {};
+    self.effortTable = {};
     self.validateOptions(self.options);
+    self.defaultProvider = self.options.provider ||
+      Object.keys(self.options.providers)[0] || null;
+    self.effortDefault = self.options.effort?.default || 'medium';
+  },
+  handlers(self) {
+    return {
+      'apostrophe:ready': {
+        async activate() {
+          await self.activateProviders();
+        }
+      }
+    };
   },
   methods(self) {
+    function fail(message) {
+      throw new Error(`@apostrophecms/ai: ${message}`);
+    }
+
     return {
+      // Register a provider adapter. Adapters self-register in their own
+      // module's init; re-registering an existing name overrides, so a
+      // custom adapter can replace a standard one.
+      addAdapter(adapter) {
+        if (!adapter || typeof adapter.name !== 'string') {
+          fail('addAdapter requires an adapter definition with a "name" string');
+        }
+        self.adapters[adapter.name] = adapter;
+      },
+      getAdapter(name) {
+        return self.adapters[name];
+      },
+      // Activate every configured provider entry: instantiate the adapter
+      // it names with the entry's config, validate it, merge the entry's
+      // service description (models, effort rows, capabilities) over the
+      // adapter's declared data, then build the effort routing table.
+      // Misconfigurations fail the startup.
+      async activateProviders() {
+        const {
+          providers = {}, effort = {}, image
+        } = self.options;
+
+        for (const [ name, entry ] of Object.entries(providers)) {
+          const adapterName = entry.adapter || name;
+          const adapter = self.getAdapter(adapterName);
+          if (!adapter) {
+            fail(`"providers.${name}" names unknown adapter "${adapterName}"`);
+          }
+          if (typeof adapter.validate !== 'function') {
+            fail(`adapter "${adapterName}" does not implement validate()`);
+          }
+          const aliased = adapterName !== name;
+          const instance = {
+            ...adapter,
+            provider: name,
+            apiKey: entry.apiKey,
+            baseUrl: entry.baseUrl || adapter.baseUrl
+          };
+          if (!process.env.APOS_AI_MOCK) {
+            await instance.validate();
+          }
+          self.providers[name] = {
+            name,
+            adapterName,
+            adapter: instance,
+            capabilities: {
+              ...adapter.capabilities,
+              ...entry.capabilities
+            },
+            models: self.mergeModels(adapter.models, entry.models),
+            // An aliased entry describes a different service than the
+            // adapter's native one, so the native effort rows do not apply
+            effort: aliased
+              ? { ...entry.effort }
+              : {
+                ...adapter.effort,
+                ...entry.effort
+              }
+          };
+        }
+
+        for (const [ level, row ] of Object.entries(effort.levels || {})) {
+          if (!self.providers[row.provider]) {
+            fail(`"effort.levels.${level}" references unconfigured provider "${row.provider}"`);
+          }
+        }
+        if (image && !self.providers[image.provider]) {
+          fail(`"image" references unconfigured provider "${image.provider}"`);
+        }
+
+        self.effortTable = self.buildEffortTable();
+        if (self.defaultProvider && !self.effortTable[self.effortDefault]) {
+          fail(`the default effort level "${self.effortDefault}" resolves to no routing entry; add it to "effort.levels" or configure a default provider whose adapter declares it`);
+        }
+      },
+      // The routing table: the default provider's rows are the base,
+      // the project's "effort.levels" replace it level by level
+      buildEffortTable() {
+        const table = {};
+        const base = self.providers[self.defaultProvider];
+        if (base) {
+          for (const [ level, row ] of Object.entries(base.effort)) {
+            table[level] = {
+              ...row,
+              provider: base.name
+            };
+          }
+        }
+        for (const [ level, row ] of Object.entries(self.options.effort?.levels || {})) {
+          table[level] = { ...row };
+        }
+        return table;
+      },
+      // Union of the adapter's and the entry's model metadata,
+      // merged per model id with the entry's fields winning
+      mergeModels(adapterModels = {}, entryModels = {}) {
+        const models = {};
+        for (const id of Object.keys({
+          ...adapterModels,
+          ...entryModels
+        })) {
+          models[id] = {
+            ...adapterModels[id],
+            ...entryModels[id]
+          };
+        }
+        return models;
+      },
       // Validate the shape of the module options, throwing a clear error
       // naming the offending entry. Checks that need the adapter registry
       // (unknown adapters, dangling routing references, effort levels with
       // no row) happen later, at activation.
       validateOptions(options) {
-        const fail = (message) => {
-          throw new Error(message);
-        };
         const isObject = (value) => value && typeof value === 'object' &&
           !Array.isArray(value);
         const checkString = (value, name) => {
@@ -99,6 +223,9 @@ module.exports = {
         checkString(provider, 'provider');
         if (provider && !providers[provider]) {
           fail(`"provider" names "${provider}" which is not a configured provider`);
+        }
+        if (!provider && Object.keys(providers).length > 1) {
+          fail('"provider" must name the default provider when several providers are configured');
         }
 
         if (effort !== undefined) {

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -22,6 +22,9 @@ module.exports = {
     self.adapters = {};
     self.providers = {};
     self.effortTable = {};
+    // "Is AI operational?" — true only once activation has configured
+    // at least one provider, so feature code can ask before calling
+    self.active = false;
     self.validateOptions(self.options);
     self.defaultProvider = self.options.provider ||
       Object.keys(self.options.providers)[0] || null;
@@ -64,6 +67,8 @@ module.exports = {
           providers = {}, effort = {}, image
         } = self.options;
 
+        self.active = false;
+
         for (const [ name, entry ] of Object.entries(providers)) {
           const adapterName = entry.adapter || name;
           const adapter = self.getAdapter(adapterName);
@@ -103,6 +108,11 @@ module.exports = {
           };
         }
 
+        if (Object.keys(providers).length &&
+          !self.providers[self.defaultProvider]) {
+          fail('no default provider is available; name one with the "provider" option');
+        }
+
         for (const [ level, row ] of Object.entries(effort.levels || {})) {
           if (!self.providers[row.provider]) {
             fail(`"effort.levels.${level}" references unconfigured provider "${row.provider}"`);
@@ -116,6 +126,8 @@ module.exports = {
         if (self.defaultProvider && !self.effortTable[self.effortDefault]) {
           fail(`the default effort level "${self.effortDefault}" resolves to no routing entry; add it to "effort.levels" or configure a default provider whose adapter declares it`);
         }
+
+        self.active = Object.keys(self.providers).length > 0;
       },
       // The routing table: the default provider's rows are the base,
       // the project's "effort.levels" replace it level by level
@@ -134,6 +146,97 @@ module.exports = {
           table[level] = { ...row };
         }
         return table;
+      },
+      // Resolve a call's routing options to a concrete routing entry,
+      // with the same precedence generate will use: explicit
+      // provider+model, else the call's effort level, else the default
+      // level. Throws "invalid" on unresolvable calls; unknown models
+      // are not an error.
+      //
+      // Options:
+      // `provider`, `model` (strings, only together): the explicit
+      //   target, bypassing the routing table;
+      // `effort` (string): the routing level to resolve;
+      // `capability` (only 'image'): resolve the image route instead of
+      //   the effort table;
+      // `reasoning` (string): override the resolved entry's reasoning.
+      resolve(options = {}) {
+        const invalid = (message) => {
+          throw self.apos.error('invalid', message);
+        };
+        const {
+          provider, model, effort, capability, reasoning
+        } = options;
+
+        if (capability !== undefined && capability !== 'image') {
+          invalid(`unknown capability "${capability}"`);
+        }
+        if (provider || model) {
+          if (!provider || !model) {
+            invalid('"provider" and "model" must be given together');
+          }
+          if (!self.providers[provider]) {
+            invalid(`"${provider}" is not a configured provider`);
+          }
+          return {
+            provider,
+            model,
+            ...(reasoning !== undefined && { reasoning })
+          };
+        }
+        let row;
+        if (capability === 'image') {
+          if (!self.options.image) {
+            invalid('no "image" route is configured');
+          }
+          row = self.options.image;
+        } else {
+          const level = effort || self.effortDefault;
+          row = self.effortTable[level];
+          if (!row) {
+            invalid(`effort level "${level}" resolves to no routing entry`);
+          }
+        }
+        return {
+          ...row,
+          ...(reasoning !== undefined && { reasoning })
+        };
+      },
+      // Synchronous introspection: the model a call with these options
+      // would hit and what it offers. Accepts the same options as
+      // `resolve` and resolves exactly like a call would, including
+      // its "invalid" errors — a call that cannot resolve here would
+      // fail the same way for real. An unknown model is different: the
+      // call would work, so it yields undefined limits, never an error.
+      // Check `self.active` first to ask whether AI is configured at
+      // all.
+      //
+      // Returns `{ provider, model, reasoning?, contextWindow,
+      // maxOutputTokens, capabilities }`, plus the model's declared
+      // `aspects` for an image resolution. Model metadata merges the
+      // provider's model maps with any fields carried inline on the
+      // routing entry.
+      modelInfo(options = {}) {
+        const {
+          provider, model, reasoning, aspect, quality, ...inline
+        } = self.resolve(options);
+        const record = self.providers[provider];
+        const metadata = {
+          ...record.models[model],
+          ...inline
+        };
+        const info = {
+          provider,
+          model,
+          ...(reasoning !== undefined && { reasoning }),
+          contextWindow: metadata.contextWindow,
+          maxOutputTokens: metadata.maxOutputTokens,
+          capabilities: { ...record.capabilities }
+        };
+        if (options.capability === 'image') {
+          info.aspects = metadata.aspects;
+        }
+        return info;
       },
       // Union of the adapter's and the entry's model metadata,
       // merged per model id with the entry's fields winning

--- a/packages/apostrophe/test/ai-children/ai-malformed-child.js
+++ b/packages/apostrophe/test/ai-children/ai-malformed-child.js
@@ -1,0 +1,14 @@
+const t = require('../../test-lib/test.js');
+
+(async function () {
+  await t.create({
+    root: module,
+    modules: {
+      '@apostrophecms/ai': {
+        options: {
+          providers: { openai: 'key' }
+        }
+      }
+    }
+  });
+})();

--- a/packages/apostrophe/test/ai.js
+++ b/packages/apostrophe/test/ai.js
@@ -1,0 +1,224 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert');
+const { spawn } = require('child_process');
+
+describe('AI engine', function() {
+  this.timeout(t.timeout);
+
+  let apos;
+
+  after(async function() {
+    return t.destroy(apos);
+  });
+
+  it('boots with no AI configuration and exposes apos.ai', async function() {
+    apos = await t.create({
+      root: module
+    });
+    assert(apos.ai);
+    assert.strictEqual(apos.ai.options.maxSteps, 5);
+    assert.deepStrictEqual(apos.ai.options.providers, {});
+  });
+
+  describe('options validation', function() {
+    // A valid baseline the cases below mutate
+    const valid = () => ({
+      providers: {},
+      maxSteps: 5
+    });
+
+    it('accepts the minimal single-provider configuration', function() {
+      apos.ai.validateOptions({
+        ...valid(),
+        providers: {
+          anthropic: { apiKey: 'k' }
+        }
+      });
+    });
+
+    it('accepts a multi-provider configuration with partial override', function() {
+      apos.ai.validateOptions({
+        ...valid(),
+        provider: 'anthropic',
+        providers: {
+          anthropic: { apiKey: 'k1' },
+          openai: { apiKey: 'k2' },
+          google: { apiKey: 'k3' }
+        },
+        effort: {
+          default: 'medium',
+          levels: {
+            high: {
+              provider: 'openai',
+              model: 'gpt-5.1',
+              reasoning: 'high'
+            }
+          }
+        },
+        image: {
+          provider: 'openai',
+          model: 'gpt-image-1-mini',
+          aspect: 'square',
+          quality: 'medium'
+        },
+        maxSteps: 25
+      });
+    });
+
+    it('accepts an aliased provider entry describing its own service', function() {
+      apos.ai.validateOptions({
+        ...valid(),
+        providers: {
+          openai: { apiKey: 'k1' },
+          groq: {
+            adapter: 'openai',
+            baseUrl: 'https://api.groq.com/openai/v1',
+            apiKey: 'k2',
+            models: {
+              'llama-3.1-8b-instant': {
+                contextWindow: 131072,
+                maxOutputTokens: 8192
+              }
+            },
+            effort: {
+              low: { model: 'llama-3.1-8b-instant' },
+              medium: { model: 'llama-3.3-70b-versatile' },
+              high: { model: 'llama-3.3-70b-versatile' }
+            },
+            capabilities: { image: false }
+          }
+        },
+        provider: 'openai'
+      });
+    });
+
+    const rejects = (options, pattern) => {
+      assert.throws(() => apos.ai.validateOptions(options), (e) => {
+        assert.match(e.message, /^@apostrophecms\/ai: /);
+        assert.match(e.message, pattern);
+        return true;
+      });
+    };
+
+    it('rejects providers that are not an object of entries', function() {
+      rejects({
+        ...valid(),
+        providers: []
+      }, /"providers" must be an object/);
+      rejects({
+        ...valid(),
+        providers: { openai: 'key' }
+      }, /"providers\.openai" must be an object/);
+    });
+
+    it('rejects malformed provider entry fields', function() {
+      rejects({
+        ...valid(),
+        providers: { openai: { apiKey: 42 } }
+      }, /"providers\.openai\.apiKey" must be a string/);
+      rejects({
+        ...valid(),
+        providers: {
+          groq: {
+            effort: { low: { reasoning: 'high' } }
+          }
+        }
+      }, /"providers\.groq\.effort\.low\.model" must be a string/);
+      rejects({
+        ...valid(),
+        providers: {
+          groq: {
+            capabilities: { image: 'no' }
+          }
+        }
+      }, /"providers\.groq\.capabilities\.image" must be a boolean/);
+      rejects({
+        ...valid(),
+        providers: {
+          groq: {
+            models: { 'llama-3.1-8b-instant': 131072 }
+          }
+        }
+      }, /"providers\.groq\.models\.llama-3\.1-8b-instant" must be an object/);
+    });
+
+    it('rejects a default provider that is not configured', function() {
+      rejects({
+        ...valid(),
+        provider: 'anthropic'
+      }, /"provider" names "anthropic" which is not a configured provider/);
+    });
+
+    it('rejects malformed effort configuration', function() {
+      rejects({
+        ...valid(),
+        effort: 'high'
+      }, /"effort" must be an object/);
+      // No string alias: routing entries are canonical objects
+      rejects({
+        ...valid(),
+        effort: {
+          levels: { high: 'openai/gpt-5.1' }
+        }
+      }, /"effort\.levels\.high" must be an object like \{ provider, model \}/);
+      rejects({
+        ...valid(),
+        effort: {
+          levels: { high: { model: 'gpt-5.1' } }
+        }
+      }, /"effort\.levels\.high\.provider" must be a string/);
+      rejects({
+        ...valid(),
+        effort: {
+          levels: {
+            high: {
+              provider: 'openai',
+              reasoning: 'high'
+            }
+          }
+        }
+      }, /"effort\.levels\.high\.model" must be a string/);
+    });
+
+    it('rejects a malformed image route', function() {
+      rejects({
+        ...valid(),
+        image: { provider: 'openai' }
+      }, /"image\.model" must be a string/);
+      rejects({
+        ...valid(),
+        image: {
+          provider: 'openai',
+          model: 'gpt-image-1-mini',
+          aspect: 16
+        }
+      }, /"image\.aspect" must be a string/);
+    });
+
+    it('rejects malformed maxSteps and mock', function() {
+      rejects({
+        ...valid(),
+        maxSteps: 0
+      }, /"maxSteps" must be a positive integer/);
+      rejects({
+        ...valid(),
+        mock: 'fixture reply'
+      }, /"mock" must be a function/);
+    });
+  });
+
+  it('fails fast at startup on a malformed configuration', function(done) {
+    const child = spawn('node', [ './test/ai-children/ai-malformed-child.js' ]);
+    let stderr = '';
+
+    child.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    child.on('close', (code) => {
+      assert.strictEqual(code, 1);
+      assert.match(stderr, /@apostrophecms\/ai: "providers\.openai" must be an object/);
+      done();
+    });
+  });
+});

--- a/packages/apostrophe/test/ai.js
+++ b/packages/apostrophe/test/ai.js
@@ -68,6 +68,13 @@ describe('AI engine', function() {
     assert.strictEqual(apos.ai.options.maxSteps, 5);
     assert.deepStrictEqual(apos.ai.options.providers, {});
     assert.strictEqual(apos.ai.defaultProvider, null);
+    assert.strictEqual(apos.ai.active, false);
+    // Unconfigured: a call falls through to an empty routing table
+    assert.throws(() => apos.ai.modelInfo(), (e) => {
+      assert.strictEqual(e.name, 'invalid');
+      assert.match(e.message, /effort level "medium" resolves to no routing entry/);
+      return true;
+    });
   });
 
   describe('options validation', function() {
@@ -330,6 +337,7 @@ describe('AI engine', function() {
       assert(apos.ai.providers.fake);
       assert(apos.ai.providers.other);
       assert(apos.ai.providers.custom);
+      assert.strictEqual(apos.ai.active, true);
     });
 
     it('instantiates adapters with the entry config', function() {
@@ -390,6 +398,31 @@ describe('AI engine', function() {
       });
     });
 
+    it('panics on activation when providers exist but no default resolves', async function() {
+      const saved = apos.ai.defaultProvider;
+      try {
+        apos.ai.defaultProvider = null;
+        await assert.rejects(
+          apos.ai.activateProviders(),
+          /@apostrophecms\/ai: no default provider is available/
+        );
+        // A failed activation leaves the engine inactive
+        assert.strictEqual(apos.ai.active, false);
+      } finally {
+        apos.ai.defaultProvider = saved;
+        await apos.ai.activateProviders();
+        assert.strictEqual(apos.ai.active, true);
+      }
+    });
+
+    it('rejects an image resolution when no image route is configured', function() {
+      assert.throws(() => apos.ai.modelInfo({ capability: 'image' }), (e) => {
+        assert.strictEqual(e.name, 'invalid');
+        assert.match(e.message, /no "image" route is configured/);
+        return true;
+      });
+    });
+
     it('overrides an adapter on re-registration and requires a name', function() {
       assert.strictEqual(apos.ai.getAdapter('fake').label, 'Fake (fake)');
       apos.ai.addAdapter(fakeAdapter('fake', { label: 'Replaced' }));
@@ -423,6 +456,7 @@ describe('AI engine', function() {
         assert(mockApos.ai.providers.fake);
         // The sole configured provider is inferred as the default
         assert.strictEqual(mockApos.ai.defaultProvider, 'fake');
+        assert.strictEqual(mockApos.ai.active, true);
       } finally {
         delete process.env.APOS_AI_MOCK;
         await t.destroy(mockApos);
@@ -525,6 +559,201 @@ describe('AI engine', function() {
           }
         }, /@apostrophecms\/ai: the default effort level "medium" resolves to no routing entry/);
       });
+    });
+  });
+
+  describe('resolution and modelInfo', function() {
+    // The fake adapter's declared capabilities, unchanged by the entries
+    const capabilities = {
+      text: true,
+      tools: true,
+      structured: true,
+      imageInput: true,
+      image: false,
+      caching: true
+    };
+
+    before(async function() {
+      await t.destroy(apos);
+      apos = await t.create({
+        root: module,
+        modules: {
+          'fake-adapters': {
+            init(self) {
+              self.apos.ai.addAdapter(fakeAdapter('fake'));
+              self.apos.ai.addAdapter(fakeAdapter('other'));
+            }
+          },
+          '@apostrophecms/ai': {
+            options: {
+              provider: 'fake',
+              providers: {
+                fake: { apiKey: 'k1' },
+                other: {
+                  apiKey: 'k2',
+                  models: {
+                    'other-image': { aspects: [ '1:1', '16:9' ] }
+                  }
+                }
+              },
+              effort: {
+                levels: {
+                  high: {
+                    provider: 'other',
+                    model: 'other-large'
+                  },
+                  ultra: {
+                    provider: 'other',
+                    model: 'other-ultra',
+                    reasoning: 'max',
+                    contextWindow: 1000000,
+                    maxOutputTokens: 64000
+                  }
+                }
+              },
+              image: {
+                provider: 'other',
+                model: 'other-image',
+                aspect: 'square',
+                quality: 'medium'
+              }
+            }
+          }
+        }
+      });
+    });
+
+    after(async function() {
+      return t.destroy(apos);
+    });
+
+    it('resolves the default effort level', function() {
+      assert.deepStrictEqual(apos.ai.modelInfo(), {
+        provider: 'fake',
+        model: 'fake-medium',
+        contextWindow: 200000,
+        maxOutputTokens: 16000,
+        capabilities
+      });
+    });
+
+    it('resolves a call effort level', function() {
+      assert.deepStrictEqual(apos.ai.modelInfo({ effort: 'low' }), {
+        provider: 'fake',
+        model: 'fake-small',
+        contextWindow: 100000,
+        maxOutputTokens: 8000,
+        capabilities
+      });
+    });
+
+    it('resolves an overridden level routed to another provider', function() {
+      assert.deepStrictEqual(apos.ai.modelInfo({ effort: 'high' }), {
+        provider: 'other',
+        model: 'other-large',
+        contextWindow: 400000,
+        maxOutputTokens: 32000,
+        capabilities
+      });
+    });
+
+    it('merges inline routing-entry metadata over the model maps', function() {
+      assert.deepStrictEqual(apos.ai.modelInfo({ effort: 'ultra' }), {
+        provider: 'other',
+        model: 'other-ultra',
+        reasoning: 'max',
+        contextWindow: 1000000,
+        maxOutputTokens: 64000,
+        capabilities
+      });
+    });
+
+    it('resolves an explicit provider and model directly', function() {
+      assert.deepStrictEqual(apos.ai.modelInfo({
+        provider: 'other',
+        model: 'other-medium'
+      }), {
+        provider: 'other',
+        model: 'other-medium',
+        contextWindow: 200000,
+        maxOutputTokens: 16000,
+        capabilities
+      });
+    });
+
+    it('yields undefined limits for an unknown model, never an error', function() {
+      assert.deepStrictEqual(apos.ai.modelInfo({
+        provider: 'fake',
+        model: 'mystery'
+      }), {
+        provider: 'fake',
+        model: 'mystery',
+        contextWindow: undefined,
+        maxOutputTokens: undefined,
+        capabilities
+      });
+    });
+
+    it('resolves the image route via capability', function() {
+      assert.deepStrictEqual(apos.ai.modelInfo({ capability: 'image' }), {
+        provider: 'other',
+        model: 'other-image',
+        contextWindow: undefined,
+        maxOutputTokens: undefined,
+        capabilities,
+        aspects: [ '1:1', '16:9' ]
+      });
+    });
+
+    it('reports aspects for an explicit image model too', function() {
+      assert.deepStrictEqual(apos.ai.modelInfo({
+        capability: 'image',
+        provider: 'other',
+        model: 'other-image'
+      }), {
+        provider: 'other',
+        model: 'other-image',
+        contextWindow: undefined,
+        maxOutputTokens: undefined,
+        capabilities,
+        aspects: [ '1:1', '16:9' ]
+      });
+    });
+
+    it('applies a call-level reasoning override', function() {
+      assert.strictEqual(
+        apos.ai.modelInfo({
+          effort: 'ultra',
+          reasoning: 'low'
+        }).reasoning,
+        'low'
+      );
+      assert.strictEqual(
+        apos.ai.modelInfo({
+          provider: 'fake',
+          model: 'fake-large',
+          reasoning: 'high'
+        }).reasoning,
+        'high'
+      );
+    });
+
+    it('rejects unresolvable calls with "invalid"', function() {
+      const rejects = (options, pattern) => {
+        assert.throws(() => apos.ai.modelInfo(options), (e) => {
+          assert.strictEqual(e.name, 'invalid');
+          assert.match(e.message, pattern);
+          return true;
+        });
+      };
+      rejects({
+        provider: 'nope',
+        model: 'some-model'
+      }, /"nope" is not a configured provider/);
+      rejects({ provider: 'fake' }, /"provider" and "model" must be given together/);
+      rejects({ model: 'fake-small' }, /"provider" and "model" must be given together/);
+      rejects({ effort: 'unknown' }, /effort level "unknown" resolves to no routing entry/);
+      rejects({ capability: 'tools' }, /unknown capability "tools"/);
     });
   });
 

--- a/packages/apostrophe/test/ai.js
+++ b/packages/apostrophe/test/ai.js
@@ -2,22 +2,72 @@ const t = require('../test-lib/test.js');
 const assert = require('assert');
 const { spawn } = require('child_process');
 
+// A registrable fake adapter following the adapter contract, minus
+// anything that would talk to a network
+const fakeAdapter = (name, extras = {}) => ({
+  name,
+  label: `Fake (${name})`,
+  capabilities: {
+    text: true,
+    tools: true,
+    structured: true,
+    imageInput: true,
+    image: false,
+    caching: true
+  },
+  effort: {
+    low: { model: `${name}-small` },
+    medium: { model: `${name}-medium` },
+    high: {
+      model: `${name}-large`,
+      reasoning: 'high'
+    }
+  },
+  models: {
+    [`${name}-small`]: {
+      contextWindow: 100000,
+      maxOutputTokens: 8000
+    },
+    [`${name}-medium`]: {
+      contextWindow: 200000,
+      maxOutputTokens: 16000
+    },
+    [`${name}-large`]: {
+      contextWindow: 400000,
+      maxOutputTokens: 32000
+    }
+  },
+  validate() {
+    if (!this.apiKey) {
+      throw new Error(`${name}: apiKey missing`);
+    }
+  },
+  normalizeError(err) {
+    return err;
+  },
+  ...extras
+});
+
 describe('AI engine', function() {
   this.timeout(t.timeout);
 
   let apos;
 
+  before(async function() {
+    apos = await t.create({
+      root: module
+    });
+  });
+
   after(async function() {
     return t.destroy(apos);
   });
 
-  it('boots with no AI configuration and exposes apos.ai', async function() {
-    apos = await t.create({
-      root: module
-    });
+  it('boots with no AI configuration and exposes apos.ai', function() {
     assert(apos.ai);
     assert.strictEqual(apos.ai.options.maxSteps, 5);
     assert.deepStrictEqual(apos.ai.options.providers, {});
+    assert.strictEqual(apos.ai.defaultProvider, null);
   });
 
   describe('options validation', function() {
@@ -94,7 +144,7 @@ describe('AI engine', function() {
 
     const rejects = (options, pattern) => {
       assert.throws(() => apos.ai.validateOptions(options), (e) => {
-        assert.match(e.message, /^@apostrophecms\/ai: /);
+        assert.match(e.message, /@apostrophecms\/ai: /);
         assert.match(e.message, pattern);
         return true;
       });
@@ -147,6 +197,16 @@ describe('AI engine', function() {
         ...valid(),
         provider: 'anthropic'
       }, /"provider" names "anthropic" which is not a configured provider/);
+    });
+
+    it('rejects several providers without a named default', function() {
+      rejects({
+        ...valid(),
+        providers: {
+          anthropic: { apiKey: 'k1' },
+          openai: { apiKey: 'k2' }
+        }
+      }, /"provider" must name the default provider when several providers are configured/);
     });
 
     it('rejects malformed effort configuration', function() {
@@ -204,6 +264,267 @@ describe('AI engine', function() {
         ...valid(),
         mock: 'fixture reply'
       }, /"mock" must be a function/);
+    });
+  });
+
+  describe('registry and activation', function() {
+    before(async function() {
+      await t.destroy(apos);
+      apos = await t.create({
+        root: module,
+        modules: {
+          'fake-adapters': {
+            init(self) {
+              self.apos.ai.addAdapter(fakeAdapter('fake'));
+              self.apos.ai.addAdapter(fakeAdapter('other'));
+            }
+          },
+          '@apostrophecms/ai': {
+            options: {
+              provider: 'fake',
+              providers: {
+                fake: {
+                  apiKey: 'k1',
+                  effort: {
+                    medium: { model: 'fake-medium-2' }
+                  }
+                },
+                other: { apiKey: 'k2' },
+                custom: {
+                  adapter: 'fake',
+                  apiKey: 'k3',
+                  baseUrl: 'https://custom.example/v1',
+                  models: {
+                    'custom-small': {
+                      contextWindow: 32000,
+                      maxOutputTokens: 4000
+                    },
+                    'fake-small': { maxOutputTokens: 1234 }
+                  },
+                  effort: {
+                    low: { model: 'custom-small' },
+                    medium: { model: 'custom-large' }
+                  },
+                  capabilities: { imageInput: false }
+                }
+              },
+              effort: {
+                levels: {
+                  high: {
+                    provider: 'other',
+                    model: 'other-large'
+                  }
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+
+    after(async function() {
+      return t.destroy(apos);
+    });
+
+    it('activates configured providers on ready', function() {
+      assert(apos.ai.providers.fake);
+      assert(apos.ai.providers.other);
+      assert(apos.ai.providers.custom);
+    });
+
+    it('instantiates adapters with the entry config', function() {
+      const { fake, custom } = apos.ai.providers;
+      assert.strictEqual(fake.adapterName, 'fake');
+      assert.strictEqual(fake.adapter.apiKey, 'k1');
+      assert.strictEqual(custom.adapterName, 'fake');
+      assert.strictEqual(custom.adapter.provider, 'custom');
+      assert.strictEqual(custom.adapter.apiKey, 'k3');
+      assert.strictEqual(custom.adapter.baseUrl, 'https://custom.example/v1');
+    });
+
+    it('merges the entry service description over the adapter data', function() {
+      const { fake, custom } = apos.ai.providers;
+      // Native entry: adapter rows with entry overrides, level by level
+      assert.deepStrictEqual(fake.effort, {
+        low: { model: 'fake-small' },
+        medium: { model: 'fake-medium-2' },
+        high: {
+          model: 'fake-large',
+          reasoning: 'high'
+        }
+      });
+      // Aliased entry: its own rows only, the native table does not apply
+      assert.deepStrictEqual(custom.effort, {
+        low: { model: 'custom-small' },
+        medium: { model: 'custom-large' }
+      });
+      assert.strictEqual(custom.capabilities.imageInput, false);
+      assert.strictEqual(custom.capabilities.text, true);
+      assert.deepStrictEqual(custom.models['custom-small'], {
+        contextWindow: 32000,
+        maxOutputTokens: 4000
+      });
+      // Per-model metadata merge, entry fields winning
+      assert.deepStrictEqual(custom.models['fake-small'], {
+        contextWindow: 100000,
+        maxOutputTokens: 1234
+      });
+    });
+
+    it('builds the effort routing table from the default provider plus level overrides', function() {
+      assert.strictEqual(apos.ai.defaultProvider, 'fake');
+      assert.strictEqual(apos.ai.effortDefault, 'medium');
+      assert.deepStrictEqual(apos.ai.effortTable, {
+        low: {
+          provider: 'fake',
+          model: 'fake-small'
+        },
+        medium: {
+          provider: 'fake',
+          model: 'fake-medium-2'
+        },
+        high: {
+          provider: 'other',
+          model: 'other-large'
+        }
+      });
+    });
+
+    it('overrides an adapter on re-registration and requires a name', function() {
+      assert.strictEqual(apos.ai.getAdapter('fake').label, 'Fake (fake)');
+      apos.ai.addAdapter(fakeAdapter('fake', { label: 'Replaced' }));
+      assert.strictEqual(apos.ai.getAdapter('fake').label, 'Replaced');
+      assert.throws(
+        () => apos.ai.addAdapter({ label: 'anonymous' }),
+        /requires an adapter definition with a "name" string/
+      );
+    });
+
+    it('skips adapter validate() under APOS_AI_MOCK', async function() {
+      process.env.APOS_AI_MOCK = '1';
+      let mockApos;
+      try {
+        mockApos = await t.create({
+          root: module,
+          modules: {
+            'fake-adapters': {
+              init(self) {
+                self.apos.ai.addAdapter(fakeAdapter('fake'));
+              }
+            },
+            '@apostrophecms/ai': {
+              options: {
+                // No apiKey: validate() would throw outside mock mode
+                providers: { fake: {} }
+              }
+            }
+          }
+        });
+        assert(mockApos.ai.providers.fake);
+        // The sole configured provider is inferred as the default
+        assert.strictEqual(mockApos.ai.defaultProvider, 'fake');
+      } finally {
+        delete process.env.APOS_AI_MOCK;
+        await t.destroy(mockApos);
+      }
+    });
+
+    describe('activation failures', function() {
+      // Activation throws on ready, after every init has run, so the
+      // partially booted instance can be captured and destroyed
+      const failsToActivate = async (
+        aiOptions,
+        pattern,
+        setup = (apos) => apos.ai.addAdapter(fakeAdapter('fake'))
+      ) => {
+        let captured;
+        try {
+          await assert.rejects(t.create({
+            root: module,
+            exit: 'throw',
+            modules: {
+              'fake-adapters': {
+                init(self) {
+                  captured = self.apos;
+                  setup(self.apos);
+                }
+              },
+              '@apostrophecms/ai': {
+                options: aiOptions
+              }
+            }
+          }), pattern);
+        } finally {
+          await t.destroy(captured);
+        }
+      };
+
+      it('fails on an unknown adapter name', async function() {
+        await failsToActivate({
+          providers: { nope: { apiKey: 'k' } }
+        }, /@apostrophecms\/ai: "providers\.nope" names unknown adapter "nope"/);
+        await failsToActivate({
+          providers: {
+            groq: {
+              adapter: 'missing',
+              apiKey: 'k'
+            }
+          }
+        }, /@apostrophecms\/ai: "providers\.groq" names unknown adapter "missing"/);
+      });
+
+      it('fails when the adapter validate() throws', async function() {
+        await failsToActivate({
+          providers: { fake: {} }
+        }, /fake: apiKey missing/);
+      });
+
+      it('fails on an adapter without validate()', async function() {
+        await failsToActivate({
+          providers: { noval: { apiKey: 'k' } }
+        }, /@apostrophecms\/ai: adapter "noval" does not implement validate\(\)/,
+        (apos) => apos.ai.addAdapter({ name: 'noval' }));
+      });
+
+      it('fails on a routing entry referencing an unconfigured provider', async function() {
+        await failsToActivate({
+          providers: { fake: { apiKey: 'k' } },
+          effort: {
+            levels: {
+              high: {
+                provider: 'openai',
+                model: 'gpt-5.1'
+              }
+            }
+          }
+        }, /@apostrophecms\/ai: "effort\.levels\.high" references unconfigured provider "openai"/);
+      });
+
+      it('fails on an image route referencing an unconfigured provider', async function() {
+        await failsToActivate({
+          providers: { fake: { apiKey: 'k' } },
+          image: {
+            provider: 'openai',
+            model: 'gpt-image-1'
+          }
+        }, /@apostrophecms\/ai: "image" references unconfigured provider "openai"/);
+      });
+
+      it('fails when the default effort level resolves to no row', async function() {
+        await failsToActivate({
+          providers: { fake: { apiKey: 'k' } },
+          effort: { default: 'ultra' }
+        }, /@apostrophecms\/ai: the default effort level "ultra" resolves to no routing entry/);
+        // An aliased sole provider supplies no rows of its own
+        await failsToActivate({
+          providers: {
+            custom: {
+              adapter: 'fake',
+              apiKey: 'k'
+            }
+          }
+        }, /@apostrophecms\/ai: the default effort level "medium" resolves to no routing entry/);
+      });
     });
   });
 


### PR DESCRIPTION
Create the new core module `@apostrophecms/ai` (alias `apos.ai`) with everything
that can be built and fully tested without a single HTTP call: the adapter
registry, provider configuration and activation, effort routing, and model
introspection. Real adapters plug into this in follow-up issues.