### PR TITLE
AI generate

### DIFF
--- a/packages/apostrophe/defaults.js
+++ b/packages/apostrophe/defaults.js
@@ -28,6 +28,7 @@ module.exports = {
     '@apostrophecms/doc': {},
     '@apostrophecms/job': {},
     '@apostrophecms/ai': {},
+    '@apostrophecms/ai-adapter-anthropic': {},
     '@apostrophecms/modal': {},
     '@apostrophecms/oembed': {},
     '@apostrophecms/pager': {},

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-anthropic/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-anthropic/index.js
@@ -1,0 +1,295 @@
+// The standard Anthropic (Claude) adapter for `apos.ai`. It registers
+// itself with the AI engine at startup; configure the provider with just
+// a key under the engine's `providers.anthropic` entry to use it. All
+// knowledge of the Anthropic Messages dialect — request translation,
+// prompt-cache markers, response parsing, error mapping - lives here.
+//
+// The transport is `apos.http`, no SDK. Projects can adjust the dialect
+// by extending this module and overriding its methods.
+
+module.exports = {
+  options: {
+    // The anthropic-version request header
+    version: '2023-06-01',
+    // Per-request timeout in milliseconds; a timed-out call is a
+    // transient failure the engine retries
+    timeout: 600000,
+    // reasoning level - extended-thinking budget_tokens (Anthropic's
+    // floor for a budget is 1024).
+    thinkingBudgets: {
+      low: 1024,
+      medium: 4096,
+      high: 16384
+    }
+  },
+  init(self) {
+    self.apos.ai.addAdapter(self.adapter());
+  },
+  methods(self) {
+    return {
+      // The adapter definition registered with `apos.ai`. The engine
+      // instantiates it per configured provider entry, assigning
+      // `provider`, `apiKey` and `baseUrl` — which is why `chat` and
+      // `validate` read config from `this` while the dialect work
+      // delegates to the module's methods.
+      adapter() {
+        return {
+          name: 'anthropic',
+          label: 'Anthropic (Claude)',
+          baseUrl: 'https://api.anthropic.com',
+          envKey: 'APOS_ANTHROPIC_KEY',
+          capabilities: {
+            text: true,
+            tools: true,
+            structured: true,
+            stream: true,
+            imageInput: true,
+            image: false,
+            caching: true
+          },
+          effort: {
+            low: { model: 'claude-haiku-4-5' },
+            medium: { model: 'claude-sonnet-4-6' },
+            high: {
+              model: 'claude-opus-4-8',
+              reasoning: 'high'
+            }
+          },
+          models: {
+            'claude-haiku-4-5': {
+              contextWindow: 200000,
+              maxOutputTokens: 32000
+            },
+            'claude-sonnet-4-6': {
+              contextWindow: 200000,
+              maxOutputTokens: 64000
+            },
+            'claude-opus-4-8': {
+              contextWindow: 200000,
+              maxOutputTokens: 64000
+            }
+          },
+          validate() {
+            if (!this.apiKey) {
+              throw new Error(`the "${this.provider}" provider requires an apiKey`);
+            }
+          },
+          async chat(req, request) {
+            const response = await self.apos.http.post(`${this.baseUrl}/v1/messages`, {
+              headers: {
+                'x-api-key': this.apiKey,
+                'anthropic-version': self.options.version
+              },
+              body: self.buildBody(request),
+              timeout: self.options.timeout,
+              ...(request.signal && { signal: request.signal })
+            });
+            return self.parseResponse(response);
+          },
+          normalizeError(error) {
+            return self.normalizeError(error);
+          }
+        };
+      },
+      // Translate a normalized adapter request (see the engine's
+      // buildRequest) to an Anthropic Messages API body: content parts
+      // become Anthropic blocks, `reasoning` becomes a thinking budget,
+      // and the cache policy is placed as `cache_control` markers — one
+      // on the system tail (the static prefix) and a rolling one on the
+      // last message, so the next call in a conversation reads what
+      // this one wrote. Throws "invalid" on requests the dialect cannot
+      // express.
+      buildBody(request) {
+        const invalid = (message) => {
+          throw self.apos.error('invalid', message);
+        };
+        const {
+          system, messages, model, maxTokens, reasoning, cache
+        } = request;
+        if (!Number.isInteger(maxTokens)) {
+          invalid(`"maxTokens" is required: model "${model}" declares no maxOutputTokens to default to`);
+        }
+        const body = {
+          model,
+          max_tokens: maxTokens,
+          ...(system !== undefined && { system }),
+          messages: messages.map((message) => ({
+            role: message.role,
+            content: message.content.map(toBlock)
+          }))
+        };
+        if (reasoning !== undefined) {
+          body.thinking = toThinking(reasoning);
+        }
+        if (cache) {
+          const marker = {
+            type: 'ephemeral',
+            ...(cache.ttl === 'long' && { ttl: '1h' })
+          };
+          if (body.system !== undefined) {
+            body.system = [ {
+              type: 'text',
+              text: body.system,
+              cache_control: marker
+            } ];
+          }
+          const parts = body.messages.at(-1).content;
+          parts[parts.length - 1].cache_control = marker;
+        }
+        return body;
+
+        function toBlock(part) {
+          if (part.type === 'text') {
+            return {
+              type: 'text',
+              text: part.text
+            };
+          }
+          // part.type === 'image', in one of the two normalized forms
+          return {
+            type: 'image',
+            source: part.image.url !== undefined
+              ? {
+                type: 'url',
+                url: part.image.url
+              }
+              : {
+                type: 'base64',
+                media_type: part.image.mediaType,
+                data: part.image.data
+              }
+          };
+        }
+        // Anthropic wants an absolute token budget, mapped by the
+        // thinkingBudgets option; the budget must leave max_tokens
+        // room for the answer
+        function toThinking(reasoning) {
+          const budget = self.options.thinkingBudgets[reasoning];
+          if (!budget) {
+            invalid(`no thinking budget is configured for reasoning "${reasoning}"`);
+          }
+          if (maxTokens <= budget) {
+            invalid(`"maxTokens" (${maxTokens}) must exceed the "${reasoning}" thinking budget (${budget})`);
+          }
+          return {
+            type: 'enabled',
+            budget_tokens: budget
+          };
+        }
+      },
+      // Translate an Anthropic Messages response to the normalized
+      // assistant turn { content, finishReason, usage, model }. Thinking
+      // blocks are not conversation content and do not travel. A
+      // `refusal` stop reason throws the refusal error here, so
+      // "refused" always arrives as an error. An unknown stop reason
+      // maps to no finishReason — the engine's turn validation treats
+      // that as a malformed (retryable) response, never a truncated
+      // success.
+      parseResponse(response) {
+        if (response.stop_reason === 'refusal') {
+          throw self.apos.error('aiRefusal', 'the model refused this request');
+        }
+        return {
+          content: (response.content || [])
+            .map(fromBlock)
+            .filter(Boolean),
+          finishReason: {
+            end_turn: 'stop',
+            stop_sequence: 'stop',
+            max_tokens: 'length',
+            tool_use: 'toolCalls'
+          }[response.stop_reason],
+          usage: {
+            inputTokens: response.usage?.input_tokens,
+            outputTokens: response.usage?.output_tokens
+          },
+          model: response.model
+        };
+
+        function fromBlock(block) {
+          if (block.type === 'text') {
+            return {
+              type: 'text',
+              text: block.text
+            };
+          }
+          if (block.type === 'tool_use') {
+            return {
+              type: 'toolCall',
+              id: block.id,
+              name: block.name,
+              input: block.input
+            };
+          }
+          return null;
+        }
+      },
+      // Map any error the transport produced to a normalized apos
+      // error, the only shape the engine reacts to. Transient failures
+      // — 429, 5xx, network trouble, our own timeout — become the
+      // retryable code with a `kind` hint; the provider's Retry-After
+      // (seconds or an HTTP date) is parsed into `retryAfter` seconds
+      // and its request id is carried for the failure records. A
+      // caller's own abort is not a provider failure and passes
+      // through untouched.
+      normalizeError(error) {
+        if (error?.name === 'AbortError') {
+          return error;
+        }
+        if (error?.name === 'TimeoutError') {
+          return self.apos.error('aiRetry', 'the provider request timed out', {
+            kind: 'timeout'
+          });
+        }
+        const status = error?.status;
+        if (!Number.isInteger(status)) {
+          return self.apos.error('aiRetry', `network failure: ${error?.message}`, {
+            kind: 'network'
+          });
+        }
+        const headers = error.headers || {};
+        const retryAfter = retryAfterSeconds(headers['retry-after']);
+        const data = {
+          status,
+          ...(headers['request-id'] !== undefined && { requestId: headers['request-id'] }),
+          ...(retryAfter !== undefined && { retryAfter })
+        };
+        const message = error.body?.error?.message || error.message;
+        if (status === 429) {
+          return self.apos.error('aiRetry', message, {
+            ...data,
+            kind: 'rateLimit'
+          });
+        }
+        if (status >= 500) {
+          return self.apos.error('aiRetry', message, {
+            ...data,
+            kind: 'overload'
+          });
+        }
+        if (status === 401 || status === 403) {
+          return self.apos.error('forbidden', message, data);
+        }
+        if (status === 404) {
+          return self.apos.error('notfound', message, data);
+        }
+        return self.apos.error('invalid', message, data);
+
+        function retryAfterSeconds(value) {
+          if (value === undefined) {
+            return undefined;
+          }
+          const seconds = Number(value);
+          if (Number.isFinite(seconds)) {
+            return Math.max(0, seconds);
+          }
+          const date = Date.parse(value);
+          if (Number.isNaN(date)) {
+            return undefined;
+          }
+          return Math.max(0, Math.ceil((date - Date.now()) / 1000));
+        }
+      }
+    };
+  }
+};

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -29,6 +29,8 @@ module.exports = {
     self.defaultProvider = self.options.provider ||
       Object.keys(self.options.providers)[0] || null;
     self.effortDefault = self.options.effort?.default || 'medium';
+    self.apos.http.addError('aiRetry', 503);
+    self.apos.http.addError('aiRefusal', 422);
   },
   handlers(self) {
     return {
@@ -42,6 +44,10 @@ module.exports = {
   methods(self) {
     function fail(message) {
       throw new Error(`@apostrophecms/ai: ${message}`);
+    }
+    function isObject(value) {
+      return Boolean(value) && typeof value === 'object' &&
+        !Array.isArray(value);
     }
 
     return {
@@ -238,6 +244,209 @@ module.exports = {
         }
         return info;
       },
+      // Parse and validate generate's (stringOrOptions, options)
+      // arguments into one canonical options object. The positional
+      // string is the final user turn: the sole message alone, appended
+      // when "messages" is present. Message content collapses to
+      // content-part form and "cache" defaults to 'short'. Unknown
+      // options are rejected as "invalid"; the reserved ones (tools,
+      // schema, maxSteps) as "unimplemented" until their phase ships.
+      normalizeGenerateOptions(stringOrOptions, options) {
+        const invalid = (message) => {
+          throw self.apos.error('invalid', message);
+        };
+        let prompt = null;
+        if (typeof stringOrOptions === 'string') {
+          if (!stringOrOptions) {
+            invalid('the prompt string must not be empty');
+          }
+          prompt = stringOrOptions;
+          options = options === undefined ? {} : options;
+          if (!isObject(options)) {
+            invalid('"options" must be an object');
+          }
+        } else if (isObject(stringOrOptions)) {
+          if (options !== undefined) {
+            invalid('a second argument is not accepted when the first is an options object');
+          }
+          options = stringOrOptions;
+        } else {
+          invalid('a prompt string or an options object is required');
+        }
+        for (const name of [ 'tools', 'schema', 'maxSteps' ]) {
+          if (options[name] !== undefined) {
+            throw self.apos.error('unimplemented', `"${name}" is not yet supported`);
+          }
+        }
+        const known = [
+          'system', 'messages', 'effort', 'provider', 'model',
+          'reasoning', 'maxTokens', 'cache', 'signal'
+        ];
+        for (const name of Object.keys(options)) {
+          if (!known.includes(name)) {
+            invalid(`unknown option "${name}"`);
+          }
+        }
+        const {
+          system, effort, provider, model, reasoning,
+          maxTokens, cache = 'short', signal
+        } = options;
+        for (const [ name, value ] of Object.entries({
+          system,
+          effort,
+          provider,
+          model,
+          reasoning
+        })) {
+          if (value !== undefined && typeof value !== 'string') {
+            invalid(`"${name}" must be a string`);
+          }
+        }
+        if (maxTokens !== undefined &&
+          (!Number.isInteger(maxTokens) || maxTokens < 1)) {
+          invalid('"maxTokens" must be a positive integer');
+        }
+        if (cache !== false && cache !== 'short' && cache !== 'long') {
+          invalid('"cache" must be false, "short" or "long"');
+        }
+        if (signal !== undefined && !(signal instanceof AbortSignal)) {
+          invalid('"signal" must be an AbortSignal');
+        }
+        const messages = self.normalizeMessages(options.messages);
+        if (prompt !== null) {
+          messages.push({
+            role: 'user',
+            content: [ {
+              type: 'text',
+              text: prompt
+            } ]
+          });
+        }
+        if (!messages.length) {
+          invalid('a prompt string or "messages" is required');
+        }
+        return {
+          system,
+          messages,
+          effort,
+          provider,
+          model,
+          reasoning,
+          maxTokens,
+          cache,
+          signal
+        };
+      },
+      // Validate and normalize chat messages to content-part form:
+      // roles user/assistant, string content becomes a single text
+      // part. Messages are rebuilt from the recognized properties, so a
+      // stored transcript carrying app metadata round-trips. Tool
+      // messages arrive with the loop and are rejected until then.
+      normalizeMessages(messages = []) {
+        const invalid = (message) => {
+          throw self.apos.error('invalid', message);
+        };
+        if (!Array.isArray(messages)) {
+          invalid('"messages" must be an array');
+        }
+        return messages.map((message, index) => {
+          const name = `messages[${index}]`;
+          if (!isObject(message)) {
+            invalid(`${name} must be an object like { role, content }`);
+          }
+          if (message.role === 'tool') {
+            throw self.apos.error('unimplemented', `${name}: "tool" messages are not yet supported`);
+          }
+          if (message.role !== 'user' && message.role !== 'assistant') {
+            invalid(`${name}.role must be "user" or "assistant"`);
+          }
+          return {
+            role: message.role,
+            content: contentParts(message.content, name)
+          };
+        });
+
+        // One message's content → validated content-part array, rebuilt
+        // so extra properties never travel. A plain string is shorthand
+        // for a single text part.
+        function contentParts(content, name) {
+          if (typeof content === 'string') {
+            return [ {
+              type: 'text',
+              text: content
+            } ];
+          }
+          if (!Array.isArray(content) || !content.length) {
+            throw self.apos.error('invalid', `${name}.content must be a string or a non-empty array of content parts`);
+          }
+          return content.map((part, index) => {
+            const partName = `${name}.content[${index}]`;
+            if (!isObject(part)) {
+              throw self.apos.error('invalid', `${partName} must be an object like { type }`);
+            }
+            if (part.type === 'toolCall' || part.type === 'toolResult') {
+              throw self.apos.error('unimplemented', `${partName}: "${part.type}" parts are not yet supported`);
+            }
+            if (part.type === 'text') {
+              if (typeof part.text !== 'string') {
+                throw self.apos.error('invalid', `${partName}.text must be a string`);
+              }
+              return {
+                type: 'text',
+                text: part.text
+              };
+            }
+            if (part.type === 'image') {
+              const image = part.image;
+              if (isObject(image) && typeof image.url === 'string') {
+                return {
+                  type: 'image',
+                  image: { url: image.url }
+                };
+              }
+              if (isObject(image) && typeof image.data === 'string' &&
+                typeof image.mediaType === 'string') {
+                return {
+                  type: 'image',
+                  image: {
+                    data: image.data,
+                    mediaType: image.mediaType
+                  }
+                };
+              }
+              throw self.apos.error('invalid', `${partName}.image must be an object like { url } or { data, mediaType }`);
+            }
+            throw self.apos.error('invalid', `${partName}.type "${part.type}" is unknown`);
+          });
+        }
+      },
+      // Assemble the normalized adapter request from canonical generate
+      // options: resolve routing, default maxTokens to the model's
+      // declared output ceiling when it is known, translate the cache
+      // level to the { ttl } policy. Returns { provider, request }.
+      buildRequest(options) {
+        const info = self.modelInfo({
+          provider: options.provider,
+          model: options.model,
+          effort: options.effort,
+          reasoning: options.reasoning
+        });
+        const maxTokens = options.maxTokens ?? info.maxOutputTokens;
+        return {
+          provider: info.provider,
+          request: {
+            ...(options.system !== undefined && { system: options.system }),
+            messages: options.messages,
+            model: info.model,
+            ...(maxTokens !== undefined && { maxTokens }),
+            ...(info.reasoning !== undefined && { reasoning: info.reasoning }),
+            cache: options.cache === false
+              ? false
+              : { ttl: options.cache },
+            ...(options.signal !== undefined && { signal: options.signal })
+          }
+        };
+      },
       // Union of the adapter's and the entry's model metadata,
       // merged per model id with the entry's fields winning
       mergeModels(adapterModels = {}, entryModels = {}) {
@@ -258,8 +467,6 @@ module.exports = {
       // (unknown adapters, dangling routing references, effort levels with
       // no row) happen later, at activation.
       validateOptions(options) {
-        const isObject = (value) => value && typeof value === 'object' &&
-          !Array.isArray(value);
         const checkString = (value, name) => {
           if (value !== undefined && typeof value !== 'string') {
             fail(`"${name}" must be a string`);

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -9,7 +9,8 @@
 module.exports = {
   options: {
     alias: 'ai',
-    // providers: { name: { apiKey, baseUrl, adapter, models, effort, capabilities } }
+    // providers: { name: { apiKey, envKey, baseUrl, adapter, models,
+    //   effort, capabilities } }
     providers: {},
     // provider: the default provider name; inferred when only one is configured
     // effort: { default, levels: { name: { provider, model, reasoning } } }
@@ -76,7 +77,9 @@ module.exports = {
       // it names with the entry's config, validate it, merge the entry's
       // service description (models, effort rows, capabilities) over the
       // adapter's declared data, then build the effort routing table.
-      // Misconfigurations fail the startup.
+      // Misconfigurations fail the startup. An entry's key prefers the
+      // environment: the variable named by its envKey (the entry's own
+      // over the adapter's default) overrides the configured apiKey.
       async activateProviders() {
         const {
           providers = {}, effort = {}, image
@@ -94,10 +97,12 @@ module.exports = {
             fail(`adapter "${adapterName}" does not implement validate()`);
           }
           const aliased = adapterName !== name;
+          const envKey = entry.envKey || adapter.envKey;
+          const envApiKey = envKey && process.env[envKey];
           const instance = {
             ...adapter,
             provider: name,
-            apiKey: entry.apiKey,
+            apiKey: envApiKey || entry.apiKey,
             baseUrl: entry.baseUrl || adapter.baseUrl
           };
           if (!self.mockMode) {
@@ -661,6 +666,22 @@ module.exports = {
       // whole, so response validation belongs inside it: a truncated
       // body must travel the same retry path.
       //
+      // A normalized error may carry hints in `error.data`, the only
+      // properties the engine reads — all optional, attached by the
+      // adapter's normalizeError:
+      // `status` (integer): the provider's HTTP status code;
+      // `kind` (string, on the transient code): which transient
+      //   failure this is — 'rateLimit', 'overload', 'timeout' or
+      //   'network';
+      // `retryAfter` (number, in SECONDS): the provider's Retry-After;
+      //   replaces the computed backoff delay (see retryDelay);
+      // `requestId` (string): the provider's request id, for support.
+      // Hints shape the delay and the records, never the routing: the
+      // error's code alone decides retry versus stop. All of these
+      // are written to the failure and retry log records — treat
+      // `error.data` as log-bound and never put sensitive data (keys,
+      // credentials, personal data) in it.
+      //
       // Every failure and every retry decision emits one structured log
       // record: type `retry` (warn) when the call will be retried, type
       // `failure` (error) when it stops, with { provider, model, code,
@@ -858,6 +879,7 @@ module.exports = {
             fail(`"providers.${name}" must be an object`);
           }
           checkString(entry.apiKey, `providers.${name}.apiKey`);
+          checkString(entry.envKey, `providers.${name}.envKey`);
           checkString(entry.baseUrl, `providers.${name}.baseUrl`);
           checkString(entry.adapter, `providers.${name}.adapter`);
           if (entry.models !== undefined) {

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -16,7 +16,9 @@ module.exports = {
     // image: { provider, model, aspect, quality }
     // mock: (request) => assistant turn, consulted only under APOS_AI_MOCK
     // Conservative agent-loop cap; any call may override it
-    maxSteps: 5
+    maxSteps: 5,
+    // Transient-failure retry cap, counting calls
+    retryAttempts: 5
   },
   init(self) {
     self.adapters = {};
@@ -244,13 +246,14 @@ module.exports = {
         }
         return info;
       },
-      // Parse and validate generate's (stringOrOptions, options)
-      // arguments into one canonical options object. The positional
-      // string is the final user turn: the sole message alone, appended
-      // when "messages" is present. Message content collapses to
-      // content-part form and "cache" defaults to 'short'. Unknown
-      // options are rejected as "invalid"; the reserved ones (tools,
-      // schema, maxSteps) as "unimplemented" until their phase ships.
+      // Parse and validate generate's `(stringOrOptions, options)`
+      // arguments, exactly as passed to it, into one canonical options
+      // object `{ system, messages, effort, provider, model, reasoning,
+      // maxTokens, cache, signal }` — the positional prompt string
+      // appended to `messages` as the final user turn, message content
+      // collapsed to content-part form, `cache` defaulted to 'short',
+      // unset options left undefined. Unknown options are rejected as
+      // "invalid".
       normalizeGenerateOptions(stringOrOptions, options) {
         const invalid = (message) => {
           throw self.apos.error('invalid', message);
@@ -337,11 +340,13 @@ module.exports = {
           signal
         };
       },
-      // Validate and normalize chat messages to content-part form:
-      // roles user/assistant, string content becomes a single text
-      // part. Messages are rebuilt from the recognized properties, so a
-      // stored transcript carrying app metadata round-trips. Tool
-      // messages arrive with the loop and are rejected until then.
+      // Validate and normalize an array of chat messages, as accepted
+      // by generate's `messages` option (undefined is an empty
+      // conversation). Returns a new array of { role, content } with
+      // `content` always an array of content parts: roles user or
+      // assistant, string content becomes a single text part. Messages
+      // are rebuilt from the recognized properties, so a stored
+      // transcript carrying app metadata round-trips.
       normalizeMessages(messages = []) {
         const invalid = (message) => {
           throw self.apos.error('invalid', message);
@@ -420,10 +425,15 @@ module.exports = {
           });
         }
       },
-      // Assemble the normalized adapter request from canonical generate
-      // options: resolve routing, default maxTokens to the model's
-      // declared output ceiling when it is known, translate the cache
-      // level to the { ttl } policy. Returns { provider, request }.
+      // Assemble the normalized adapter request from `options`, a
+      // canonical object as produced by normalizeGenerateOptions:
+      // resolve routing, default maxTokens to the model's declared
+      // output ceiling when it is known, translate the cache level to
+      // the { ttl } policy. Returns { provider, request }: the resolved
+      // provider name and the request handed to its adapter —
+      // { system?, messages, model, maxTokens?, reasoning?,
+      // cache: false | { ttl }, signal? }, optional fields present only
+      // when they resolved to a value.
       buildRequest(options) {
         const info = self.modelInfo({
           provider: options.provider,
@@ -445,6 +455,170 @@ module.exports = {
               : { ttl: options.cache },
             ...(options.signal !== undefined && { signal: options.signal })
           }
+        };
+      },
+      // The language method: plain text and multi-turn chat against the
+      // routed provider.
+      //
+      // `req` is the caller's request object, carried into events, the
+      // adapter and (later) tool handlers — the core never invents auth.
+      //
+      // `stringOrOptions` is either the user prompt string, optionally
+      // followed by an `options` object, or one options object alone
+      // (then a third argument is not accepted). A prompt string is the
+      // final user turn: the sole message alone, appended as the latest
+      // turn when `messages` is present.
+      //
+      // Options:
+      // `system` (string): the system prompt — a top-level option,
+      //   never a message;
+      // `messages` (array): the conversation so far, each entry
+      //   { role: 'user' | 'assistant', content } with content a string
+      //   or an array of `text` / `image` content parts;
+      // `effort` (string): the routing level to resolve, defaulting to
+      //   the module's default level;
+      // `provider`, `model` (strings, only together): the explicit
+      //   target, bypassing the routing table;
+      // `reasoning` (string): override the resolved entry's reasoning;
+      // `maxTokens` (positive integer): output-token cap, defaulting to
+      //   the routed model's declared ceiling when it is known;
+      // `cache` (false | 'short' | 'long', default 'short'): the
+      //   prompt-cache policy the adapter translates for its provider;
+      // `signal` (AbortSignal): aborts the in-flight provider call.
+      //
+      // Returns { text, messages, finishReason, usage, model, provider }:
+      // `text` is the assistant's text (may be ''), `messages` the full
+      // transcript ending with the assistant turn — pass it back as
+      // `messages` to continue the conversation — `finishReason` is
+      // 'stop' or 'length', `usage` counts { inputTokens, outputTokens }
+      // and `model` / `provider` name what actually answered.
+      //
+      // Throws normalized apos errors only: "invalid"
+      // for bad calls, "aiRetry" when transient provider failures
+      // outlast the retry budget, "aiRefusal" when the model refuses.
+      // Emits `beforeGenerate` and `afterGenerate` around the call.
+      async generate(req, stringOrOptions, options) {
+        const canonical = self.normalizeGenerateOptions(stringOrOptions, options);
+        const { provider, request } = self.buildRequest(canonical);
+        self.checkCapability(provider, 'text');
+        const record = self.providers[provider];
+        // One shared, mutable payload for both events, so handlers can
+        // enrich the request and correlate the two
+        const context = {
+          provider,
+          request
+        };
+        await self.emit('beforeGenerate', req, context);
+        const turn = await self.callAdapter(record, async () => {
+          return self.validateTurn(await record.adapter.chat(req, context.request));
+        });
+        if (turn.finishReason === 'refusal') {
+          throw self.apos.error('aiRefusal', 'the model refused this request');
+        }
+        if (turn.finishReason === 'toolCalls') {
+          throw self.apos.error(
+            'invalid',
+            'the model returned tool calls but the call sent no tools'
+          );
+        }
+        context.result = self.assembleResult(context, turn);
+        await self.emit('afterGenerate', req, context);
+        return context.result;
+      },
+      // Throw "invalid" when the configured provider named by
+      // `provider` does not declare `capability` (a key of the
+      // capabilities map, e.g. 'text'). A call needing a capability the
+      // routed provider lacks is a clear error, never a silent
+      // re-route.
+      checkCapability(provider, capability) {
+        if (!self.providers[provider]?.capabilities?.[capability]) {
+          throw self.apos.error(
+            'invalid',
+            `provider "${provider}" does not declare the "${capability}" capability`
+          );
+        }
+      },
+      // Run one adapter call with retries. `record` is an activated
+      // entry of `self.providers` (supplies the adapter and its
+      // normalizeError); `call` is an async thunk performing a single
+      // adapter call and validating its response. Resolves with the
+      // thunk's value; throws normalized apos errors — every throw is
+      // routed through the adapter's required normalizeError, the core
+      // reacts on codes only, and only the transient code is retried.
+      // `call` is retried whole, so response validation belongs inside
+      // it: a truncated body must travel the same retry path. Backoff,
+      // budgets and failure records arrive with the retry policy.
+      async callAdapter(record, call) {
+        for (let attempt = 1; ; attempt++) {
+          try {
+            return await call();
+          } catch (e) {
+            const error = (e?.aposError ? e : record.adapter.normalizeError(e)) || e;
+            if (error.name !== 'aiRetry' || attempt >= self.options.retryAttempts) {
+              throw error;
+            }
+          }
+        }
+      },
+      // Enforce the assistant-turn contract on `turn`, an adapter chat
+      // response { content, finishReason, usage, model? }, and return
+      // it unchanged. A missing or unknown finishReason, or malformed
+      // content or usage, is a truncated or malformed response: it
+      // throws the transient code so the call travels the retry path —
+      // never a shorter-than-intended "success".
+      validateTurn(turn) {
+        const malformed = (detail) => {
+          throw self.apos.error('aiRetry', `malformed assistant turn: ${detail}`);
+        };
+        if (!isObject(turn)) {
+          malformed('not an object');
+        }
+        if (!Array.isArray(turn.content)) {
+          malformed('"content" must be an array of content parts');
+        }
+        for (const part of turn.content) {
+          if (!isObject(part) || typeof part.type !== 'string') {
+            malformed('content parts must be objects with a "type"');
+          }
+          if (part.type === 'text' && typeof part.text !== 'string') {
+            malformed('text parts must carry a string "text"');
+          }
+        }
+        if (![ 'stop', 'toolCalls', 'length', 'refusal' ].includes(turn.finishReason)) {
+          malformed(`"${turn.finishReason}" is not a finish reason`);
+        }
+        if (!isObject(turn.usage) ||
+          !Number.isFinite(turn.usage.inputTokens) ||
+          !Number.isFinite(turn.usage.outputTokens)) {
+          malformed('"usage" must carry inputTokens and outputTokens');
+        }
+        return turn;
+      },
+      // Build generate's unified return object from `context` (the
+      // event payload carrying the provider name and the request) and
+      // `turn` (the validated adapter response). Returns { text,
+      // messages, finishReason, usage, model, provider }; which fields
+      // are populated tells the caller what happened. The transcript
+      // includes the assistant turn, so it is resumable as the next
+      // call's `messages`.
+      assembleResult(context, turn) {
+        const text = turn.content
+          .filter(part => part.type === 'text')
+          .map(part => part.text)
+          .join('');
+        return {
+          text,
+          messages: [
+            ...context.request.messages,
+            {
+              role: 'assistant',
+              content: turn.content
+            }
+          ],
+          finishReason: turn.finishReason,
+          usage: turn.usage,
+          model: turn.model || context.request.model,
+          provider: context.provider
         };
       },
       // Union of the adapter's and the entry's model metadata,
@@ -486,7 +660,7 @@ module.exports = {
         };
 
         const {
-          providers, provider, effort, image, maxSteps, mock
+          providers, provider, effort, image, maxSteps, mock, retryAttempts
         } = options;
 
         if (!isObject(providers)) {
@@ -565,6 +739,10 @@ module.exports = {
 
         if (mock !== undefined && typeof mock !== 'function') {
           fail('"mock" must be a function');
+        }
+
+        if (!Number.isInteger(retryAttempts) || retryAttempts < 1) {
+          fail('"retryAttempts" must be a positive integer');
         }
       }
     };

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -29,13 +29,15 @@ module.exports = {
     self.adapters = {};
     self.providers = {};
     self.effortTable = {};
-    // "Is AI operational?" — true only once activation has configured
-    // at least one provider, so feature code can ask before calling
+    // "Is AI operational?" — true once activation has configured at
+    // least one provider, or unconditionally under APOS_AI_MOCK, so
+    // feature code can ask before calling
     self.active = false;
     self.validateOptions(self.options);
     self.defaultProvider = self.options.provider ||
       Object.keys(self.options.providers)[0] || null;
     self.effortDefault = self.options.effort?.default || 'medium';
+    self.mockMode = process.env.APOS_AI_MOCK === '1';
     self.apos.http.addError('aiRetry', 503);
     self.apos.http.addError('aiRefusal', 422);
   },
@@ -98,7 +100,7 @@ module.exports = {
             apiKey: entry.apiKey,
             baseUrl: entry.baseUrl || adapter.baseUrl
           };
-          if (!process.env.APOS_AI_MOCK) {
+          if (!self.mockMode) {
             await instance.validate();
           }
           self.providers[name] = {
@@ -140,7 +142,8 @@ module.exports = {
           fail(`the default effort level "${self.effortDefault}" resolves to no routing entry; add it to "effort.levels" or configure a default provider whose adapter declares it`);
         }
 
-        self.active = Object.keys(self.providers).length > 0;
+        self.active = Object.keys(self.providers).length > 0 ||
+          self.mockMode;
       },
       // The routing table: the default provider's rows are the base,
       // the project's "effort.levels" replace it level by level
@@ -462,6 +465,89 @@ module.exports = {
           }
         };
       },
+      // Assemble the adapter request without routing, for mock mode
+      // with no providers configured. Same input and return shape as
+      // buildRequest, with the call's explicit provider and model when
+      // given and "mock" placeholders otherwise; no model metadata
+      // exists here, so maxTokens appears only when the call sets it.
+      buildMockRequest(options) {
+        return {
+          provider: options.provider ?? 'mock',
+          request: {
+            ...(options.system !== undefined && { system: options.system }),
+            messages: options.messages,
+            model: options.model ?? 'mock',
+            ...(options.maxTokens !== undefined && { maxTokens: options.maxTokens }),
+            ...(options.reasoning !== undefined && { reasoning: options.reasoning }),
+            cache: options.cache === false
+              ? false
+              : { ttl: options.cache },
+            ...(options.signal !== undefined && { signal: options.signal })
+          }
+        };
+      },
+      // The built-in mock standing in for every adapter chat under
+      // APOS_AI_MOCK. Consults the "mock" option first when the module
+      // has one: it may return a complete assistant turn, a { text }
+      // shorthand filled out into one, or undefined to fall through to
+      // the deterministic default — canned text echoing the
+      // conversation's final message, usage estimated from the text
+      // sizes. Runs inside the same retry and validation seam as a
+      // real adapter call, so a mock that throws normalized codes
+      // exercises the real error paths.
+      async mockChat(req, request) {
+        const custom = self.options.mock
+          ? await self.options.mock(request)
+          : undefined;
+        if (custom == null) {
+          const tail = textOf(request.messages.at(-1).content);
+          return turn(`[mock] ${tail}`);
+        }
+        if (isObject(custom) && Array.isArray(custom.content)) {
+          return custom;
+        }
+        if (isObject(custom) && typeof custom.text === 'string') {
+          return turn(custom.text);
+        }
+        throw self.apos.error(
+          'invalid',
+          '"mock" must return an assistant turn, a { text } object or undefined'
+        );
+
+        function turn(text) {
+          const input = [
+            request.system,
+            ...request.messages.map((message) => textOf(message.content))
+          ].filter(Boolean).join(' ');
+          return {
+            content: [ {
+              type: 'text',
+              text
+            } ],
+            finishReason: 'stop',
+            usage: {
+              inputTokens: tokens(input),
+              outputTokens: tokens(text)
+            }
+          };
+        }
+        function textOf(content) {
+          return content
+            .filter((part) => part.type === 'text')
+            .map((part) => part.text)
+            .join(' ');
+        }
+        // ~4 characters per token, the usual plain-text ballpark
+        function tokens(text) {
+          return Math.max(1, Math.round(text.length / 4));
+        }
+      },
+      // The mock adapter's error normalization: errors pass through
+      // untouched, so a mock throwing normalized codes exercises the
+      // real error paths
+      mockNormalizeError(error) {
+        return error;
+      },
       // The language method: plain text and multi-turn chat against the
       // routed provider.
       //
@@ -502,11 +588,29 @@ module.exports = {
       // for bad calls, "aiRetry" when transient provider failures
       // outlast the retry budget, "aiRefusal" when the model refuses.
       // Emits `beforeGenerate` and `afterGenerate` around the call.
+      //
+      // Under APOS_AI_MOCK the built-in mock answers every call in
+      // place of any adapter — same pipeline, no network; with no
+      // providers configured at all, placeholder routing stands in.
       async generate(req, stringOrOptions, options) {
         const canonical = self.normalizeGenerateOptions(stringOrOptions, options);
-        const { provider, request } = self.buildRequest(canonical);
-        self.checkCapability(provider, 'text');
-        const record = self.providers[provider];
+        let provider;
+        let request;
+        if (self.mockMode && !Object.keys(self.providers).length) {
+          ({ provider, request } = self.buildMockRequest(canonical));
+        } else {
+          ({ provider, request } = self.buildRequest(canonical));
+          self.checkCapability(provider, 'text');
+        }
+        const record = self.mockMode
+          ? {
+            name: provider,
+            adapter: {
+              chat: self.mockChat,
+              normalizeError: self.mockNormalizeError
+            }
+          }
+          : self.providers[provider];
         // One shared, mutable payload for both events, so handlers can
         // enrich the request and correlate the two
         const context = {

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -18,7 +18,12 @@ module.exports = {
     // Conservative agent-loop cap; any call may override it
     maxSteps: 5,
     // Transient-failure retry cap, counting calls
-    retryAttempts: 5
+    retryAttempts: 5,
+    // Base delay in milliseconds for the exponential retry curve
+    retryBaseDelay: 1000,
+    // Elapsed-time budget in milliseconds for one call including its
+    // retry waits; a delay that would land past it stops the call
+    retryMaxElapsed: 60000
   },
   init(self) {
     self.adapters = {};
@@ -509,7 +514,7 @@ module.exports = {
           request
         };
         await self.emit('beforeGenerate', req, context);
-        const turn = await self.callAdapter(record, async () => {
+        const turn = await self.callAdapter(req, record, context.request, async () => {
           return self.validateTurn(await record.adapter.chat(req, context.request));
         });
         if (turn.finishReason === 'refusal') {
@@ -538,27 +543,104 @@ module.exports = {
           );
         }
       },
-      // Run one adapter call with retries. `record` is an activated
-      // entry of `self.providers` (supplies the adapter and its
-      // normalizeError); `call` is an async thunk performing a single
-      // adapter call and validating its response. Resolves with the
-      // thunk's value; throws normalized apos errors — every throw is
-      // routed through the adapter's required normalizeError, the core
-      // reacts on codes only, and only the transient code is retried.
-      // `call` is retried whole, so response validation belongs inside
-      // it: a truncated body must travel the same retry path. Backoff,
-      // budgets and failure records arrive with the retry policy.
-      async callAdapter(record, call) {
+      // Run one adapter call with retries. `req` is the caller's
+      // request, enriching the failure records; `record` is an
+      // activated entry of `self.providers` (supplies the adapter and
+      // its normalizeError); `request` is the normalized adapter
+      // request, read only for record context; `call` is an async thunk
+      // performing a single adapter call and validating its response.
+      // Resolves with the thunk's value; throws normalized apos errors
+      // — every throw is routed through the adapter's required
+      // normalizeError, the core reacts on codes only, and only the
+      // transient code is retried, waiting per retryDelay under the
+      // retryAttempts and retryMaxElapsed budgets. `call` is retried
+      // whole, so response validation belongs inside it: a truncated
+      // body must travel the same retry path.
+      //
+      // Every failure and every retry decision emits one structured log
+      // record: type `retry` (warn) when the call will be retried, type
+      // `failure` (error) when it stops, with { provider, model, code,
+      // status, kind, requestId, retryAfter, attempt, elapsed, action,
+      // reason?, delay? } — enough to tell a rate limit from an
+      // overload, a timeout or bad config from the one record. A
+      // `failure` record also carries the stack of the original throw.
+      async callAdapter(req, record, request, call) {
+        const started = Date.now();
         for (let attempt = 1; ; attempt++) {
           try {
             return await call();
           } catch (e) {
             const error = (e?.aposError ? e : record.adapter.normalizeError(e)) || e;
-            if (error.name !== 'aiRetry' || attempt >= self.options.retryAttempts) {
+            const elapsed = Date.now() - started;
+            const data = {
+              provider: record.name,
+              model: request.model,
+              code: error.name,
+              status: error.data?.status,
+              kind: error.data?.kind,
+              requestId: error.data?.requestId,
+              retryAfter: error.data?.retryAfter,
+              attempt,
+              elapsed
+            };
+            // The original throw site is the useful trace when the
+            // adapter wrapped a client error
+            const stack = e?.stack || error.stack;
+            if (error.name !== 'aiRetry') {
+              self.logError(req, 'failure', error.message, {
+                ...data,
+                action: 'stop',
+                stack
+              });
               throw error;
             }
+            if (attempt >= self.options.retryAttempts) {
+              self.logError(req, 'failure', error.message, {
+                ...data,
+                action: 'stop',
+                reason: 'attempts',
+                stack
+              });
+              throw error;
+            }
+            const delay = self.retryDelay(attempt, error);
+            if (elapsed + delay > self.options.retryMaxElapsed) {
+              self.logError(req, 'failure', error.message, {
+                ...data,
+                action: 'stop',
+                reason: 'budget',
+                delay,
+                stack
+              });
+              throw error;
+            }
+            self.logWarn(req, 'retry', error.message, {
+              ...data,
+              action: 'retry',
+              delay
+            });
+            await self.pause(delay);
           }
         }
+      },
+      // The wait in milliseconds before the attempt following `attempt`
+      // (1-based), after the normalized transient failure `error`: the
+      // provider's Retry-After (seconds, in the error's
+      // `data.retryAfter`) when it sent one, else exponential backoff
+      // with jitter — retryBaseDelay * 2^(attempt - 1), scaled by a
+      // random factor in [1, 2) so synchronized clients spread out.
+      retryDelay(attempt, error) {
+        const retryAfter = error.data?.retryAfter;
+        if (Number.isFinite(retryAfter) && retryAfter >= 0) {
+          return retryAfter * 1000;
+        }
+        const curve = self.options.retryBaseDelay * Math.pow(2, attempt - 1);
+        return Math.round(curve * (1 + Math.random()));
+      },
+      // Wait `ms` before the next attempt; a separate method so tests
+      // can observe or skip real waiting
+      pause(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
       },
       // Enforce the assistant-turn contract on `turn`, an adapter chat
       // response { content, finishReason, usage, model? }, and return
@@ -660,7 +742,8 @@ module.exports = {
         };
 
         const {
-          providers, provider, effort, image, maxSteps, mock, retryAttempts
+          providers, provider, effort, image, maxSteps, mock,
+          retryAttempts, retryBaseDelay, retryMaxElapsed
         } = options;
 
         if (!isObject(providers)) {
@@ -741,8 +824,14 @@ module.exports = {
           fail('"mock" must be a function');
         }
 
-        if (!Number.isInteger(retryAttempts) || retryAttempts < 1) {
-          fail('"retryAttempts" must be a positive integer');
+        for (const [ name, value ] of Object.entries({
+          retryAttempts,
+          retryBaseDelay,
+          retryMaxElapsed
+        })) {
+          if (!Number.isInteger(value) || value < 1) {
+            fail(`"${name}" must be a positive integer`);
+          }
         }
       }
     };

--- a/packages/apostrophe/test/ai-adapter-anthropic.js
+++ b/packages/apostrophe/test/ai-adapter-anthropic.js
@@ -1,0 +1,685 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert/strict');
+
+describe('AI adapter: anthropic', function() {
+  this.timeout(t.timeout);
+
+  let apos;
+  // The adapter module instance, for unit access to the dialect methods
+  let adapter;
+  let savedLiveKey;
+
+  before(async function() {
+    // A real key in the environment would override the fixture keys
+    // below (envKey); keep the suite hermetic and restore at the end
+    savedLiveKey = process.env.APOS_ANTHROPIC_KEY;
+    delete process.env.APOS_ANTHROPIC_KEY;
+    apos = await t.create({
+      root: module,
+      modules: {
+        '@apostrophecms/ai': {
+          options: {
+            provider: 'anthropic',
+            providers: {
+              anthropic: { apiKey: 'sk-test' },
+              gateway: {
+                adapter: 'anthropic',
+                apiKey: 'sk-gw',
+                baseUrl: 'https://llm-gateway.example.com/anthropic'
+              }
+            },
+            // Keep retried tests fast; the delay engine has its own suite
+            retryBaseDelay: 1
+          }
+        }
+      }
+    });
+    adapter = apos.modules['@apostrophecms/ai-adapter-anthropic'];
+  });
+
+  after(async function() {
+    if (savedLiveKey !== undefined) {
+      process.env.APOS_ANTHROPIC_KEY = savedLiveKey;
+    }
+    if (apos) {
+      return t.destroy(apos);
+    }
+  });
+
+  const text = (value) => ({
+    type: 'text',
+    text: value
+  });
+  const userMessage = (value) => ({
+    role: 'user',
+    content: [ text(value) ]
+  });
+  // A minimal normalized adapter request, as the engine assembles it
+  const request = (extras = {}) => ({
+    messages: [ userMessage('write a haiku about cats') ],
+    model: 'claude-sonnet-4-6',
+    maxTokens: 64000,
+    cache: false,
+    ...extras
+  });
+  // A canned Messages API response body
+  const fixture = (extras = {}) => ({
+    id: 'msg_1',
+    type: 'message',
+    role: 'assistant',
+    content: [ text('a haiku') ],
+    model: 'claude-sonnet-4-6-20250929',
+    stop_reason: 'end_turn',
+    stop_sequence: null,
+    usage: {
+      input_tokens: 12,
+      output_tokens: 7
+    },
+    ...extras
+  });
+  // An apos.http >= 400 throw: Error with status, headers, body
+  const httpError = (status, headers = {}, body) => Object.assign(
+    new Error(`HTTP error ${status}`),
+    {
+      status,
+      headers,
+      body
+    }
+  );
+
+  it('registers the adapter and activates the provider', function() {
+    assert(apos.ai.getAdapter('anthropic'));
+    assert.equal(apos.ai.active, true);
+    const info = apos.ai.modelInfo();
+    assert.equal(info.provider, 'anthropic');
+    assert.equal(info.model, 'claude-sonnet-4-6');
+    assert.equal(info.contextWindow, 200000);
+    assert.equal(info.maxOutputTokens, 64000);
+    const high = apos.ai.modelInfo({ effort: 'high' });
+    assert.equal(high.model, 'claude-opus-4-8');
+    assert.equal(high.reasoning, 'high');
+  });
+
+  describe('request translation', function() {
+    it('builds the minimal body', function() {
+      assert.deepEqual(adapter.buildBody(request()), {
+        model: 'claude-sonnet-4-6',
+        max_tokens: 64000,
+        messages: [ {
+          role: 'user',
+          content: [ {
+            type: 'text',
+            text: 'write a haiku about cats'
+          } ]
+        } ]
+      });
+    });
+
+    it('places the cache markers on the system tail and the last message', function() {
+      const body = adapter.buildBody(request({
+        system: 'You help editors.',
+        messages: [
+          userMessage('Do we have a pricing page?'),
+          {
+            role: 'assistant',
+            content: [ text('No, I did not find one.') ]
+          },
+          userMessage('Create one.')
+        ],
+        cache: { ttl: 'short' }
+      }));
+      assert.deepEqual(body.system, [ {
+        type: 'text',
+        text: 'You help editors.',
+        cache_control: { type: 'ephemeral' }
+      } ]);
+      // Only the rolling marker on the final message, nothing earlier
+      assert.deepEqual(body.messages.map((message) =>
+        message.content.some((block) => block.cache_control)
+      ), [ false, false, true ]);
+      assert.deepEqual(body.messages.at(-1).content.at(-1).cache_control, {
+        type: 'ephemeral'
+      });
+    });
+
+    it('maps the long cache level to the 1h ttl', function() {
+      const body = adapter.buildBody(request({ cache: { ttl: 'long' } }));
+      assert.deepEqual(body.messages.at(-1).content.at(-1).cache_control, {
+        type: 'ephemeral',
+        ttl: '1h'
+      });
+    });
+
+    it('places no markers when caching is off', function() {
+      const body = adapter.buildBody(request({ system: 'S' }));
+      assert.equal(body.system, 'S');
+      assert.equal(body.messages.at(-1).content.at(-1).cache_control, undefined);
+    });
+
+    it('translates both image part forms', function() {
+      const body = adapter.buildBody(request({
+        messages: [ {
+          role: 'user',
+          content: [
+            text('describe these'),
+            {
+              type: 'image',
+              image: { url: 'https://example.com/a.png' }
+            },
+            {
+              type: 'image',
+              image: {
+                data: 'aGk=',
+                mediaType: 'image/png'
+              }
+            }
+          ]
+        } ]
+      }));
+      assert.deepEqual(body.messages[0].content.slice(1), [
+        {
+          type: 'image',
+          source: {
+            type: 'url',
+            url: 'https://example.com/a.png'
+          }
+        },
+        {
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: 'image/png',
+            data: 'aGk='
+          }
+        }
+      ]);
+    });
+
+    it('maps reasoning levels to thinking budgets', function() {
+      for (const [ level, budget ] of [
+        [ 'low', 1024 ],
+        [ 'medium', 4096 ],
+        [ 'high', 16384 ]
+      ]) {
+        assert.deepEqual(
+          adapter.buildBody(request({ reasoning: level })).thinking,
+          {
+            type: 'enabled',
+            budget_tokens: budget
+          }
+        );
+      }
+    });
+
+    it('reads the budgets from the thinkingBudgets option', function() {
+      const saved = adapter.options.thinkingBudgets;
+      try {
+        adapter.options.thinkingBudgets = {
+          ...saved,
+          medium: 8192
+        };
+        assert.equal(
+          adapter.buildBody(request({ reasoning: 'medium' })).thinking.budget_tokens,
+          8192
+        );
+      } finally {
+        adapter.options.thinkingBudgets = saved;
+      }
+    });
+
+    it('rejects untranslatable requests', function() {
+      const throwsInvalid = (fn, pattern) => {
+        assert.throws(fn, (e) => {
+          assert.equal(e.name, 'invalid');
+          assert.match(e.message, pattern);
+          return true;
+        });
+      };
+      throwsInvalid(
+        () => adapter.buildBody(request({ reasoning: 'extreme' })),
+        /no thinking budget is configured for reasoning "extreme"/
+      );
+      throwsInvalid(
+        () => adapter.buildBody(request({
+          reasoning: 'high',
+          maxTokens: 1000
+        })),
+        /must exceed the "high" thinking budget/
+      );
+      throwsInvalid(
+        () => adapter.buildBody(request({ maxTokens: undefined })),
+        /"maxTokens" is required/
+      );
+    });
+  });
+
+  describe('response parsing', function() {
+    it('parses a text turn', function() {
+      assert.deepEqual(adapter.parseResponse(fixture()), {
+        content: [ text('a haiku') ],
+        finishReason: 'stop',
+        usage: {
+          inputTokens: 12,
+          outputTokens: 7
+        },
+        model: 'claude-sonnet-4-6-20250929'
+      });
+    });
+
+    it('maps the stop reasons', function() {
+      for (const [ theirs, ours ] of [
+        [ 'end_turn', 'stop' ],
+        [ 'stop_sequence', 'stop' ],
+        [ 'max_tokens', 'length' ],
+        [ 'tool_use', 'toolCalls' ],
+        // Unknown reasons yield none: the engine treats the turn as
+        // malformed and retries, never a truncated success
+        [ 'pause_turn', undefined ]
+      ]) {
+        assert.equal(
+          adapter.parseResponse(fixture({ stop_reason: theirs })).finishReason,
+          ours
+        );
+      }
+    });
+
+    it('translates tool_use blocks and drops thinking blocks', function() {
+      const turn = adapter.parseResponse(fixture({
+        content: [
+          {
+            type: 'thinking',
+            thinking: 'let me see',
+            signature: 'x'
+          },
+          text('checking'),
+          {
+            type: 'tool_use',
+            id: 'toolu_1',
+            name: 'find_pages',
+            input: { title: 'Pricing' }
+          }
+        ],
+        stop_reason: 'tool_use'
+      }));
+      assert.deepEqual(turn.content, [
+        text('checking'),
+        {
+          type: 'toolCall',
+          id: 'toolu_1',
+          name: 'find_pages',
+          input: { title: 'Pricing' }
+        }
+      ]);
+      assert.equal(turn.finishReason, 'toolCalls');
+    });
+
+    it('throws the refusal error on a refusal stop reason', function() {
+      assert.throws(
+        () => adapter.parseResponse(fixture({ stop_reason: 'refusal' })),
+        (e) => {
+          assert.equal(e.name, 'aiRefusal');
+          return true;
+        }
+      );
+    });
+  });
+
+  describe('error normalization', function() {
+    it('maps the statuses to the normalized codes', function() {
+      for (const [ status, code, kind ] of [
+        [ 429, 'aiRetry', 'rateLimit' ],
+        [ 500, 'aiRetry', 'overload' ],
+        [ 529, 'aiRetry', 'overload' ],
+        [ 401, 'forbidden', undefined ],
+        [ 403, 'forbidden', undefined ],
+        [ 404, 'notfound', undefined ],
+        [ 400, 'invalid', undefined ]
+      ]) {
+        const error = adapter.normalizeError(httpError(status));
+        assert.equal(error.name, code);
+        assert.equal(error.data.status, status);
+        assert.equal(error.data.kind, kind);
+      }
+    });
+
+    it('prefers the provider message and carries the request id', function() {
+      const error = adapter.normalizeError(httpError(401, {
+        'request-id': 'req_9'
+      }, {
+        type: 'error',
+        error: {
+          type: 'authentication_error',
+          message: 'invalid x-api-key'
+        }
+      }));
+      assert.equal(error.message, 'invalid x-api-key');
+      assert.equal(error.data.requestId, 'req_9');
+    });
+
+    it('parses Retry-After as seconds and as an HTTP date', function() {
+      const seconds = adapter.normalizeError(httpError(429, { 'retry-after': '7' }));
+      assert.equal(seconds.data.retryAfter, 7);
+      const date = adapter.normalizeError(httpError(429, {
+        'retry-after': new Date(Date.now() + 30000).toUTCString()
+      }));
+      assert(date.data.retryAfter >= 28 && date.data.retryAfter <= 31);
+      const garbage = adapter.normalizeError(httpError(429, { 'retry-after': 'soon' }));
+      assert.equal(garbage.data.retryAfter, undefined);
+    });
+
+    it('maps timeouts and network failures to the transient code', function() {
+      const timeout = adapter.normalizeError(
+        new DOMException('The operation timed out', 'TimeoutError')
+      );
+      assert.equal(timeout.name, 'aiRetry');
+      assert.equal(timeout.data.kind, 'timeout');
+      const network = adapter.normalizeError(new TypeError('fetch failed'));
+      assert.equal(network.name, 'aiRetry');
+      assert.equal(network.data.kind, 'network');
+      assert.match(network.message, /fetch failed/);
+    });
+
+    it('passes a caller abort through untouched', function() {
+      const abort = new DOMException('The operation was aborted', 'AbortError');
+      assert.equal(adapter.normalizeError(abort), abort);
+    });
+  });
+
+  describe('the wire', function() {
+    // Thunks consumed by the stubbed apos.http.post, one per call
+    let httpScript;
+    let httpCalls;
+    let logRecords;
+    let waits;
+    let originalPost;
+
+    before(function() {
+      originalPost = apos.http.post;
+    });
+
+    after(function() {
+      apos.http.post = originalPost;
+    });
+
+    beforeEach(function() {
+      httpScript = [];
+      httpCalls = [];
+      waits = [];
+      logRecords = [];
+      apos.http.post = async (url, options) => {
+        httpCalls.push({
+          url,
+          options
+        });
+        const step = httpScript.shift();
+        if (step === undefined) {
+          throw new Error('post called beyond its script');
+        }
+        return step();
+      };
+      apos.ai.pause = async (ms) => {
+        waits.push(ms);
+      };
+      for (const severity of [ 'Warn', 'Error' ]) {
+        apos.ai[`log${severity}`] = (req, type, message, data) => {
+          logRecords.push({
+            severity: severity.toLowerCase(),
+            type,
+            message,
+            data
+          });
+        };
+      }
+    });
+
+    it('generates end to end against the dialect', async function() {
+      httpScript = [ () => fixture() ];
+      const result = await apos.ai.generate(
+        apos.task.getReq(),
+        'write a haiku about cats'
+      );
+      assert.equal(result.text, 'a haiku');
+      assert.equal(result.finishReason, 'stop');
+      assert.equal(result.provider, 'anthropic');
+      // The model the response named, not the routed alias
+      assert.equal(result.model, 'claude-sonnet-4-6-20250929');
+      assert.deepEqual(result.usage, {
+        inputTokens: 12,
+        outputTokens: 7
+      });
+
+      const [ call ] = httpCalls;
+      assert.equal(call.url, 'https://api.anthropic.com/v1/messages');
+      assert.equal(call.options.headers['x-api-key'], 'sk-test');
+      assert.equal(call.options.headers['anthropic-version'], '2023-06-01');
+      assert.equal(call.options.timeout, 600000);
+      assert.equal(call.options.body.model, 'claude-sonnet-4-6');
+      assert.equal(call.options.body.max_tokens, 64000);
+      // The default short cache policy became the rolling marker
+      assert.deepEqual(call.options.body.messages, [ {
+        role: 'user',
+        content: [ {
+          type: 'text',
+          text: 'write a haiku about cats',
+          cache_control: { type: 'ephemeral' }
+        } ]
+      } ]);
+    });
+
+    it('honors an aliased entry: its baseUrl, key and merged model metadata', async function() {
+      httpScript = [ () => fixture() ];
+      await apos.ai.generate(apos.task.getReq(), 'p', {
+        provider: 'gateway',
+        model: 'claude-sonnet-4-6'
+      });
+      const [ call ] = httpCalls;
+      assert.equal(call.url, 'https://llm-gateway.example.com/anthropic/v1/messages');
+      assert.equal(call.options.headers['x-api-key'], 'sk-gw');
+      assert.equal(call.options.body.max_tokens, 64000);
+    });
+
+    it('retries a 429 at the Retry-After delay', async function() {
+      httpScript = [
+        () => {
+          throw httpError(429, {
+            'retry-after': '2',
+            'request-id': 'req_9'
+          }, {
+            type: 'error',
+            error: {
+              type: 'rate_limit_error',
+              message: 'rate limited'
+            }
+          });
+        },
+        () => fixture()
+      ];
+      const result = await apos.ai.generate(apos.task.getReq(), 'p');
+      assert.equal(result.text, 'a haiku');
+      assert.equal(httpCalls.length, 2);
+      assert.deepEqual(waits, [ 2000 ]);
+      const [ record ] = logRecords;
+      assert.equal(record.type, 'retry');
+      assert.equal(record.message, 'rate limited');
+      assert.equal(record.data.kind, 'rateLimit');
+      assert.equal(record.data.status, 429);
+      assert.equal(record.data.retryAfter, 2);
+      assert.equal(record.data.requestId, 'req_9');
+    });
+
+    it('retries an overloaded response', async function() {
+      httpScript = [
+        () => {
+          throw httpError(529, {}, {
+            type: 'error',
+            error: {
+              type: 'overloaded_error',
+              message: 'Overloaded'
+            }
+          });
+        },
+        () => fixture()
+      ];
+      const result = await apos.ai.generate(apos.task.getReq(), 'p');
+      assert.equal(result.text, 'a haiku');
+      assert.equal(logRecords[0].data.kind, 'overload');
+    });
+
+    it('hard-stops a 401 as forbidden', async function() {
+      httpScript = [ () => {
+        throw httpError(401, { 'request-id': 'req_1' }, {
+          type: 'error',
+          error: {
+            type: 'authentication_error',
+            message: 'invalid x-api-key'
+          }
+        });
+      } ];
+      await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+        assert.equal(e.name, 'forbidden');
+        assert.equal(e.message, 'invalid x-api-key');
+        return true;
+      });
+      assert.equal(httpCalls.length, 1);
+      assert.deepEqual(
+        logRecords.map((record) => [ record.type, record.data.code ]),
+        [ [ 'failure', 'forbidden' ] ]
+      );
+    });
+
+    it('surfaces an in-flight refusal as the refusal error', async function() {
+      httpScript = [ () => fixture({ stop_reason: 'refusal' }) ];
+      await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+        assert.equal(e.name, 'aiRefusal');
+        return true;
+      });
+    });
+
+    it('retries an unknown stop reason as a malformed turn', async function() {
+      httpScript = [
+        () => fixture({ stop_reason: 'pause_turn' }),
+        () => fixture()
+      ];
+      const result = await apos.ai.generate(apos.task.getReq(), 'p');
+      assert.equal(result.text, 'a haiku');
+      assert.equal(httpCalls.length, 2);
+    });
+
+    it('lets a caller abort surface as its own error', async function() {
+      httpScript = [ () => {
+        throw new DOMException('The operation was aborted', 'AbortError');
+      } ];
+      await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+        assert.equal(e.name, 'AbortError');
+        return true;
+      });
+      assert.equal(httpCalls.length, 1);
+    });
+  });
+
+  describe('environment key', function() {
+    before(async function() {
+      process.env.APOS_ANTHROPIC_KEY = 'sk-env';
+      process.env.APOS_SECOND_KEY = 'sk-second';
+      await t.destroy(apos);
+      apos = await t.create({
+        root: module,
+        modules: {
+          '@apostrophecms/ai': {
+            options: {
+              provider: 'anthropic',
+              providers: {
+                // Native and keyless: validate() passes via the
+                // environment alone
+                anthropic: {},
+                // An alias naming its own variable: a second account
+                second: {
+                  adapter: 'anthropic',
+                  envKey: 'APOS_SECOND_KEY'
+                },
+                // An alias without envKey shares the native secret;
+                // the environment overrides even its configured key
+                shared: {
+                  adapter: 'anthropic',
+                  apiKey: 'sk-config'
+                },
+                // A named variable that is unset falls back to config
+                fallback: {
+                  adapter: 'anthropic',
+                  envKey: 'APOS_UNSET_KEY',
+                  apiKey: 'sk-fallback'
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+
+    after(function() {
+      delete process.env.APOS_ANTHROPIC_KEY;
+      delete process.env.APOS_SECOND_KEY;
+    });
+
+    it('resolves each entry to the key its envKey names', function() {
+      const keys = Object.fromEntries(
+        Object.entries(apos.ai.providers).map(([ name, record ]) =>
+          [ name, record.adapter.apiKey ])
+      );
+      assert.deepEqual(keys, {
+        anthropic: 'sk-env',
+        second: 'sk-second',
+        shared: 'sk-env',
+        fallback: 'sk-fallback'
+      });
+    });
+  });
+
+  describe('live smoke', function() {
+    const liveKey = process.env.APOS_ANTHROPIC_KEY;
+    let liveApos;
+
+    before(async function() {
+      if (!liveKey) {
+        this.skip();
+      }
+      await t.destroy(apos);
+      apos = null;
+      liveApos = await t.create({
+        root: module,
+        modules: {
+          '@apostrophecms/ai': {
+            options: {
+              providers: {
+                anthropic: { apiKey: liveKey }
+              }
+            }
+          }
+        }
+      });
+    });
+
+    after(async function() {
+      if (liveApos) {
+        return t.destroy(liveApos);
+      }
+    });
+
+    it('generates against Anthropic for real', async function() {
+      const result = await liveApos.ai.generate(
+        liveApos.task.getReq(),
+        'write a haiku about cats',
+        {
+          effort: 'low',
+          maxTokens: 200,
+          cache: false
+        }
+      );
+      assert(result.text.length > 0);
+      assert.equal(result.provider, 'anthropic');
+      assert.equal(result.finishReason, 'stop');
+      assert(Number.isFinite(result.usage.inputTokens));
+      assert(Number.isFinite(result.usage.outputTokens));
+    });
+  });
+});

--- a/packages/apostrophe/test/ai-generate.js
+++ b/packages/apostrophe/test/ai-generate.js
@@ -1,0 +1,430 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert');
+
+// A registrable fake adapter following the adapter contract, minus
+// anything that would talk to a network
+const fakeAdapter = (name, extras = {}) => ({
+  name,
+  label: `Fake (${name})`,
+  capabilities: {
+    text: true,
+    tools: true,
+    structured: true,
+    imageInput: true,
+    image: false,
+    caching: true
+  },
+  effort: {
+    low: { model: `${name}-small` },
+    medium: { model: `${name}-medium` },
+    high: {
+      model: `${name}-large`,
+      reasoning: 'high'
+    }
+  },
+  models: {
+    [`${name}-small`]: {
+      contextWindow: 100000,
+      maxOutputTokens: 8000
+    },
+    [`${name}-medium`]: {
+      contextWindow: 200000,
+      maxOutputTokens: 16000
+    },
+    [`${name}-large`]: {
+      contextWindow: 400000,
+      maxOutputTokens: 32000
+    }
+  },
+  validate() {
+    if (!this.apiKey) {
+      throw new Error(`${name}: apiKey missing`);
+    }
+  },
+  normalizeError(err) {
+    return err;
+  },
+  ...extras
+});
+
+describe('AI generate', function() {
+  this.timeout(t.timeout);
+
+  let apos;
+
+  before(async function() {
+    apos = await t.create({
+      root: module,
+      modules: {
+        'fake-adapters': {
+          init(self) {
+            self.apos.ai.addAdapter(fakeAdapter('fake'));
+          }
+        },
+        '@apostrophecms/ai': {
+          options: {
+            providers: {
+              fake: { apiKey: 'k1' }
+            }
+          }
+        }
+      }
+    });
+  });
+
+  after(async function() {
+    return t.destroy(apos);
+  });
+
+  // Error-throwing assertion helpers for the normalized apos codes
+  const throwsInvalid = (fn, pattern) => {
+    assert.throws(fn, (e) => {
+      assert.strictEqual(e.name, 'invalid');
+      assert.match(e.message, pattern);
+      return true;
+    });
+  };
+  const throwsUnimplemented = (fn, pattern) => {
+    assert.throws(fn, (e) => {
+      assert.strictEqual(e.name, 'unimplemented');
+      assert.match(e.message, pattern);
+      return true;
+    });
+  };
+
+  describe('argument sugar', function() {
+    it('turns a string positional into the sole user message', function() {
+      const canonical = apos.ai.normalizeGenerateOptions('write a haiku about cats');
+      assert.deepStrictEqual(canonical.messages, [ {
+        role: 'user',
+        content: [ {
+          type: 'text',
+          text: 'write a haiku about cats'
+        } ]
+      } ]);
+      assert.strictEqual(canonical.cache, 'short');
+    });
+
+    it('appends a string positional to messages as the latest user turn', function() {
+      const canonical = apos.ai.normalizeGenerateOptions('Create one from the standard template.', {
+        messages: [
+          {
+            role: 'user',
+            content: 'Do we have a pricing page?'
+          },
+          {
+            role: 'assistant',
+            content: 'No, I did not find one.'
+          }
+        ]
+      });
+      assert.strictEqual(canonical.messages.length, 3);
+      assert.deepStrictEqual(canonical.messages[2], {
+        role: 'user',
+        content: [ {
+          type: 'text',
+          text: 'Create one from the standard template.'
+        } ]
+      });
+    });
+
+    it('accepts a standalone options object', function() {
+      const canonical = apos.ai.normalizeGenerateOptions({
+        system: 'You help editors.',
+        messages: [ {
+          role: 'user',
+          content: 'hello'
+        } ],
+        effort: 'high'
+      });
+      assert.strictEqual(canonical.system, 'You help editors.');
+      assert.strictEqual(canonical.effort, 'high');
+      assert.strictEqual(canonical.messages.length, 1);
+    });
+
+    it('rejects an options object followed by a second argument', function() {
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions({ messages: [] }, { effort: 'low' }),
+        /a second argument is not accepted/
+      );
+    });
+
+    it('rejects an empty prompt and a promptless, messageless call', function() {
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions(''),
+        /the prompt string must not be empty/
+      );
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions({}),
+        /a prompt string or "messages" is required/
+      );
+    });
+
+    it('rejects a first argument that is neither string nor object', function() {
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions(42),
+        /a prompt string or an options object is required/
+      );
+    });
+  });
+
+  describe('option validation', function() {
+    it('rejects the reserved options as not yet supported', function() {
+      throwsUnimplemented(
+        () => apos.ai.normalizeGenerateOptions('p', { tools: [] }),
+        /"tools" is not yet supported/
+      );
+      throwsUnimplemented(
+        () => apos.ai.normalizeGenerateOptions('p', { schema: { type: 'object' } }),
+        /"schema" is not yet supported/
+      );
+      throwsUnimplemented(
+        () => apos.ai.normalizeGenerateOptions('p', { maxSteps: 3 }),
+        /"maxSteps" is not yet supported/
+      );
+    });
+
+    it('rejects an unknown option', function() {
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions('p', { maxtokens: 100 }),
+        /unknown option "maxtokens"/
+      );
+    });
+
+    it('rejects malformed scalar options', function() {
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions('p', { system: 5 }),
+        /"system" must be a string/
+      );
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions('p', { maxTokens: 0 }),
+        /"maxTokens" must be a positive integer/
+      );
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions('p', { cache: true }),
+        /"cache" must be false, "short" or "long"/
+      );
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions('p', { signal: {} }),
+        /"signal" must be an AbortSignal/
+      );
+    });
+
+    it('defaults cache to short and honors an explicit false', function() {
+      assert.strictEqual(apos.ai.normalizeGenerateOptions('p').cache, 'short');
+      assert.strictEqual(
+        apos.ai.normalizeGenerateOptions('p', { cache: false }).cache,
+        false
+      );
+      assert.strictEqual(
+        apos.ai.normalizeGenerateOptions('p', { cache: 'long' }).cache,
+        'long'
+      );
+    });
+  });
+
+  describe('message normalization', function() {
+    it('collapses string content to a text part', function() {
+      assert.deepStrictEqual(apos.ai.normalizeMessages([ {
+        role: 'assistant',
+        content: 'No, I did not find one.'
+      } ]), [ {
+        role: 'assistant',
+        content: [ {
+          type: 'text',
+          text: 'No, I did not find one.'
+        } ]
+      } ]);
+    });
+
+    it('rebuilds text and image parts in canonical form', function() {
+      const normalized = apos.ai.normalizeMessages([ {
+        role: 'user',
+        // Extra properties, as on a stored transcript, do not travel
+        _id: 'stored',
+        content: [
+          {
+            type: 'text',
+            text: 'describe this',
+            stray: true
+          },
+          {
+            type: 'image',
+            image: { url: 'https://example.com/a.png' }
+          },
+          {
+            type: 'image',
+            image: {
+              data: 'aGk=',
+              mediaType: 'image/png',
+              stray: true
+            }
+          }
+        ]
+      } ]);
+      assert.deepStrictEqual(normalized, [ {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'describe this'
+          },
+          {
+            type: 'image',
+            image: { url: 'https://example.com/a.png' }
+          },
+          {
+            type: 'image',
+            image: {
+              data: 'aGk=',
+              mediaType: 'image/png'
+            }
+          }
+        ]
+      } ]);
+    });
+
+    it('rejects tool messages and tool parts as not yet supported', function() {
+      throwsUnimplemented(
+        () => apos.ai.normalizeMessages([ {
+          role: 'tool',
+          content: 'result'
+        } ]),
+        /"tool" messages are not yet supported/
+      );
+      throwsUnimplemented(
+        () => apos.ai.normalizeMessages([ {
+          role: 'assistant',
+          content: [ {
+            type: 'toolCall',
+            id: 'x',
+            name: 'find_pages',
+            input: {}
+          } ]
+        } ]),
+        /"toolCall" parts are not yet supported/
+      );
+    });
+
+    it('rejects malformed messages', function() {
+      throwsInvalid(
+        () => apos.ai.normalizeMessages('not an array'),
+        /"messages" must be an array/
+      );
+      throwsInvalid(
+        () => apos.ai.normalizeMessages([ 'hello' ]),
+        /messages\[0\] must be an object/
+      );
+      throwsInvalid(
+        () => apos.ai.normalizeMessages([ {
+          role: 'system',
+          content: 'x'
+        } ]),
+        /messages\[0\]\.role must be "user" or "assistant"/
+      );
+      throwsInvalid(
+        () => apos.ai.normalizeMessages([ {
+          role: 'user',
+          content: []
+        } ]),
+        /messages\[0\]\.content must be a string or a non-empty array/
+      );
+      throwsInvalid(
+        () => apos.ai.normalizeMessages([ {
+          role: 'user',
+          content: [ { type: 'video' } ]
+        } ]),
+        /messages\[0\]\.content\[0\]\.type "video" is unknown/
+      );
+      throwsInvalid(
+        () => apos.ai.normalizeMessages([ {
+          role: 'user',
+          content: [ {
+            type: 'image',
+            image: { data: 'x' }
+          } ]
+        } ]),
+        /messages\[0\]\.content\[0\]\.image must be an object/
+      );
+    });
+  });
+
+  describe('request assembly', function() {
+    const canonical = (stringOrOptions, options) =>
+      apos.ai.normalizeGenerateOptions(stringOrOptions, options);
+
+    it('assembles the default-effort request', function() {
+      const { provider, request } = apos.ai.buildRequest(canonical('write a haiku'));
+      assert.strictEqual(provider, 'fake');
+      assert.deepStrictEqual(request, {
+        messages: [ {
+          role: 'user',
+          content: [ {
+            type: 'text',
+            text: 'write a haiku'
+          } ]
+        } ],
+        model: 'fake-medium',
+        // The model's declared output ceiling
+        maxTokens: 16000,
+        cache: { ttl: 'short' }
+      });
+    });
+
+    it('resolves effort and honors per-call overrides', function() {
+      const high = apos.ai.buildRequest(canonical('p', { effort: 'high' }));
+      assert.strictEqual(high.request.model, 'fake-large');
+      assert.strictEqual(high.request.reasoning, 'high');
+      assert.strictEqual(high.request.maxTokens, 32000);
+
+      const overridden = apos.ai.buildRequest(canonical('p', {
+        effort: 'high',
+        reasoning: 'low',
+        maxTokens: 500
+      }));
+      assert.strictEqual(overridden.request.reasoning, 'low');
+      assert.strictEqual(overridden.request.maxTokens, 500);
+    });
+
+    it('omits maxTokens for a model with no declared metadata', function() {
+      const { request } = apos.ai.buildRequest(canonical('p', {
+        provider: 'fake',
+        model: 'fake-next'
+      }));
+      assert.strictEqual(request.model, 'fake-next');
+      assert(!('maxTokens' in request));
+    });
+
+    it('translates the cache level to the { ttl } policy', function() {
+      assert.deepStrictEqual(
+        apos.ai.buildRequest(canonical('p', { cache: 'long' })).request.cache,
+        { ttl: 'long' }
+      );
+      assert.strictEqual(
+        apos.ai.buildRequest(canonical('p', { cache: false })).request.cache,
+        false
+      );
+    });
+
+    it('carries system and signal through', function() {
+      const controller = new AbortController();
+      const { request } = apos.ai.buildRequest(canonical('p', {
+        system: 'You are terse.',
+        signal: controller.signal
+      }));
+      assert.strictEqual(request.system, 'You are terse.');
+      assert.strictEqual(request.signal, controller.signal);
+    });
+
+    it('throws the routing errors a real call would', function() {
+      assert.throws(
+        () => apos.ai.buildRequest(canonical('p', { effort: 'extreme' })),
+        (e) => {
+          assert.strictEqual(e.name, 'invalid');
+          assert.match(e.message, /effort level "extreme" resolves to no routing entry/);
+          return true;
+        }
+      );
+    });
+  });
+});

--- a/packages/apostrophe/test/ai-generate.js
+++ b/packages/apostrophe/test/ai-generate.js
@@ -433,6 +433,8 @@ describe('AI generate', function() {
     // one consumed per call, returning a turn or throwing
     let chatScript;
     let chatCalls;
+    // Captured structured failure records, [{ severity, type, message, data }]
+    let logRecords;
     const events = [];
 
     const turn = (extras = {}) => ({
@@ -471,15 +473,19 @@ describe('AI generate', function() {
                   return step();
                 },
                 normalizeError(err) {
+                  // Optional hints a real adapter would parse from the
+                  // response, passed through for the tests to script
+                  const hints = {
+                    status: err.status,
+                    ...(err.retryAfter !== undefined && { retryAfter: err.retryAfter }),
+                    ...(err.kind !== undefined && { kind: err.kind }),
+                    ...(err.requestId !== undefined && { requestId: err.requestId })
+                  };
                   if (err.status === 429 || err.status >= 500) {
-                    return self.apos.error('aiRetry', 'transient failure', {
-                      status: err.status
-                    });
+                    return self.apos.error('aiRetry', 'transient failure', hints);
                   }
                   if (err.status === 401 || err.status === 403) {
-                    return self.apos.error('forbidden', 'bad credentials', {
-                      status: err.status
-                    });
+                    return self.apos.error('forbidden', 'bad credentials', hints);
                   }
                   return err;
                 }
@@ -512,7 +518,9 @@ describe('AI generate', function() {
                   apiKey: 'k2',
                   capabilities: { text: false }
                 }
-              }
+              },
+              // Keep retried tests fast; the delay engine has its own suite
+              retryBaseDelay: 1
             }
           }
         }
@@ -527,6 +535,19 @@ describe('AI generate', function() {
       chatScript = [];
       chatCalls = [];
       events.length = 0;
+      // Capture the structured failure records (and keep them off the
+      // test output)
+      logRecords = [];
+      for (const severity of [ 'Warn', 'Error' ]) {
+        apos.ai[`log${severity}`] = (req, type, message, data) => {
+          logRecords.push({
+            severity: severity.toLowerCase(),
+            type,
+            message,
+            data
+          });
+        };
+      }
     });
 
     it('generates text end to end', async function() {
@@ -730,6 +751,168 @@ describe('AI generate', function() {
       );
       assert.strictEqual(chatCalls.length, 0);
       assert.strictEqual(events.length, 0);
+    });
+
+    describe('retry policy', function() {
+      let waits;
+      let savedPause;
+
+      beforeEach(function() {
+        // Observe the delays without really waiting
+        waits = [];
+        savedPause = apos.ai.pause;
+        apos.ai.pause = async (ms) => {
+          waits.push(ms);
+        };
+      });
+
+      afterEach(function() {
+        apos.ai.pause = savedPause;
+      });
+
+      it('computes exponential backoff with jitter within bounds', function() {
+        const saved = apos.ai.options.retryBaseDelay;
+        try {
+          apos.ai.options.retryBaseDelay = 1000;
+          const error = apos.error('aiRetry', 'x');
+          for (const [ attempt, min, max ] of [
+            [ 1, 1000, 2000 ],
+            [ 2, 2000, 4000 ],
+            [ 3, 4000, 8000 ]
+          ]) {
+            for (let i = 0; i < 25; i++) {
+              const delay = apos.ai.retryDelay(attempt, error);
+              assert(
+                delay >= min && delay < max,
+                `delay ${delay} out of [${min}, ${max}) at attempt ${attempt}`
+              );
+            }
+          }
+        } finally {
+          apos.ai.options.retryBaseDelay = saved;
+        }
+      });
+
+      it('honors Retry-After over the computed curve', function() {
+        const error = apos.error('aiRetry', 'x', { retryAfter: 7 });
+        assert.strictEqual(apos.ai.retryDelay(1, error), 7000);
+        assert.strictEqual(apos.ai.retryDelay(3, error), 7000);
+      });
+
+      it('waits the Retry-After delay between attempts', async function() {
+        chatScript = [
+          () => {
+            const e = httpError(429);
+            e.retryAfter = 3;
+            throw e;
+          },
+          () => turn()
+        ];
+        const result = await apos.ai.generate(apos.task.getReq(), 'p');
+        assert.strictEqual(result.text, 'a haiku');
+        assert.deepStrictEqual(waits, [ 3000 ]);
+      });
+
+      it('stops without sleeping when the delay would exceed the elapsed budget', async function() {
+        chatScript = [ () => {
+          const e = httpError(429);
+          // Beyond the 60s budget
+          e.retryAfter = 120;
+          throw e;
+        } ];
+        await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+          assert.strictEqual(e.name, 'aiRetry');
+          return true;
+        });
+        assert.strictEqual(chatCalls.length, 1);
+        assert.deepStrictEqual(waits, []);
+        const [ record ] = logRecords;
+        assert.strictEqual(record.severity, 'error');
+        assert.strictEqual(record.type, 'failure');
+        assert.strictEqual(record.data.action, 'stop');
+        assert.strictEqual(record.data.reason, 'budget');
+        assert.strictEqual(record.data.retryAfter, 120);
+        assert.strictEqual(record.data.delay, 120000);
+      });
+
+      it('emits one record per retry decision with the failure context', async function() {
+        chatScript = [
+          () => {
+            const e = httpError(429);
+            e.kind = 'rateLimit';
+            throw e;
+          },
+          () => {
+            throw httpError(503);
+          },
+          () => turn()
+        ];
+        await apos.ai.generate(apos.task.getReq(), 'p');
+        assert.strictEqual(logRecords.length, 2);
+        const [ first, second ] = logRecords;
+        assert.strictEqual(first.severity, 'warn');
+        assert.strictEqual(first.type, 'retry');
+        assert.strictEqual(first.data.provider, 'fake');
+        assert.strictEqual(first.data.model, 'fake-medium');
+        assert.strictEqual(first.data.code, 'aiRetry');
+        assert.strictEqual(first.data.status, 429);
+        assert.strictEqual(first.data.kind, 'rateLimit');
+        assert.strictEqual(first.data.attempt, 1);
+        assert.strictEqual(first.data.action, 'retry');
+        assert(Number.isFinite(first.data.delay));
+        assert.strictEqual(second.data.status, 503);
+        assert.strictEqual(second.data.attempt, 2);
+      });
+
+      it('records a hard stop with its context', async function() {
+        chatScript = [ () => {
+          const e = httpError(401);
+          e.requestId = 'req_123';
+          throw e;
+        } ];
+        await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+          assert.strictEqual(e.name, 'forbidden');
+          return true;
+        });
+        assert.strictEqual(logRecords.length, 1);
+        const [ record ] = logRecords;
+        assert.strictEqual(record.severity, 'error');
+        assert.strictEqual(record.type, 'failure');
+        assert.strictEqual(record.message, 'bad credentials');
+        assert.strictEqual(record.data.code, 'forbidden');
+        assert.strictEqual(record.data.status, 401);
+        assert.strictEqual(record.data.requestId, 'req_123');
+        assert.strictEqual(record.data.attempt, 1);
+        assert.strictEqual(record.data.action, 'stop');
+        assert.strictEqual(record.data.reason, undefined);
+        // The stack of the original throw, not the normalized wrapper
+        assert.match(record.data.stack, /HTTP error 401/);
+      });
+
+      it('records exhausted attempts as the stop reason', async function() {
+        const saved = apos.ai.options.retryAttempts;
+        try {
+          apos.ai.options.retryAttempts = 2;
+          chatScript = [
+            () => {
+              throw httpError(429);
+            },
+            () => {
+              throw httpError(429);
+            }
+          ];
+          await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+            assert.strictEqual(e.name, 'aiRetry');
+            return true;
+          });
+          assert.deepStrictEqual(
+            logRecords.map((record) => [ record.type, record.data.reason ]),
+            [ [ 'retry', undefined ], [ 'failure', 'attempts' ] ]
+          );
+        } finally {
+          apos.ai.options.retryAttempts = saved;
+        }
+      });
     });
   });
 });

--- a/packages/apostrophe/test/ai-generate.js
+++ b/packages/apostrophe/test/ai-generate.js
@@ -1,5 +1,5 @@
 const t = require('../test-lib/test.js');
-const assert = require('assert');
+const assert = require('assert/strict');
 
 // A registrable fake adapter following the adapter contract, minus
 // anything that would talk to a network
@@ -79,14 +79,14 @@ describe('AI generate', function() {
   // Error-throwing assertion helpers for the normalized apos codes
   const throwsInvalid = (fn, pattern) => {
     assert.throws(fn, (e) => {
-      assert.strictEqual(e.name, 'invalid');
+      assert.equal(e.name, 'invalid');
       assert.match(e.message, pattern);
       return true;
     });
   };
   const throwsUnimplemented = (fn, pattern) => {
     assert.throws(fn, (e) => {
-      assert.strictEqual(e.name, 'unimplemented');
+      assert.equal(e.name, 'unimplemented');
       assert.match(e.message, pattern);
       return true;
     });
@@ -95,14 +95,14 @@ describe('AI generate', function() {
   describe('argument sugar', function() {
     it('turns a string positional into the sole user message', function() {
       const canonical = apos.ai.normalizeGenerateOptions('write a haiku about cats');
-      assert.deepStrictEqual(canonical.messages, [ {
+      assert.deepEqual(canonical.messages, [ {
         role: 'user',
         content: [ {
           type: 'text',
           text: 'write a haiku about cats'
         } ]
       } ]);
-      assert.strictEqual(canonical.cache, 'short');
+      assert.equal(canonical.cache, 'short');
     });
 
     it('appends a string positional to messages as the latest user turn', function() {
@@ -118,8 +118,8 @@ describe('AI generate', function() {
           }
         ]
       });
-      assert.strictEqual(canonical.messages.length, 3);
-      assert.deepStrictEqual(canonical.messages[2], {
+      assert.equal(canonical.messages.length, 3);
+      assert.deepEqual(canonical.messages[2], {
         role: 'user',
         content: [ {
           type: 'text',
@@ -137,9 +137,9 @@ describe('AI generate', function() {
         } ],
         effort: 'high'
       });
-      assert.strictEqual(canonical.system, 'You help editors.');
-      assert.strictEqual(canonical.effort, 'high');
-      assert.strictEqual(canonical.messages.length, 1);
+      assert.equal(canonical.system, 'You help editors.');
+      assert.equal(canonical.effort, 'high');
+      assert.equal(canonical.messages.length, 1);
     });
 
     it('rejects an options object followed by a second argument', function() {
@@ -211,12 +211,12 @@ describe('AI generate', function() {
     });
 
     it('defaults cache to short and honors an explicit false', function() {
-      assert.strictEqual(apos.ai.normalizeGenerateOptions('p').cache, 'short');
-      assert.strictEqual(
+      assert.equal(apos.ai.normalizeGenerateOptions('p').cache, 'short');
+      assert.equal(
         apos.ai.normalizeGenerateOptions('p', { cache: false }).cache,
         false
       );
-      assert.strictEqual(
+      assert.equal(
         apos.ai.normalizeGenerateOptions('p', { cache: 'long' }).cache,
         'long'
       );
@@ -225,7 +225,7 @@ describe('AI generate', function() {
 
   describe('message normalization', function() {
     it('collapses string content to a text part', function() {
-      assert.deepStrictEqual(apos.ai.normalizeMessages([ {
+      assert.deepEqual(apos.ai.normalizeMessages([ {
         role: 'assistant',
         content: 'No, I did not find one.'
       } ]), [ {
@@ -262,7 +262,7 @@ describe('AI generate', function() {
           }
         ]
       } ]);
-      assert.deepStrictEqual(normalized, [ {
+      assert.deepEqual(normalized, [ {
         role: 'user',
         content: [
           {
@@ -355,8 +355,8 @@ describe('AI generate', function() {
 
     it('assembles the default-effort request', function() {
       const { provider, request } = apos.ai.buildRequest(canonical('write a haiku'));
-      assert.strictEqual(provider, 'fake');
-      assert.deepStrictEqual(request, {
+      assert.equal(provider, 'fake');
+      assert.deepEqual(request, {
         messages: [ {
           role: 'user',
           content: [ {
@@ -373,17 +373,17 @@ describe('AI generate', function() {
 
     it('resolves effort and honors per-call overrides', function() {
       const high = apos.ai.buildRequest(canonical('p', { effort: 'high' }));
-      assert.strictEqual(high.request.model, 'fake-large');
-      assert.strictEqual(high.request.reasoning, 'high');
-      assert.strictEqual(high.request.maxTokens, 32000);
+      assert.equal(high.request.model, 'fake-large');
+      assert.equal(high.request.reasoning, 'high');
+      assert.equal(high.request.maxTokens, 32000);
 
       const overridden = apos.ai.buildRequest(canonical('p', {
         effort: 'high',
         reasoning: 'low',
         maxTokens: 500
       }));
-      assert.strictEqual(overridden.request.reasoning, 'low');
-      assert.strictEqual(overridden.request.maxTokens, 500);
+      assert.equal(overridden.request.reasoning, 'low');
+      assert.equal(overridden.request.maxTokens, 500);
     });
 
     it('omits maxTokens for a model with no declared metadata', function() {
@@ -391,16 +391,16 @@ describe('AI generate', function() {
         provider: 'fake',
         model: 'fake-next'
       }));
-      assert.strictEqual(request.model, 'fake-next');
+      assert.equal(request.model, 'fake-next');
       assert(!('maxTokens' in request));
     });
 
     it('translates the cache level to the { ttl } policy', function() {
-      assert.deepStrictEqual(
+      assert.deepEqual(
         apos.ai.buildRequest(canonical('p', { cache: 'long' })).request.cache,
         { ttl: 'long' }
       );
-      assert.strictEqual(
+      assert.equal(
         apos.ai.buildRequest(canonical('p', { cache: false })).request.cache,
         false
       );
@@ -412,15 +412,15 @@ describe('AI generate', function() {
         system: 'You are terse.',
         signal: controller.signal
       }));
-      assert.strictEqual(request.system, 'You are terse.');
-      assert.strictEqual(request.signal, controller.signal);
+      assert.equal(request.system, 'You are terse.');
+      assert.equal(request.signal, controller.signal);
     });
 
     it('throws the routing errors a real call would', function() {
       assert.throws(
         () => apos.ai.buildRequest(canonical('p', { effort: 'extreme' })),
         (e) => {
-          assert.strictEqual(e.name, 'invalid');
+          assert.equal(e.name, 'invalid');
           assert.match(e.message, /effort level "extreme" resolves to no routing entry/);
           return true;
         }
@@ -520,7 +520,11 @@ describe('AI generate', function() {
                 }
               },
               // Keep retried tests fast; the delay engine has its own suite
-              retryBaseDelay: 1
+              retryBaseDelay: 1,
+              // Must stay inert without APOS_AI_MOCK
+              mock() {
+                throw new Error('the mock option was consulted without APOS_AI_MOCK');
+              }
             }
           }
         }
@@ -556,7 +560,7 @@ describe('AI generate', function() {
         apos.task.getReq(),
         'write a haiku about cats'
       );
-      assert.deepStrictEqual(result, {
+      assert.deepEqual(result, {
         text: 'a haiku',
         messages: [
           {
@@ -583,10 +587,10 @@ describe('AI generate', function() {
         provider: 'fake'
       });
       // The adapter received the assembled request
-      assert.strictEqual(chatCalls.length, 1);
-      assert.strictEqual(chatCalls[0].model, 'fake-medium');
-      assert.strictEqual(chatCalls[0].maxTokens, 16000);
-      assert.deepStrictEqual(chatCalls[0].cache, { ttl: 'short' });
+      assert.equal(chatCalls.length, 1);
+      assert.equal(chatCalls[0].model, 'fake-medium');
+      assert.equal(chatCalls[0].maxTokens, 16000);
+      assert.deepEqual(chatCalls[0].cache, { ttl: 'short' });
     });
 
     it('continues a conversation with the string positional appended', async function() {
@@ -611,11 +615,11 @@ describe('AI generate', function() {
             }
           ]
         });
-      assert.strictEqual(chatCalls[0].messages.length, 3);
-      assert.strictEqual(result.text, 'Done.');
+      assert.equal(chatCalls[0].messages.length, 3);
+      assert.equal(result.text, 'Done.');
       // The transcript is resumable: it ends with the assistant turn
-      assert.strictEqual(result.messages.length, 4);
-      assert.deepStrictEqual(result.messages[3], {
+      assert.equal(result.messages.length, 4);
+      assert.deepEqual(result.messages[3], {
         role: 'assistant',
         content: [ {
           type: 'text',
@@ -627,13 +631,13 @@ describe('AI generate', function() {
     it('emits beforeGenerate and afterGenerate around the call', async function() {
       chatScript = [ () => turn() ];
       await apos.ai.generate(apos.task.getReq(), 'p');
-      assert.deepStrictEqual(events.map(([ name ]) => name), [ 'before', 'after' ]);
+      assert.deepEqual(events.map(([ name ]) => name), [ 'before', 'after' ]);
       const [ [ , beforeContext ], [ , afterContext ] ] = events;
       // One shared, mutable context correlates the two
-      assert.strictEqual(beforeContext, afterContext);
-      assert.strictEqual(beforeContext.provider, 'fake');
+      assert.equal(beforeContext, afterContext);
+      assert.equal(beforeContext.provider, 'fake');
       assert(Array.isArray(beforeContext.request.messages));
-      assert.strictEqual(afterContext.result.text, 'a haiku');
+      assert.equal(afterContext.result.text, 'a haiku');
     });
 
     it('retries the transient code and succeeds', async function() {
@@ -647,8 +651,8 @@ describe('AI generate', function() {
         () => turn()
       ];
       const result = await apos.ai.generate(apos.task.getReq(), 'p');
-      assert.strictEqual(result.text, 'a haiku');
-      assert.strictEqual(chatCalls.length, 3);
+      assert.equal(result.text, 'a haiku');
+      assert.equal(chatCalls.length, 3);
     });
 
     it('gives up when the attempts cap is exhausted', async function() {
@@ -656,10 +660,10 @@ describe('AI generate', function() {
         throw httpError(429);
       });
       await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
-        assert.strictEqual(e.name, 'aiRetry');
+        assert.equal(e.name, 'aiRetry');
         return true;
       });
-      assert.strictEqual(chatCalls.length, 5);
+      assert.equal(chatCalls.length, 5);
     });
 
     it('honors the retryAttempts option', async function() {
@@ -670,10 +674,10 @@ describe('AI generate', function() {
           throw httpError(429);
         });
         await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
-          assert.strictEqual(e.name, 'aiRetry');
+          assert.equal(e.name, 'aiRetry');
           return true;
         });
-        assert.strictEqual(chatCalls.length, 2);
+        assert.equal(chatCalls.length, 2);
       } finally {
         apos.ai.options.retryAttempts = saved;
       }
@@ -684,12 +688,12 @@ describe('AI generate', function() {
         throw httpError(401);
       } ];
       await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
-        assert.strictEqual(e.name, 'forbidden');
+        assert.equal(e.name, 'forbidden');
         return true;
       });
-      assert.strictEqual(chatCalls.length, 1);
+      assert.equal(chatCalls.length, 1);
       // beforeGenerate fired, afterGenerate did not
-      assert.deepStrictEqual(events.map(([ name ]) => name), [ 'before' ]);
+      assert.deepEqual(events.map(([ name ]) => name), [ 'before' ]);
     });
 
     it('passes an adapter-thrown normalized error through untouched', async function() {
@@ -698,10 +702,10 @@ describe('AI generate', function() {
         throw refusal;
       } ];
       await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
-        assert.strictEqual(e, refusal);
+        assert.equal(e, refusal);
         return true;
       });
-      assert.strictEqual(chatCalls.length, 1);
+      assert.equal(chatCalls.length, 1);
     });
 
     it('treats a truncated turn as transient and retries it', async function() {
@@ -716,14 +720,14 @@ describe('AI generate', function() {
         () => turn()
       ];
       const result = await apos.ai.generate(apos.task.getReq(), 'p');
-      assert.strictEqual(result.text, 'a haiku');
-      assert.strictEqual(chatCalls.length, 2);
+      assert.equal(result.text, 'a haiku');
+      assert.equal(chatCalls.length, 2);
     });
 
     it('converts a refusal finish reason to the refusal error', async function() {
       chatScript = [ () => turn({ finishReason: 'refusal' }) ];
       await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
-        assert.strictEqual(e.name, 'aiRefusal');
+        assert.equal(e.name, 'aiRefusal');
         return true;
       });
     });
@@ -731,10 +735,22 @@ describe('AI generate', function() {
     it('rejects unexpected tool calls from the adapter', async function() {
       chatScript = [ () => turn({ finishReason: 'toolCalls' }) ];
       await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
-        assert.strictEqual(e.name, 'invalid');
+        assert.equal(e.name, 'invalid');
         assert.match(e.message, /tool calls/);
         return true;
       });
+    });
+
+    it('ignores APOS_AI_MOCK set after startup', async function() {
+      try {
+        process.env.APOS_AI_MOCK = '1';
+        chatScript = [ () => turn() ];
+        const result = await apos.ai.generate(apos.task.getReq(), 'p');
+        assert.equal(result.text, 'a haiku');
+        assert.equal(chatCalls.length, 1);
+      } finally {
+        delete process.env.APOS_AI_MOCK;
+      }
     });
 
     it('refuses to route to a provider lacking the needed capability', async function() {
@@ -744,13 +760,13 @@ describe('AI generate', function() {
           model: 'fake-medium'
         }),
         (e) => {
-          assert.strictEqual(e.name, 'invalid');
+          assert.equal(e.name, 'invalid');
           assert.match(e.message, /does not declare the "text" capability/);
           return true;
         }
       );
-      assert.strictEqual(chatCalls.length, 0);
-      assert.strictEqual(events.length, 0);
+      assert.equal(chatCalls.length, 0);
+      assert.equal(events.length, 0);
     });
 
     describe('retry policy', function() {
@@ -795,8 +811,8 @@ describe('AI generate', function() {
 
       it('honors Retry-After over the computed curve', function() {
         const error = apos.error('aiRetry', 'x', { retryAfter: 7 });
-        assert.strictEqual(apos.ai.retryDelay(1, error), 7000);
-        assert.strictEqual(apos.ai.retryDelay(3, error), 7000);
+        assert.equal(apos.ai.retryDelay(1, error), 7000);
+        assert.equal(apos.ai.retryDelay(3, error), 7000);
       });
 
       it('waits the Retry-After delay between attempts', async function() {
@@ -809,8 +825,8 @@ describe('AI generate', function() {
           () => turn()
         ];
         const result = await apos.ai.generate(apos.task.getReq(), 'p');
-        assert.strictEqual(result.text, 'a haiku');
-        assert.deepStrictEqual(waits, [ 3000 ]);
+        assert.equal(result.text, 'a haiku');
+        assert.deepEqual(waits, [ 3000 ]);
       });
 
       it('stops without sleeping when the delay would exceed the elapsed budget', async function() {
@@ -821,18 +837,18 @@ describe('AI generate', function() {
           throw e;
         } ];
         await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
-          assert.strictEqual(e.name, 'aiRetry');
+          assert.equal(e.name, 'aiRetry');
           return true;
         });
-        assert.strictEqual(chatCalls.length, 1);
-        assert.deepStrictEqual(waits, []);
+        assert.equal(chatCalls.length, 1);
+        assert.deepEqual(waits, []);
         const [ record ] = logRecords;
-        assert.strictEqual(record.severity, 'error');
-        assert.strictEqual(record.type, 'failure');
-        assert.strictEqual(record.data.action, 'stop');
-        assert.strictEqual(record.data.reason, 'budget');
-        assert.strictEqual(record.data.retryAfter, 120);
-        assert.strictEqual(record.data.delay, 120000);
+        assert.equal(record.severity, 'error');
+        assert.equal(record.type, 'failure');
+        assert.equal(record.data.action, 'stop');
+        assert.equal(record.data.reason, 'budget');
+        assert.equal(record.data.retryAfter, 120);
+        assert.equal(record.data.delay, 120000);
       });
 
       it('emits one record per retry decision with the failure context', async function() {
@@ -848,20 +864,20 @@ describe('AI generate', function() {
           () => turn()
         ];
         await apos.ai.generate(apos.task.getReq(), 'p');
-        assert.strictEqual(logRecords.length, 2);
+        assert.equal(logRecords.length, 2);
         const [ first, second ] = logRecords;
-        assert.strictEqual(first.severity, 'warn');
-        assert.strictEqual(first.type, 'retry');
-        assert.strictEqual(first.data.provider, 'fake');
-        assert.strictEqual(first.data.model, 'fake-medium');
-        assert.strictEqual(first.data.code, 'aiRetry');
-        assert.strictEqual(first.data.status, 429);
-        assert.strictEqual(first.data.kind, 'rateLimit');
-        assert.strictEqual(first.data.attempt, 1);
-        assert.strictEqual(first.data.action, 'retry');
+        assert.equal(first.severity, 'warn');
+        assert.equal(first.type, 'retry');
+        assert.equal(first.data.provider, 'fake');
+        assert.equal(first.data.model, 'fake-medium');
+        assert.equal(first.data.code, 'aiRetry');
+        assert.equal(first.data.status, 429);
+        assert.equal(first.data.kind, 'rateLimit');
+        assert.equal(first.data.attempt, 1);
+        assert.equal(first.data.action, 'retry');
         assert(Number.isFinite(first.data.delay));
-        assert.strictEqual(second.data.status, 503);
-        assert.strictEqual(second.data.attempt, 2);
+        assert.equal(second.data.status, 503);
+        assert.equal(second.data.attempt, 2);
       });
 
       it('records a hard stop with its context', async function() {
@@ -871,20 +887,20 @@ describe('AI generate', function() {
           throw e;
         } ];
         await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
-          assert.strictEqual(e.name, 'forbidden');
+          assert.equal(e.name, 'forbidden');
           return true;
         });
-        assert.strictEqual(logRecords.length, 1);
+        assert.equal(logRecords.length, 1);
         const [ record ] = logRecords;
-        assert.strictEqual(record.severity, 'error');
-        assert.strictEqual(record.type, 'failure');
-        assert.strictEqual(record.message, 'bad credentials');
-        assert.strictEqual(record.data.code, 'forbidden');
-        assert.strictEqual(record.data.status, 401);
-        assert.strictEqual(record.data.requestId, 'req_123');
-        assert.strictEqual(record.data.attempt, 1);
-        assert.strictEqual(record.data.action, 'stop');
-        assert.strictEqual(record.data.reason, undefined);
+        assert.equal(record.severity, 'error');
+        assert.equal(record.type, 'failure');
+        assert.equal(record.message, 'bad credentials');
+        assert.equal(record.data.code, 'forbidden');
+        assert.equal(record.data.status, 401);
+        assert.equal(record.data.requestId, 'req_123');
+        assert.equal(record.data.attempt, 1);
+        assert.equal(record.data.action, 'stop');
+        assert.equal(record.data.reason, undefined);
         // The stack of the original throw, not the normalized wrapper
         assert.match(record.data.stack, /HTTP error 401/);
       });
@@ -902,16 +918,315 @@ describe('AI generate', function() {
             }
           ];
           await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
-            assert.strictEqual(e.name, 'aiRetry');
+            assert.equal(e.name, 'aiRetry');
             return true;
           });
-          assert.deepStrictEqual(
+          assert.deepEqual(
             logRecords.map((record) => [ record.type, record.data.reason ]),
             [ [ 'retry', undefined ], [ 'failure', 'attempts' ] ]
           );
         } finally {
           apos.ai.options.retryAttempts = saved;
         }
+      });
+    });
+  });
+
+  describe('mock mode', function() {
+    before(function() {
+      process.env.APOS_AI_MOCK = '1';
+    });
+
+    after(function() {
+      delete process.env.APOS_AI_MOCK;
+    });
+
+    describe('with providers configured', function() {
+      // Thunks consumed by the mock option, one per call; empty means
+      // the request-aware default
+      let mockScript;
+      let chatCalls;
+      let logRecords;
+
+      before(async function() {
+        await t.destroy(apos);
+        apos = await t.create({
+          root: module,
+          modules: {
+            'fake-adapters': {
+              init(self) {
+                self.apos.ai.addAdapter(fakeAdapter('fake', {
+                  async chat(req, request) {
+                    chatCalls.push(request);
+                    throw new Error('a real adapter was called in mock mode');
+                  }
+                }));
+              }
+            },
+            '@apostrophecms/ai': {
+              options: {
+                provider: 'fake',
+                providers: {
+                  // No apiKey: booting proves validate() is skipped
+                  fake: {},
+                  notext: {
+                    adapter: 'fake',
+                    capabilities: { text: false }
+                  }
+                },
+                retryBaseDelay: 1,
+                mock(request) {
+                  const step = mockScript.shift();
+                  return step && step(request);
+                }
+              }
+            }
+          }
+        });
+      });
+
+      beforeEach(function() {
+        mockScript = [];
+        chatCalls = [];
+        logRecords = [];
+        for (const severity of [ 'Warn', 'Error' ]) {
+          apos.ai[`log${severity}`] = (req, type, message, data) => {
+            logRecords.push({
+              severity: severity.toLowerCase(),
+              type,
+              message,
+              data
+            });
+          };
+        }
+      });
+
+      it('answers with the request-aware default and no adapter call', async function() {
+        const result = await apos.ai.generate(
+          apos.task.getReq(),
+          'write a haiku about cats'
+        );
+        assert.deepEqual(result, {
+          text: '[mock] write a haiku about cats',
+          messages: [
+            {
+              role: 'user',
+              content: [ {
+                type: 'text',
+                text: 'write a haiku about cats'
+              } ]
+            },
+            {
+              role: 'assistant',
+              content: [ {
+                type: 'text',
+                text: '[mock] write a haiku about cats'
+              } ]
+            }
+          ],
+          finishReason: 'stop',
+          usage: {
+            inputTokens: 6,
+            outputTokens: 8
+          },
+          // Routing still resolves for real
+          model: 'fake-medium',
+          provider: 'fake'
+        });
+        assert.equal(chatCalls.length, 0);
+      });
+
+      it('hands the fully assembled request to the mock option', async function() {
+        let seen;
+        mockScript = [ (request) => {
+          seen = request;
+          return { text: 'scripted' };
+        } ];
+        const result = await apos.ai.generate(apos.task.getReq(), 'p', {
+          system: 'You are terse.',
+          effort: 'high'
+        });
+        assert.equal(result.text, 'scripted');
+        assert.equal(seen.model, 'fake-large');
+        assert.equal(seen.reasoning, 'high');
+        assert.equal(seen.system, 'You are terse.');
+        assert.equal(seen.maxTokens, 32000);
+      });
+
+      it('returns a complete assistant turn from the mock option as-is', async function() {
+        mockScript = [ () => ({
+          content: [ {
+            type: 'text',
+            text: 'full turn'
+          } ],
+          finishReason: 'length',
+          usage: {
+            inputTokens: 100,
+            outputTokens: 200
+          },
+          model: 'scripted-model'
+        }) ];
+        const result = await apos.ai.generate(apos.task.getReq(), 'p');
+        assert.equal(result.text, 'full turn');
+        assert.equal(result.finishReason, 'length');
+        assert.deepEqual(result.usage, {
+          inputTokens: 100,
+          outputTokens: 200
+        });
+        assert.equal(result.model, 'scripted-model');
+      });
+
+      it('falls through to the default when the mock option returns undefined', async function() {
+        mockScript = [ () => undefined ];
+        const result = await apos.ai.generate(apos.task.getReq(), 'hello there');
+        assert.equal(result.text, '[mock] hello there');
+      });
+
+      it('rejects a mock return that is neither a turn nor { text }', async function() {
+        mockScript = [ () => 'a plain string' ];
+        await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+          assert.equal(e.name, 'invalid');
+          assert.match(e.message, /"mock" must return/);
+          return true;
+        });
+      });
+
+      it('mimics transient failures through the real retry path', async function() {
+        mockScript = [
+          () => {
+            throw apos.error('aiRetry', 'scripted overload', { kind: 'overload' });
+          },
+          () => ({ text: 'recovered' })
+        ];
+        const result = await apos.ai.generate(apos.task.getReq(), 'p');
+        assert.equal(result.text, 'recovered');
+        assert.equal(logRecords.length, 1);
+        const [ record ] = logRecords;
+        assert.equal(record.type, 'retry');
+        assert.equal(record.data.kind, 'overload');
+        assert.equal(record.data.provider, 'fake');
+      });
+
+      it('mimics a hard failure with its failure record', async function() {
+        mockScript = [ () => {
+          throw apos.error('forbidden', 'scripted bad key');
+        } ];
+        await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+          assert.equal(e.name, 'forbidden');
+          return true;
+        });
+        assert.deepEqual(
+          logRecords.map((record) => [ record.type, record.data.code ]),
+          [ [ 'failure', 'forbidden' ] ]
+        );
+      });
+
+      it('converts a mock refusal turn to the refusal error', async function() {
+        mockScript = [ () => ({
+          content: [],
+          finishReason: 'refusal',
+          usage: {
+            inputTokens: 1,
+            outputTokens: 0
+          }
+        }) ];
+        await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+          assert.equal(e.name, 'aiRefusal');
+          return true;
+        });
+      });
+
+      it('still refuses routing to a provider lacking the capability', async function() {
+        await assert.rejects(
+          apos.ai.generate(apos.task.getReq(), 'p', {
+            provider: 'notext',
+            model: 'fake-medium'
+          }),
+          (e) => {
+            assert.equal(e.name, 'invalid');
+            assert.match(e.message, /does not declare the "text" capability/);
+            return true;
+          }
+        );
+      });
+    });
+
+    describe('with zero configuration', function() {
+      before(async function() {
+        await t.destroy(apos);
+        apos = await t.create({
+          root: module,
+          modules: {}
+        });
+      });
+
+      it('is active and generates with no providers, keys or adapters', async function() {
+        assert.equal(apos.ai.mockMode, true);
+        assert.equal(apos.ai.active, true);
+        const result = await apos.ai.generate(
+          apos.task.getReq(),
+          'write a haiku about cats'
+        );
+        assert.equal(result.text, '[mock] write a haiku about cats');
+        assert.equal(result.provider, 'mock');
+        assert.equal(result.model, 'mock');
+        assert.equal(result.finishReason, 'stop');
+        assert(Number.isFinite(result.usage.inputTokens));
+        assert(Number.isFinite(result.usage.outputTokens));
+      });
+
+      it('echoes an explicit provider and model into the placeholder routing', async function() {
+        const result = await apos.ai.generate(apos.task.getReq(), 'p', {
+          provider: 'anthropic',
+          model: 'claude-sonnet-x'
+        });
+        assert.equal(result.provider, 'anthropic');
+        assert.equal(result.model, 'claude-sonnet-x');
+      });
+
+      it('continues a conversation', async function() {
+        const result = await apos.ai.generate(
+          apos.task.getReq(),
+          'Create one from the standard template.',
+          {
+            messages: [
+              {
+                role: 'user',
+                content: 'Do we have a pricing page?'
+              },
+              {
+                role: 'assistant',
+                content: 'No, I did not find one.'
+              }
+            ]
+          }
+        );
+        assert.equal(result.messages.length, 4);
+        assert.equal(result.text, '[mock] Create one from the standard template.');
+      });
+    });
+  });
+
+  describe('APOS_AI_MOCK=0', function() {
+    before(async function() {
+      process.env.APOS_AI_MOCK = '0';
+      await t.destroy(apos);
+      apos = await t.create({
+        root: module,
+        modules: {}
+      });
+    });
+
+    after(function() {
+      delete process.env.APOS_AI_MOCK;
+    });
+
+    it('means off: no mock rescue for a zero configuration', async function() {
+      assert.equal(apos.ai.mockMode, false);
+      assert.equal(apos.ai.active, false);
+      await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+        assert.equal(e.name, 'invalid');
+        return true;
       });
     });
   });

--- a/packages/apostrophe/test/ai-generate.js
+++ b/packages/apostrophe/test/ai-generate.js
@@ -427,4 +427,309 @@ describe('AI generate', function() {
       );
     });
   });
+
+  describe('the call pipeline', function() {
+    // Each test scripts the fake adapter's chat: an array of thunks,
+    // one consumed per call, returning a turn or throwing
+    let chatScript;
+    let chatCalls;
+    const events = [];
+
+    const turn = (extras = {}) => ({
+      content: [ {
+        type: 'text',
+        text: 'a haiku'
+      } ],
+      finishReason: 'stop',
+      usage: {
+        inputTokens: 12,
+        outputTokens: 7
+      },
+      model: 'fake-medium',
+      ...extras
+    });
+    const httpError = (status) => {
+      const error = new Error(`HTTP error ${status}`);
+      error.status = status;
+      return error;
+    };
+
+    before(async function() {
+      await t.destroy(apos);
+      apos = await t.create({
+        root: module,
+        modules: {
+          'fake-adapters': {
+            init(self) {
+              self.apos.ai.addAdapter(fakeAdapter('fake', {
+                async chat(req, request) {
+                  chatCalls.push(request);
+                  const step = chatScript.shift();
+                  if (step === undefined) {
+                    throw new Error('chat called beyond its script');
+                  }
+                  return step();
+                },
+                normalizeError(err) {
+                  if (err.status === 429 || err.status >= 500) {
+                    return self.apos.error('aiRetry', 'transient failure', {
+                      status: err.status
+                    });
+                  }
+                  if (err.status === 401 || err.status === 403) {
+                    return self.apos.error('forbidden', 'bad credentials', {
+                      status: err.status
+                    });
+                  }
+                  return err;
+                }
+              }));
+            }
+          },
+          'ai-events': {
+            handlers(self) {
+              return {
+                '@apostrophecms/ai:beforeGenerate': {
+                  record(req, context) {
+                    events.push([ 'before', context ]);
+                  }
+                },
+                '@apostrophecms/ai:afterGenerate': {
+                  record(req, context) {
+                    events.push([ 'after', context ]);
+                  }
+                }
+              };
+            }
+          },
+          '@apostrophecms/ai': {
+            options: {
+              provider: 'fake',
+              providers: {
+                fake: { apiKey: 'k1' },
+                notext: {
+                  adapter: 'fake',
+                  apiKey: 'k2',
+                  capabilities: { text: false }
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+
+    after(async function() {
+      return t.destroy(apos);
+    });
+
+    beforeEach(function() {
+      chatScript = [];
+      chatCalls = [];
+      events.length = 0;
+    });
+
+    it('generates text end to end', async function() {
+      chatScript = [ () => turn() ];
+      const result = await apos.ai.generate(
+        apos.task.getReq(),
+        'write a haiku about cats'
+      );
+      assert.deepStrictEqual(result, {
+        text: 'a haiku',
+        messages: [
+          {
+            role: 'user',
+            content: [ {
+              type: 'text',
+              text: 'write a haiku about cats'
+            } ]
+          },
+          {
+            role: 'assistant',
+            content: [ {
+              type: 'text',
+              text: 'a haiku'
+            } ]
+          }
+        ],
+        finishReason: 'stop',
+        usage: {
+          inputTokens: 12,
+          outputTokens: 7
+        },
+        model: 'fake-medium',
+        provider: 'fake'
+      });
+      // The adapter received the assembled request
+      assert.strictEqual(chatCalls.length, 1);
+      assert.strictEqual(chatCalls[0].model, 'fake-medium');
+      assert.strictEqual(chatCalls[0].maxTokens, 16000);
+      assert.deepStrictEqual(chatCalls[0].cache, { ttl: 'short' });
+    });
+
+    it('continues a conversation with the string positional appended', async function() {
+      chatScript = [ () => turn({
+        content: [ {
+          type: 'text',
+          text: 'Done.'
+        } ]
+      }) ];
+      const result = await apos.ai.generate(
+        apos.task.getReq(),
+        'Create one from the standard template.',
+        {
+          messages: [
+            {
+              role: 'user',
+              content: 'Do we have a pricing page?'
+            },
+            {
+              role: 'assistant',
+              content: 'No, I did not find one.'
+            }
+          ]
+        });
+      assert.strictEqual(chatCalls[0].messages.length, 3);
+      assert.strictEqual(result.text, 'Done.');
+      // The transcript is resumable: it ends with the assistant turn
+      assert.strictEqual(result.messages.length, 4);
+      assert.deepStrictEqual(result.messages[3], {
+        role: 'assistant',
+        content: [ {
+          type: 'text',
+          text: 'Done.'
+        } ]
+      });
+    });
+
+    it('emits beforeGenerate and afterGenerate around the call', async function() {
+      chatScript = [ () => turn() ];
+      await apos.ai.generate(apos.task.getReq(), 'p');
+      assert.deepStrictEqual(events.map(([ name ]) => name), [ 'before', 'after' ]);
+      const [ [ , beforeContext ], [ , afterContext ] ] = events;
+      // One shared, mutable context correlates the two
+      assert.strictEqual(beforeContext, afterContext);
+      assert.strictEqual(beforeContext.provider, 'fake');
+      assert(Array.isArray(beforeContext.request.messages));
+      assert.strictEqual(afterContext.result.text, 'a haiku');
+    });
+
+    it('retries the transient code and succeeds', async function() {
+      chatScript = [
+        () => {
+          throw httpError(429);
+        },
+        () => {
+          throw httpError(503);
+        },
+        () => turn()
+      ];
+      const result = await apos.ai.generate(apos.task.getReq(), 'p');
+      assert.strictEqual(result.text, 'a haiku');
+      assert.strictEqual(chatCalls.length, 3);
+    });
+
+    it('gives up when the attempts cap is exhausted', async function() {
+      chatScript = Array.from({ length: 5 }, () => () => {
+        throw httpError(429);
+      });
+      await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+        assert.strictEqual(e.name, 'aiRetry');
+        return true;
+      });
+      assert.strictEqual(chatCalls.length, 5);
+    });
+
+    it('honors the retryAttempts option', async function() {
+      const saved = apos.ai.options.retryAttempts;
+      try {
+        apos.ai.options.retryAttempts = 2;
+        chatScript = Array.from({ length: 3 }, () => () => {
+          throw httpError(429);
+        });
+        await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+          assert.strictEqual(e.name, 'aiRetry');
+          return true;
+        });
+        assert.strictEqual(chatCalls.length, 2);
+      } finally {
+        apos.ai.options.retryAttempts = saved;
+      }
+    });
+
+    it('hard-stops on a standard code without retrying', async function() {
+      chatScript = [ () => {
+        throw httpError(401);
+      } ];
+      await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+        assert.strictEqual(e.name, 'forbidden');
+        return true;
+      });
+      assert.strictEqual(chatCalls.length, 1);
+      // beforeGenerate fired, afterGenerate did not
+      assert.deepStrictEqual(events.map(([ name ]) => name), [ 'before' ]);
+    });
+
+    it('passes an adapter-thrown normalized error through untouched', async function() {
+      const refusal = apos.error('aiRefusal', 'safety policy');
+      chatScript = [ () => {
+        throw refusal;
+      } ];
+      await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+        assert.strictEqual(e, refusal);
+        return true;
+      });
+      assert.strictEqual(chatCalls.length, 1);
+    });
+
+    it('treats a truncated turn as transient and retries it', async function() {
+      chatScript = [
+        // No finishReason, no usage
+        () => ({
+          content: [ {
+            type: 'text',
+            text: 'half a hai'
+          } ]
+        }),
+        () => turn()
+      ];
+      const result = await apos.ai.generate(apos.task.getReq(), 'p');
+      assert.strictEqual(result.text, 'a haiku');
+      assert.strictEqual(chatCalls.length, 2);
+    });
+
+    it('converts a refusal finish reason to the refusal error', async function() {
+      chatScript = [ () => turn({ finishReason: 'refusal' }) ];
+      await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+        assert.strictEqual(e.name, 'aiRefusal');
+        return true;
+      });
+    });
+
+    it('rejects unexpected tool calls from the adapter', async function() {
+      chatScript = [ () => turn({ finishReason: 'toolCalls' }) ];
+      await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+        assert.strictEqual(e.name, 'invalid');
+        assert.match(e.message, /tool calls/);
+        return true;
+      });
+    });
+
+    it('refuses to route to a provider lacking the needed capability', async function() {
+      await assert.rejects(
+        apos.ai.generate(apos.task.getReq(), 'p', {
+          provider: 'notext',
+          model: 'fake-medium'
+        }),
+        (e) => {
+          assert.strictEqual(e.name, 'invalid');
+          assert.match(e.message, /does not declare the "text" capability/);
+          return true;
+        }
+      );
+      assert.strictEqual(chatCalls.length, 0);
+      assert.strictEqual(events.length, 0);
+    });
+  });
 });

--- a/packages/apostrophe/test/ai.js
+++ b/packages/apostrophe/test/ai.js
@@ -69,6 +69,7 @@ describe('AI engine', function() {
     assert.deepStrictEqual(apos.ai.options.providers, {});
     assert.strictEqual(apos.ai.defaultProvider, null);
     assert.strictEqual(apos.ai.active, false);
+    assert.strictEqual(apos.ai.options.retryAttempts, 5);
     // Unconfigured: a call falls through to an empty routing table
     assert.throws(() => apos.ai.modelInfo(), (e) => {
       assert.strictEqual(e.name, 'invalid');
@@ -81,7 +82,8 @@ describe('AI engine', function() {
     // A valid baseline the cases below mutate
     const valid = () => ({
       providers: {},
-      maxSteps: 5
+      maxSteps: 5,
+      retryAttempts: 5
     });
 
     it('accepts the minimal single-provider configuration', function() {
@@ -271,6 +273,17 @@ describe('AI engine', function() {
         ...valid(),
         mock: 'fixture reply'
       }, /"mock" must be a function/);
+    });
+
+    it('rejects malformed retryAttempts', function() {
+      rejects({
+        ...valid(),
+        retryAttempts: 0
+      }, /"retryAttempts" must be a positive integer/);
+      rejects({
+        ...valid(),
+        retryAttempts: 'many'
+      }, /"retryAttempts" must be a positive integer/);
     });
   });
 

--- a/packages/apostrophe/test/ai.js
+++ b/packages/apostrophe/test/ai.js
@@ -70,6 +70,8 @@ describe('AI engine', function() {
     assert.strictEqual(apos.ai.defaultProvider, null);
     assert.strictEqual(apos.ai.active, false);
     assert.strictEqual(apos.ai.options.retryAttempts, 5);
+    assert.strictEqual(apos.ai.options.retryBaseDelay, 1000);
+    assert.strictEqual(apos.ai.options.retryMaxElapsed, 60000);
     // Unconfigured: a call falls through to an empty routing table
     assert.throws(() => apos.ai.modelInfo(), (e) => {
       assert.strictEqual(e.name, 'invalid');
@@ -83,7 +85,9 @@ describe('AI engine', function() {
     const valid = () => ({
       providers: {},
       maxSteps: 5,
-      retryAttempts: 5
+      retryAttempts: 5,
+      retryBaseDelay: 1000,
+      retryMaxElapsed: 60000
     });
 
     it('accepts the minimal single-provider configuration', function() {
@@ -275,7 +279,7 @@ describe('AI engine', function() {
       }, /"mock" must be a function/);
     });
 
-    it('rejects malformed retryAttempts', function() {
+    it('rejects malformed retry options', function() {
       rejects({
         ...valid(),
         retryAttempts: 0
@@ -284,6 +288,14 @@ describe('AI engine', function() {
         ...valid(),
         retryAttempts: 'many'
       }, /"retryAttempts" must be a positive integer/);
+      rejects({
+        ...valid(),
+        retryBaseDelay: -1
+      }, /"retryBaseDelay" must be a positive integer/);
+      rejects({
+        ...valid(),
+        retryMaxElapsed: 1.5
+      }, /"retryMaxElapsed" must be a positive integer/);
     });
   });
 

--- a/packages/apostrophe/test/ai.js
+++ b/packages/apostrophe/test/ai.js
@@ -1,5 +1,5 @@
 const t = require('../test-lib/test.js');
-const assert = require('assert');
+const assert = require('assert/strict');
 const { spawn } = require('child_process');
 
 // A registrable fake adapter following the adapter contract, minus
@@ -65,16 +65,16 @@ describe('AI engine', function() {
 
   it('boots with no AI configuration and exposes apos.ai', function() {
     assert(apos.ai);
-    assert.strictEqual(apos.ai.options.maxSteps, 5);
-    assert.deepStrictEqual(apos.ai.options.providers, {});
-    assert.strictEqual(apos.ai.defaultProvider, null);
-    assert.strictEqual(apos.ai.active, false);
-    assert.strictEqual(apos.ai.options.retryAttempts, 5);
-    assert.strictEqual(apos.ai.options.retryBaseDelay, 1000);
-    assert.strictEqual(apos.ai.options.retryMaxElapsed, 60000);
+    assert.equal(apos.ai.options.maxSteps, 5);
+    assert.deepEqual(apos.ai.options.providers, {});
+    assert.equal(apos.ai.defaultProvider, null);
+    assert.equal(apos.ai.active, false);
+    assert.equal(apos.ai.options.retryAttempts, 5);
+    assert.equal(apos.ai.options.retryBaseDelay, 1000);
+    assert.equal(apos.ai.options.retryMaxElapsed, 60000);
     // Unconfigured: a call falls through to an empty routing table
     assert.throws(() => apos.ai.modelInfo(), (e) => {
-      assert.strictEqual(e.name, 'invalid');
+      assert.equal(e.name, 'invalid');
       assert.match(e.message, /effort level "medium" resolves to no routing entry/);
       return true;
     });
@@ -362,23 +362,23 @@ describe('AI engine', function() {
       assert(apos.ai.providers.fake);
       assert(apos.ai.providers.other);
       assert(apos.ai.providers.custom);
-      assert.strictEqual(apos.ai.active, true);
+      assert.equal(apos.ai.active, true);
     });
 
     it('instantiates adapters with the entry config', function() {
       const { fake, custom } = apos.ai.providers;
-      assert.strictEqual(fake.adapterName, 'fake');
-      assert.strictEqual(fake.adapter.apiKey, 'k1');
-      assert.strictEqual(custom.adapterName, 'fake');
-      assert.strictEqual(custom.adapter.provider, 'custom');
-      assert.strictEqual(custom.adapter.apiKey, 'k3');
-      assert.strictEqual(custom.adapter.baseUrl, 'https://custom.example/v1');
+      assert.equal(fake.adapterName, 'fake');
+      assert.equal(fake.adapter.apiKey, 'k1');
+      assert.equal(custom.adapterName, 'fake');
+      assert.equal(custom.adapter.provider, 'custom');
+      assert.equal(custom.adapter.apiKey, 'k3');
+      assert.equal(custom.adapter.baseUrl, 'https://custom.example/v1');
     });
 
     it('merges the entry service description over the adapter data', function() {
       const { fake, custom } = apos.ai.providers;
       // Native entry: adapter rows with entry overrides, level by level
-      assert.deepStrictEqual(fake.effort, {
+      assert.deepEqual(fake.effort, {
         low: { model: 'fake-small' },
         medium: { model: 'fake-medium-2' },
         high: {
@@ -387,27 +387,27 @@ describe('AI engine', function() {
         }
       });
       // Aliased entry: its own rows only, the native table does not apply
-      assert.deepStrictEqual(custom.effort, {
+      assert.deepEqual(custom.effort, {
         low: { model: 'custom-small' },
         medium: { model: 'custom-large' }
       });
-      assert.strictEqual(custom.capabilities.imageInput, false);
-      assert.strictEqual(custom.capabilities.text, true);
-      assert.deepStrictEqual(custom.models['custom-small'], {
+      assert.equal(custom.capabilities.imageInput, false);
+      assert.equal(custom.capabilities.text, true);
+      assert.deepEqual(custom.models['custom-small'], {
         contextWindow: 32000,
         maxOutputTokens: 4000
       });
       // Per-model metadata merge, entry fields winning
-      assert.deepStrictEqual(custom.models['fake-small'], {
+      assert.deepEqual(custom.models['fake-small'], {
         contextWindow: 100000,
         maxOutputTokens: 1234
       });
     });
 
     it('builds the effort routing table from the default provider plus level overrides', function() {
-      assert.strictEqual(apos.ai.defaultProvider, 'fake');
-      assert.strictEqual(apos.ai.effortDefault, 'medium');
-      assert.deepStrictEqual(apos.ai.effortTable, {
+      assert.equal(apos.ai.defaultProvider, 'fake');
+      assert.equal(apos.ai.effortDefault, 'medium');
+      assert.deepEqual(apos.ai.effortTable, {
         low: {
           provider: 'fake',
           model: 'fake-small'
@@ -432,26 +432,26 @@ describe('AI engine', function() {
           /@apostrophecms\/ai: no default provider is available/
         );
         // A failed activation leaves the engine inactive
-        assert.strictEqual(apos.ai.active, false);
+        assert.equal(apos.ai.active, false);
       } finally {
         apos.ai.defaultProvider = saved;
         await apos.ai.activateProviders();
-        assert.strictEqual(apos.ai.active, true);
+        assert.equal(apos.ai.active, true);
       }
     });
 
     it('rejects an image resolution when no image route is configured', function() {
       assert.throws(() => apos.ai.modelInfo({ capability: 'image' }), (e) => {
-        assert.strictEqual(e.name, 'invalid');
+        assert.equal(e.name, 'invalid');
         assert.match(e.message, /no "image" route is configured/);
         return true;
       });
     });
 
     it('overrides an adapter on re-registration and requires a name', function() {
-      assert.strictEqual(apos.ai.getAdapter('fake').label, 'Fake (fake)');
+      assert.equal(apos.ai.getAdapter('fake').label, 'Fake (fake)');
       apos.ai.addAdapter(fakeAdapter('fake', { label: 'Replaced' }));
-      assert.strictEqual(apos.ai.getAdapter('fake').label, 'Replaced');
+      assert.equal(apos.ai.getAdapter('fake').label, 'Replaced');
       assert.throws(
         () => apos.ai.addAdapter({ label: 'anonymous' }),
         /requires an adapter definition with a "name" string/
@@ -480,8 +480,8 @@ describe('AI engine', function() {
         });
         assert(mockApos.ai.providers.fake);
         // The sole configured provider is inferred as the default
-        assert.strictEqual(mockApos.ai.defaultProvider, 'fake');
-        assert.strictEqual(mockApos.ai.active, true);
+        assert.equal(mockApos.ai.defaultProvider, 'fake');
+        assert.equal(mockApos.ai.active, true);
       } finally {
         delete process.env.APOS_AI_MOCK;
         await t.destroy(mockApos);
@@ -653,7 +653,7 @@ describe('AI engine', function() {
     });
 
     it('resolves the default effort level', function() {
-      assert.deepStrictEqual(apos.ai.modelInfo(), {
+      assert.deepEqual(apos.ai.modelInfo(), {
         provider: 'fake',
         model: 'fake-medium',
         contextWindow: 200000,
@@ -663,7 +663,7 @@ describe('AI engine', function() {
     });
 
     it('resolves a call effort level', function() {
-      assert.deepStrictEqual(apos.ai.modelInfo({ effort: 'low' }), {
+      assert.deepEqual(apos.ai.modelInfo({ effort: 'low' }), {
         provider: 'fake',
         model: 'fake-small',
         contextWindow: 100000,
@@ -673,7 +673,7 @@ describe('AI engine', function() {
     });
 
     it('resolves an overridden level routed to another provider', function() {
-      assert.deepStrictEqual(apos.ai.modelInfo({ effort: 'high' }), {
+      assert.deepEqual(apos.ai.modelInfo({ effort: 'high' }), {
         provider: 'other',
         model: 'other-large',
         contextWindow: 400000,
@@ -683,7 +683,7 @@ describe('AI engine', function() {
     });
 
     it('merges inline routing-entry metadata over the model maps', function() {
-      assert.deepStrictEqual(apos.ai.modelInfo({ effort: 'ultra' }), {
+      assert.deepEqual(apos.ai.modelInfo({ effort: 'ultra' }), {
         provider: 'other',
         model: 'other-ultra',
         reasoning: 'max',
@@ -694,7 +694,7 @@ describe('AI engine', function() {
     });
 
     it('resolves an explicit provider and model directly', function() {
-      assert.deepStrictEqual(apos.ai.modelInfo({
+      assert.deepEqual(apos.ai.modelInfo({
         provider: 'other',
         model: 'other-medium'
       }), {
@@ -707,7 +707,7 @@ describe('AI engine', function() {
     });
 
     it('yields undefined limits for an unknown model, never an error', function() {
-      assert.deepStrictEqual(apos.ai.modelInfo({
+      assert.deepEqual(apos.ai.modelInfo({
         provider: 'fake',
         model: 'mystery'
       }), {
@@ -720,7 +720,7 @@ describe('AI engine', function() {
     });
 
     it('resolves the image route via capability', function() {
-      assert.deepStrictEqual(apos.ai.modelInfo({ capability: 'image' }), {
+      assert.deepEqual(apos.ai.modelInfo({ capability: 'image' }), {
         provider: 'other',
         model: 'other-image',
         contextWindow: undefined,
@@ -731,7 +731,7 @@ describe('AI engine', function() {
     });
 
     it('reports aspects for an explicit image model too', function() {
-      assert.deepStrictEqual(apos.ai.modelInfo({
+      assert.deepEqual(apos.ai.modelInfo({
         capability: 'image',
         provider: 'other',
         model: 'other-image'
@@ -746,14 +746,14 @@ describe('AI engine', function() {
     });
 
     it('applies a call-level reasoning override', function() {
-      assert.strictEqual(
+      assert.equal(
         apos.ai.modelInfo({
           effort: 'ultra',
           reasoning: 'low'
         }).reasoning,
         'low'
       );
-      assert.strictEqual(
+      assert.equal(
         apos.ai.modelInfo({
           provider: 'fake',
           model: 'fake-large',
@@ -766,7 +766,7 @@ describe('AI engine', function() {
     it('rejects unresolvable calls with "invalid"', function() {
       const rejects = (options, pattern) => {
         assert.throws(() => apos.ai.modelInfo(options), (e) => {
-          assert.strictEqual(e.name, 'invalid');
+          assert.equal(e.name, 'invalid');
           assert.match(e.message, pattern);
           return true;
         });
@@ -791,7 +791,7 @@ describe('AI engine', function() {
     });
 
     child.on('close', (code) => {
-      assert.strictEqual(code, 1);
+      assert.equal(code, 1);
       assert.match(stderr, /@apostrophecms\/ai: "providers\.openai" must be an object/);
       done();
     });


### PR DESCRIPTION
Implement `apos.ai.generate(req, promptOrOptions, options?)` for plain text and
multi-turn chat, end to end against one real provider (Anthropic), together
with all the cross-cutting plumbing the core owns once: retries, error
normalization, failure logging, prompt-cache policy, usage metadata, events,
and mock mode. 