### PR TITLE
AI adapters

### DIFF
--- a/packages/apostrophe/defaults.js
+++ b/packages/apostrophe/defaults.js
@@ -29,6 +29,7 @@ module.exports = {
     '@apostrophecms/job': {},
     '@apostrophecms/ai': {},
     '@apostrophecms/ai-adapter-anthropic': {},
+    '@apostrophecms/ai-adapter-openai': {},
     '@apostrophecms/modal': {},
     '@apostrophecms/oembed': {},
     '@apostrophecms/pager': {},

--- a/packages/apostrophe/defaults.js
+++ b/packages/apostrophe/defaults.js
@@ -30,6 +30,7 @@ module.exports = {
     '@apostrophecms/ai': {},
     '@apostrophecms/ai-adapter-anthropic': {},
     '@apostrophecms/ai-adapter-openai': {},
+    '@apostrophecms/ai-adapter-google': {},
     '@apostrophecms/modal': {},
     '@apostrophecms/oembed': {},
     '@apostrophecms/pager': {},

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-google/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-google/index.js
@@ -1,0 +1,276 @@
+// The standard Google (Gemini) adapter for `apos.ai`. It registers
+// itself with the AI engine at startup; configure the provider with
+// just a key under the engine's `providers.google` entry to use it.
+// All knowledge of the Gemini generateContent dialect — request
+// translation, response parsing, error mapping — lives here.
+//
+// Url-form image parts translate to the dialect's `fileData.fileUri`,
+// which the service accepts for its own Files API URIs, not for
+// arbitrary web URLs — pass base64 `{ data, mediaType }` parts for
+// images the service cannot reach.
+//
+// The transport is `apos.http`, no SDK. Projects can adjust the dialect
+// by extending this module and overriding its methods.
+
+module.exports = {
+  options: {
+    // Per-request timeout in milliseconds; a timed-out call is a
+    // transient failure the engine retries
+    timeout: 600000
+  },
+  init(self) {
+    self.apos.ai.addAdapter(self.adapter());
+  },
+  methods(self) {
+    return {
+      // The adapter definition registered with `apos.ai`. The engine
+      // instantiates it per configured provider entry, assigning
+      // `provider`, `apiKey` and `baseUrl` — which is why `chat` and
+      // `validate` read config from `this` while the dialect work
+      // delegates to the module's methods.
+      adapter() {
+        return {
+          name: 'google',
+          label: 'Google (Gemini)',
+          baseUrl: 'https://generativelanguage.googleapis.com',
+          envKey: 'APOS_GEMINI_KEY',
+          capabilities: {
+            text: true,
+            tools: true,
+            structured: true,
+            stream: true,
+            imageInput: true,
+            image: true,
+            caching: true
+          },
+          effort: {
+            low: { model: 'gemini-3.1-flash-lite' },
+            medium: { model: 'gemini-3.5-flash' },
+            high: {
+              model: 'gemini-3.5-flash',
+              reasoning: 'high'
+            }
+          },
+          models: {
+            'gemini-3.1-flash-lite': {
+              contextWindow: 1048576,
+              maxOutputTokens: 65536
+            },
+            'gemini-3.5-flash': {
+              contextWindow: 1048576,
+              maxOutputTokens: 65536
+            }
+          },
+          validate() {
+            if (!this.apiKey) {
+              throw new Error(`the "${this.provider}" provider requires an apiKey`);
+            }
+          },
+          async chat(req, request) {
+            const response = await self.apos.http.post(
+              `${this.baseUrl}/v1beta/models/${request.model}:generateContent`,
+              {
+                headers: {
+                  'x-goog-api-key': this.apiKey
+                },
+                body: self.buildBody(request),
+                timeout: self.options.timeout,
+                ...(request.signal && { signal: request.signal })
+              }
+            );
+            return self.parseResponse(response);
+          },
+          normalizeError(error) {
+            return self.normalizeError(error);
+          }
+        };
+      },
+      // Translate a normalized adapter request (see the engine's
+      // buildRequest) to a generateContent body: the system prompt
+      // becomes `systemInstruction`, the assistant role becomes
+      // `model`, `maxTokens` and `reasoning` travel in
+      // `generationConfig` (as `maxOutputTokens` and the thinking
+      // level, verbatim), each omitted when unresolved. The model is
+      // not part of the body — it rides in the request URL. The cache
+      // policy places nothing: the provider caches prompt prefixes
+      // automatically and the ttl level is not settable per request.
+      buildBody(request) {
+        const {
+          system, messages, maxTokens, reasoning
+        } = request;
+        const generationConfig = {
+          ...(maxTokens !== undefined && { maxOutputTokens: maxTokens }),
+          ...(reasoning !== undefined && {
+            thinkingConfig: { thinkingLevel: reasoning }
+          })
+        };
+        return {
+          ...(system !== undefined && {
+            systemInstruction: {
+              parts: [ { text: system } ]
+            }
+          }),
+          contents: messages.map((message) => ({
+            role: message.role === 'assistant' ? 'model' : 'user',
+            parts: message.content.map(toPart)
+          })),
+          ...(Object.keys(generationConfig).length && { generationConfig })
+        };
+
+        function toPart(part) {
+          if (part.type === 'text') {
+            return { text: part.text };
+          }
+          // part.type === 'image', in one of the two normalized forms
+          return part.image.url !== undefined
+            ? {
+              fileData: { fileUri: part.image.url }
+            }
+            : {
+              inlineData: {
+                mimeType: part.image.mediaType,
+                data: part.image.data
+              }
+            };
+        }
+      },
+      // Translate a generateContent response to the normalized
+      // assistant turn { content, finishReason, usage, model }. A
+      // blocked prompt arrives with no candidates and throws the
+      // refusal error here; a safety-family finish reason maps to the
+      // refusal finish reason — "refused" always arrives as an error.
+      // The dialect reports STOP on tool-call turns, so functionCall
+      // parts force the toolCalls finish reason; they carry no call
+      // id. Thought parts are not conversation content and do not
+      // travel. Thinking tokens are billed as output, so they add
+      // into outputTokens. An unknown finish reason maps to no
+      // finishReason — the engine's turn validation treats that as a
+      // malformed (retryable) response, never a truncated success.
+      parseResponse(response) {
+        const blockReason = response.promptFeedback?.blockReason;
+        if (blockReason) {
+          throw self.apos.error('aiRefusal', `the model blocked this request: ${blockReason}`);
+        }
+        const [ candidate ] = response.candidates || [];
+        const content = (candidate?.content?.parts || [])
+          .filter((part) => !part.thought)
+          .map(fromPart)
+          .filter(Boolean);
+        const usage = response.usageMetadata;
+        return {
+          content,
+          finishReason: content.some((part) => part.type === 'toolCall')
+            ? 'toolCalls'
+            : {
+              STOP: 'stop',
+              MAX_TOKENS: 'length',
+              SAFETY: 'refusal',
+              RECITATION: 'refusal',
+              PROHIBITED_CONTENT: 'refusal',
+              BLOCKLIST: 'refusal',
+              SPII: 'refusal',
+              IMAGE_SAFETY: 'refusal'
+            }[candidate?.finishReason],
+          usage: {
+            inputTokens: usage?.promptTokenCount,
+            outputTokens: usage?.candidatesTokenCount === undefined
+              ? undefined
+              : usage.candidatesTokenCount + (usage.thoughtsTokenCount || 0)
+          },
+          model: response.modelVersion
+        };
+
+        function fromPart(part) {
+          if (typeof part.text === 'string') {
+            return {
+              type: 'text',
+              text: part.text
+            };
+          }
+          if (part.functionCall) {
+            return {
+              type: 'toolCall',
+              name: part.functionCall.name,
+              input: part.functionCall.args
+            };
+          }
+          return null;
+        }
+      },
+      // Map any error the transport produced to a normalized apos
+      // error, the only shape the engine reacts to. Transient failures
+      // — 429, 5xx, network trouble, our own timeout — become the
+      // retryable code with a `kind` hint. The provider's retry hint
+      // is read from the Retry-After header or, failing that, from
+      // the RetryInfo detail Gemini puts in the error body, into
+      // `retryAfter` seconds. No request id header exists on this
+      // API. A caller's own abort is not a provider failure and
+      // passes through untouched.
+      normalizeError(error) {
+        if (error?.name === 'AbortError') {
+          return error;
+        }
+        if (error?.name === 'TimeoutError') {
+          return self.apos.error('aiRetry', 'the provider request timed out', {
+            kind: 'timeout'
+          });
+        }
+        const status = error?.status;
+        if (!Number.isInteger(status)) {
+          return self.apos.error('aiRetry', `network failure: ${error?.message}`, {
+            kind: 'network'
+          });
+        }
+        const retryAfter = retryAfterSeconds(error.headers?.['retry-after']) ??
+          retryInfoSeconds(error.body?.error?.details);
+        const data = {
+          status,
+          ...(retryAfter !== undefined && { retryAfter })
+        };
+        const message = error.body?.error?.message || error.message;
+        if (status === 429) {
+          return self.apos.error('aiRetry', message, {
+            ...data,
+            kind: 'rateLimit'
+          });
+        }
+        if (status >= 500) {
+          return self.apos.error('aiRetry', message, {
+            ...data,
+            kind: 'overload'
+          });
+        }
+        if (status === 401 || status === 403) {
+          return self.apos.error('forbidden', message, data);
+        }
+        if (status === 404) {
+          return self.apos.error('notfound', message, data);
+        }
+        return self.apos.error('invalid', message, data);
+
+        function retryAfterSeconds(value) {
+          if (value === undefined) {
+            return undefined;
+          }
+          const seconds = Number(value);
+          if (Number.isFinite(seconds)) {
+            return Math.max(0, seconds);
+          }
+          const date = Date.parse(value);
+          if (Number.isNaN(date)) {
+            return undefined;
+          }
+          return Math.max(0, Math.ceil((date - Date.now()) / 1000));
+        }
+        // The google.rpc.RetryInfo detail carries a protobuf Duration
+        // like "37s"
+        function retryInfoSeconds(details) {
+          const info = (details || []).find((detail) =>
+            detail['@type'] === 'type.googleapis.com/google.rpc.RetryInfo');
+          const match = /^(\d+(?:\.\d+)?)s$/.exec(info?.retryDelay || '');
+          return match ? Math.ceil(Number(match[1])) : undefined;
+        }
+      }
+    };
+  }
+};

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai/index.js
@@ -1,0 +1,262 @@
+// The standard OpenAI adapter for `apos.ai`. It registers itself with
+// the AI engine at startup; configure the provider with just a key
+// under the engine's `providers.openai` entry to use it. All knowledge
+// of the OpenAI dialect — request translation, response parsing, error
+// mapping — lives here.
+//
+// The adapter speaks the Chat Completions dialect only, the de facto
+// wire standard of the ecosystem: an aliased provider entry
+// (`adapter: 'openai'`) pointing `baseUrl` at any compatible vendor or
+// local runtime (Groq, Mistral, OpenRouter, Ollama, vLLM, …) is a
+// custom provider with zero adapter code — the entry's own `models`,
+// `effort` and `capabilities` describe the actual service.
+//
+// The transport is `apos.http`, no SDK. Projects can adjust the dialect
+// by extending this module and overriding its methods.
+
+module.exports = {
+  options: {
+    // Per-request timeout in milliseconds; a timed-out call is a
+    // transient failure the engine retries
+    timeout: 600000
+  },
+  init(self) {
+    self.apos.ai.addAdapter(self.adapter());
+  },
+  methods(self) {
+    return {
+      // The adapter definition registered with `apos.ai`. The engine
+      // instantiates it per configured provider entry, assigning
+      // `provider`, `apiKey` and `baseUrl` — which is why `chat` and
+      // `validate` read config from `this` while the dialect work
+      // delegates to the module's methods.
+      adapter() {
+        return {
+          name: 'openai',
+          label: 'OpenAI',
+          baseUrl: 'https://api.openai.com/v1',
+          envKey: 'APOS_OPENAI_KEY',
+          capabilities: {
+            text: true,
+            tools: true,
+            structured: true,
+            stream: true,
+            imageInput: true,
+            image: true,
+            caching: true
+          },
+          effort: {
+            low: { model: 'gpt-5.6-luna' },
+            medium: { model: 'gpt-5.6-terra' },
+            high: {
+              model: 'gpt-5.6-sol',
+              reasoning: 'high'
+            }
+          },
+          models: {
+            'gpt-5.6-luna': {
+              contextWindow: 1050000,
+              maxOutputTokens: 128000
+            },
+            'gpt-5.6-terra': {
+              contextWindow: 1050000,
+              maxOutputTokens: 128000
+            },
+            'gpt-5.6-sol': {
+              contextWindow: 1050000,
+              maxOutputTokens: 128000
+            }
+          },
+          validate() {
+            if (!this.apiKey) {
+              throw new Error(`the "${this.provider}" provider requires an apiKey`);
+            }
+          },
+          async chat(req, request) {
+            const response = await self.apos.http.post(`${this.baseUrl}/chat/completions`, {
+              headers: {
+                authorization: `Bearer ${this.apiKey}`
+              },
+              body: self.buildBody(request),
+              timeout: self.options.timeout,
+              ...(request.signal && { signal: request.signal })
+            });
+            return self.parseResponse(response);
+          },
+          normalizeError(error) {
+            return self.normalizeError(error);
+          }
+        };
+      },
+      // Translate a normalized adapter request (see the engine's
+      // buildRequest) to a Chat Completions body: the system prompt
+      // leads the messages as a `system` turn, `maxTokens` becomes
+      // `max_completion_tokens` (optional here, so an unresolved cap
+      // is omitted) and `reasoning` travels as `reasoning_effort`,
+      // verbatim. A message whose content is a single text part
+      // collapses to the plain-string form every compatible host
+      // accepts; anything else stays a parts array. The cache policy
+      // places nothing: the provider caches prompt prefixes
+      // automatically and the ttl level is not settable in this
+      // dialect.
+      buildBody(request) {
+        const {
+          system, messages, model, maxTokens, reasoning
+        } = request;
+        return {
+          model,
+          messages: [
+            ...(system !== undefined
+              ? [ {
+                role: 'system',
+                content: system
+              } ]
+              : []),
+            ...messages.map((message) => ({
+              role: message.role,
+              content: toContent(message.content)
+            }))
+          ],
+          ...(maxTokens !== undefined && { max_completion_tokens: maxTokens }),
+          ...(reasoning !== undefined && { reasoning_effort: reasoning })
+        };
+
+        function toContent(parts) {
+          if (parts.length === 1 && parts[0].type === 'text') {
+            return parts[0].text;
+          }
+          return parts.map(toPart);
+        }
+        function toPart(part) {
+          if (part.type === 'text') {
+            return {
+              type: 'text',
+              text: part.text
+            };
+          }
+          // part.type === 'image', in one of the two normalized forms
+          return {
+            type: 'image_url',
+            image_url: {
+              url: part.image.url !== undefined
+                ? part.image.url
+                : `data:${part.image.mediaType};base64,${part.image.data}`
+            }
+          };
+        }
+      },
+      // Translate a Chat Completions response to the normalized
+      // assistant turn { content, finishReason, usage, model }. An
+      // in-body `refusal` message throws the refusal error here, and a
+      // `content_filter` finish reason maps to the refusal finish
+      // reason — "refused" always arrives as an error, never a silent
+      // empty turn. Tool calls carry their arguments as a JSON string,
+      // parsed into the normalized input object. An unknown finish
+      // reason maps to no finishReason — the engine's turn validation
+      // treats that as a malformed (retryable) response, never a
+      // truncated success.
+      parseResponse(response) {
+        const [ choice ] = response.choices || [];
+        const message = choice?.message || {};
+        if (message.refusal) {
+          throw self.apos.error('aiRefusal', message.refusal);
+        }
+        const content = [];
+        if (typeof message.content === 'string' && message.content !== '') {
+          content.push({
+            type: 'text',
+            text: message.content
+          });
+        }
+        for (const call of message.tool_calls || []) {
+          content.push({
+            type: 'toolCall',
+            id: call.id,
+            name: call.function?.name,
+            input: JSON.parse(call.function?.arguments || '{}')
+          });
+        }
+        return {
+          content,
+          finishReason: {
+            stop: 'stop',
+            length: 'length',
+            tool_calls: 'toolCalls',
+            content_filter: 'refusal'
+          }[choice?.finish_reason],
+          usage: {
+            inputTokens: response.usage?.prompt_tokens,
+            outputTokens: response.usage?.completion_tokens
+          },
+          model: response.model
+        };
+      },
+      // Map any error the transport produced to a normalized apos
+      // error, the only shape the engine reacts to. Transient failures
+      // — 429, 5xx, network trouble, our own timeout — become the
+      // retryable code with a `kind` hint; the provider's Retry-After
+      // (seconds or an HTTP date) is parsed into `retryAfter` seconds
+      // and its request id is carried for the failure records. A
+      // caller's own abort is not a provider failure and passes
+      // through untouched.
+      normalizeError(error) {
+        if (error?.name === 'AbortError') {
+          return error;
+        }
+        if (error?.name === 'TimeoutError') {
+          return self.apos.error('aiRetry', 'the provider request timed out', {
+            kind: 'timeout'
+          });
+        }
+        const status = error?.status;
+        if (!Number.isInteger(status)) {
+          return self.apos.error('aiRetry', `network failure: ${error?.message}`, {
+            kind: 'network'
+          });
+        }
+        const headers = error.headers || {};
+        const retryAfter = retryAfterSeconds(headers['retry-after']);
+        const data = {
+          status,
+          ...(headers['x-request-id'] !== undefined && { requestId: headers['x-request-id'] }),
+          ...(retryAfter !== undefined && { retryAfter })
+        };
+        const message = error.body?.error?.message || error.message;
+        if (status === 429) {
+          return self.apos.error('aiRetry', message, {
+            ...data,
+            kind: 'rateLimit'
+          });
+        }
+        if (status >= 500) {
+          return self.apos.error('aiRetry', message, {
+            ...data,
+            kind: 'overload'
+          });
+        }
+        if (status === 401 || status === 403) {
+          return self.apos.error('forbidden', message, data);
+        }
+        if (status === 404) {
+          return self.apos.error('notfound', message, data);
+        }
+        return self.apos.error('invalid', message, data);
+
+        function retryAfterSeconds(value) {
+          if (value === undefined) {
+            return undefined;
+          }
+          const seconds = Number(value);
+          if (Number.isFinite(seconds)) {
+            return Math.max(0, seconds);
+          }
+          const date = Date.parse(value);
+          if (Number.isNaN(date)) {
+            return undefined;
+          }
+          return Math.max(0, Math.ceil((date - Date.now()) / 1000));
+        }
+      }
+    };
+  }
+};

--- a/packages/apostrophe/test/ai-adapter-google.js
+++ b/packages/apostrophe/test/ai-adapter-google.js
@@ -1,0 +1,614 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert/strict');
+
+describe('AI adapter: google', function() {
+  this.timeout(t.timeout);
+
+  let apos;
+  // The adapter module instance, for unit access to the dialect methods
+  let adapter;
+  let savedLiveKey;
+
+  before(async function() {
+    // A real key in the environment would override the fixture keys
+    // below (envKey); keep the suite hermetic and restore at the end
+    savedLiveKey = process.env.APOS_GEMINI_KEY;
+    delete process.env.APOS_GEMINI_KEY;
+    apos = await t.create({
+      root: module,
+      modules: {
+        '@apostrophecms/ai': {
+          options: {
+            provider: 'google',
+            providers: {
+              google: { apiKey: 'sk-test' },
+              gateway: {
+                adapter: 'google',
+                apiKey: 'sk-gw',
+                baseUrl: 'https://llm-gateway.example.com/google'
+              }
+            },
+            // Keep retried tests fast; the delay engine has its own suite
+            retryBaseDelay: 1
+          }
+        }
+      }
+    });
+    adapter = apos.modules['@apostrophecms/ai-adapter-google'];
+  });
+
+  after(async function() {
+    if (savedLiveKey !== undefined) {
+      process.env.APOS_GEMINI_KEY = savedLiveKey;
+    }
+    if (apos) {
+      return t.destroy(apos);
+    }
+  });
+
+  const text = (value) => ({
+    type: 'text',
+    text: value
+  });
+  const userMessage = (value) => ({
+    role: 'user',
+    content: [ text(value) ]
+  });
+  // A minimal normalized adapter request, as the engine assembles it
+  const request = (extras = {}) => ({
+    messages: [ userMessage('write a haiku about cats') ],
+    model: 'gemini-3.5-flash',
+    maxTokens: 65536,
+    cache: false,
+    ...extras
+  });
+  // A canned generateContent candidate and response body
+  const candidate = (extras = {}) => ({
+    content: {
+      role: 'model',
+      parts: [ { text: 'a haiku' } ]
+    },
+    finishReason: 'STOP',
+    index: 0,
+    ...extras
+  });
+  const fixture = (extras = {}) => ({
+    candidates: [ candidate() ],
+    usageMetadata: {
+      promptTokenCount: 12,
+      candidatesTokenCount: 7,
+      totalTokenCount: 19
+    },
+    modelVersion: 'gemini-3.5-flash-0519',
+    responseId: 'resp_1',
+    ...extras
+  });
+  // An apos.http >= 400 throw: Error with status, headers, body
+  const httpError = (status, headers = {}, body) => Object.assign(
+    new Error(`HTTP error ${status}`),
+    {
+      status,
+      headers,
+      body
+    }
+  );
+
+  it('registers the adapter and activates the provider', function() {
+    assert(apos.ai.getAdapter('google'));
+    assert.equal(apos.ai.getAdapter('google').envKey, 'APOS_GEMINI_KEY');
+    assert.equal(apos.ai.active, true);
+    const info = apos.ai.modelInfo();
+    assert.equal(info.provider, 'google');
+    assert.equal(info.model, 'gemini-3.5-flash');
+    assert.equal(info.contextWindow, 1048576);
+    assert.equal(info.maxOutputTokens, 65536);
+    assert.equal(apos.ai.modelInfo({ effort: 'low' }).model, 'gemini-3.1-flash-lite');
+    const high = apos.ai.modelInfo({ effort: 'high' });
+    assert.equal(high.model, 'gemini-3.5-flash');
+    assert.equal(high.reasoning, 'high');
+  });
+
+  describe('request translation', function() {
+    it('builds the minimal body', function() {
+      assert.deepEqual(adapter.buildBody(request()), {
+        contents: [ {
+          role: 'user',
+          parts: [ { text: 'write a haiku about cats' } ]
+        } ],
+        generationConfig: { maxOutputTokens: 65536 }
+      });
+    });
+
+    it('carries the system prompt as systemInstruction', function() {
+      const body = adapter.buildBody(request({ system: 'You help editors.' }));
+      assert.deepEqual(body.systemInstruction, {
+        parts: [ { text: 'You help editors.' } ]
+      });
+      assert.equal(body.contents.length, 1);
+    });
+
+    it('translates the assistant role to model', function() {
+      const body = adapter.buildBody(request({
+        messages: [
+          userMessage('Do we have a pricing page?'),
+          {
+            role: 'assistant',
+            content: [ text('No, I did not find one.') ]
+          },
+          userMessage('Create one.')
+        ]
+      }));
+      assert.deepEqual(
+        body.contents.map((content) => content.role),
+        [ 'user', 'model', 'user' ]
+      );
+    });
+
+    it('translates both image part forms', function() {
+      const body = adapter.buildBody(request({
+        messages: [ {
+          role: 'user',
+          content: [
+            text('describe these'),
+            {
+              type: 'image',
+              image: { url: 'https://generativelanguage.googleapis.com/v1beta/files/f1' }
+            },
+            {
+              type: 'image',
+              image: {
+                data: 'aGk=',
+                mediaType: 'image/png'
+              }
+            }
+          ]
+        } ]
+      }));
+      assert.deepEqual(body.contents[0].parts.slice(1), [
+        {
+          fileData: {
+            fileUri: 'https://generativelanguage.googleapis.com/v1beta/files/f1'
+          }
+        },
+        {
+          inlineData: {
+            mimeType: 'image/png',
+            data: 'aGk='
+          }
+        }
+      ]);
+    });
+
+    it('passes reasoning through as the thinking level', function() {
+      assert.equal(
+        adapter.buildBody(request()).generationConfig.thinkingConfig,
+        undefined
+      );
+      assert.deepEqual(
+        adapter.buildBody(request({ reasoning: 'high' })).generationConfig,
+        {
+          maxOutputTokens: 65536,
+          thinkingConfig: { thinkingLevel: 'high' }
+        }
+      );
+    });
+
+    it('omits generationConfig entirely when nothing resolved', function() {
+      const body = adapter.buildBody(request({ maxTokens: undefined }));
+      assert.equal('generationConfig' in body, false);
+    });
+
+    it('places nothing for any cache policy', function() {
+      for (const cache of [ { ttl: 'short' }, { ttl: 'long' } ]) {
+        assert.deepEqual(
+          adapter.buildBody(request({ cache })),
+          adapter.buildBody(request())
+        );
+      }
+    });
+  });
+
+  describe('response parsing', function() {
+    it('parses a text turn', function() {
+      assert.deepEqual(adapter.parseResponse(fixture()), {
+        content: [ text('a haiku') ],
+        finishReason: 'stop',
+        usage: {
+          inputTokens: 12,
+          outputTokens: 7
+        },
+        model: 'gemini-3.5-flash-0519'
+      });
+    });
+
+    it('maps the finish reasons', function() {
+      for (const [ theirs, ours ] of [
+        [ 'STOP', 'stop' ],
+        [ 'MAX_TOKENS', 'length' ],
+        // The engine converts the refusal finish reason to the
+        // refusal error
+        [ 'SAFETY', 'refusal' ],
+        [ 'PROHIBITED_CONTENT', 'refusal' ],
+        // Unknown reasons yield none: the engine treats the turn as
+        // malformed and retries, never a truncated success
+        [ 'MALFORMED_FUNCTION_CALL', undefined ]
+      ]) {
+        assert.equal(
+          adapter.parseResponse(fixture({
+            candidates: [ candidate({ finishReason: theirs }) ]
+          })).finishReason,
+          ours
+        );
+      }
+    });
+
+    it('adds thinking tokens into the output count', function() {
+      const turn = adapter.parseResponse(fixture({
+        usageMetadata: {
+          promptTokenCount: 12,
+          candidatesTokenCount: 7,
+          thoughtsTokenCount: 5,
+          totalTokenCount: 24
+        }
+      }));
+      assert.deepEqual(turn.usage, {
+        inputTokens: 12,
+        outputTokens: 12
+      });
+    });
+
+    it('translates function calls, forcing the toolCalls finish reason, and drops thought parts', function() {
+      const turn = adapter.parseResponse(fixture({
+        candidates: [ candidate({
+          content: {
+            role: 'model',
+            parts: [
+              {
+                thought: true,
+                text: 'let me see'
+              },
+              { text: 'checking' },
+              {
+                functionCall: {
+                  name: 'find_pages',
+                  args: { title: 'Pricing' }
+                }
+              }
+            ]
+          },
+          // The dialect reports STOP on tool-call turns
+          finishReason: 'STOP'
+        }) ]
+      }));
+      assert.deepEqual(turn.content, [
+        text('checking'),
+        {
+          type: 'toolCall',
+          name: 'find_pages',
+          input: { title: 'Pricing' }
+        }
+      ]);
+      assert.equal(turn.finishReason, 'toolCalls');
+    });
+
+    it('throws the refusal error on a blocked prompt', function() {
+      assert.throws(
+        () => adapter.parseResponse({
+          promptFeedback: { blockReason: 'SAFETY' },
+          usageMetadata: { promptTokenCount: 12 }
+        }),
+        (e) => {
+          assert.equal(e.name, 'aiRefusal');
+          assert.match(e.message, /SAFETY/);
+          return true;
+        }
+      );
+    });
+  });
+
+  describe('error normalization', function() {
+    it('maps the statuses to the normalized codes', function() {
+      for (const [ status, code, kind ] of [
+        [ 429, 'aiRetry', 'rateLimit' ],
+        [ 500, 'aiRetry', 'overload' ],
+        [ 503, 'aiRetry', 'overload' ],
+        [ 401, 'forbidden', undefined ],
+        [ 403, 'forbidden', undefined ],
+        [ 404, 'notfound', undefined ],
+        [ 400, 'invalid', undefined ]
+      ]) {
+        const error = adapter.normalizeError(httpError(status));
+        assert.equal(error.name, code);
+        assert.equal(error.data.status, status);
+        assert.equal(error.data.kind, kind);
+      }
+    });
+
+    it('prefers the provider message', function() {
+      const error = adapter.normalizeError(httpError(400, {}, {
+        error: {
+          code: 400,
+          message: 'API key not valid. Please pass a valid API key.',
+          status: 'INVALID_ARGUMENT'
+        }
+      }));
+      assert.equal(error.name, 'invalid');
+      assert.equal(error.message, 'API key not valid. Please pass a valid API key.');
+    });
+
+    it('reads the retry hint from the header or the RetryInfo detail', function() {
+      const header = adapter.normalizeError(httpError(429, { 'retry-after': '7' }));
+      assert.equal(header.data.retryAfter, 7);
+      const detail = adapter.normalizeError(httpError(429, {}, {
+        error: {
+          code: 429,
+          message: 'Resource has been exhausted (e.g. check quota).',
+          status: 'RESOURCE_EXHAUSTED',
+          details: [ {
+            '@type': 'type.googleapis.com/google.rpc.RetryInfo',
+            retryDelay: '37s'
+          } ]
+        }
+      }));
+      assert.equal(detail.data.retryAfter, 37);
+      const garbage = adapter.normalizeError(httpError(429, {}, {
+        error: {
+          code: 429,
+          message: 'Resource has been exhausted (e.g. check quota).',
+          status: 'RESOURCE_EXHAUSTED',
+          details: [ {
+            '@type': 'type.googleapis.com/google.rpc.RetryInfo',
+            retryDelay: 'soon'
+          } ]
+        }
+      }));
+      assert.equal(garbage.data.retryAfter, undefined);
+    });
+
+    it('maps timeouts and network failures to the transient code', function() {
+      const timeout = adapter.normalizeError(
+        new DOMException('The operation timed out', 'TimeoutError')
+      );
+      assert.equal(timeout.name, 'aiRetry');
+      assert.equal(timeout.data.kind, 'timeout');
+      const network = adapter.normalizeError(new TypeError('fetch failed'));
+      assert.equal(network.name, 'aiRetry');
+      assert.equal(network.data.kind, 'network');
+      assert.match(network.message, /fetch failed/);
+    });
+
+    it('passes a caller abort through untouched', function() {
+      const abort = new DOMException('The operation was aborted', 'AbortError');
+      assert.equal(adapter.normalizeError(abort), abort);
+    });
+  });
+
+  describe('the wire', function() {
+    // Thunks consumed by the stubbed apos.http.post, one per call
+    let httpScript;
+    let httpCalls;
+    let logRecords;
+    let waits;
+    let originalPost;
+
+    before(function() {
+      originalPost = apos.http.post;
+    });
+
+    after(function() {
+      apos.http.post = originalPost;
+    });
+
+    beforeEach(function() {
+      httpScript = [];
+      httpCalls = [];
+      waits = [];
+      logRecords = [];
+      apos.http.post = async (url, options) => {
+        httpCalls.push({
+          url,
+          options
+        });
+        const step = httpScript.shift();
+        if (step === undefined) {
+          throw new Error('post called beyond its script');
+        }
+        return step();
+      };
+      apos.ai.pause = async (ms) => {
+        waits.push(ms);
+      };
+      for (const severity of [ 'Warn', 'Error' ]) {
+        apos.ai[`log${severity}`] = (req, type, message, data) => {
+          logRecords.push({
+            severity: severity.toLowerCase(),
+            type,
+            message,
+            data
+          });
+        };
+      }
+    });
+
+    it('generates end to end against the dialect', async function() {
+      httpScript = [ () => fixture() ];
+      const result = await apos.ai.generate(
+        apos.task.getReq(),
+        'write a haiku about cats'
+      );
+      assert.equal(result.text, 'a haiku');
+      assert.equal(result.finishReason, 'stop');
+      assert.equal(result.provider, 'google');
+      // The model the response named, not the routed alias
+      assert.equal(result.model, 'gemini-3.5-flash-0519');
+      assert.deepEqual(result.usage, {
+        inputTokens: 12,
+        outputTokens: 7
+      });
+
+      const [ call ] = httpCalls;
+      assert.equal(
+        call.url,
+        'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent'
+      );
+      assert.equal(call.options.headers['x-goog-api-key'], 'sk-test');
+      assert.equal(call.options.timeout, 600000);
+      // The whole body: the default short cache policy adds nothing
+      assert.deepEqual(call.options.body, {
+        contents: [ {
+          role: 'user',
+          parts: [ { text: 'write a haiku about cats' } ]
+        } ],
+        generationConfig: { maxOutputTokens: 65536 }
+      });
+    });
+
+    it('honors an aliased entry: its baseUrl, key and merged model metadata', async function() {
+      httpScript = [ () => fixture() ];
+      await apos.ai.generate(apos.task.getReq(), 'p', {
+        provider: 'gateway',
+        model: 'gemini-3.5-flash'
+      });
+      const [ call ] = httpCalls;
+      assert.equal(
+        call.url,
+        'https://llm-gateway.example.com/google/v1beta/models/gemini-3.5-flash:generateContent'
+      );
+      assert.equal(call.options.headers['x-goog-api-key'], 'sk-gw');
+      assert.equal(call.options.body.generationConfig.maxOutputTokens, 65536);
+    });
+
+    it('retries a 429 at the RetryInfo delay', async function() {
+      httpScript = [
+        () => {
+          throw httpError(429, {}, {
+            error: {
+              code: 429,
+              message: 'Resource has been exhausted (e.g. check quota).',
+              status: 'RESOURCE_EXHAUSTED',
+              details: [ {
+                '@type': 'type.googleapis.com/google.rpc.RetryInfo',
+                retryDelay: '2s'
+              } ]
+            }
+          });
+        },
+        () => fixture()
+      ];
+      const result = await apos.ai.generate(apos.task.getReq(), 'p');
+      assert.equal(result.text, 'a haiku');
+      assert.equal(httpCalls.length, 2);
+      assert.deepEqual(waits, [ 2000 ]);
+      const [ record ] = logRecords;
+      assert.equal(record.type, 'retry');
+      assert.equal(record.message, 'Resource has been exhausted (e.g. check quota).');
+      assert.equal(record.data.kind, 'rateLimit');
+      assert.equal(record.data.status, 429);
+      assert.equal(record.data.retryAfter, 2);
+    });
+
+    it('hard-stops an invalid API key, arriving as the 400 quirk', async function() {
+      httpScript = [ () => {
+        throw httpError(400, {}, {
+          error: {
+            code: 400,
+            message: 'API key not valid. Please pass a valid API key.',
+            status: 'INVALID_ARGUMENT'
+          }
+        });
+      } ];
+      await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+        assert.equal(e.name, 'invalid');
+        assert.equal(e.message, 'API key not valid. Please pass a valid API key.');
+        return true;
+      });
+      assert.equal(httpCalls.length, 1);
+      assert.deepEqual(
+        logRecords.map((record) => [ record.type, record.data.code ]),
+        [ [ 'failure', 'invalid' ] ]
+      );
+    });
+
+    it('surfaces a blocked prompt as the refusal error, without a retry', async function() {
+      httpScript = [ () => ({
+        promptFeedback: { blockReason: 'SAFETY' },
+        usageMetadata: { promptTokenCount: 12 }
+      }) ];
+      await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+        assert.equal(e.name, 'aiRefusal');
+        return true;
+      });
+      assert.equal(httpCalls.length, 1);
+    });
+
+    it('retries an unknown finish reason as a malformed turn', async function() {
+      httpScript = [
+        () => fixture({ candidates: [ candidate({ finishReason: 'WEIRD' }) ] }),
+        () => fixture()
+      ];
+      const result = await apos.ai.generate(apos.task.getReq(), 'p');
+      assert.equal(result.text, 'a haiku');
+      assert.equal(httpCalls.length, 2);
+    });
+
+    it('lets a caller abort surface as its own error', async function() {
+      httpScript = [ () => {
+        throw new DOMException('The operation was aborted', 'AbortError');
+      } ];
+      await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+        assert.equal(e.name, 'AbortError');
+        return true;
+      });
+      assert.equal(httpCalls.length, 1);
+    });
+  });
+
+  describe('live smoke', function() {
+    const liveKey = process.env.APOS_GEMINI_KEY;
+    let liveApos;
+
+    before(async function() {
+      if (!liveKey) {
+        this.skip();
+      }
+      await t.destroy(apos);
+      apos = null;
+      liveApos = await t.create({
+        root: module,
+        modules: {
+          '@apostrophecms/ai': {
+            options: {
+              providers: {
+                google: { apiKey: liveKey }
+              }
+            }
+          }
+        }
+      });
+    });
+
+    after(async function() {
+      if (liveApos) {
+        return t.destroy(liveApos);
+      }
+    });
+
+    it('generates against Google for real', async function() {
+      const result = await liveApos.ai.generate(
+        liveApos.task.getReq(),
+        'write a haiku about cats',
+        {
+          effort: 'low',
+          // Room for the model's thinking tokens ahead of the text
+          maxTokens: 2000,
+          cache: false
+        }
+      );
+      assert(result.text.length > 0);
+      assert.equal(result.provider, 'google');
+      assert.equal(result.finishReason, 'stop');
+      assert(Number.isFinite(result.usage.inputTokens));
+      assert(Number.isFinite(result.usage.outputTokens));
+    });
+  });
+});

--- a/packages/apostrophe/test/ai-adapter-openai.js
+++ b/packages/apostrophe/test/ai-adapter-openai.js
@@ -1,0 +1,567 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert/strict');
+
+describe('AI adapter: openai', function() {
+  this.timeout(t.timeout);
+
+  let apos;
+  // The adapter module instance, for unit access to the dialect methods
+  let adapter;
+  let savedLiveKey;
+
+  before(async function() {
+    // A real key in the environment would override the fixture keys
+    // below (envKey); keep the suite hermetic and restore at the end
+    savedLiveKey = process.env.APOS_OPENAI_KEY;
+    delete process.env.APOS_OPENAI_KEY;
+    apos = await t.create({
+      root: module,
+      modules: {
+        '@apostrophecms/ai': {
+          options: {
+            provider: 'openai',
+            providers: {
+              openai: { apiKey: 'sk-test' },
+              gateway: {
+                adapter: 'openai',
+                apiKey: 'sk-gw',
+                baseUrl: 'https://llm-gateway.example.com/openai/v1'
+              }
+            },
+            // Keep retried tests fast; the delay engine has its own suite
+            retryBaseDelay: 1
+          }
+        }
+      }
+    });
+    adapter = apos.modules['@apostrophecms/ai-adapter-openai'];
+  });
+
+  after(async function() {
+    if (savedLiveKey !== undefined) {
+      process.env.APOS_OPENAI_KEY = savedLiveKey;
+    }
+    if (apos) {
+      return t.destroy(apos);
+    }
+  });
+
+  const text = (value) => ({
+    type: 'text',
+    text: value
+  });
+  const userMessage = (value) => ({
+    role: 'user',
+    content: [ text(value) ]
+  });
+  // A minimal normalized adapter request, as the engine assembles it
+  const request = (extras = {}) => ({
+    messages: [ userMessage('write a haiku about cats') ],
+    model: 'gpt-5.6-terra',
+    maxTokens: 128000,
+    cache: false,
+    ...extras
+  });
+  // A canned Chat Completions choice and response body
+  const choice = (extras = {}) => ({
+    index: 0,
+    message: {
+      role: 'assistant',
+      content: 'a haiku',
+      refusal: null
+    },
+    finish_reason: 'stop',
+    ...extras
+  });
+  const fixture = (extras = {}) => ({
+    id: 'chatcmpl-1',
+    object: 'chat.completion',
+    model: 'gpt-5.6-terra-2026-06-26',
+    choices: [ choice() ],
+    usage: {
+      prompt_tokens: 12,
+      completion_tokens: 7
+    },
+    ...extras
+  });
+  // An apos.http >= 400 throw: Error with status, headers, body
+  const httpError = (status, headers = {}, body) => Object.assign(
+    new Error(`HTTP error ${status}`),
+    {
+      status,
+      headers,
+      body
+    }
+  );
+
+  it('registers the adapter and activates the provider', function() {
+    assert(apos.ai.getAdapter('openai'));
+    assert.equal(apos.ai.getAdapter('openai').envKey, 'APOS_OPENAI_KEY');
+    assert.equal(apos.ai.active, true);
+    const info = apos.ai.modelInfo();
+    assert.equal(info.provider, 'openai');
+    assert.equal(info.model, 'gpt-5.6-terra');
+    assert.equal(info.contextWindow, 1050000);
+    assert.equal(info.maxOutputTokens, 128000);
+    const high = apos.ai.modelInfo({ effort: 'high' });
+    assert.equal(high.model, 'gpt-5.6-sol');
+    assert.equal(high.reasoning, 'high');
+  });
+
+  describe('request translation', function() {
+    it('builds the minimal body, collapsing one text part to a string', function() {
+      assert.deepEqual(adapter.buildBody(request()), {
+        model: 'gpt-5.6-terra',
+        messages: [ {
+          role: 'user',
+          content: 'write a haiku about cats'
+        } ],
+        max_completion_tokens: 128000
+      });
+    });
+
+    it('leads with the system prompt as a system message', function() {
+      const body = adapter.buildBody(request({ system: 'You help editors.' }));
+      assert.deepEqual(body.messages, [
+        {
+          role: 'system',
+          content: 'You help editors.'
+        },
+        {
+          role: 'user',
+          content: 'write a haiku about cats'
+        }
+      ]);
+    });
+
+    it('keeps multi-part content as parts and translates both image forms', function() {
+      const body = adapter.buildBody(request({
+        messages: [ {
+          role: 'user',
+          content: [
+            text('describe these'),
+            {
+              type: 'image',
+              image: { url: 'https://example.com/a.png' }
+            },
+            {
+              type: 'image',
+              image: {
+                data: 'aGk=',
+                mediaType: 'image/png'
+              }
+            }
+          ]
+        } ]
+      }));
+      assert.deepEqual(body.messages[0].content, [
+        {
+          type: 'text',
+          text: 'describe these'
+        },
+        {
+          type: 'image_url',
+          image_url: { url: 'https://example.com/a.png' }
+        },
+        {
+          type: 'image_url',
+          image_url: { url: 'data:image/png;base64,aGk=' }
+        }
+      ]);
+    });
+
+    it('passes reasoning through as reasoning_effort', function() {
+      assert.equal(adapter.buildBody(request()).reasoning_effort, undefined);
+      assert.equal(
+        adapter.buildBody(request({ reasoning: 'high' })).reasoning_effort,
+        'high'
+      );
+    });
+
+    it('omits the token cap when none resolved', function() {
+      const body = adapter.buildBody(request({ maxTokens: undefined }));
+      assert.equal('max_completion_tokens' in body, false);
+    });
+
+    it('places nothing for any cache policy', function() {
+      for (const cache of [ { ttl: 'short' }, { ttl: 'long' } ]) {
+        assert.deepEqual(
+          adapter.buildBody(request({ cache })),
+          adapter.buildBody(request())
+        );
+      }
+    });
+  });
+
+  describe('response parsing', function() {
+    it('parses a text turn', function() {
+      assert.deepEqual(adapter.parseResponse(fixture()), {
+        content: [ text('a haiku') ],
+        finishReason: 'stop',
+        usage: {
+          inputTokens: 12,
+          outputTokens: 7
+        },
+        model: 'gpt-5.6-terra-2026-06-26'
+      });
+    });
+
+    it('maps the finish reasons', function() {
+      for (const [ theirs, ours ] of [
+        [ 'stop', 'stop' ],
+        [ 'length', 'length' ],
+        [ 'tool_calls', 'toolCalls' ],
+        // The engine converts the refusal finish reason to the
+        // refusal error
+        [ 'content_filter', 'refusal' ],
+        // Unknown reasons yield none: the engine treats the turn as
+        // malformed and retries, never a truncated success
+        [ 'weird', undefined ]
+      ]) {
+        assert.equal(
+          adapter.parseResponse(fixture({
+            choices: [ choice({ finish_reason: theirs }) ]
+          })).finishReason,
+          ours
+        );
+      }
+    });
+
+    it('translates tool calls, parsing their arguments', function() {
+      const turn = adapter.parseResponse(fixture({
+        choices: [ choice({
+          message: {
+            role: 'assistant',
+            content: null,
+            refusal: null,
+            tool_calls: [ {
+              id: 'call_1',
+              type: 'function',
+              function: {
+                name: 'find_pages',
+                arguments: '{"title":"Pricing"}'
+              }
+            } ]
+          },
+          finish_reason: 'tool_calls'
+        }) ]
+      }));
+      assert.deepEqual(turn.content, [ {
+        type: 'toolCall',
+        id: 'call_1',
+        name: 'find_pages',
+        input: { title: 'Pricing' }
+      } ]);
+      assert.equal(turn.finishReason, 'toolCalls');
+    });
+
+    it('throws the refusal error on an in-body refusal', function() {
+      assert.throws(
+        () => adapter.parseResponse(fixture({
+          choices: [ choice({
+            message: {
+              role: 'assistant',
+              content: null,
+              refusal: 'I cannot help with that.'
+            }
+          }) ]
+        })),
+        (e) => {
+          assert.equal(e.name, 'aiRefusal');
+          assert.equal(e.message, 'I cannot help with that.');
+          return true;
+        }
+      );
+    });
+  });
+
+  describe('error normalization', function() {
+    it('maps the statuses to the normalized codes', function() {
+      for (const [ status, code, kind ] of [
+        [ 429, 'aiRetry', 'rateLimit' ],
+        [ 500, 'aiRetry', 'overload' ],
+        [ 503, 'aiRetry', 'overload' ],
+        [ 401, 'forbidden', undefined ],
+        [ 403, 'forbidden', undefined ],
+        [ 404, 'notfound', undefined ],
+        [ 400, 'invalid', undefined ]
+      ]) {
+        const error = adapter.normalizeError(httpError(status));
+        assert.equal(error.name, code);
+        assert.equal(error.data.status, status);
+        assert.equal(error.data.kind, kind);
+      }
+    });
+
+    it('prefers the provider message and carries the request id', function() {
+      const error = adapter.normalizeError(httpError(401, {
+        'x-request-id': 'req_9'
+      }, {
+        error: {
+          message: 'Incorrect API key provided',
+          type: 'invalid_request_error',
+          code: 'invalid_api_key'
+        }
+      }));
+      assert.equal(error.message, 'Incorrect API key provided');
+      assert.equal(error.data.requestId, 'req_9');
+    });
+
+    it('parses Retry-After as seconds and as an HTTP date', function() {
+      const seconds = adapter.normalizeError(httpError(429, { 'retry-after': '7' }));
+      assert.equal(seconds.data.retryAfter, 7);
+      const date = adapter.normalizeError(httpError(429, {
+        'retry-after': new Date(Date.now() + 30000).toUTCString()
+      }));
+      assert(date.data.retryAfter >= 28 && date.data.retryAfter <= 31);
+      const garbage = adapter.normalizeError(httpError(429, { 'retry-after': 'soon' }));
+      assert.equal(garbage.data.retryAfter, undefined);
+    });
+
+    it('maps timeouts and network failures to the transient code', function() {
+      const timeout = adapter.normalizeError(
+        new DOMException('The operation timed out', 'TimeoutError')
+      );
+      assert.equal(timeout.name, 'aiRetry');
+      assert.equal(timeout.data.kind, 'timeout');
+      const network = adapter.normalizeError(new TypeError('fetch failed'));
+      assert.equal(network.name, 'aiRetry');
+      assert.equal(network.data.kind, 'network');
+      assert.match(network.message, /fetch failed/);
+    });
+
+    it('passes a caller abort through untouched', function() {
+      const abort = new DOMException('The operation was aborted', 'AbortError');
+      assert.equal(adapter.normalizeError(abort), abort);
+    });
+  });
+
+  describe('the wire', function() {
+    // Thunks consumed by the stubbed apos.http.post, one per call
+    let httpScript;
+    let httpCalls;
+    let logRecords;
+    let waits;
+    let originalPost;
+
+    before(function() {
+      originalPost = apos.http.post;
+    });
+
+    after(function() {
+      apos.http.post = originalPost;
+    });
+
+    beforeEach(function() {
+      httpScript = [];
+      httpCalls = [];
+      waits = [];
+      logRecords = [];
+      apos.http.post = async (url, options) => {
+        httpCalls.push({
+          url,
+          options
+        });
+        const step = httpScript.shift();
+        if (step === undefined) {
+          throw new Error('post called beyond its script');
+        }
+        return step();
+      };
+      apos.ai.pause = async (ms) => {
+        waits.push(ms);
+      };
+      for (const severity of [ 'Warn', 'Error' ]) {
+        apos.ai[`log${severity}`] = (req, type, message, data) => {
+          logRecords.push({
+            severity: severity.toLowerCase(),
+            type,
+            message,
+            data
+          });
+        };
+      }
+    });
+
+    it('generates end to end against the dialect', async function() {
+      httpScript = [ () => fixture() ];
+      const result = await apos.ai.generate(
+        apos.task.getReq(),
+        'write a haiku about cats'
+      );
+      assert.equal(result.text, 'a haiku');
+      assert.equal(result.finishReason, 'stop');
+      assert.equal(result.provider, 'openai');
+      // The model the response named, not the routed alias
+      assert.equal(result.model, 'gpt-5.6-terra-2026-06-26');
+      assert.deepEqual(result.usage, {
+        inputTokens: 12,
+        outputTokens: 7
+      });
+
+      const [ call ] = httpCalls;
+      assert.equal(call.url, 'https://api.openai.com/v1/chat/completions');
+      assert.equal(call.options.headers.authorization, 'Bearer sk-test');
+      assert.equal(call.options.timeout, 600000);
+      // The whole body: the default short cache policy adds nothing
+      assert.deepEqual(call.options.body, {
+        model: 'gpt-5.6-terra',
+        messages: [ {
+          role: 'user',
+          content: 'write a haiku about cats'
+        } ],
+        max_completion_tokens: 128000
+      });
+    });
+
+    it('honors an aliased entry: its baseUrl, key and merged model metadata', async function() {
+      httpScript = [ () => fixture() ];
+      await apos.ai.generate(apos.task.getReq(), 'p', {
+        provider: 'gateway',
+        model: 'gpt-5.6-terra'
+      });
+      const [ call ] = httpCalls;
+      assert.equal(call.url, 'https://llm-gateway.example.com/openai/v1/chat/completions');
+      assert.equal(call.options.headers.authorization, 'Bearer sk-gw');
+      assert.equal(call.options.body.max_completion_tokens, 128000);
+    });
+
+    it('retries a 429 at the Retry-After delay', async function() {
+      httpScript = [
+        () => {
+          throw httpError(429, {
+            'retry-after': '2',
+            'x-request-id': 'req_9'
+          }, {
+            error: {
+              message: 'Rate limit reached',
+              type: 'tokens',
+              code: 'rate_limit_exceeded'
+            }
+          });
+        },
+        () => fixture()
+      ];
+      const result = await apos.ai.generate(apos.task.getReq(), 'p');
+      assert.equal(result.text, 'a haiku');
+      assert.equal(httpCalls.length, 2);
+      assert.deepEqual(waits, [ 2000 ]);
+      const [ record ] = logRecords;
+      assert.equal(record.type, 'retry');
+      assert.equal(record.message, 'Rate limit reached');
+      assert.equal(record.data.kind, 'rateLimit');
+      assert.equal(record.data.status, 429);
+      assert.equal(record.data.retryAfter, 2);
+      assert.equal(record.data.requestId, 'req_9');
+    });
+
+    it('hard-stops a 401 as forbidden', async function() {
+      httpScript = [ () => {
+        throw httpError(401, { 'x-request-id': 'req_1' }, {
+          error: {
+            message: 'Incorrect API key provided',
+            type: 'invalid_request_error',
+            code: 'invalid_api_key'
+          }
+        });
+      } ];
+      await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+        assert.equal(e.name, 'forbidden');
+        assert.equal(e.message, 'Incorrect API key provided');
+        return true;
+      });
+      assert.equal(httpCalls.length, 1);
+      assert.deepEqual(
+        logRecords.map((record) => [ record.type, record.data.code ]),
+        [ [ 'failure', 'forbidden' ] ]
+      );
+    });
+
+    it('surfaces an in-body refusal as the refusal error, without a retry', async function() {
+      httpScript = [ () => fixture({
+        choices: [ choice({
+          message: {
+            role: 'assistant',
+            content: null,
+            refusal: 'I cannot help with that.'
+          }
+        }) ]
+      }) ];
+      await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+        assert.equal(e.name, 'aiRefusal');
+        return true;
+      });
+      assert.equal(httpCalls.length, 1);
+    });
+
+    it('retries an unknown finish reason as a malformed turn', async function() {
+      httpScript = [
+        () => fixture({ choices: [ choice({ finish_reason: 'weird' }) ] }),
+        () => fixture()
+      ];
+      const result = await apos.ai.generate(apos.task.getReq(), 'p');
+      assert.equal(result.text, 'a haiku');
+      assert.equal(httpCalls.length, 2);
+    });
+
+    it('lets a caller abort surface as its own error', async function() {
+      httpScript = [ () => {
+        throw new DOMException('The operation was aborted', 'AbortError');
+      } ];
+      await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+        assert.equal(e.name, 'AbortError');
+        return true;
+      });
+      assert.equal(httpCalls.length, 1);
+    });
+  });
+
+  describe('live smoke', function() {
+    const liveKey = process.env.APOS_OPENAI_KEY;
+    let liveApos;
+
+    before(async function() {
+      if (!liveKey) {
+        this.skip();
+      }
+      await t.destroy(apos);
+      apos = null;
+      liveApos = await t.create({
+        root: module,
+        modules: {
+          '@apostrophecms/ai': {
+            options: {
+              providers: {
+                openai: { apiKey: liveKey }
+              }
+            }
+          }
+        }
+      });
+    });
+
+    after(async function() {
+      if (liveApos) {
+        return t.destroy(liveApos);
+      }
+    });
+
+    it('generates against OpenAI for real', async function() {
+      const result = await liveApos.ai.generate(
+        liveApos.task.getReq(),
+        'write a haiku about cats',
+        {
+          effort: 'low',
+          // Room for the model's reasoning tokens ahead of the text
+          maxTokens: 2000,
+          cache: false
+        }
+      );
+      assert(result.text.length > 0);
+      assert.equal(result.provider, 'openai');
+      assert.equal(result.finishReason, 'stop');
+      assert(Number.isFinite(result.usage.inputTokens));
+      assert(Number.isFinite(result.usage.outputTokens));
+    });
+  });
+});

--- a/packages/apostrophe/test/ai-providers.js
+++ b/packages/apostrophe/test/ai-providers.js
@@ -1,0 +1,253 @@
+const http = require('http');
+const t = require('../test-lib/test.js');
+const assert = require('assert/strict');
+
+// The provider ecosystem story, end to end: a free-named provider entry
+// over the openai adapter runs against any host speaking the Chat
+// Completions dialect — here a real local HTTP server standing in for
+// Groq, Ollama, vLLM or an internal gateway — with zero adapter code.
+// Unlike the adapter suites, nothing is stubbed: the request travels
+// the real transport.
+describe('AI: named providers and baseUrl', function() {
+  this.timeout(t.timeout);
+
+  let apos;
+  let server;
+  let baseUrl;
+  // The requests the stub host captured, one per adapter call
+  let hits;
+  let savedOpenaiKey;
+  let savedAnthropicKey;
+
+  before(async function() {
+    // The adapters' default envKey variables would override the
+    // fixture keys below; keep the suite hermetic and restore at the end
+    savedOpenaiKey = process.env.APOS_OPENAI_KEY;
+    savedAnthropicKey = process.env.APOS_ANTHROPIC_KEY;
+    delete process.env.APOS_OPENAI_KEY;
+    delete process.env.APOS_ANTHROPIC_KEY;
+
+    // A minimal host speaking the Chat Completions dialect, echoing
+    // the requested model like a real vendor would
+    hits = [];
+    server = http.createServer((request, response) => {
+      let raw = '';
+      request.on('data', (chunk) => {
+        raw += chunk;
+      });
+      request.on('end', () => {
+        const body = JSON.parse(raw);
+        hits.push({
+          method: request.method,
+          url: request.url,
+          headers: request.headers,
+          body
+        });
+        response.setHeader('content-type', 'application/json');
+        response.end(JSON.stringify({
+          id: 'chatcmpl-1',
+          object: 'chat.completion',
+          model: body.model,
+          choices: [ {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: 'a llama haiku',
+              refusal: null
+            },
+            finish_reason: 'stop'
+          } ],
+          usage: {
+            prompt_tokens: 12,
+            completion_tokens: 7
+          }
+        }));
+      });
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    baseUrl = `http://127.0.0.1:${server.address().port}/v1`;
+
+    apos = await t.create({
+      root: module,
+      modules: {
+        '@apostrophecms/ai': {
+          options: {
+            provider: 'groq',
+            providers: {
+              // The named-provider recipe: the entry describes the
+              // actual service, the adapter supplies the dialect
+              groq: {
+                adapter: 'openai',
+                baseUrl,
+                apiKey: 'gsk-test',
+                models: {
+                  'llama-3.1-8b-instant': {
+                    contextWindow: 131072,
+                    maxOutputTokens: 8192
+                  },
+                  'llama-3.3-70b-versatile': {
+                    contextWindow: 131072,
+                    maxOutputTokens: 32768
+                  }
+                },
+                effort: {
+                  low: { model: 'llama-3.1-8b-instant' },
+                  medium: { model: 'llama-3.3-70b-versatile' },
+                  high: { model: 'llama-3.3-70b-versatile' }
+                },
+                capabilities: { image: false }
+              },
+              anthropic: { apiKey: 'sk-test' }
+            }
+          }
+        }
+      }
+    });
+  });
+
+  after(async function() {
+    if (savedOpenaiKey !== undefined) {
+      process.env.APOS_OPENAI_KEY = savedOpenaiKey;
+    }
+    if (savedAnthropicKey !== undefined) {
+      process.env.APOS_ANTHROPIC_KEY = savedAnthropicKey;
+    }
+    if (server) {
+      await new Promise((resolve) => server.close(resolve));
+    }
+    if (apos) {
+      return t.destroy(apos);
+    }
+  });
+
+  beforeEach(function() {
+    hits.length = 0;
+  });
+
+  it('activates the free-named entry over the openai adapter', function() {
+    assert.equal(apos.ai.active, true);
+    assert.equal(apos.ai.providers.groq.adapterName, 'openai');
+    assert.equal(apos.ai.providers.groq.adapter.apiKey, 'gsk-test');
+  });
+
+  it('resolves modelInfo from the entry\'s effort rows and models', function() {
+    const info = apos.ai.modelInfo();
+    assert.equal(info.provider, 'groq');
+    assert.equal(info.model, 'llama-3.3-70b-versatile');
+    assert.equal(info.contextWindow, 131072);
+    assert.equal(info.maxOutputTokens, 32768);
+    const low = apos.ai.modelInfo({ effort: 'low' });
+    assert.equal(low.model, 'llama-3.1-8b-instant');
+    assert.equal(low.maxOutputTokens, 8192);
+  });
+
+  it('overrides the adapter\'s capabilities with the entry\'s', function() {
+    assert.equal(apos.ai.providers.groq.capabilities.image, false);
+    assert.equal(apos.ai.providers.groq.capabilities.text, true);
+    assert.equal(apos.ai.modelInfo().capabilities.image, false);
+  });
+
+  it('throws the clear capability error, never a silent degrade', function() {
+    const throwsCapability = (provider, capability) => {
+      assert.throws(() => apos.ai.checkCapability(provider, capability), (e) => {
+        assert.equal(e.name, 'invalid');
+        assert.match(
+          e.message,
+          new RegExp(`"${provider}" does not declare the "${capability}"`)
+        );
+        return true;
+      });
+    };
+    // The entry's own override, and anthropic's native declaration
+    throwsCapability('groq', 'image');
+    throwsCapability('anthropic', 'image');
+    apos.ai.checkCapability('groq', 'text');
+    apos.ai.checkCapability('anthropic', 'text');
+  });
+
+  describe('the wire, for real', function() {
+    it('generates through the stub host with zero adapter code', async function() {
+      const result = await apos.ai.generate(
+        apos.task.getReq(),
+        'write a haiku about llamas',
+        { effort: 'low' }
+      );
+      assert.equal(result.text, 'a llama haiku');
+      assert.equal(result.provider, 'groq');
+      assert.equal(result.model, 'llama-3.1-8b-instant');
+      assert.equal(result.finishReason, 'stop');
+      assert.deepEqual(result.usage, {
+        inputTokens: 12,
+        outputTokens: 7
+      });
+
+      const [ hit ] = hits;
+      assert.equal(hit.method, 'POST');
+      assert.equal(hit.url, '/v1/chat/completions');
+      assert.equal(hit.headers.authorization, 'Bearer gsk-test');
+      assert.match(hit.headers['content-type'], /application\/json/);
+      // The entry's model metadata sized the request
+      assert.deepEqual(hit.body, {
+        model: 'llama-3.1-8b-instant',
+        messages: [ {
+          role: 'user',
+          content: 'write a haiku about llamas'
+        } ],
+        max_completion_tokens: 8192
+      });
+    });
+
+    it('routes a per-call override by the free provider name', async function() {
+      const result = await apos.ai.generate(apos.task.getReq(), 'p', {
+        provider: 'groq',
+        model: 'llama-3.3-70b-versatile'
+      });
+      assert.equal(result.model, 'llama-3.3-70b-versatile');
+      const [ hit ] = hits;
+      assert.equal(hit.body.model, 'llama-3.3-70b-versatile');
+      assert.equal(hit.body.max_completion_tokens, 32768);
+    });
+  });
+
+  describe('a native entry through a gateway baseUrl', function() {
+    before(async function() {
+      await t.destroy(apos);
+      apos = await t.create({
+        root: module,
+        modules: {
+          '@apostrophecms/ai': {
+            options: {
+              providers: {
+                // Same service, different door: only the endpoint moves
+                openai: {
+                  apiKey: 'sk-test',
+                  baseUrl
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+
+    it('keeps the native defaults: effort table and model metadata', function() {
+      const info = apos.ai.modelInfo();
+      assert.equal(info.provider, 'openai');
+      assert.equal(info.model, 'gpt-5.6-terra');
+      assert.equal(info.contextWindow, 1050000);
+      assert.equal(info.maxOutputTokens, 128000);
+      assert.equal(info.capabilities.image, true);
+    });
+
+    it('sends the native-routed call through the gateway door', async function() {
+      const result = await apos.ai.generate(apos.task.getReq(), 'p');
+      assert.equal(result.provider, 'openai');
+      assert.equal(result.model, 'gpt-5.6-terra');
+      const [ hit ] = hits;
+      assert.equal(hit.url, '/v1/chat/completions');
+      assert.equal(hit.headers.authorization, 'Bearer sk-test');
+      assert.equal(hit.body.model, 'gpt-5.6-terra');
+      assert.equal(hit.body.max_completion_tokens, 128000);
+    });
+  });
+});


### PR DESCRIPTION
Ship the remaining two standard adapters and make the provider ecosystem story
real: nearly every commercial vendor and local runtime (Groq, Mistral,
OpenRouter, Ollama, vLLM, …) exposes an OpenAI-compatible endpoint, so a
provider entry that names the OpenAI adapter and points `baseUrl` at such a
host becomes a custom provider with zero adapter code.