### PR TITLE
AI `generate` loop, structured response

### DIFF
--- a/packages/apostrophe/defaults.js
+++ b/packages/apostrophe/defaults.js
@@ -29,7 +29,7 @@ module.exports = {
     '@apostrophecms/job': {},
     '@apostrophecms/ai': {},
     '@apostrophecms/ai-adapter-anthropic': {},
-    '@apostrophecms/ai-adapter-openai': {},
+    '@apostrophecms/ai-adapter-openai-compatible': {},
     '@apostrophecms/ai-adapter-google': {},
     '@apostrophecms/modal': {},
     '@apostrophecms/oembed': {},

--- a/packages/apostrophe/defaults.js
+++ b/packages/apostrophe/defaults.js
@@ -29,6 +29,7 @@ module.exports = {
     '@apostrophecms/job': {},
     '@apostrophecms/ai': {},
     '@apostrophecms/ai-adapter-anthropic': {},
+    '@apostrophecms/ai-adapter-openai': {},
     '@apostrophecms/ai-adapter-openai-compatible': {},
     '@apostrophecms/ai-adapter-google': {},
     '@apostrophecms/modal': {},

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-anthropic/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-anthropic/index.js
@@ -26,6 +26,14 @@ module.exports = {
     self.apos.ai.addAdapter(self.adapter());
   },
   methods(self) {
+    // Anthropic has no response-schema mode, so structured output is
+    // delivered through tool use: a synthetic tool whose input schema is
+    // the request's `schema`. The model calls it to answer; parseResponse
+    // turns that call back into a plain structured answer. Its name leads
+    // with an underscore, which the engine's tool-name rule forbids, so
+    // it can never collide with a real tool.
+    const FINAL_ANSWER = '_final_answer';
+    const FINAL_ANSWER_DESCRIPTION = 'Provide your final answer by calling this tool with the required fields. This is the only way to return your response.';
     return {
       // The adapter definition registered with `apos.ai`. The engine
       // instantiates it per configured provider entry, assigning
@@ -84,7 +92,7 @@ module.exports = {
               timeout: self.options.timeout,
               ...(request.signal && { signal: request.signal })
             });
-            return self.parseResponse(response);
+            return self.parseResponse(response, request);
           },
           normalizeError(error) {
             return self.normalizeError(error);
@@ -101,23 +109,46 @@ module.exports = {
       // requests and results ride the conversation as `tool_use` and
       // `tool_result` blocks; the dialect has no tool role, so a
       // normalized `tool` message becomes a `user` message of
-      // `tool_result` blocks. Throws "invalid" on requests the dialect
-      // cannot express.
+      // `tool_result` blocks. A structured-output `schema` adds the
+      // synthetic final-answer tool, forced when nothing competes for
+      // the turn. Throws "invalid" on requests the dialect cannot
+      // express.
       buildBody(request) {
         const invalid = (message) => {
           throw self.apos.error('invalid', message);
         };
         const {
-          system, messages, model, maxTokens, reasoning, cache, tools
+          system, messages, model, maxTokens, reasoning, cache, tools, schema
         } = request;
         if (!Number.isInteger(maxTokens)) {
           invalid(`"maxTokens" is required: model "${model}" declares no maxOutputTokens to default to`);
         }
+        const wireTools = [
+          ...(tools || []).map(toTool),
+          ...(schema
+            ? [ {
+              name: FINAL_ANSWER,
+              description: FINAL_ANSWER_DESCRIPTION,
+              input_schema: schema
+            } ]
+            : [])
+        ];
         const body = {
           model,
           max_tokens: maxTokens,
           ...(system !== undefined && { system }),
-          ...(tools && { tools: tools.map(toTool) }),
+          ...(wireTools.length && { tools: wireTools }),
+          // Force the structured answer only when nothing else needs the
+          // turn: a real tool the model must be free to call first, or
+          // extended thinking, which Anthropic forbids alongside a forced
+          // tool. Otherwise the tool's description drives it and the
+          // engine's backstop retries a miss.
+          ...(schema && !(tools && tools.length) && reasoning === undefined && {
+            tool_choice: {
+              type: 'tool',
+              name: FINAL_ANSWER
+            }
+          }),
           messages: messages.map((message) => ({
             role: message.role === 'tool' ? 'user' : message.role,
             content: message.content.map(toBlock)
@@ -217,28 +248,53 @@ module.exports = {
       // assistant turn { content, finishReason, usage, model }. Thinking
       // blocks are not conversation content and do not travel. A
       // `refusal` stop reason throws the refusal error here, so
-      // "refused" always arrives as an error. An unknown stop reason
-      // maps to no finishReason — the engine's turn validation treats
-      // that as a malformed (retryable) response, never a truncated
-      // success.
-      parseResponse(response) {
+      // "refused" always arrives as an error. When the request asked for
+      // structured output and the model called the synthetic
+      // final-answer tool, that call is the answer, not a tool for the
+      // core to run: it becomes a `stop` turn carrying the arguments on
+      // `object` (and their JSON in the text, so the transcript
+      // round-trips). Anything else — free text, a real tool call —
+      // parses normally, leaving no `object` for the engine backstop to
+      // retry on. An unknown stop reason maps to no finishReason — the
+      // engine's turn validation treats that as a malformed (retryable)
+      // response, never a truncated success.
+      parseResponse(response, request = {}) {
         if (response.stop_reason === 'refusal') {
           throw self.apos.error('aiRefusal', 'the model refused this request');
         }
+        const usage = {
+          inputTokens: response.usage?.input_tokens,
+          outputTokens: response.usage?.output_tokens
+        };
+        const content = (response.content || [])
+          .map(fromBlock)
+          .filter(Boolean);
+        if (request.schema) {
+          const answer = content.find(
+            (part) => part.type === 'toolCall' && part.name === FINAL_ANSWER
+          );
+          if (answer) {
+            return {
+              content: [ {
+                type: 'text',
+                text: JSON.stringify(answer.input)
+              } ],
+              object: answer.input,
+              finishReason: 'stop',
+              usage,
+              model: response.model
+            };
+          }
+        }
         return {
-          content: (response.content || [])
-            .map(fromBlock)
-            .filter(Boolean),
+          content,
           finishReason: {
             end_turn: 'stop',
             stop_sequence: 'stop',
             max_tokens: 'length',
             tool_use: 'toolCalls'
           }[response.stop_reason],
-          usage: {
-            inputTokens: response.usage?.input_tokens,
-            outputTokens: response.usage?.output_tokens
-          },
+          usage,
           model: response.model
         };
 

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-anthropic/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-anthropic/index.js
@@ -93,18 +93,22 @@ module.exports = {
       },
       // Translate a normalized adapter request (see the engine's
       // buildRequest) to an Anthropic Messages API body: content parts
-      // become Anthropic blocks, `reasoning` becomes a thinking budget,
-      // and the cache policy is placed as `cache_control` markers — one
-      // on the system tail (the static prefix) and a rolling one on the
-      // last message, so the next call in a conversation reads what
-      // this one wrote. Throws "invalid" on requests the dialect cannot
-      // express.
+      // become Anthropic blocks, tool definitions become `tools`,
+      // `reasoning` becomes a thinking budget, and the cache policy is
+      // placed as `cache_control` markers — one on the system tail (the
+      // static prefix) and a rolling one on the last message, so the
+      // next call in a conversation reads what this one wrote. Tool
+      // requests and results ride the conversation as `tool_use` and
+      // `tool_result` blocks; the dialect has no tool role, so a
+      // normalized `tool` message becomes a `user` message of
+      // `tool_result` blocks. Throws "invalid" on requests the dialect
+      // cannot express.
       buildBody(request) {
         const invalid = (message) => {
           throw self.apos.error('invalid', message);
         };
         const {
-          system, messages, model, maxTokens, reasoning, cache
+          system, messages, model, maxTokens, reasoning, cache, tools
         } = request;
         if (!Number.isInteger(maxTokens)) {
           invalid(`"maxTokens" is required: model "${model}" declares no maxOutputTokens to default to`);
@@ -113,8 +117,9 @@ module.exports = {
           model,
           max_tokens: maxTokens,
           ...(system !== undefined && { system }),
+          ...(tools && { tools: tools.map(toTool) }),
           messages: messages.map((message) => ({
-            role: message.role,
+            role: message.role === 'tool' ? 'user' : message.role,
             content: message.content.map(toBlock)
           }))
         };
@@ -138,11 +143,42 @@ module.exports = {
         }
         return body;
 
+        // The model-facing tool definition; the JSON Schema travels
+        // verbatim as input_schema
+        function toTool(tool) {
+          return {
+            name: tool.name,
+            description: tool.description,
+            input_schema: tool.input
+          };
+        }
         function toBlock(part) {
           if (part.type === 'text') {
             return {
               type: 'text',
               text: part.text
+            };
+          }
+          if (part.type === 'toolCall') {
+            return {
+              type: 'tool_use',
+              id: part.id,
+              name: part.name,
+              input: part.input
+            };
+          }
+          if (part.type === 'toolResult') {
+            // Anthropic carries the result as a string; an object output
+            // is serialized, an error is flagged
+            return {
+              type: 'tool_result',
+              tool_use_id: part.toolCallId,
+              ...(part.error !== undefined
+                ? {
+                  content: part.error,
+                  is_error: true
+                }
+                : { content: JSON.stringify(part.output) })
             };
           }
           // part.type === 'image', in one of the two normalized forms

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-anthropic/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-anthropic/index.js
@@ -109,10 +109,14 @@ module.exports = {
       // requests and results ride the conversation as `tool_use` and
       // `tool_result` blocks; the dialect has no tool role, so a
       // normalized `tool` message becomes a `user` message of
-      // `tool_result` blocks. A structured-output `schema` adds the
-      // synthetic final-answer tool, forced when nothing competes for
-      // the turn. Throws "invalid" on requests the dialect cannot
-      // express.
+      // `tool_result` blocks. This adapter's own opaque `thinking`
+      // parts are replayed as the raw signed blocks they carry, ahead
+      // of the turn's other blocks — Anthropic requires an assistant
+      // turn's thinking preserved unmodified when its tool results come
+      // back. Part types this dialect does not own are skipped. A
+      // structured-output `schema` adds the synthetic final-answer
+      // tool, forced when nothing competes for the turn. Throws
+      // "invalid" on requests the dialect cannot express.
       buildBody(request) {
         const invalid = (message) => {
           throw self.apos.error('invalid', message);
@@ -151,7 +155,7 @@ module.exports = {
           }),
           messages: messages.map((message) => ({
             role: message.role === 'tool' ? 'user' : message.role,
-            content: message.content.map(toBlock)
+            content: message.content.map(toBlock).filter(Boolean)
           }))
         };
         if (reasoning !== undefined) {
@@ -212,20 +216,28 @@ module.exports = {
                 : { content: JSON.stringify(part.output) })
             };
           }
-          // part.type === 'image', in one of the two normalized forms
-          return {
-            type: 'image',
-            source: part.image.url !== undefined
-              ? {
-                type: 'url',
-                url: part.image.url
-              }
-              : {
-                type: 'base64',
-                media_type: part.image.mediaType,
-                data: part.image.data
-              }
-          };
+          // The raw signed thinking block this adapter's parseResponse
+          // carried over, replayed verbatim
+          if (part.type === 'thinking') {
+            return part.block;
+          }
+          if (part.type === 'image') {
+            return {
+              type: 'image',
+              source: part.image.url !== undefined
+                ? {
+                  type: 'url',
+                  url: part.image.url
+                }
+                : {
+                  type: 'base64',
+                  media_type: part.image.mediaType,
+                  data: part.image.data
+                }
+            };
+          }
+          // Another dialect's part; not ours to translate
+          return null;
         }
         // Anthropic wants an absolute token budget, mapped by the
         // thinkingBudgets option; the budget must leave max_tokens
@@ -245,10 +257,13 @@ module.exports = {
         }
       },
       // Translate an Anthropic Messages response to the normalized
-      // assistant turn { content, finishReason, usage, model }. Thinking
-      // blocks are not conversation content and do not travel. A
-      // `refusal` stop reason throws the refusal error here, so
-      // "refused" always arrives as an error. When the request asked for
+      // assistant turn { content, finishReason, usage, model }. A
+      // thinking (or redacted thinking) block rides along as this
+      // adapter's opaque `thinking` part carrying the raw signed block:
+      // Anthropic requires it back, unmodified, when the turn's tool
+      // results are submitted, so the loop replays what buildBody then
+      // restores. A `refusal` stop reason throws the refusal error
+      // here, so "refused" always arrives as an error. When the request asked for
       // structured output and the model called the synthetic
       // final-answer tool, that call is the answer, not a tool for the
       // core to run: it becomes a `stop` turn carrying the arguments on
@@ -311,6 +326,12 @@ module.exports = {
               id: block.id,
               name: block.name,
               input: block.input
+            };
+          }
+          if (block.type === 'thinking' || block.type === 'redacted_thinking') {
+            return {
+              type: 'thinking',
+              block
             };
           }
           return null;

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-google/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-google/index.js
@@ -98,10 +98,14 @@ module.exports = {
       // becomes `systemInstruction`, the assistant role becomes
       // `model`, `maxTokens` and `reasoning` travel in
       // `generationConfig` (as `maxOutputTokens` and the thinking
-      // level, verbatim), each omitted when unresolved. The model is
-      // not part of the body — it rides in the request URL. The cache
-      // policy places nothing: the provider caches prompt prefixes
-      // automatically and the ttl level is not settable per request.
+      // level, verbatim), each omitted when unresolved. A thought
+      // signature parseResponse carried on a part is restored at the
+      // part level, exactly as received — Gemini requires it back when
+      // a function call is replayed. Part types this dialect does not
+      // own are skipped. The model is not part of the body — it rides
+      // in the request URL. The cache policy places nothing: the
+      // provider caches prompt prefixes automatically and the ttl
+      // level is not settable per request.
       buildBody(request) {
         const {
           system, messages, maxTokens, reasoning, tools, schema
@@ -141,7 +145,7 @@ module.exports = {
           }),
           contents: messages.map((message) => ({
             role: message.role === 'assistant' ? 'model' : 'user',
-            parts: message.content.map(toPart)
+            parts: message.content.map(toPart).filter(Boolean)
           })),
           ...(functionDeclarations.length && {
             tools: [ { functionDeclarations } ]
@@ -172,15 +176,23 @@ module.exports = {
           };
         }
         function toPart(part) {
+          // The thought signature parseResponse carried over, restored
+          // at the part level exactly as the service sent it
+          const signature = part.thoughtSignature !== undefined &&
+            { thoughtSignature: part.thoughtSignature };
           if (part.type === 'text') {
-            return { text: part.text };
+            return {
+              text: part.text,
+              ...signature
+            };
           }
           if (part.type === 'toolCall') {
             return {
               functionCall: {
                 name: part.name,
                 args: part.input
-              }
+              },
+              ...signature
             };
           }
           if (part.type === 'toolResult') {
@@ -193,17 +205,21 @@ module.exports = {
               }
             };
           }
-          // part.type === 'image', in one of the two normalized forms
-          return part.image.url !== undefined
-            ? {
-              fileData: { fileUri: part.image.url }
-            }
-            : {
-              inlineData: {
-                mimeType: part.image.mediaType,
-                data: part.image.data
+          if (part.type === 'image') {
+            // In one of the two normalized forms
+            return part.image.url !== undefined
+              ? {
+                fileData: { fileUri: part.image.url }
               }
-            };
+              : {
+                inlineData: {
+                  mimeType: part.image.mediaType,
+                  data: part.image.data
+                }
+              };
+          }
+          // Another dialect's part; not ours to translate
+          return null;
         }
       },
       // Translate a generateContent response to the normalized
@@ -222,10 +238,13 @@ module.exports = {
       // arguments on `object` (and their JSON in the text, so the
       // transcript round-trips). Anything else — free text, a real
       // function call — parses normally, leaving no `object` for the
-      // engine backstop to retry on. Thought parts are not conversation
-      // content and do not travel. Thinking tokens are billed as output,
-      // so they add into outputTokens. An unknown finish reason maps to
-      // no finishReason — the engine's turn validation treats that as a
+      // engine backstop to retry on. Thought summary parts are not
+      // conversation content and do not travel, but a part-level
+      // thought signature does: it rides the normalized part, and
+      // buildBody must send it back exactly as received when the part
+      // is replayed. Thinking tokens are billed as output, so they add
+      // into outputTokens. An unknown finish reason maps to no
+      // finishReason — the engine's turn validation treats that as a
       // malformed (retryable) response, never a truncated success.
       parseResponse(response, request = {}) {
         const blockReason = response.promptFeedback?.blockReason;
@@ -281,10 +300,17 @@ module.exports = {
         };
 
         function fromPart(part) {
+          // Gemini attaches a thought signature at the part level and
+          // requires it back, exactly as received, when the part is
+          // replayed — it rides the normalized part for buildBody to
+          // restore
+          const signature = part.thoughtSignature !== undefined &&
+            { thoughtSignature: part.thoughtSignature };
           if (typeof part.text === 'string') {
             return {
               type: 'text',
-              text: part.text
+              text: part.text,
+              ...signature
             };
           }
           if (part.functionCall) {
@@ -292,7 +318,8 @@ module.exports = {
               type: 'toolCall',
               id: `${part.functionCall.name}-${callIndex++}`,
               name: part.functionCall.name,
-              input: part.functionCall.args || {}
+              input: part.functionCall.args || {},
+              ...signature
             };
           }
           return null;

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-google/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-google/index.js
@@ -96,7 +96,7 @@ module.exports = {
       // automatically and the ttl level is not settable per request.
       buildBody(request) {
         const {
-          system, messages, maxTokens, reasoning
+          system, messages, maxTokens, reasoning, tools
         } = request;
         const generationConfig = {
           ...(maxTokens !== undefined && { maxOutputTokens: maxTokens }),
@@ -104,6 +104,17 @@ module.exports = {
             thinkingConfig: { thinkingLevel: reasoning }
           })
         };
+        // Gemini pairs a function response to its call by name, not id,
+        // so recover the name of the call the engine's synthesized id
+        // refers to (parseResponse mints those ids)
+        const toolNamesById = new Map();
+        for (const message of messages) {
+          for (const part of message.content) {
+            if (part.type === 'toolCall') {
+              toolNamesById.set(part.id, part.name);
+            }
+          }
+        }
         return {
           ...(system !== undefined && {
             systemInstruction: {
@@ -114,12 +125,43 @@ module.exports = {
             role: message.role === 'assistant' ? 'model' : 'user',
             parts: message.content.map(toPart)
           })),
+          ...(tools && {
+            tools: [ { functionDeclarations: tools.map(toFunctionDeclaration) } ]
+          }),
           ...(Object.keys(generationConfig).length && { generationConfig })
         };
 
+        // The model-facing tool definition; the JSON Schema travels
+        // verbatim as the OpenAPI-subset parameters (the service polices
+        // any keyword it does not accept)
+        function toFunctionDeclaration(tool) {
+          return {
+            name: tool.name,
+            description: tool.description,
+            parameters: tool.input
+          };
+        }
         function toPart(part) {
           if (part.type === 'text') {
             return { text: part.text };
+          }
+          if (part.type === 'toolCall') {
+            return {
+              functionCall: {
+                name: part.name,
+                args: part.input
+              }
+            };
+          }
+          if (part.type === 'toolResult') {
+            return {
+              functionResponse: {
+                name: toolNamesById.get(part.toolCallId),
+                response: part.error !== undefined
+                  ? { error: part.error }
+                  : part.output
+              }
+            };
           }
           // part.type === 'image', in one of the two normalized forms
           return part.image.url !== undefined
@@ -140,18 +182,22 @@ module.exports = {
       // refusal error here; a safety-family finish reason maps to the
       // refusal finish reason — "refused" always arrives as an error.
       // The dialect reports STOP on tool-call turns, so functionCall
-      // parts force the toolCalls finish reason; they carry no call
-      // id. Thought parts are not conversation content and do not
-      // travel. Thinking tokens are billed as output, so they add
-      // into outputTokens. An unknown finish reason maps to no
-      // finishReason — the engine's turn validation treats that as a
-      // malformed (retryable) response, never a truncated success.
+      // parts force the toolCalls finish reason. Gemini function calls
+      // carry no id, but the normalized shape needs one to pair a
+      // result back to its call: the adapter synthesizes a per-turn id
+      // (buildBody recovers the tool name from it). Thought parts are
+      // not conversation content and do not travel. Thinking tokens are
+      // billed as output, so they add into outputTokens. An unknown
+      // finish reason maps to no finishReason — the engine's turn
+      // validation treats that as a malformed (retryable) response,
+      // never a truncated success.
       parseResponse(response) {
         const blockReason = response.promptFeedback?.blockReason;
         if (blockReason) {
           throw self.apos.error('aiRefusal', `the model blocked this request: ${blockReason}`);
         }
         const [ candidate ] = response.candidates || [];
+        let callIndex = 0;
         const content = (candidate?.content?.parts || [])
           .filter((part) => !part.thought)
           .map(fromPart)
@@ -190,8 +236,9 @@ module.exports = {
           if (part.functionCall) {
             return {
               type: 'toolCall',
+              id: `${part.functionCall.name}-${callIndex++}`,
               name: part.functionCall.name,
-              input: part.functionCall.args
+              input: part.functionCall.args || {}
             };
           }
           return null;

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-google/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-google/index.js
@@ -22,6 +22,14 @@ module.exports = {
     self.apos.ai.addAdapter(self.adapter());
   },
   methods(self) {
+    // Gemini forbids a response schema alongside function calling, so
+    // structured output is delivered through a synthetic tool whose
+    // parameters are the request's `schema`. The model calls it to
+    // answer; parseResponse turns that call back into a plain structured
+    // answer. Its name leads with an underscore, which the engine's
+    // tool-name rule forbids, so it can never collide with a real tool.
+    const FINAL_ANSWER = '_final_answer';
+    const FINAL_ANSWER_DESCRIPTION = 'Provide your final answer by calling this function with the required fields. This is the only way to return your response.';
     return {
       // The adapter definition registered with `apos.ai`. The engine
       // instantiates it per configured provider entry, assigning
@@ -78,7 +86,7 @@ module.exports = {
                 ...(request.signal && { signal: request.signal })
               }
             );
-            return self.parseResponse(response);
+            return self.parseResponse(response, request);
           },
           normalizeError(error) {
             return self.normalizeError(error);
@@ -96,7 +104,7 @@ module.exports = {
       // automatically and the ttl level is not settable per request.
       buildBody(request) {
         const {
-          system, messages, maxTokens, reasoning, tools
+          system, messages, maxTokens, reasoning, tools, schema
         } = request;
         const generationConfig = {
           ...(maxTokens !== undefined && { maxOutputTokens: maxTokens }),
@@ -115,6 +123,16 @@ module.exports = {
             }
           }
         }
+        const functionDeclarations = [
+          ...(tools || []).map(toFunctionDeclaration),
+          ...(schema
+            ? [ {
+              name: FINAL_ANSWER,
+              description: FINAL_ANSWER_DESCRIPTION,
+              parameters: schema
+            } ]
+            : [])
+        ];
         return {
           ...(system !== undefined && {
             systemInstruction: {
@@ -125,8 +143,20 @@ module.exports = {
             role: message.role === 'assistant' ? 'model' : 'user',
             parts: message.content.map(toPart)
           })),
-          ...(tools && {
-            tools: [ { functionDeclarations: tools.map(toFunctionDeclaration) } ]
+          ...(functionDeclarations.length && {
+            tools: [ { functionDeclarations } ]
+          }),
+          // Force the structured answer only when nothing else needs the
+          // turn: a real tool the model must be free to call first, or
+          // thinking. Otherwise the description drives it and the
+          // engine's backstop retries a miss.
+          ...(schema && !(tools && tools.length) && reasoning === undefined && {
+            toolConfig: {
+              functionCallingConfig: {
+                mode: 'ANY',
+                allowedFunctionNames: [ FINAL_ANSWER ]
+              }
+            }
           }),
           ...(Object.keys(generationConfig).length && { generationConfig })
         };
@@ -185,13 +215,19 @@ module.exports = {
       // parts force the toolCalls finish reason. Gemini function calls
       // carry no id, but the normalized shape needs one to pair a
       // result back to its call: the adapter synthesizes a per-turn id
-      // (buildBody recovers the tool name from it). Thought parts are
-      // not conversation content and do not travel. Thinking tokens are
-      // billed as output, so they add into outputTokens. An unknown
-      // finish reason maps to no finishReason — the engine's turn
-      // validation treats that as a malformed (retryable) response,
-      // never a truncated success.
-      parseResponse(response) {
+      // (buildBody recovers the tool name from it). When the request
+      // asked for structured output and the model called the synthetic
+      // final-answer function, that call is the answer, not a function
+      // for the core to run: it becomes a `stop` turn carrying the
+      // arguments on `object` (and their JSON in the text, so the
+      // transcript round-trips). Anything else — free text, a real
+      // function call — parses normally, leaving no `object` for the
+      // engine backstop to retry on. Thought parts are not conversation
+      // content and do not travel. Thinking tokens are billed as output,
+      // so they add into outputTokens. An unknown finish reason maps to
+      // no finishReason — the engine's turn validation treats that as a
+      // malformed (retryable) response, never a truncated success.
+      parseResponse(response, request = {}) {
         const blockReason = response.promptFeedback?.blockReason;
         if (blockReason) {
           throw self.apos.error('aiRefusal', `the model blocked this request: ${blockReason}`);
@@ -203,6 +239,29 @@ module.exports = {
           .map(fromPart)
           .filter(Boolean);
         const usage = response.usageMetadata;
+        const usageTokens = {
+          inputTokens: usage?.promptTokenCount,
+          outputTokens: usage?.candidatesTokenCount === undefined
+            ? undefined
+            : usage.candidatesTokenCount + (usage.thoughtsTokenCount || 0)
+        };
+        if (request.schema) {
+          const answer = content.find(
+            (part) => part.type === 'toolCall' && part.name === FINAL_ANSWER
+          );
+          if (answer) {
+            return {
+              content: [ {
+                type: 'text',
+                text: JSON.stringify(answer.input)
+              } ],
+              object: answer.input,
+              finishReason: 'stop',
+              usage: usageTokens,
+              model: response.modelVersion
+            };
+          }
+        }
         return {
           content,
           finishReason: content.some((part) => part.type === 'toolCall')
@@ -217,12 +276,7 @@ module.exports = {
               SPII: 'refusal',
               IMAGE_SAFETY: 'refusal'
             }[candidate?.finishReason],
-          usage: {
-            inputTokens: usage?.promptTokenCount,
-            outputTokens: usage?.candidatesTokenCount === undefined
-              ? undefined
-              : usage.candidatesTokenCount + (usage.thoughtsTokenCount || 0)
-          },
+          usage: usageTokens,
           model: response.modelVersion
         };
 

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai-compatible/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai-compatible/index.js
@@ -8,7 +8,10 @@
 //
 // For OpenAI proper, prefer the `openai` adapter, which speaks OpenAI's
 // first-class Responses API; this dialect still works against
-// api.openai.com (the default `baseUrl`) for cases that want it.
+// api.openai.com (the default `baseUrl`) for cases that want it —
+// though there a tools request drops `reasoning` (the service rejects
+// the combination in this dialect). Aliased entries describe other
+// services, which accept it, and pass through untouched.
 //
 // The transport is `apos.http`, no SDK. Projects can adjust the dialect
 // by extending this module and overriding its methods.
@@ -23,6 +26,9 @@ module.exports = {
     self.apos.ai.addAdapter(self.adapter());
   },
   methods(self) {
+    // OpenAI proper's endpoint: an instance still pointing here fronts
+    // the native service, where the reasoning degrade applies
+    const NATIVE_BASE_URL = 'https://api.openai.com/v1';
     return {
       // The adapter definition registered with `apos.ai`. The engine
       // instantiates it per configured provider entry, assigning
@@ -33,7 +39,7 @@ module.exports = {
         return {
           name: 'openai-compatible',
           label: 'OpenAI Completions',
-          baseUrl: 'https://api.openai.com/v1',
+          baseUrl: NATIVE_BASE_URL,
           envKey: 'APOS_OPENAI_KEY',
           capabilities: {
             text: true,
@@ -47,10 +53,10 @@ module.exports = {
           effort: {
             low: { model: 'gpt-5.6-luna' },
             medium: { model: 'gpt-5.6-terra' },
-            high: {
-              model: 'gpt-5.6-sol',
-              reasoning: 'high'
-            }
+            // No reasoning on the high row: the native service rejects
+            // it beside tools in this dialect, and the openai adapter
+            // is the reasoning path for OpenAI proper
+            high: { model: 'gpt-5.6-sol' }
           },
           models: {
             'gpt-5.6-luna': {
@@ -72,6 +78,9 @@ module.exports = {
             }
           },
           async chat(req, request) {
+            if (this.baseUrl === NATIVE_BASE_URL) {
+              request = self.nativeRequest(request);
+            }
             const response = await self.apos.http.post(`${this.baseUrl}/chat/completions`, {
               headers: {
                 authorization: `Bearer ${this.apiKey}`
@@ -86,6 +95,23 @@ module.exports = {
             return self.normalizeError(error);
           }
         };
+      },
+      // Adjust a request for OpenAI proper, which this adapter fronts
+      // only when the entry keeps the native baseUrl: since gpt-5.4 the
+      // service rejects function tools combined with a reasoning effort
+      // other than 'none' in this dialect, so reasoning is dropped from
+      // a tools request rather than failing the call. The openai
+      // adapter's Responses dialect accepts the combination and is the
+      // reasoning path for OpenAI proper; aliased entries describe
+      // other services, which accept it too, and never pass through
+      // here.
+      nativeRequest(request) {
+        if (request.tools &&
+          request.reasoning !== undefined && request.reasoning !== 'none') {
+          const { reasoning, ...rest } = request;
+          return rest;
+        }
+        return request;
       },
       // Translate a normalized adapter request (see the engine's
       // buildRequest) to a Chat Completions body: the system prompt
@@ -153,7 +179,11 @@ module.exports = {
           }
           if (message.role === 'assistant') {
             const calls = message.content.filter((part) => part.type === 'toolCall');
-            const rest = message.content.filter((part) => part.type !== 'toolCall');
+            // Text and image parts only: part types another dialect
+            // owns are not ours to translate
+            const rest = message.content.filter(
+              (part) => [ 'text', 'image' ].includes(part.type)
+            );
             return [ {
               role: 'assistant',
               content: rest.length ? toContent(rest) : null,

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai-compatible/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai-compatible/index.js
@@ -1,15 +1,14 @@
-// The standard OpenAI adapter for `apos.ai`. It registers itself with
-// the AI engine at startup; configure the provider with just a key
-// under the engine's `providers.openai` entry to use it. All knowledge
-// of the OpenAI dialect — request translation, response parsing, error
-// mapping — lives here.
+// The OpenAI-compatible adapter for `apos.ai`: the Chat Completions
+// dialect, the de facto wire standard of the ecosystem. It registers
+// itself with the AI engine at startup. An aliased provider entry
+// (`adapter: 'openai-compatible'`) pointing `baseUrl` at any compatible
+// vendor or local runtime (Groq, Mistral, OpenRouter, Ollama, vLLM, …)
+// is a custom provider with zero adapter code — the entry's own
+// `models`, `effort` and `capabilities` describe the actual service.
 //
-// The adapter speaks the Chat Completions dialect only, the de facto
-// wire standard of the ecosystem: an aliased provider entry
-// (`adapter: 'openai'`) pointing `baseUrl` at any compatible vendor or
-// local runtime (Groq, Mistral, OpenRouter, Ollama, vLLM, …) is a
-// custom provider with zero adapter code — the entry's own `models`,
-// `effort` and `capabilities` describe the actual service.
+// For OpenAI proper, prefer the `openai` adapter, which speaks OpenAI's
+// first-class Responses API; this dialect still works against
+// api.openai.com (the default `baseUrl`) for cases that want it.
 //
 // The transport is `apos.http`, no SDK. Projects can adjust the dialect
 // by extending this module and overriding its methods.
@@ -32,8 +31,8 @@ module.exports = {
       // delegates to the module's methods.
       adapter() {
         return {
-          name: 'openai',
-          label: 'OpenAI',
+          name: 'openai-compatible',
+          label: 'OpenAI Completions',
           baseUrl: 'https://api.openai.com/v1',
           envKey: 'APOS_OPENAI_KEY',
           capabilities: {

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai/index.js
@@ -1,0 +1,380 @@
+// The standard OpenAI adapter for `apos.ai`. It registers itself with
+// the AI engine at startup; configure the provider with just a key
+// under the engine's `providers.openai` entry to use it. All knowledge
+// of the OpenAI dialect — request translation, response parsing, error
+// mapping — lives here.
+//
+// The adapter speaks the Responses API, OpenAI's first-class surface,
+// where function tools and reasoning work together. Requests are
+// stateless (`store: false`): the engine drives its own loop and owns
+// the transcript, so no server-side conversation state is created. For
+// the OpenAI-compatible ecosystem (Groq, Mistral, Ollama, vLLM, …) use
+// the `openai-compatible` adapter, which speaks the Chat Completions
+// dialect those hosts implement.
+//
+// The transport is `apos.http`, no SDK. Projects can adjust the dialect
+// by extending this module and overriding its methods.
+
+module.exports = {
+  options: {
+    // Per-request timeout in milliseconds; a timed-out call is a
+    // transient failure the engine retries
+    timeout: 600000
+  },
+  init(self) {
+    self.apos.ai.addAdapter(self.adapter());
+  },
+  methods(self) {
+    return {
+      // The adapter definition registered with `apos.ai`. The engine
+      // instantiates it per configured provider entry, assigning
+      // `provider`, `apiKey` and `baseUrl` — which is why `chat` and
+      // `validate` read config from `this` while the dialect work
+      // delegates to the module's methods.
+      adapter() {
+        return {
+          name: 'openai',
+          label: 'OpenAI',
+          baseUrl: 'https://api.openai.com/v1',
+          envKey: 'APOS_OPENAI_KEY',
+          capabilities: {
+            text: true,
+            tools: true,
+            structured: true,
+            stream: true,
+            imageInput: true,
+            image: true,
+            caching: true
+          },
+          effort: {
+            low: { model: 'gpt-5.6-luna' },
+            medium: { model: 'gpt-5.6-terra' },
+            high: {
+              model: 'gpt-5.6-sol',
+              reasoning: 'high'
+            }
+          },
+          models: {
+            'gpt-5.6-luna': {
+              contextWindow: 1050000,
+              maxOutputTokens: 128000
+            },
+            'gpt-5.6-terra': {
+              contextWindow: 1050000,
+              maxOutputTokens: 128000
+            },
+            'gpt-5.6-sol': {
+              contextWindow: 1050000,
+              maxOutputTokens: 128000
+            }
+          },
+          validate() {
+            if (!this.apiKey) {
+              throw new Error(`the "${this.provider}" provider requires an apiKey`);
+            }
+          },
+          async chat(req, request) {
+            const response = await self.apos.http.post(`${this.baseUrl}/responses`, {
+              headers: {
+                authorization: `Bearer ${this.apiKey}`
+              },
+              body: self.buildBody(request),
+              timeout: self.options.timeout,
+              ...(request.signal && { signal: request.signal })
+            });
+            return self.parseResponse(response, request);
+          },
+          normalizeError(error) {
+            return self.normalizeError(error);
+          }
+        };
+      },
+      // Translate a normalized adapter request (see the engine's
+      // buildRequest) to a Responses API body: the system prompt travels
+      // as `instructions`, messages become `input` items, tool
+      // definitions become flattened function tools, a structured-output
+      // `schema` becomes the `json_schema` text format, `maxTokens`
+      // becomes `max_output_tokens` (optional here, so an unresolved cap
+      // is omitted) and `reasoning` becomes `{ reasoning: { effort } }`,
+      // the level verbatim. An assistant turn translates part by part,
+      // in order: text parts to assistant message items, tool requests
+      // to `function_call` items, and this adapter's own opaque
+      // `reasoning` parts replayed as the raw reasoning items they carry
+      // — the Responses API requires a reasoning item to precede its
+      // `function_call` when function outputs come back, which is why a
+      // tools-and-reasoning request also asks for
+      // `reasoning.encrypted_content`. Part types this dialect does not
+      // own are skipped. A `tool` message (a batch's results) becomes
+      // one `function_call_output` item per result. The cache policy
+      // places nothing: the provider caches prompt prefixes
+      // automatically and the ttl level is not settable in this
+      // dialect.
+      buildBody(request) {
+        const {
+          system, messages, model, maxTokens, reasoning, tools, schema
+        } = request;
+        return {
+          model,
+          // Stateless: the engine drives its own loop and owns the
+          // transcript; no server-side conversation state
+          store: false,
+          ...(system !== undefined && { instructions: system }),
+          input: messages.flatMap(toItems),
+          ...(tools && { tools: tools.map(toTool) }),
+          // The portable JSON Schema goes as the text format with
+          // `strict` off: strict mode would demand an OpenAI-specific
+          // schema subset (every object additionalProperties:false,
+          // every property required), which the same schema on Anthropic
+          // and Google does not — so the model is schema-guided here and
+          // the engine's backstop catches a stray.
+          ...(schema && {
+            text: {
+              format: {
+                type: 'json_schema',
+                name: 'response',
+                schema,
+                strict: false
+              }
+            }
+          }),
+          ...(maxTokens !== undefined && { max_output_tokens: maxTokens }),
+          ...(reasoning !== undefined && { reasoning: { effort: reasoning } }),
+          // The encrypted reasoning content makes the reasoning items
+          // replayable across the loop's stateless turns; without tools
+          // there is no loop and nothing to replay
+          ...(reasoning !== undefined && tools && {
+            include: [ 'reasoning.encrypted_content' ]
+          })
+        };
+
+        // One normalized message → one or more Responses input items
+        function toItems(message) {
+          if (message.role === 'tool') {
+            return message.content.map((part) => ({
+              type: 'function_call_output',
+              call_id: part.toolCallId,
+              output: part.error !== undefined
+                ? part.error
+                : JSON.stringify(part.output)
+            }));
+          }
+          if (message.role === 'assistant') {
+            return message.content.flatMap(toAssistantItem);
+          }
+          return [ {
+            role: 'user',
+            content: message.content.map(toInputPart)
+          } ];
+        }
+        function toAssistantItem(part) {
+          if (part.type === 'text') {
+            return [ {
+              role: 'assistant',
+              content: [ {
+                type: 'output_text',
+                text: part.text
+              } ]
+            } ];
+          }
+          if (part.type === 'toolCall') {
+            return [ {
+              type: 'function_call',
+              call_id: part.id,
+              name: part.name,
+              arguments: JSON.stringify(part.input)
+            } ];
+          }
+          // The raw reasoning item this adapter's parseResponse carried
+          // over, replayed verbatim ahead of its function call
+          if (part.type === 'reasoning') {
+            return [ part.item ];
+          }
+          // Another dialect's part; not ours to translate
+          return [];
+        }
+        // The model-facing tool definition, flattened in this dialect;
+        // the JSON Schema travels verbatim as the parameters, with
+        // `strict` off for the same portability reason as the text
+        // format above
+        function toTool(tool) {
+          return {
+            type: 'function',
+            name: tool.name,
+            description: tool.description,
+            parameters: tool.input,
+            strict: false
+          };
+        }
+        function toInputPart(part) {
+          if (part.type === 'text') {
+            return {
+              type: 'input_text',
+              text: part.text
+            };
+          }
+          // part.type === 'image', in one of the two normalized forms
+          return {
+            type: 'input_image',
+            image_url: part.image.url !== undefined
+              ? part.image.url
+              : `data:${part.image.mediaType};base64,${part.image.data}`
+          };
+        }
+      },
+      // Translate a Responses API response to the normalized assistant
+      // turn { content, finishReason, usage, model }. The output items
+      // translate in order — order matters, because a reasoning item
+      // must be replayed ahead of its function call: a message item's
+      // `output_text` parts become text parts (a `refusal` part throws
+      // the refusal error, so "refused" always arrives as an error),
+      // `function_call` items become toolCall parts with their JSON
+      // arguments parsed, and a reasoning item carrying
+      // `encrypted_content` rides along as this adapter's opaque
+      // `reasoning` part (one without it is not replayable and is
+      // dropped). The dialect has no finish reason; it is derived: a
+      // completed response finishes as 'toolCalls' when it requested
+      // tools, else 'stop'; an incomplete one maps its reason
+      // (max_output_tokens → 'length', content_filter → 'refusal');
+      // anything else maps to no finishReason — the engine's turn
+      // validation treats that as a malformed (retryable) response,
+      // never a truncated success. When the request asked for structured
+      // output, the final answer's text is the JSON object: it is parsed
+      // onto the turn's `object` ([D35]), which the engine
+      // backstop-validates; malformed JSON is a retryable response.
+      parseResponse(response, request = {}) {
+        const content = [];
+        for (const item of response.output || []) {
+          if (item.type === 'message') {
+            for (const part of item.content || []) {
+              if (part.type === 'refusal') {
+                throw self.apos.error('aiRefusal', part.refusal);
+              }
+              if (part.type === 'output_text') {
+                content.push({
+                  type: 'text',
+                  text: part.text
+                });
+              }
+            }
+          } else if (item.type === 'function_call') {
+            content.push({
+              type: 'toolCall',
+              id: item.call_id,
+              name: item.name,
+              input: JSON.parse(item.arguments || '{}')
+            });
+          } else if (item.type === 'reasoning' &&
+            item.encrypted_content != null) {
+            content.push({
+              type: 'reasoning',
+              item
+            });
+          }
+        }
+        const finishReason = deriveFinishReason();
+        const turn = {
+          content,
+          finishReason,
+          usage: {
+            inputTokens: response.usage?.input_tokens,
+            outputTokens: response.usage?.output_tokens
+          },
+          model: response.model
+        };
+        if (request.schema && finishReason === 'stop') {
+          const text = content
+            .filter((part) => part.type === 'text')
+            .map((part) => part.text)
+            .join('');
+          try {
+            turn.object = JSON.parse(text);
+          } catch (e) {
+            throw self.apos.error('aiRetry', 'the model returned malformed structured JSON');
+          }
+        }
+        return turn;
+
+        function deriveFinishReason() {
+          if (response.status === 'completed') {
+            return content.some((part) => part.type === 'toolCall')
+              ? 'toolCalls'
+              : 'stop';
+          }
+          if (response.status === 'incomplete') {
+            return {
+              max_output_tokens: 'length',
+              content_filter: 'refusal'
+            }[response.incomplete_details?.reason];
+          }
+          return undefined;
+        }
+      },
+      // Map any error the transport produced to a normalized apos
+      // error, the only shape the engine reacts to. Transient failures
+      // — 429, 5xx, network trouble, our own timeout — become the
+      // retryable code with a `kind` hint; the provider's Retry-After
+      // (seconds or an HTTP date) is parsed into `retryAfter` seconds
+      // and its request id is carried for the failure records. A
+      // caller's own abort is not a provider failure and passes
+      // through untouched.
+      normalizeError(error) {
+        if (error?.name === 'AbortError') {
+          return error;
+        }
+        if (error?.name === 'TimeoutError') {
+          return self.apos.error('aiRetry', 'the provider request timed out', {
+            kind: 'timeout'
+          });
+        }
+        const status = error?.status;
+        if (!Number.isInteger(status)) {
+          return self.apos.error('aiRetry', `network failure: ${error?.message}`, {
+            kind: 'network'
+          });
+        }
+        const headers = error.headers || {};
+        const retryAfter = retryAfterSeconds(headers['retry-after']);
+        const data = {
+          status,
+          ...(headers['x-request-id'] !== undefined && { requestId: headers['x-request-id'] }),
+          ...(retryAfter !== undefined && { retryAfter })
+        };
+        const message = error.body?.error?.message || error.message;
+        if (status === 429) {
+          return self.apos.error('aiRetry', message, {
+            ...data,
+            kind: 'rateLimit'
+          });
+        }
+        if (status >= 500) {
+          return self.apos.error('aiRetry', message, {
+            ...data,
+            kind: 'overload'
+          });
+        }
+        if (status === 401 || status === 403) {
+          return self.apos.error('forbidden', message, data);
+        }
+        if (status === 404) {
+          return self.apos.error('notfound', message, data);
+        }
+        return self.apos.error('invalid', message, data);
+
+        function retryAfterSeconds(value) {
+          if (value === undefined) {
+            return undefined;
+          }
+          const seconds = Number(value);
+          if (Number.isFinite(seconds)) {
+            return Math.max(0, seconds);
+          }
+          const date = Date.parse(value);
+          if (Number.isNaN(date)) {
+            return undefined;
+          }
+          return Math.max(0, Math.ceil((date - Date.now()) / 1000));
+        }
+      }
+    };
+  }
+};

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai/index.js
@@ -81,7 +81,7 @@ module.exports = {
               timeout: self.options.timeout,
               ...(request.signal && { signal: request.signal })
             });
-            return self.parseResponse(response);
+            return self.parseResponse(response, request);
           },
           normalizeError(error) {
             return self.normalizeError(error);
@@ -91,10 +91,11 @@ module.exports = {
       // Translate a normalized adapter request (see the engine's
       // buildRequest) to a Chat Completions body: the system prompt
       // leads the messages as a `system` turn, tool definitions become
-      // `tools`, `maxTokens` becomes `max_completion_tokens` (optional
-      // here, so an unresolved cap is omitted) and `reasoning` travels
-      // as `reasoning_effort`, verbatim. A message whose content is a
-      // single text part collapses to the plain-string form every
+      // `tools`, a structured-output `schema` becomes a `json_schema`
+      // response format, `maxTokens` becomes `max_completion_tokens`
+      // (optional here, so an unresolved cap is omitted) and `reasoning`
+      // travels as `reasoning_effort`, verbatim. A message whose content
+      // is a single text part collapses to the plain-string form every
       // compatible host accepts; anything else stays a parts array. Tool
       // requests ride an assistant message's `tool_calls`; the dialect
       // wants one `tool` message per result, so a normalized `tool`
@@ -104,7 +105,7 @@ module.exports = {
       // dialect.
       buildBody(request) {
         const {
-          system, messages, model, maxTokens, reasoning, tools
+          system, messages, model, maxTokens, reasoning, tools, schema
         } = request;
         return {
           model,
@@ -118,6 +119,21 @@ module.exports = {
             ...messages.flatMap(toMessages)
           ],
           ...(tools && { tools: tools.map(toTool) }),
+          // The portable JSON Schema goes as the response format without
+          // `strict`: strict mode would demand an OpenAI-specific schema
+          // subset (every object additionalProperties:false, every
+          // property required), which the same schema on Anthropic and
+          // Google does not — so the model is schema-guided here and the
+          // engine's backstop catches a stray.
+          ...(schema && {
+            response_format: {
+              type: 'json_schema',
+              json_schema: {
+                name: 'response',
+                schema
+              }
+            }
+          }),
           ...(maxTokens !== undefined && { max_completion_tokens: maxTokens }),
           ...(reasoning !== undefined && { reasoning_effort: reasoning })
         };
@@ -202,11 +218,14 @@ module.exports = {
       // `content_filter` finish reason maps to the refusal finish
       // reason — "refused" always arrives as an error, never a silent
       // empty turn. Tool calls carry their arguments as a JSON string,
-      // parsed into the normalized input object. An unknown finish
-      // reason maps to no finishReason — the engine's turn validation
-      // treats that as a malformed (retryable) response, never a
-      // truncated success.
-      parseResponse(response) {
+      // parsed into the normalized input object. When the request asked
+      // for structured output, the final answer's text is the JSON
+      // object: it is parsed onto the turn's `object` ([D35]), which the
+      // engine backstop-validates; malformed JSON is a retryable
+      // response. An unknown finish reason maps to no finishReason — the
+      // engine's turn validation treats that as a malformed (retryable)
+      // response, never a truncated success.
+      parseResponse(response, request = {}) {
         const [ choice ] = response.choices || [];
         const message = choice?.message || {};
         if (message.refusal) {
@@ -227,20 +246,29 @@ module.exports = {
             input: JSON.parse(call.function?.arguments || '{}')
           });
         }
-        return {
+        const finishReason = {
+          stop: 'stop',
+          length: 'length',
+          tool_calls: 'toolCalls',
+          content_filter: 'refusal'
+        }[choice?.finish_reason];
+        const turn = {
           content,
-          finishReason: {
-            stop: 'stop',
-            length: 'length',
-            tool_calls: 'toolCalls',
-            content_filter: 'refusal'
-          }[choice?.finish_reason],
+          finishReason,
           usage: {
             inputTokens: response.usage?.prompt_tokens,
             outputTokens: response.usage?.completion_tokens
           },
           model: response.model
         };
+        if (request.schema && finishReason === 'stop') {
+          try {
+            turn.object = JSON.parse(message.content);
+          } catch (e) {
+            throw self.apos.error('aiRetry', 'the model returned malformed structured JSON');
+          }
+        }
+        return turn;
       },
       // Map any error the transport produced to a normalized apos
       // error, the only shape the engine reacts to. Transient failures

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai/index.js
@@ -90,18 +90,21 @@ module.exports = {
       },
       // Translate a normalized adapter request (see the engine's
       // buildRequest) to a Chat Completions body: the system prompt
-      // leads the messages as a `system` turn, `maxTokens` becomes
-      // `max_completion_tokens` (optional here, so an unresolved cap
-      // is omitted) and `reasoning` travels as `reasoning_effort`,
-      // verbatim. A message whose content is a single text part
-      // collapses to the plain-string form every compatible host
-      // accepts; anything else stays a parts array. The cache policy
-      // places nothing: the provider caches prompt prefixes
+      // leads the messages as a `system` turn, tool definitions become
+      // `tools`, `maxTokens` becomes `max_completion_tokens` (optional
+      // here, so an unresolved cap is omitted) and `reasoning` travels
+      // as `reasoning_effort`, verbatim. A message whose content is a
+      // single text part collapses to the plain-string form every
+      // compatible host accepts; anything else stays a parts array. Tool
+      // requests ride an assistant message's `tool_calls`; the dialect
+      // wants one `tool` message per result, so a normalized `tool`
+      // message (all of a batch's results) fans out into several. The
+      // cache policy places nothing: the provider caches prompt prefixes
       // automatically and the ttl level is not settable in this
       // dialect.
       buildBody(request) {
         const {
-          system, messages, model, maxTokens, reasoning
+          system, messages, model, maxTokens, reasoning, tools
         } = request;
         return {
           model,
@@ -112,15 +115,63 @@ module.exports = {
                 content: system
               } ]
               : []),
-            ...messages.map((message) => ({
-              role: message.role,
-              content: toContent(message.content)
-            }))
+            ...messages.flatMap(toMessages)
           ],
+          ...(tools && { tools: tools.map(toTool) }),
           ...(maxTokens !== undefined && { max_completion_tokens: maxTokens }),
           ...(reasoning !== undefined && { reasoning_effort: reasoning })
         };
 
+        // One normalized message → one or more Chat Completions
+        // messages. An assistant turn carries its tool requests as
+        // `tool_calls` beside any text; a `tool` batch splits into one
+        // `tool` message per result
+        function toMessages(message) {
+          if (message.role === 'tool') {
+            return message.content.map((part) => ({
+              role: 'tool',
+              tool_call_id: part.toolCallId,
+              content: part.error !== undefined
+                ? part.error
+                : JSON.stringify(part.output)
+            }));
+          }
+          if (message.role === 'assistant') {
+            const calls = message.content.filter((part) => part.type === 'toolCall');
+            const rest = message.content.filter((part) => part.type !== 'toolCall');
+            return [ {
+              role: 'assistant',
+              content: rest.length ? toContent(rest) : null,
+              ...(calls.length && { tool_calls: calls.map(toToolCall) })
+            } ];
+          }
+          return [ {
+            role: 'user',
+            content: toContent(message.content)
+          } ];
+        }
+        function toToolCall(call) {
+          return {
+            id: call.id,
+            type: 'function',
+            function: {
+              name: call.name,
+              arguments: JSON.stringify(call.input)
+            }
+          };
+        }
+        // The model-facing tool definition; the JSON Schema travels
+        // verbatim as the function parameters
+        function toTool(tool) {
+          return {
+            type: 'function',
+            function: {
+              name: tool.name,
+              description: tool.description,
+              parameters: tool.input
+            }
+          };
+        }
         function toContent(parts) {
           if (parts.length === 1 && parts[0].type === 'text') {
             return parts[0].text;

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -45,6 +45,8 @@ module.exports = {
     // least one provider, or unconditionally under APOS_AI_MOCK, so
     // feature code can ask before calling
     self.active = false;
+    // Allowed sub-agent depth (spawned by tools), zero based index
+    self.allowedDepth = 1;
     self.validateOptions(self.options);
     self.defaultProvider = self.options.provider ||
       Object.keys(self.options.providers)[0] || null;
@@ -275,11 +277,13 @@ module.exports = {
       },
       // Parse and validate generate's `(stringOrOptions, options)`
       // arguments, exactly as passed to it, into one canonical options
-      // object `{ system, messages, effort, provider, model, reasoning,
-      // maxTokens, cache, signal }` — the positional prompt string
-      // appended to `messages` as the final user turn, message content
-      // collapsed to content-part form, `cache` defaulted to 'short',
-      // unset options left undefined. Unknown options are rejected as
+      // object `{ system, messages, tools, maxSteps, effort, provider,
+      // model, reasoning, maxTokens, cache, signal }` — the positional
+      // prompt string appended to `messages` as the final user turn,
+      // message content collapsed to content-part form, `tools` names
+      // resolved to their activated definitions, `maxSteps` defaulted
+      // from the module option, `cache` defaulted to 'short', unset
+      // options left undefined. Unknown options are rejected as
       // "invalid".
       normalizeGenerateOptions(stringOrOptions, options) {
         const invalid = (message) => {
@@ -303,14 +307,12 @@ module.exports = {
         } else {
           invalid('a prompt string or an options object is required');
         }
-        for (const name of [ 'tools', 'schema', 'maxSteps' ]) {
-          if (options[name] !== undefined) {
-            throw self.apos.error('unimplemented', `"${name}" is not yet supported`);
-          }
+        if (options.schema !== undefined) {
+          throw self.apos.error('unimplemented', '"schema" is not yet supported');
         }
         const known = [
-          'system', 'messages', 'effort', 'provider', 'model',
-          'reasoning', 'maxTokens', 'cache', 'signal'
+          'system', 'messages', 'tools', 'maxSteps', 'effort', 'provider',
+          'model', 'reasoning', 'maxTokens', 'cache', 'signal'
         ];
         for (const name of Object.keys(options)) {
           if (!known.includes(name)) {
@@ -342,6 +344,13 @@ module.exports = {
         if (signal !== undefined && !(signal instanceof AbortSignal)) {
           invalid('"signal" must be an AbortSignal');
         }
+        const maxSteps = options.maxSteps === undefined
+          ? self.options.maxSteps
+          : options.maxSteps;
+        if (!Number.isInteger(maxSteps) || maxSteps < 1) {
+          invalid('"maxSteps" must be a positive integer');
+        }
+        const tools = toolDefinitions(options.tools);
         const messages = self.normalizeMessages(options.messages);
         if (prompt !== null) {
           messages.push({
@@ -358,6 +367,8 @@ module.exports = {
         return {
           system,
           messages,
+          tools,
+          maxSteps,
           effort,
           provider,
           model,
@@ -366,14 +377,42 @@ module.exports = {
           cache,
           signal
         };
+
+        // The tools option → the activated definitions it names; every
+        // name must be registered, each at most once
+        function toolDefinitions(names = []) {
+          if (!Array.isArray(names)) {
+            invalid('"tools" must be an array of registered tool names');
+          }
+          const seen = new Set();
+          return names.map((toolName) => {
+            if (typeof toolName !== 'string') {
+              invalid('"tools" must be an array of registered tool names');
+            }
+            if (seen.has(toolName)) {
+              invalid(`"tools" names "${toolName}" twice`);
+            }
+            seen.add(toolName);
+            const tool = self.getTool(toolName);
+            if (!tool) {
+              invalid(`"tools" names unknown tool "${toolName}"`);
+            }
+            return tool;
+          });
+        }
       },
       // Validate and normalize an array of chat messages, as accepted
       // by generate's `messages` option (undefined is an empty
       // conversation). Returns a new array of { role, content } with
-      // `content` always an array of content parts: roles user or
-      // assistant, string content becomes a single text part. Messages
-      // are rebuilt from the recognized properties, so a stored
-      // transcript carrying app metadata round-trips.
+      // `content` always an array of content parts: string content
+      // becomes a single text part. Roles are user, assistant and
+      // tool; each part type is valid in specific roles only — text
+      // and image in user or assistant messages, toolCall (a model's
+      // tool request) in assistant messages, toolResult (its answer)
+      // in tool messages — so a returned transcript round-trips and a
+      // hand-built one fails clearly. Messages are rebuilt from the
+      // recognized properties, so a stored transcript carrying app
+      // metadata round-trips.
       normalizeMessages(messages = []) {
         const invalid = (message) => {
           throw self.apos.error('invalid', message);
@@ -386,24 +425,22 @@ module.exports = {
           if (!isObject(message)) {
             invalid(`${name} must be an object like { role, content }`);
           }
-          if (message.role === 'tool') {
-            throw self.apos.error('unimplemented', `${name}: "tool" messages are not yet supported`);
-          }
-          if (message.role !== 'user' && message.role !== 'assistant') {
-            invalid(`${name}.role must be "user" or "assistant"`);
+          if (![ 'user', 'assistant', 'tool' ].includes(message.role)) {
+            invalid(`${name}.role must be "user", "assistant" or "tool"`);
           }
           return {
             role: message.role,
-            content: contentParts(message.content, name)
+            content: contentParts(message.content, name, message.role)
           };
         });
 
         // One message's content → validated content-part array, rebuilt
         // so extra properties never travel. A plain string is shorthand
-        // for a single text part.
-        function contentParts(content, name) {
+        // for a single text part. Every part type is checked against
+        // the message's role.
+        function contentParts(content, name, role) {
           if (typeof content === 'string') {
-            return [ {
+            content = [ {
               type: 'text',
               text: content
             } ];
@@ -416,8 +453,49 @@ module.exports = {
             if (!isObject(part)) {
               throw self.apos.error('invalid', `${partName} must be an object like { type }`);
             }
-            if (part.type === 'toolCall' || part.type === 'toolResult') {
-              throw self.apos.error('unimplemented', `${partName}: "${part.type}" parts are not yet supported`);
+            const roles = {
+              text: [ 'user', 'assistant' ],
+              image: [ 'user', 'assistant' ],
+              toolCall: [ 'assistant' ],
+              toolResult: [ 'tool' ]
+            }[part.type];
+            if (!roles) {
+              throw self.apos.error('invalid', `${partName}.type "${part.type}" is unknown`);
+            }
+            if (!roles.includes(role)) {
+              throw self.apos.error('invalid', `${partName}: a "${part.type}" part is not valid in a "${role}" message`);
+            }
+            if (part.type === 'toolCall') {
+              if (typeof part.id !== 'string' || !part.id ||
+                typeof part.name !== 'string' || !isObject(part.input)) {
+                throw self.apos.error('invalid', `${partName} must be an object like { type, id, name, input }`);
+              }
+              return {
+                type: 'toolCall',
+                id: part.id,
+                name: part.name,
+                input: part.input
+              };
+            }
+            if (part.type === 'toolResult') {
+              if (typeof part.toolCallId !== 'string' || !part.toolCallId) {
+                throw self.apos.error('invalid', `${partName}.toolCallId must be a string`);
+              }
+              if (typeof part.error === 'string' && part.output === undefined) {
+                return {
+                  type: 'toolResult',
+                  toolCallId: part.toolCallId,
+                  error: part.error
+                };
+              }
+              if (isObject(part.output) && part.error === undefined) {
+                return {
+                  type: 'toolResult',
+                  toolCallId: part.toolCallId,
+                  output: part.output
+                };
+              }
+              throw self.apos.error('invalid', `${partName} must carry an object "output" or a string "error", not both`);
             }
             if (part.type === 'text') {
               if (typeof part.text !== 'string') {
@@ -428,27 +506,25 @@ module.exports = {
                 text: part.text
               };
             }
-            if (part.type === 'image') {
-              const image = part.image;
-              if (isObject(image) && typeof image.url === 'string') {
-                return {
-                  type: 'image',
-                  image: { url: image.url }
-                };
-              }
-              if (isObject(image) && typeof image.data === 'string' &&
-                typeof image.mediaType === 'string') {
-                return {
-                  type: 'image',
-                  image: {
-                    data: image.data,
-                    mediaType: image.mediaType
-                  }
-                };
-              }
-              throw self.apos.error('invalid', `${partName}.image must be an object like { url } or { data, mediaType }`);
+            // image, the only remaining type
+            const image = part.image;
+            if (isObject(image) && typeof image.url === 'string') {
+              return {
+                type: 'image',
+                image: { url: image.url }
+              };
             }
-            throw self.apos.error('invalid', `${partName}.type "${part.type}" is unknown`);
+            if (isObject(image) && typeof image.data === 'string' &&
+              typeof image.mediaType === 'string') {
+              return {
+                type: 'image',
+                image: {
+                  data: image.data,
+                  mediaType: image.mediaType
+                }
+              };
+            }
+            throw self.apos.error('invalid', `${partName}.image must be an object like { url } or { data, mediaType }`);
           });
         }
       },
@@ -483,9 +559,14 @@ module.exports = {
       //   schema fields, like a module's `add` configuration;
       //   internal — never sent to the model — every result is
       //   validated against it via apos.schema.convert;
-      // `access`: 'read' or 'write' (the default) — orders execution
-      //   within one batch of tool calls, reads in parallel, writes
-      //   serial in model order; not a permission;
+      // `access`: 'read', 'write' (the default) or 'agent' — not a
+      //   permission. Reads run in parallel within one batch of tool
+      //   calls; writes and agents follow serially in model order.
+      //   'agent' declares that the handler makes its own generate
+      //   call (a subagent, with its own budgets). One level of
+      //   nesting is allowed: a nested call silently drops agent
+      //   tools from its set — a subagent cannot spawn subagents —
+      //   and generation below the subagent level fails;
       // `handler` (required): the implementation — an async
       //   (req, args) function or a 'moduleName:methodName'
       //   reference. Runs with the caller's req and the validated
@@ -606,8 +687,8 @@ module.exports = {
             fail(`${name}: "schema" is not a valid schema: ${e.message}`);
           }
           const access = tool.access === undefined ? 'write' : tool.access;
-          if (access !== 'read' && access !== 'write') {
-            fail(`${name}: "access" must be "read" or "write"`);
+          if (![ 'read', 'write', 'agent' ].includes(access)) {
+            fail(`${name}: "access" must be "read", "write" or "agent"`);
           }
           return {
             name: tool.name,
@@ -707,9 +788,11 @@ module.exports = {
       // output ceiling when it is known, translate the cache level to
       // the { ttl } policy. Returns { provider, request }: the resolved
       // provider name and the request handed to its adapter —
-      // { system?, messages, model, maxTokens?, reasoning?,
+      // { system?, messages, tools?, model, maxTokens?, reasoning?,
       // cache: false | { ttl }, signal? }, optional fields present only
-      // when they resolved to a value.
+      // when they resolved to a value. Request tools carry only
+      // { name, description, input } — handlers and result schemas
+      // never reach an adapter.
       buildRequest(options) {
         const info = self.modelInfo({
           provider: options.provider,
@@ -723,6 +806,7 @@ module.exports = {
           request: {
             ...(options.system !== undefined && { system: options.system }),
             messages: options.messages,
+            ...(options.tools.length && { tools: self.wireTools(options.tools) }),
             model: info.model,
             ...(maxTokens !== undefined && { maxTokens }),
             ...(info.reasoning !== undefined && { reasoning: info.reasoning }),
@@ -744,6 +828,7 @@ module.exports = {
           request: {
             ...(options.system !== undefined && { system: options.system }),
             messages: options.messages,
+            ...(options.tools.length && { tools: self.wireTools(options.tools) }),
             model: options.model ?? 'mock',
             ...(options.maxTokens !== undefined && { maxTokens: options.maxTokens }),
             ...(options.reasoning !== undefined && { reasoning: options.reasoning }),
@@ -753,6 +838,15 @@ module.exports = {
             ...(options.signal !== undefined && { signal: options.signal })
           }
         };
+      },
+      // The model-facing face of activated tool definitions, as placed
+      // on the adapter request
+      wireTools(tools) {
+        return tools.map((tool) => ({
+          name: tool.name,
+          description: tool.description,
+          input: tool.input
+        }));
       },
       // The built-in mock standing in for every adapter chat under
       // APOS_AI_MOCK. Consults the "mock" option first when the module
@@ -816,11 +910,11 @@ module.exports = {
       mockNormalizeError(error) {
         return error;
       },
-      // The language method: plain text and multi-turn chat against the
-      // routed provider.
+      // The language method: text, multi-turn chat and the tool-calling
+      // agent loop against the routed provider.
       //
       // `req` is the caller's request object, carried into events, the
-      // adapter and (later) tool handlers — the core never invents auth.
+      // adapter and every tool handler — the core never invents auth.
       //
       // `stringOrOptions` is either the user prompt string, optionally
       // followed by an `options` object, or one options object alone
@@ -832,8 +926,20 @@ module.exports = {
       // `system` (string): the system prompt — a top-level option,
       //   never a message;
       // `messages` (array): the conversation so far, each entry
-      //   { role: 'user' | 'assistant', content } with content a string
-      //   or an array of `text` / `image` content parts;
+      //   { role, content } as normalizeMessages accepts — including a
+      //   transcript a previous call returned;
+      // `tools` (array of registered tool names): what the model may
+      //   call — see addTool. The loop validates the model's
+      //   arguments, executes the handlers by their `access`
+      //   scheduling (reads in parallel first, writes serial in model
+      //   order), feeds results back, and asks the model again until
+      //   it answers or `maxSteps` is spent;
+      // `maxSteps` (positive integer, defaults to the module's
+      //   `maxSteps` option): the cap on model turns for this call.
+      //   When the last allowed turn still requests tools, the call
+      //   finishes as 'maxSteps' and the requests come back unexecuted
+      //   on `toolCalls` — so `maxSteps: 1` is manual mode: one turn,
+      //   inspect, run them yourself;
       // `effort` (string): the routing level to resolve, defaulting to
       //   the module's default level;
       // `provider`, `model` (strings, only together): the explicit
@@ -843,25 +949,54 @@ module.exports = {
       //   the routed model's declared ceiling when it is known;
       // `cache` (false | 'short' | 'long', default 'short'): the
       //   prompt-cache policy the adapter translates for its provider;
-      // `signal` (AbortSignal): aborts the in-flight provider call.
+      // `signal` (AbortSignal): aborts the in-flight provider call;
+      //   also injected into every handler's `args._context`.
       //
-      // Returns { text, messages, finishReason, usage, model, provider }:
-      // `text` is the assistant's text (may be ''), `messages` the full
-      // transcript ending with the assistant turn — pass it back as
-      // `messages` to continue the conversation — `finishReason` is
-      // 'stop' or 'length', `usage` counts { inputTokens, outputTokens }
-      // and `model` / `provider` name what actually answered.
+      // Returns { text, messages, finishReason, usage, model,
+      // provider }, plus `steps` when the call carried tools and
+      // `toolCalls` when it stopped with pending requests. `text` is
+      // the final assistant text (may be ''); `messages` is the full
+      // transcript — tool requests and results included — resumable as
+      // the next call's `messages`; `steps` lists what the loop
+      // executed in model order, { toolCall, result } per success and
+      // { toolCall, error } per recoverable failure the model was told
+      // about; `toolCalls` are unexecuted requests the caller must run
+      // itself; `finishReason` is 'stop', 'length' or — whenever
+      // `toolCalls` is present — 'maxSteps', the step budget's
+      // counterpart of 'length'; `usage` aggregates { inputTokens,
+      // outputTokens } across every model turn; `model` / `provider`
+      // name what actually answered.
       //
-      // Throws normalized apos errors only: "invalid"
-      // for bad calls, "aiRetry" when transient provider failures
-      // outlast the retry budget, "aiRefusal" when the model refuses.
-      // Emits `beforeGenerate` and `afterGenerate` around the call.
+      // Throws normalized apos errors: "invalid" for bad calls,
+      // "aiRetry" when transient provider failures outlast the retry
+      // budget, "aiRefusal" when the model refuses; a tool handler's
+      // standard-coded throw (and any handler bug) stops the call
+      // as-is, with no trace of it in any model-bound message. Emits
+      // `beforeGenerate` and `afterGenerate` around the call and
+      // `beforeToolCall` / `afterToolCall` around each handler
+      // execution.
       //
       // Under APOS_AI_MOCK the built-in mock answers every call in
       // place of any adapter — same pipeline, no network; with no
-      // providers configured at all, placeholder routing stands in.
+      // providers configured at all, placeholder routing stands in. A
+      // scripted mock turn may request tools: the loop then runs the
+      // real handlers, so tool code is testable offline.
       async generate(req, stringOrOptions, options) {
         const canonical = self.normalizeGenerateOptions(stringOrOptions, options);
+        // Tool handlers receive a req clone stamped with their depth
+        // (executeToolCalls). One level of nesting is allowed: a
+        // handler may run a subagent, whose own tools may not generate
+        // further, whatever they carry. At the allowed level, agent
+        // tools are dropped rather than rejected — a toolset needs no
+        // curating per depth — so a subagent simply cannot spawn
+        // subagents.
+        const depth = req.aposAiDepth || 0;
+        if (depth > self.allowedDepth) {
+          throw self.apos.error('invalid', 'AI generation is limited to one level of nesting: the tools of a subagent cannot generate');
+        }
+        if (depth === self.allowedDepth) {
+          canonical.tools = canonical.tools.filter((tool) => tool.access !== 'agent');
+        }
         let provider;
         let request;
         if (self.mockMode && !Object.keys(self.providers).length) {
@@ -869,6 +1004,9 @@ module.exports = {
         } else {
           ({ provider, request } = self.buildRequest(canonical));
           self.checkCapability(provider, 'text');
+          if (canonical.tools.length) {
+            self.checkCapability(provider, 'tools');
+          }
         }
         const record = self.mockMode
           ? {
@@ -879,28 +1017,162 @@ module.exports = {
             }
           }
           : self.providers[provider];
-        // One shared, mutable payload for both events, so handlers can
-        // enrich the request and correlate the two
+        const tools = new Map(canonical.tools.map((tool) => [ tool.name, tool ]));
+        const handlerContext = request.signal ? { signal: request.signal } : {};
+        // One shared, mutable payload for both generate events, so
+        // handlers can enrich the request and correlate the two; its
+        // messages grow as the loop appends turns
         const context = {
           provider,
           request
         };
         await self.emit('beforeGenerate', req, context);
-        const turn = await self.callAdapter(req, record, context.request, async () => {
-          return self.validateTurn(await record.adapter.chat(req, context.request));
+        const steps = [];
+        const usage = {
+          inputTokens: 0,
+          outputTokens: 0
+        };
+        let turn;
+        let pending = null;
+        for (let turns = 1; ; turns++) {
+          turn = await self.callAdapter(req, record, context.request, async () => {
+            return self.validateTurn(await record.adapter.chat(req, context.request));
+          });
+          usage.inputTokens += turn.usage.inputTokens;
+          usage.outputTokens += turn.usage.outputTokens;
+          if (turn.finishReason === 'refusal') {
+            throw self.apos.error('aiRefusal', 'the model refused this request');
+          }
+          if (turn.finishReason === 'toolCalls' && !tools.size) {
+            throw self.apos.error(
+              'invalid',
+              'the model returned tool calls but the call sent no tools'
+            );
+          }
+          context.request.messages.push({
+            role: 'assistant',
+            content: turn.content
+          });
+          if (turn.finishReason !== 'toolCalls') {
+            break;
+          }
+          const calls = turn.content.filter((part) => part.type === 'toolCall');
+          if (turns === canonical.maxSteps) {
+            pending = calls;
+            break;
+          }
+          const outcomes = await self.executeToolCalls(req, tools, calls, handlerContext);
+          steps.push(...outcomes);
+          context.request.messages.push({
+            role: 'tool',
+            content: outcomes.map((outcome) => ({
+              type: 'toolResult',
+              toolCallId: outcome.toolCall.id,
+              ...(outcome.error !== undefined
+                ? { error: outcome.error }
+                : { output: outcome.result })
+            }))
+          });
+        }
+        context.result = self.assembleResult(context, turn, {
+          steps,
+          usage,
+          pending,
+          hadTools: tools.size > 0
         });
-        if (turn.finishReason === 'refusal') {
-          throw self.apos.error('aiRefusal', 'the model refused this request');
-        }
-        if (turn.finishReason === 'toolCalls') {
-          throw self.apos.error(
-            'invalid',
-            'the model returned tool calls but the call sent no tools'
-          );
-        }
-        context.result = self.assembleResult(context, turn);
         await self.emit('afterGenerate', req, context);
         return context.result;
+      },
+      // Execute one batch of model-requested tool calls — the toolCall
+      // parts of a single assistant turn — against `tools`, the call's
+      // selected definitions as a Map by name. Reads run first, in
+      // parallel; writes follow serially, in the order the model
+      // requested them; `context` reaches every handler as
+      // `args._context`, extended with `depth` — 1 inside a top-level
+      // call's batch, deeper inside a subagent's. Handlers run on a
+      // clone of the caller's req stamped with that depth
+      // (`aposAiDepth`) — an immutable property of the request each
+      // handler received, never shared mutable state — so a generate
+      // call a handler makes with its own req knows it is nested, even
+      // delayed or from a stashed reference, while the caller's
+      // original req is untouched and concurrent calls sharing it are
+      // unaffected. Every batch is stamped, not only agent tools, so a
+      // handler that spawns without declaring `access: 'agent'` is
+      // contained all the same; `_context.depth` is the informational
+      // copy a handler may act on. Returns outcomes in model order
+      // regardless of
+      // scheduling: { toolCall, result } per success, { toolCall,
+      // error } per recoverable failure — a call naming a tool outside
+      // the selected set, invalid arguments, or a handler's
+      // aiToolError; the error message is what the model reads back,
+      // and siblings are unaffected. Any other throw is a hard stop:
+      // it propagates immediately, before any write runs when thrown
+      // by a read, aborting the remaining writes when thrown by one —
+      // and no trace of it is ever model-bound. Emits beforeToolCall
+      // and afterToolCall around each execution.
+      async executeToolCalls(req, tools, calls, context = {}) {
+        const outcomes = new Array(calls.length);
+        const depth = (req.aposAiDepth || 0) + 1;
+        const handlerReq = req.clone({ aposAiDepth: depth });
+        const handlerContext = {
+          ...context,
+          depth
+        };
+        const run = async (call, index) => {
+          const tool = tools.get(call.name);
+          if (!tool) {
+            outcomes[index] = {
+              toolCall: call,
+              error: `unknown tool "${call.name}"`
+            };
+            return;
+          }
+          const payload = {
+            call,
+            tool
+          };
+          await self.emit('beforeToolCall', req, payload);
+          try {
+            payload.result = await self.executeToolCall(
+              handlerReq, tool, call, handlerContext
+            );
+            outcomes[index] = {
+              toolCall: call,
+              result: payload.result
+            };
+          } catch (e) {
+            if (e?.name !== 'aiToolError') {
+              throw e;
+            }
+            payload.error = e.message;
+            outcomes[index] = {
+              toolCall: call,
+              error: e.message
+            };
+          }
+          await self.emit('afterToolCall', req, payload);
+        };
+        const reads = [];
+        const writes = [];
+        calls.forEach((call, index) => {
+          if (tools.get(call.name)?.access === 'read') {
+            reads.push([ call, index ]);
+          } else {
+            writes.push([ call, index ]);
+          }
+        });
+        const settled = await Promise.allSettled(
+          reads.map(([ call, index ]) => run(call, index))
+        );
+        for (const read of settled) {
+          if (read.status === 'rejected') {
+            throw read.reason;
+          }
+        }
+        for (const [ call, index ] of writes) {
+          await run(call, index);
+        }
+        return outcomes;
       },
       // Throw "invalid" when the configured provider named by
       // `provider` does not declare `capability` (a key of the
@@ -1053,9 +1325,19 @@ module.exports = {
           if (part.type === 'text' && typeof part.text !== 'string') {
             malformed('text parts must carry a string "text"');
           }
+          if (part.type === 'toolCall' && (
+            typeof part.id !== 'string' || !part.id ||
+            typeof part.name !== 'string' || !isObject(part.input)
+          )) {
+            malformed('toolCall parts must carry a string "id" and "name" and an object "input"');
+          }
         }
         if (![ 'stop', 'toolCalls', 'length', 'refusal' ].includes(turn.finishReason)) {
           malformed(`"${turn.finishReason}" is not a finish reason`);
+        }
+        if (turn.finishReason === 'toolCalls' &&
+          !turn.content.some(part => part.type === 'toolCall')) {
+          malformed('a "toolCalls" finish reason without toolCall parts');
         }
         if (!isObject(turn.usage) ||
           !Number.isFinite(turn.usage.inputTokens) ||
@@ -1065,28 +1347,33 @@ module.exports = {
         return turn;
       },
       // Build generate's unified return object from `context` (the
-      // event payload carrying the provider name and the request) and
-      // `turn` (the validated adapter response). Returns { text,
-      // messages, finishReason, usage, model, provider }; which fields
-      // are populated tells the caller what happened. The transcript
-      // includes the assistant turn, so it is resumable as the next
-      // call's `messages`.
-      assembleResult(context, turn) {
+      // event payload carrying the provider name and the live request,
+      // whose messages already include every appended turn), `turn`
+      // (the final validated adapter response) and the loop's
+      // accumulations: executed `steps`, `usage` aggregated across
+      // every model turn, the `pending` tool calls when the step
+      // budget cut the loop, and whether the call had tools at all
+      // (`steps` appears only then). Returns { text, messages,
+      // finishReason, usage, model, provider } plus `steps` and
+      // `toolCalls` as described on generate; which fields are
+      // populated tells the caller what happened. The transcript is
+      // resumable as the next call's `messages`.
+      assembleResult(context, turn, {
+        steps, usage, pending, hadTools
+      }) {
         const text = turn.content
           .filter(part => part.type === 'text')
           .map(part => part.text)
           .join('');
         return {
           text,
-          messages: [
-            ...context.request.messages,
-            {
-              role: 'assistant',
-              content: turn.content
-            }
-          ],
-          finishReason: turn.finishReason,
-          usage: turn.usage,
+          messages: [ ...context.request.messages ],
+          ...(hadTools && { steps }),
+          ...(pending && { toolCalls: pending }),
+          // The step budget cutting the loop is its own finish reason,
+          // like the token budget's 'length'
+          finishReason: pending ? 'maxSteps' : turn.finishReason,
+          usage,
           model: turn.model || context.request.model,
           provider: context.provider
         };

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -652,6 +652,18 @@ module.exports = {
         }
         return [ ...found ];
       },
+      // The AI permission seam: whether this AI action is permitted
+      // for `req`. Same signature and semantics as
+      // `apos.permission.can(req, action, docOrType, mode)`, and today
+      // a pure proxy to it — but tool handlers and AI feature code
+      // must call this method, never `apos.permission.can` directly,
+      // so that AI-specific policy (actions denied to the AI even for
+      // an admin's req) can later be layered here, centrally, without
+      // touching a single handler. It can only ever be as restrictive
+      // as `apos.permission.can` or more, never looser.
+      can(req, ...args) {
+        return self.apos.permission.can(req, ...args);
+      },
       // Validate every registered tool definition (the shape is
       // documented on addTool) and replace it in the registry with its
       // activated canonical form: label and access defaulted, `input`

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -889,20 +889,21 @@ module.exports = {
       // shorthand filled out into one, or undefined to fall through to
       // the deterministic default. That default is request-aware: for a
       // structured request (`request.schema`) it synthesizes a
-      // schema-conforming object and returns it as the assistant text —
-      // a JSON string the pipeline parses and backstop-validates like a
-      // real one — otherwise canned text echoing the conversation's
-      // final message; usage is estimated from the text sizes. Runs
-      // inside the same retry and validation seam as a real adapter
-      // call, so a mock that throws normalized codes exercises the real
-      // error paths.
+      // schema-conforming object and returns it on the turn's `object`,
+      // as a real adapter would ([D35]) — the pipeline backstop-validates
+      // it like a real one — otherwise canned text echoing the
+      // conversation's final message; usage is estimated from the text
+      // sizes. Runs inside the same retry and validation seam as a real
+      // adapter call, so a mock that throws normalized codes exercises
+      // the real error paths.
       async mockChat(req, request) {
         const custom = self.options.mock
           ? await self.options.mock(request)
           : undefined;
         if (custom == null) {
           if (request.schema) {
-            return turn(JSON.stringify(sample(request.schema)));
+            const object = sample(request.schema);
+            return turn(JSON.stringify(object), object);
           }
           const tail = textOf(request.messages.at(-1).content);
           return turn(`[mock] ${tail}`);
@@ -918,7 +919,13 @@ module.exports = {
           '"mock" must return an assistant turn, a { text } object or undefined'
         );
 
-        function turn(text) {
+        // A canned assistant turn. `text` is the answer's text; a
+        // structured call passes the synthesized `object` too, which
+        // rides the turn ([D35]). The text stays in the content — for a
+        // structured turn it is the object's JSON, so the transcript's
+        // assistant message is non-empty and re-normalizes on resume,
+        // as a real provider's structured answer would.
+        function turn(text, object) {
           const input = [
             request.system,
             ...request.messages.map((message) => textOf(message.content))
@@ -928,6 +935,7 @@ module.exports = {
               type: 'text',
               text
             } ],
+            ...(object !== undefined && { object }),
             finishReason: 'stop',
             usage: {
               inputTokens: tokens(input),
@@ -1135,15 +1143,15 @@ module.exports = {
             const answer = self.validateTurn(
               await record.adapter.chat(req, context.request)
             );
-            // Structured output arrives as the final answer's text;
-            // parse and backstop-validate it here so a malformed one
-            // travels the same retry path as the turn. Only a 'stop'
-            // turn is the answer: tool turns run the loop with their
-            // own validation, a refusal surfaces as aiRefusal below,
-            // and a 'length' turn's truncated text returns as-is —
-            // no object, the finish reason tells the caller why
+            // The adapter placed the final answer on `answer.object`;
+            // backstop-validate it here so a malformed one travels the
+            // same retry path as the turn. Only a 'stop' turn is the
+            // answer: tool turns run the loop with their own validation,
+            // a refusal surfaces as aiRefusal below, and a 'length'
+            // turn returns as-is — no object, the finish reason tells
+            // the caller why
             if (canonical.schema && answer.finishReason === 'stop') {
-              answer.object = self.parseStructured(answer, canonical.validateObject);
+              self.validateStructured(answer, canonical.validateObject);
             }
             return answer;
           });
@@ -1456,31 +1464,23 @@ module.exports = {
         }
         return turn;
       },
-      // The anti-hallucination backstop for structured output: parse
-      // `turn`'s text — the final answer of a structured call — as the
-      // model's JSON object and validate it against `validate`, the
-      // compiled validator for the call's `schema`
-      // (normalizeGenerateOptions). The provider's native structured
-      // mode does the real work — this only catches a stray
-      // non-conforming response. A parse failure or a schema mismatch is
-      // a malformed model response: like a malformed turn it throws the
-      // transient code so the call travels the retry path. Returns the
-      // validated object.
-      parseStructured(turn, validate) {
-        const text = turn.content
-          .filter(part => part.type === 'text')
-          .map(part => part.text)
-          .join('');
-        let object;
-        try {
-          object = JSON.parse(text);
-        } catch (e) {
-          throw self.apos.error('aiRetry', `structured output is not valid JSON: ${e.message}`);
+      // The anti-hallucination backstop for structured output. The
+      // adapter has already extracted the final answer into `turn.object`
+      // from its provider's structured mode ([D35] — an adapter concern,
+      // since only the dialect knows where the object lives); this
+      // validates it against `validate`, the compiled validator for the
+      // call's `schema` (normalizeGenerateOptions). The provider's
+      // native mode does the real work — this only catches a stray
+      // non-conforming or missing response. A missing object or a schema
+      // mismatch is a malformed model response: like a malformed turn it
+      // throws the transient code so the call travels the retry path.
+      validateStructured(turn, validate) {
+        if (turn.object === undefined) {
+          throw self.apos.error('aiRetry', 'the provider returned no structured output');
         }
-        if (!validate(object)) {
+        if (!validate(turn.object)) {
           throw self.apos.error('aiRetry', `structured output does not match the schema: ${self.ajv.errorsText(validate.errors, { dataVar: 'object' })}`);
         }
-        return object;
       },
       // Build generate's unified return object from `context` (the
       // event payload carrying the provider name and the live request,

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -1425,7 +1425,7 @@ module.exports = {
           return retryAfter * 1000;
         }
         const curve = self.options.retryBaseDelay * Math.pow(2, attempt - 1);
-        return Math.round(curve * (1 + Math.random()));
+        return Math.floor(curve * (1 + Math.random()));
       },
       // Wait `ms` before the next attempt; a separate method so tests
       // can observe or skip real waiting

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -6,6 +6,9 @@
 // each provider under `options.providers[name]` and (with more than one)
 // name the default with `options.provider`.
 
+const _ = require('lodash');
+const Ajv = require('ajv/dist/2020').default;
+
 module.exports = {
   options: {
     alias: 'ai',
@@ -30,6 +33,14 @@ module.exports = {
     self.adapters = {};
     self.providers = {};
     self.effortTable = {};
+    self.tools = {};
+    // getTools query caches, built once at activation — the registry
+    // is static, contains "references" so no memory waste.
+    self.toolList = [];
+    self.toolsByTag = new Map();
+    // Flips once activateTools has validated the registry; the
+    // registry is frozen from then on
+    self.toolsActive = false;
     // "Is AI operational?" — true once activation has configured at
     // least one provider, or unconditionally under APOS_AI_MOCK, so
     // feature code can ask before calling
@@ -39,14 +50,17 @@ module.exports = {
       Object.keys(self.options.providers)[0] || null;
     self.effortDefault = self.options.effort?.default || 'medium';
     self.mockMode = process.env.APOS_AI_MOCK === '1';
+    self.ajv = new Ajv({ allErrors: true });
     self.apos.http.addError('aiRetry', 503);
     self.apos.http.addError('aiRefusal', 422);
+    self.apos.http.addError('aiToolError', 422);
   },
   handlers(self) {
     return {
       'apostrophe:ready': {
         async activate() {
           await self.activateProviders();
+          self.activateTools();
         }
       }
     };
@@ -436,6 +450,255 @@ module.exports = {
             }
             throw self.apos.error('invalid', `${partName}.type "${part.type}" is unknown`);
           });
+        }
+      },
+      // Register an AI tool definition. Feature modules call this in
+      // their own init; core, project and third-party modules all use
+      // the same call. Re-registering an existing name overrides (last
+      // wins), so a project can replace a standard tool. Tools are
+      // static: only registered tools can participate in AI calls —
+      // generate selects them by name, definitions never travel
+      // through a call — and the registry is frozen once activated on
+      // "apostrophe:ready", so registering later fails. Only the name
+      // is checked here; everything else is validated at activation,
+      // failing the startup on any problem (see activateTools).
+      //
+      // The definition properties:
+      //
+      // `name` (required): the unique registry identifier, 1 to 64
+      //   letters, digits, "_" or "-", starting with a letter — the
+      //   intersection of the provider naming rules;
+      // `label`: a human-facing name — what a chat log or an activity
+      //   trail shows for the tool; may be an i18n key; defaults from
+      //   the name ('find_pages' → 'Find Pages'); never sent to the
+      //   model;
+      // `description` (required): non-empty text the model chooses
+      //   the tool by — treat it as part of the prompt;
+      // `tags`: an array of strings to query the registry by, see
+      //   getTools;
+      // `input` (required): the JSON Schema (draft 2020-12) the
+      //   model's arguments must satisfy; sent to the provider; must
+      //   declare an object root;
+      // `schema` (required): the handler result's shape as Apostrophe
+      //   schema fields, like a module's `add` configuration;
+      //   internal — never sent to the model — every result is
+      //   validated against it via apos.schema.convert;
+      // `access`: 'read' or 'write' (the default) — orders execution
+      //   within one batch of tool calls, reads in parallel, writes
+      //   serial in model order; not a permission;
+      // `handler` (required): the implementation — an async
+      //   (req, args) function or a 'moduleName:methodName'
+      //   reference. Runs with the caller's req and the validated
+      //   model arguments, plus the core-injected args._context, and
+      //   returns an object matching `schema`.
+      addTool(tool) {
+        if (self.toolsActive) {
+          fail('tools must be registered before "apostrophe:ready"');
+        }
+        if (!isObject(tool) || typeof tool.name !== 'string' ||
+          !/^[a-zA-Z][a-zA-Z0-9_-]{0,63}$/.test(tool.name)) {
+          fail('addTool requires a definition with a "name" of 1 to 64 letters, digits, "_" or "-", starting with a letter');
+        }
+        self.tools[tool.name] = tool;
+      },
+      // The activated canonical definition registered under `name`,
+      // or undefined. Guarded against prototype-chain names
+      // ('constructor', …): lookups here may carry model-provided or
+      // browser-provided names, which must only ever select a
+      // registered tool
+      getTool(name) {
+        return self.hasTool(name) ? self.tools[name] : undefined;
+      },
+      // An efficient way of checking (by name) if a tool exists
+      hasTool(name) {
+        return Object.hasOwn(self.tools, name);
+      },
+      // All activated tool definitions; with `tags`, those carrying
+      // at least one of them. A single tag may be passed as a string.
+      // Served from caches built at activation, so treat the returned
+      // arrays and definitions as read-only.
+      getTools({ tags } = {}) {
+        if (typeof tags === 'string') {
+          tags = [ tags ];
+        }
+        if (tags !== undefined && !Array.isArray(tags)) {
+          throw self.apos.error('invalid', '"tags" must be an array of tag strings');
+        }
+        if (!tags) {
+          return self.toolList;
+        }
+        // Union of the per-tag lists: a tool matching several of the
+        // given tags appears once
+        const found = new Set();
+        for (const tag of tags) {
+          const tools = self.toolsByTag.get(tag);
+          if (tools) {
+            for (const tool of tools) {
+              found.add(tool);
+            }
+          }
+        }
+        return [ ...found ];
+      },
+      // Validate every registered tool definition (the shape is
+      // documented on addTool) and replace it in the registry with its
+      // activated canonical form: label and access defaulted, `input`
+      // compiled into the `validateArgs` argument validator, `schema`
+      // composed to the array form apos.schema.convert consumes, and
+      // `handler` always a callable — a 'moduleName:methodName'
+      // reference is resolved here, which is why activation waits for
+      // "apostrophe:ready": every module's init has run by then, so
+      // references resolve and overrides are settled regardless of
+      // registration order. A bad definition fails the startup. The
+      // registry is frozen afterwards.
+      activateTools() {
+        for (const [ name, tool ] of Object.entries(self.tools)) {
+          self.tools[name] = activate(tool, `tool "${name}"`);
+        }
+        self.toolList = Object.values(self.tools);
+        self.toolsByTag = new Map();
+        for (const tool of self.toolList) {
+          for (const tag of tool.tags) {
+            const tools = self.toolsByTag.get(tag);
+            if (tools) {
+              tools.push(tool);
+            } else {
+              self.toolsByTag.set(tag, [ tool ]);
+            }
+          }
+        }
+        self.toolsActive = true;
+
+        function activate(tool, name) {
+          if (typeof tool.description !== 'string' || !tool.description) {
+            fail(`${name}: "description" must be a non-empty string`);
+          }
+          if (tool.label !== undefined &&
+            (typeof tool.label !== 'string' || !tool.label)) {
+            fail(`${name}: "label" must be a non-empty string`);
+          }
+          if (tool.tags !== undefined && (!Array.isArray(tool.tags) ||
+            tool.tags.some(tag => typeof tag !== 'string' || !tag))) {
+            fail(`${name}: "tags" must be an array of tag strings`);
+          }
+          if (!isObject(tool.input) || tool.input.type !== 'object') {
+            fail(`${name}: "input" must be a JSON Schema with an object root`);
+          }
+          let validateArgs;
+          try {
+            validateArgs = self.ajv.compile(tool.input);
+          } catch (e) {
+            fail(`${name}: "input" is not a valid JSON Schema: ${e.message}`);
+          }
+          if (!isObject(tool.schema)) {
+            fail(`${name}: "schema" must be an object of schema fields describing the result`);
+          }
+          let schema;
+          try {
+            schema = self.apos.schema.compose({
+              addFields: self.apos.schema.fieldsToArray(`AI tool ${tool.name}`, tool.schema)
+            });
+            self.apos.schema.validate(schema, {
+              type: 'AI tool',
+              subtype: tool.name
+            });
+          } catch (e) {
+            fail(`${name}: "schema" is not a valid schema: ${e.message}`);
+          }
+          const access = tool.access === undefined ? 'write' : tool.access;
+          if (access !== 'read' && access !== 'write') {
+            fail(`${name}: "access" must be "read" or "write"`);
+          }
+          return {
+            name: tool.name,
+            label: tool.label || _.startCase(tool.name),
+            description: tool.description,
+            tags: tool.tags || [],
+            input: tool.input,
+            validateArgs,
+            schema,
+            access,
+            handler: resolveHandler(tool.handler, name)
+          };
+        }
+
+        // The handler option → the callable the loop runs: an inline
+        // function as given, a 'moduleName:methodName' reference
+        // resolved against the named module
+        function resolveHandler(value, name) {
+          if (typeof value === 'function') {
+            return value;
+          }
+          if (typeof value !== 'string') {
+            fail(`${name}: "handler" must be a function or a "moduleName:methodName" string`);
+          }
+          const [ moduleName, methodName, ...rest ] = value.split(':');
+          if (!moduleName || !methodName || rest.length) {
+            fail(`${name}: handler "${value}" must name a module and a method, like "moduleName:methodName"`);
+          }
+          // Own-property checks: a reference must never resolve
+          // through the prototype chain ('constructor', 'toString', …)
+          if (!Object.hasOwn(self.apos.modules, moduleName)) {
+            fail(`${name}: handler names unknown module "${moduleName}"`);
+          }
+          const module = self.apos.modules[moduleName];
+          if (!Object.hasOwn(module, methodName) ||
+            typeof module[methodName] !== 'function') {
+            fail(`${name}: handler names unknown method "${methodName}" of "${moduleName}"`);
+          }
+          return (req, args) => module[methodName](req, args);
+        }
+      },
+      // Execute one model-requested tool call `call`, a toolCall
+      // content part { id, name, input }, against `tool`, its
+      // activated registry definition (getTool). Returns the
+      // handler's result converted through the tool's schema — every
+      // declared field present in normalized form — ready to be
+      // serialized for the model.
+      //
+      // The model's input is validated against the tool's `input`
+      // schema first; invalid arguments never reach the handler — they
+      // throw 'aiToolError', the recoverable code, so the loop can
+      // feed the validation message back to the model. The handler
+      // runs with the caller's `req` and a copy of the validated
+      // arguments; `context` is written to `args._context` after
+      // validation, so a model-provided property can never pose as
+      // core injection.
+      //
+      // A handler throw passes through untouched: recovery is decided
+      // elsewhere, by the error code alone. A handler result the
+      // schema rejects is a handler bug, not model misbehaviour: it
+      // throws 'invalid' naming the tool — a standard code breaks the
+      // AI chain, no retries, no further AI work — and no detail of it
+      // is ever fed back to the model.
+      async executeToolCall(req, tool, call, context = {}) {
+        if (!tool.validateArgs(call.input)) {
+          throw self.apos.error('aiToolError', `invalid arguments for tool "${tool.name}": ${self.ajv.errorsText(tool.validateArgs.errors, { dataVar: 'arguments' })}`);
+        }
+        const args = {
+          ...call.input,
+          _context: context
+        };
+        const result = await tool.handler(req, args);
+        if (!isObject(result)) {
+          throw self.apos.error('invalid', `tool "${tool.name}" must return an object matching its schema`);
+        }
+        const converted = {};
+        try {
+          await self.apos.schema.convert(req, tool.schema, result, converted);
+        } catch (errors) {
+          throw self.apos.error('invalid', `tool "${tool.name}" returned a result that does not match its schema: ${detail(errors)}`);
+        }
+        return converted;
+
+        // The convert rejection → one readable line naming each field
+        function detail(errors) {
+          if (!Array.isArray(errors)) {
+            return errors.message || String(errors);
+          }
+          return errors
+            .map((error) => `${error.path}: ${error.message || error.name}`)
+            .join('; ');
         }
       },
       // Assemble the normalized adapter request from `options`, a

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -277,14 +277,16 @@ module.exports = {
       },
       // Parse and validate generate's `(stringOrOptions, options)`
       // arguments, exactly as passed to it, into one canonical options
-      // object `{ system, messages, tools, maxSteps, effort, provider,
-      // model, reasoning, maxTokens, cache, signal }` — the positional
-      // prompt string appended to `messages` as the final user turn,
-      // message content collapsed to content-part form, `tools` names
-      // resolved to their activated definitions, `maxSteps` defaulted
-      // from the module option, `cache` defaulted to 'short', unset
-      // options left undefined. Unknown options are rejected as
-      // "invalid".
+      // object `{ system, messages, tools, maxSteps, schema,
+      // validateObject, effort, provider, model, reasoning, maxTokens,
+      // cache, signal }` — the positional prompt string appended to
+      // `messages` as the final user turn, message content collapsed to
+      // content-part form, `tools` names resolved to their activated
+      // definitions, `maxSteps` defaulted from the module option, a
+      // structured-output `schema` validated as a JSON Schema and
+      // compiled into the `validateObject` backstop, `cache` defaulted
+      // to 'short', unset options left undefined. Unknown options are
+      // rejected as "invalid".
       normalizeGenerateOptions(stringOrOptions, options) {
         const invalid = (message) => {
           throw self.apos.error('invalid', message);
@@ -307,12 +309,9 @@ module.exports = {
         } else {
           invalid('a prompt string or an options object is required');
         }
-        if (options.schema !== undefined) {
-          throw self.apos.error('unimplemented', '"schema" is not yet supported');
-        }
         const known = [
-          'system', 'messages', 'tools', 'maxSteps', 'effort', 'provider',
-          'model', 'reasoning', 'maxTokens', 'cache', 'signal'
+          'system', 'messages', 'tools', 'maxSteps', 'schema', 'effort',
+          'provider', 'model', 'reasoning', 'maxTokens', 'cache', 'signal'
         ];
         for (const name of Object.keys(options)) {
           if (!known.includes(name)) {
@@ -351,6 +350,7 @@ module.exports = {
           invalid('"maxSteps" must be a positive integer');
         }
         const tools = toolDefinitions(options.tools);
+        const { schema, validateObject } = structuredSchema(options.schema);
         const messages = self.normalizeMessages(options.messages);
         if (prompt !== null) {
           messages.push({
@@ -369,6 +369,8 @@ module.exports = {
           messages,
           tools,
           maxSteps,
+          schema,
+          validateObject,
           effort,
           provider,
           model,
@@ -399,6 +401,35 @@ module.exports = {
             }
             return tool;
           });
+        }
+
+        // The schema option → `{ schema, validateObject }`, or empty
+        // when absent. A per-call JSON Schema with an object root (what
+        // providers require for structured output), compiled into the
+        // AJV backstop here so a malformed schema fails the call before
+        // any provider request. The compile is evicted from AJV's cache
+        // (a strong-referenced Map keyed by the schema object) so
+        // per-call schemas do not accumulate; the returned validator
+        // keeps working.
+        function structuredSchema(schema) {
+          if (schema === undefined) {
+            return {};
+          }
+          if (!isObject(schema) || schema.type !== 'object') {
+            invalid('"schema" must be a JSON Schema with an object root');
+          }
+          let validateObject;
+          try {
+            validateObject = self.ajv.compile(schema);
+          } catch (e) {
+            invalid(`"schema" is not a valid JSON Schema: ${e.message}`);
+          } finally {
+            self.ajv.removeSchema(schema);
+          }
+          return {
+            schema,
+            validateObject
+          };
         }
       },
       // Validate and normalize an array of chat messages, as accepted
@@ -788,11 +819,13 @@ module.exports = {
       // output ceiling when it is known, translate the cache level to
       // the { ttl } policy. Returns { provider, request }: the resolved
       // provider name and the request handed to its adapter —
-      // { system?, messages, tools?, model, maxTokens?, reasoning?,
-      // cache: false | { ttl }, signal? }, optional fields present only
-      // when they resolved to a value. Request tools carry only
-      // { name, description, input } — handlers and result schemas
-      // never reach an adapter.
+      // { system?, messages, tools?, schema?, model, maxTokens?,
+      // reasoning?, cache: false | { ttl }, signal? }, optional fields
+      // present only when they resolved to a value. Request tools carry
+      // only { name, description, input } — handlers and result schemas
+      // never reach an adapter; a structured-output `schema` (JSON
+      // Schema) passes through for the adapter to place on its
+      // provider's native structured mode.
       buildRequest(options) {
         const info = self.modelInfo({
           provider: options.provider,
@@ -807,6 +840,7 @@ module.exports = {
             ...(options.system !== undefined && { system: options.system }),
             messages: options.messages,
             ...(options.tools.length && { tools: self.wireTools(options.tools) }),
+            ...(options.schema !== undefined && { schema: options.schema }),
             model: info.model,
             ...(maxTokens !== undefined && { maxTokens }),
             ...(info.reasoning !== undefined && { reasoning: info.reasoning }),
@@ -829,6 +863,7 @@ module.exports = {
             ...(options.system !== undefined && { system: options.system }),
             messages: options.messages,
             ...(options.tools.length && { tools: self.wireTools(options.tools) }),
+            ...(options.schema !== undefined && { schema: options.schema }),
             model: options.model ?? 'mock',
             ...(options.maxTokens !== undefined && { maxTokens: options.maxTokens }),
             ...(options.reasoning !== undefined && { reasoning: options.reasoning }),
@@ -852,16 +887,23 @@ module.exports = {
       // APOS_AI_MOCK. Consults the "mock" option first when the module
       // has one: it may return a complete assistant turn, a { text }
       // shorthand filled out into one, or undefined to fall through to
-      // the deterministic default — canned text echoing the
-      // conversation's final message, usage estimated from the text
-      // sizes. Runs inside the same retry and validation seam as a
-      // real adapter call, so a mock that throws normalized codes
-      // exercises the real error paths.
+      // the deterministic default. That default is request-aware: for a
+      // structured request (`request.schema`) it synthesizes a
+      // schema-conforming object and returns it as the assistant text —
+      // a JSON string the pipeline parses and backstop-validates like a
+      // real one — otherwise canned text echoing the conversation's
+      // final message; usage is estimated from the text sizes. Runs
+      // inside the same retry and validation seam as a real adapter
+      // call, so a mock that throws normalized codes exercises the real
+      // error paths.
       async mockChat(req, request) {
         const custom = self.options.mock
           ? await self.options.mock(request)
           : undefined;
         if (custom == null) {
+          if (request.schema) {
+            return turn(JSON.stringify(sample(request.schema)));
+          }
           const tail = textOf(request.messages.at(-1).content);
           return turn(`[mock] ${tail}`);
         }
@@ -903,6 +945,47 @@ module.exports = {
         function tokens(text) {
           return Math.max(1, Math.round(text.length / 4));
         }
+        // A deterministic value conforming to `schema`, enough to pass
+        // the structured-output backstop: `const`/`enum` honored, every
+        // declared property of an object filled, arrays sized to
+        // minItems, the simplest in-range value for a scalar
+        function sample(schema) {
+          if (!isObject(schema)) {
+            return null;
+          }
+          if (schema.const !== undefined) {
+            return schema.const;
+          }
+          if (Array.isArray(schema.enum) && schema.enum.length) {
+            return schema.enum[0];
+          }
+          const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+          if (type === 'object') {
+            const object = {};
+            const properties = isObject(schema.properties) ? schema.properties : {};
+            for (const [ key, subschema ] of Object.entries(properties)) {
+              object[key] = sample(subschema);
+            }
+            return object;
+          }
+          if (type === 'array') {
+            const min = Number.isInteger(schema.minItems) ? schema.minItems : 0;
+            const items = isObject(schema.items) ? schema.items : {};
+            return Array.from({ length: min }, () => sample(items));
+          }
+          if (type === 'boolean') {
+            return false;
+          }
+          if (type === 'null') {
+            return null;
+          }
+          if (type === 'number' || type === 'integer') {
+            return Number.isFinite(schema.minimum) ? schema.minimum : 0;
+          }
+          // string, and the no-type case (any value validates)
+          const min = Number.isInteger(schema.minLength) ? schema.minLength : 0;
+          return 'x'.repeat(min);
+        }
       },
       // The mock adapter's error normalization: errors pass through
       // untouched, so a mock throwing normalized codes exercises the
@@ -910,8 +993,8 @@ module.exports = {
       mockNormalizeError(error) {
         return error;
       },
-      // The language method: text, multi-turn chat and the tool-calling
-      // agent loop against the routed provider.
+      // The language method: text, multi-turn chat, the tool-calling
+      // agent loop and structured output against the routed provider.
       //
       // `req` is the caller's request object, carried into events, the
       // adapter and every tool handler — the core never invents auth.
@@ -940,6 +1023,13 @@ module.exports = {
       //   finishes as 'maxSteps' and the requests come back unexecuted
       //   on `toolCalls` — so `maxSteps: 1` is manual mode: one turn,
       //   inspect, run them yourself;
+      // `schema` (JSON Schema with an object root): request structured
+      //   output — the provider's native structured mode is constrained
+      //   to it, and the validated result comes back on `object`.
+      //   Capability-gated on `structured`. Combines with `tools`: the
+      //   schema constrains only the final answer — tool turns run the
+      //   loop unchanged, with their own argument and result
+      //   validation;
       // `effort` (string): the routing level to resolve, defaulting to
       //   the module's default level;
       // `provider`, `model` (strings, only together): the explicit
@@ -953,9 +1043,12 @@ module.exports = {
       //   also injected into every handler's `args._context`.
       //
       // Returns { text, messages, finishReason, usage, model,
-      // provider }, plus `steps` when the call carried tools and
-      // `toolCalls` when it stopped with pending requests. `text` is
-      // the final assistant text (may be ''); `messages` is the full
+      // provider }, plus `steps` when the call carried tools,
+      // `toolCalls` when it stopped with pending requests, and `object`
+      // — the validated structured output — when the call passed
+      // `schema` and finished 'stop' (a 'length' or 'maxSteps' finish
+      // has no complete answer to validate). `text` is the final
+      // assistant text (may be ''); `messages` is the full
       // transcript — tool requests and results included — resumable as
       // the next call's `messages`; `steps` lists what the loop
       // executed in model order, { toolCall, result } per success and
@@ -1007,6 +1100,9 @@ module.exports = {
           if (canonical.tools.length) {
             self.checkCapability(provider, 'tools');
           }
+          if (canonical.schema) {
+            self.checkCapability(provider, 'structured');
+          }
         }
         const record = self.mockMode
           ? {
@@ -1036,7 +1132,20 @@ module.exports = {
         let pending = null;
         for (let turns = 1; ; turns++) {
           turn = await self.callAdapter(req, record, context.request, async () => {
-            return self.validateTurn(await record.adapter.chat(req, context.request));
+            const answer = self.validateTurn(
+              await record.adapter.chat(req, context.request)
+            );
+            // Structured output arrives as the final answer's text;
+            // parse and backstop-validate it here so a malformed one
+            // travels the same retry path as the turn. Only a 'stop'
+            // turn is the answer: tool turns run the loop with their
+            // own validation, a refusal surfaces as aiRefusal below,
+            // and a 'length' turn's truncated text returns as-is —
+            // no object, the finish reason tells the caller why
+            if (canonical.schema && answer.finishReason === 'stop') {
+              answer.object = self.parseStructured(answer, canonical.validateObject);
+            }
+            return answer;
           });
           usage.inputTokens += turn.usage.inputTokens;
           usage.outputTokens += turn.usage.outputTokens;
@@ -1078,6 +1187,7 @@ module.exports = {
           steps,
           usage,
           pending,
+          object: turn.object,
           hadTools: tools.size > 0
         });
         await self.emit('afterGenerate', req, context);
@@ -1346,20 +1456,47 @@ module.exports = {
         }
         return turn;
       },
+      // The anti-hallucination backstop for structured output: parse
+      // `turn`'s text — the final answer of a structured call — as the
+      // model's JSON object and validate it against `validate`, the
+      // compiled validator for the call's `schema`
+      // (normalizeGenerateOptions). The provider's native structured
+      // mode does the real work — this only catches a stray
+      // non-conforming response. A parse failure or a schema mismatch is
+      // a malformed model response: like a malformed turn it throws the
+      // transient code so the call travels the retry path. Returns the
+      // validated object.
+      parseStructured(turn, validate) {
+        const text = turn.content
+          .filter(part => part.type === 'text')
+          .map(part => part.text)
+          .join('');
+        let object;
+        try {
+          object = JSON.parse(text);
+        } catch (e) {
+          throw self.apos.error('aiRetry', `structured output is not valid JSON: ${e.message}`);
+        }
+        if (!validate(object)) {
+          throw self.apos.error('aiRetry', `structured output does not match the schema: ${self.ajv.errorsText(validate.errors, { dataVar: 'object' })}`);
+        }
+        return object;
+      },
       // Build generate's unified return object from `context` (the
       // event payload carrying the provider name and the live request,
       // whose messages already include every appended turn), `turn`
       // (the final validated adapter response) and the loop's
       // accumulations: executed `steps`, `usage` aggregated across
       // every model turn, the `pending` tool calls when the step
-      // budget cut the loop, and whether the call had tools at all
+      // budget cut the loop, the validated structured `object` when the
+      // call passed a `schema`, and whether the call had tools at all
       // (`steps` appears only then). Returns { text, messages,
-      // finishReason, usage, model, provider } plus `steps` and
-      // `toolCalls` as described on generate; which fields are
+      // finishReason, usage, model, provider } plus `object`, `steps`
+      // and `toolCalls` as described on generate; which fields are
       // populated tells the caller what happened. The transcript is
       // resumable as the next call's `messages`.
       assembleResult(context, turn, {
-        steps, usage, pending, hadTools
+        steps, usage, pending, object, hadTools
       }) {
         const text = turn.content
           .filter(part => part.type === 'text')
@@ -1367,6 +1504,7 @@ module.exports = {
           .join('');
         return {
           text,
+          ...(object !== undefined && { object }),
           messages: [ ...context.request.messages ],
           ...(hadTools && { steps }),
           ...(pending && { toolCalls: pending }),

--- a/packages/apostrophe/package.json
+++ b/packages/apostrophe/package.json
@@ -64,6 +64,7 @@
     "@tiptap/starter-kit": "^2.0.3",
     "@tiptap/vue-3": "^2.0.3",
     "@vue/compiler-sfc": "^3.3.8",
+    "ajv": "^8.20.0",
     "autoprefixer": "^10.4.1",
     "bluebird": "^3.7.2",
     "body-parser": "^1.18.2",

--- a/packages/apostrophe/test/ai-adapter-anthropic.js
+++ b/packages/apostrophe/test/ai-adapter-anthropic.js
@@ -17,6 +17,22 @@ describe('AI adapter: anthropic', function() {
     apos = await t.create({
       root: module,
       modules: {
+        'tool-fixtures': {
+          init(self) {
+            self.apos.ai.addTool({
+              name: 'echo',
+              description: 'Echo the value back',
+              access: 'read',
+              input: {
+                type: 'object',
+                properties: { value: { type: 'string' } },
+                required: [ 'value' ]
+              },
+              schema: { value: { type: 'string' } },
+              handler: (req, args) => ({ value: args.value })
+            });
+          }
+        },
         '@apostrophecms/ai': {
           options: {
             provider: 'anthropic',
@@ -251,6 +267,97 @@ describe('AI adapter: anthropic', function() {
         /"maxTokens" is required/
       );
     });
+
+    it('translates tool definitions to the tools array', function() {
+      const input = {
+        type: 'object',
+        properties: { title: { type: 'string' } }
+      };
+      const body = adapter.buildBody(request({
+        tools: [ {
+          name: 'find_pages',
+          description: 'Find pages',
+          input
+        } ]
+      }));
+      assert.deepEqual(body.tools, [ {
+        name: 'find_pages',
+        description: 'Find pages',
+        input_schema: input
+      } ]);
+    });
+
+    it('carries tool requests and results as tool_use and tool_result blocks', function() {
+      const body = adapter.buildBody(request({
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              text('searching'),
+              {
+                type: 'toolCall',
+                id: 'c1',
+                name: 'find_pages',
+                input: { title: 'Pricing' }
+              }
+            ]
+          },
+          {
+            role: 'tool',
+            content: [ {
+              type: 'toolResult',
+              toolCallId: 'c1',
+              output: { id: 'p1' }
+            } ]
+          }
+        ]
+      }));
+      assert.deepEqual(body.messages, [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: 'searching'
+            },
+            {
+              type: 'tool_use',
+              id: 'c1',
+              name: 'find_pages',
+              input: { title: 'Pricing' }
+            }
+          ]
+        },
+        {
+          // No tool role in this dialect: results ride a user message
+          role: 'user',
+          content: [ {
+            type: 'tool_result',
+            tool_use_id: 'c1',
+            content: JSON.stringify({ id: 'p1' })
+          } ]
+        }
+      ]);
+    });
+
+    it('flags a tool error result', function() {
+      const body = adapter.buildBody(request({
+        messages: [ {
+          role: 'tool',
+          content: [ {
+            type: 'toolResult',
+            toolCallId: 'c1',
+            error: 'the index is rebuilding'
+          } ]
+        } ]
+      }));
+      assert.deepEqual(body.messages[0].content[0], {
+        type: 'tool_result',
+        tool_use_id: 'c1',
+        content: 'the index is rebuilding',
+        is_error: true
+      });
+    });
   });
 
   describe('response parsing', function() {
@@ -476,6 +583,57 @@ describe('AI adapter: anthropic', function() {
       assert.equal(call.url, 'https://llm-gateway.example.com/anthropic/v1/messages');
       assert.equal(call.options.headers['x-api-key'], 'sk-gw');
       assert.equal(call.options.body.max_tokens, 64000);
+    });
+
+    it('drives a tool loop end to end over the wire', async function() {
+      httpScript = [
+        () => fixture({
+          content: [ {
+            type: 'tool_use',
+            id: 'toolu_1',
+            name: 'echo',
+            input: { value: 'pricing' }
+          } ],
+          stop_reason: 'tool_use'
+        }),
+        () => fixture({ content: [ text('done') ] })
+      ];
+      const result = await apos.ai.generate(apos.task.getReq(), 'use the tool', {
+        tools: [ 'echo' ],
+        // Keep the cache markers out of the message assertion below
+        cache: false
+      });
+      assert.equal(result.text, 'done');
+      assert.equal(result.finishReason, 'stop');
+      assert.deepEqual(result.steps, [ {
+        toolCall: {
+          type: 'toolCall',
+          id: 'toolu_1',
+          name: 'echo',
+          input: { value: 'pricing' }
+        },
+        result: { value: 'pricing' }
+      } ]);
+      assert.equal(httpCalls.length, 2);
+      // The first wire call described the tool to the model
+      assert.deepEqual(httpCalls[0].options.body.tools, [ {
+        name: 'echo',
+        description: 'Echo the value back',
+        input_schema: {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+          required: [ 'value' ]
+        }
+      } ]);
+      // The second carried the tool result back as a user message
+      assert.deepEqual(httpCalls[1].options.body.messages.at(-1), {
+        role: 'user',
+        content: [ {
+          type: 'tool_result',
+          tool_use_id: 'toolu_1',
+          content: JSON.stringify({ value: 'pricing' })
+        } ]
+      });
     });
 
     it('retries a 429 at the Retry-After delay', async function() {

--- a/packages/apostrophe/test/ai-adapter-anthropic.js
+++ b/packages/apostrophe/test/ai-adapter-anthropic.js
@@ -358,6 +358,45 @@ describe('AI adapter: anthropic', function() {
         is_error: true
       });
     });
+
+    it('adds the synthetic final-answer tool and forces it for a pure structured call', function() {
+      const schema = {
+        type: 'object',
+        properties: { title: { type: 'string' } },
+        required: [ 'title' ]
+      };
+      const body = adapter.buildBody(request({ schema }));
+      assert.equal(body.tools.length, 1);
+      assert.equal(body.tools[0].name, '_final_answer');
+      assert.equal(typeof body.tools[0].description, 'string');
+      assert.deepEqual(body.tools[0].input_schema, schema);
+      assert.deepEqual(body.tool_choice, {
+        type: 'tool',
+        name: '_final_answer'
+      });
+    });
+
+    it('does not force the final-answer tool when thinking is on', function() {
+      const body = adapter.buildBody(request({
+        schema: { type: 'object' },
+        reasoning: 'high'
+      }));
+      assert.equal(body.tools[0].name, '_final_answer');
+      assert.equal('tool_choice' in body, false);
+    });
+
+    it('adds the final-answer tool beside real tools without forcing', function() {
+      const body = adapter.buildBody(request({
+        schema: { type: 'object' },
+        tools: [ {
+          name: 'find_pages',
+          description: 'Find pages',
+          input: { type: 'object' }
+        } ]
+      }));
+      assert.deepEqual(body.tools.map((tool) => tool.name), [ 'find_pages', '_final_answer' ]);
+      assert.equal('tool_choice' in body, false);
+    });
   });
 
   describe('response parsing', function() {
@@ -428,6 +467,35 @@ describe('AI adapter: anthropic', function() {
           return true;
         }
       );
+    });
+
+    it('turns a final-answer tool call into a structured stop turn', function() {
+      const object = { title: 'Pricing' };
+      const turn = adapter.parseResponse(
+        fixture({
+          content: [ {
+            type: 'tool_use',
+            id: 'toolu_1',
+            name: '_final_answer',
+            input: object
+          } ],
+          stop_reason: 'tool_use'
+        }),
+        request({ schema: { type: 'object' } })
+      );
+      assert.deepEqual(turn.object, object);
+      assert.equal(turn.finishReason, 'stop');
+      // The JSON stays on the text so the transcript round-trips
+      assert.deepEqual(turn.content, [ text(JSON.stringify(object)) ]);
+    });
+
+    it('leaves a free-text answer without an object for the backstop to retry', function() {
+      const turn = adapter.parseResponse(
+        fixture({ content: [ text('here is your answer') ] }),
+        request({ schema: { type: 'object' } })
+      );
+      assert.equal('object' in turn, false);
+      assert.equal(turn.finishReason, 'stop');
     });
   });
 
@@ -634,6 +702,79 @@ describe('AI adapter: anthropic', function() {
           content: JSON.stringify({ value: 'pricing' })
         } ]
       });
+    });
+
+    it('returns a validated object for a structured call, forcing the final-answer tool', async function() {
+      const object = {
+        title: 'Pricing',
+        description: 'Our plans'
+      };
+      httpScript = [ () => fixture({
+        content: [ {
+          type: 'tool_use',
+          id: 'toolu_1',
+          name: '_final_answer',
+          input: object
+        } ],
+        stop_reason: 'tool_use'
+      }) ];
+      const result = await apos.ai.generate(apos.task.getReq(), {
+        messages: [ {
+          role: 'user',
+          content: 'write the metadata'
+        } ],
+        schema: {
+          type: 'object',
+          properties: {
+            title: { type: 'string' },
+            description: { type: 'string' }
+          },
+          required: [ 'title', 'description' ]
+        }
+      });
+      assert.deepEqual(result.object, object);
+      // No real tools and no reasoning at medium effort: the tool is forced
+      assert.deepEqual(httpCalls[0].options.body.tool_choice, {
+        type: 'tool',
+        name: '_final_answer'
+      });
+    });
+
+    it('retries a structured call that answered in free text, then succeeds', async function() {
+      // The detail that the answer is a hidden tool must not cut off the
+      // engine's retry: a miss leaves no object, so the backstop re-asks
+      const object = {
+        title: 'Pricing',
+        description: 'Our plans'
+      };
+      httpScript = [
+        () => fixture({ content: [ text('here is the metadata') ] }),
+        () => fixture({
+          content: [ {
+            type: 'tool_use',
+            id: 'toolu_1',
+            name: '_final_answer',
+            input: object
+          } ],
+          stop_reason: 'tool_use'
+        })
+      ];
+      const result = await apos.ai.generate(apos.task.getReq(), {
+        messages: [ {
+          role: 'user',
+          content: 'write the metadata'
+        } ],
+        schema: {
+          type: 'object',
+          properties: {
+            title: { type: 'string' },
+            description: { type: 'string' }
+          },
+          required: [ 'title', 'description' ]
+        }
+      });
+      assert.deepEqual(result.object, object);
+      assert.equal(httpCalls.length, 2);
     });
 
     it('retries a 429 at the Retry-After delay', async function() {

--- a/packages/apostrophe/test/ai-adapter-anthropic.js
+++ b/packages/apostrophe/test/ai-adapter-anthropic.js
@@ -359,6 +359,56 @@ describe('AI adapter: anthropic', function() {
       });
     });
 
+    it('replays a thinking part as its raw signed block, in place', function() {
+      const block = {
+        type: 'thinking',
+        thinking: 'let me see',
+        signature: 'x'
+      };
+      const body = adapter.buildBody(request({
+        messages: [ {
+          role: 'assistant',
+          content: [
+            {
+              type: 'thinking',
+              block
+            },
+            {
+              type: 'toolCall',
+              id: 'toolu_1',
+              name: 'find_pages',
+              input: { title: 'Pricing' }
+            }
+          ]
+        } ]
+      }));
+      assert.deepEqual(body.messages[0].content, [
+        block,
+        {
+          type: 'tool_use',
+          id: 'toolu_1',
+          name: 'find_pages',
+          input: { title: 'Pricing' }
+        }
+      ]);
+    });
+
+    it('skips assistant parts another dialect owns', function() {
+      const body = adapter.buildBody(request({
+        messages: [ {
+          role: 'assistant',
+          content: [
+            {
+              type: 'reasoning',
+              item: { type: 'reasoning' }
+            },
+            text('visible')
+          ]
+        } ]
+      }));
+      assert.deepEqual(body.messages[0].content, [ text('visible') ]);
+    });
+
     it('adds the synthetic final-answer tool and forces it for a pure structured call', function() {
       const schema = {
         type: 'object',
@@ -429,14 +479,20 @@ describe('AI adapter: anthropic', function() {
       }
     });
 
-    it('translates tool_use blocks and drops thinking blocks', function() {
+    it('translates tool_use blocks and carries thinking blocks as opaque parts', function() {
+      const thinking = {
+        type: 'thinking',
+        thinking: 'let me see',
+        signature: 'x'
+      };
+      const redacted = {
+        type: 'redacted_thinking',
+        data: 'opaque'
+      };
       const turn = adapter.parseResponse(fixture({
         content: [
-          {
-            type: 'thinking',
-            thinking: 'let me see',
-            signature: 'x'
-          },
+          thinking,
+          redacted,
           text('checking'),
           {
             type: 'tool_use',
@@ -448,6 +504,14 @@ describe('AI adapter: anthropic', function() {
         stop_reason: 'tool_use'
       }));
       assert.deepEqual(turn.content, [
+        {
+          type: 'thinking',
+          block: thinking
+        },
+        {
+          type: 'thinking',
+          block: redacted
+        },
         text('checking'),
         {
           type: 'toolCall',
@@ -694,6 +758,66 @@ describe('AI adapter: anthropic', function() {
         }
       } ]);
       // The second carried the tool result back as a user message
+      assert.deepEqual(httpCalls[1].options.body.messages.at(-1), {
+        role: 'user',
+        content: [ {
+          type: 'tool_result',
+          tool_use_id: 'toolu_1',
+          content: JSON.stringify({ value: 'pricing' })
+        } ]
+      });
+    });
+
+    it('drives a thinking tool loop end to end, replaying the signed blocks', async function() {
+      const thinking = {
+        type: 'thinking',
+        thinking: 'let me see',
+        signature: 'x'
+      };
+      httpScript = [
+        () => fixture({
+          content: [
+            thinking,
+            {
+              type: 'tool_use',
+              id: 'toolu_1',
+              name: 'echo',
+              input: { value: 'pricing' }
+            }
+          ],
+          stop_reason: 'tool_use'
+        }),
+        () => fixture({ content: [ text('done') ] })
+      ];
+      const result = await apos.ai.generate(apos.task.getReq(), 'use the tool', {
+        tools: [ 'echo' ],
+        reasoning: 'high',
+        cache: false
+      });
+      assert.equal(result.text, 'done');
+      assert.equal(result.finishReason, 'stop');
+      assert.equal(httpCalls.length, 2);
+      // Thinking was on for both turns of the loop
+      for (const call of httpCalls) {
+        assert.deepEqual(call.options.body.thinking, {
+          type: 'enabled',
+          budget_tokens: 16384
+        });
+      }
+      // The second call replays the assistant turn with its signed
+      // thinking block restored, unmodified, ahead of the tool use
+      assert.deepEqual(httpCalls[1].options.body.messages[1], {
+        role: 'assistant',
+        content: [
+          thinking,
+          {
+            type: 'tool_use',
+            id: 'toolu_1',
+            name: 'echo',
+            input: { value: 'pricing' }
+          }
+        ]
+      });
       assert.deepEqual(httpCalls[1].options.body.messages.at(-1), {
         role: 'user',
         content: [ {

--- a/packages/apostrophe/test/ai-adapter-google.js
+++ b/packages/apostrophe/test/ai-adapter-google.js
@@ -17,6 +17,22 @@ describe('AI adapter: google', function() {
     apos = await t.create({
       root: module,
       modules: {
+        'tool-fixtures': {
+          init(self) {
+            self.apos.ai.addTool({
+              name: 'echo',
+              description: 'Echo the value back',
+              access: 'read',
+              input: {
+                type: 'object',
+                properties: { value: { type: 'string' } },
+                required: [ 'value' ]
+              },
+              schema: { value: { type: 'string' } },
+              handler: (req, args) => ({ value: args.value })
+            });
+          }
+        },
         '@apostrophecms/ai': {
           options: {
             provider: 'google',
@@ -308,6 +324,61 @@ describe('AI adapter: google', function() {
       });
     });
 
+    it('restores part-level thought signatures exactly as received', function() {
+      const body = adapter.buildBody(request({
+        messages: [ {
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: 'searching',
+              thoughtSignature: 'sig-text'
+            },
+            {
+              type: 'toolCall',
+              id: 'find_pages-0',
+              name: 'find_pages',
+              input: { title: 'Pricing' },
+              thoughtSignature: 'sig-call'
+            }
+          ]
+        } ]
+      }));
+      assert.deepEqual(body.contents[0].parts, [
+        {
+          text: 'searching',
+          thoughtSignature: 'sig-text'
+        },
+        {
+          functionCall: {
+            name: 'find_pages',
+            args: { title: 'Pricing' }
+          },
+          thoughtSignature: 'sig-call'
+        }
+      ]);
+    });
+
+    it('skips assistant parts another dialect owns', function() {
+      const body = adapter.buildBody(request({
+        messages: [ {
+          role: 'assistant',
+          content: [
+            {
+              type: 'thinking',
+              block: {
+                type: 'thinking',
+                thinking: 'hidden',
+                signature: 'x'
+              }
+            },
+            text('visible')
+          ]
+        } ]
+      }));
+      assert.deepEqual(body.contents[0].parts, [ { text: 'visible' } ]);
+    });
+
     it('adds the synthetic final-answer function and forces it for a pure structured call', function() {
       const schema = {
         type: 'object',
@@ -447,6 +518,44 @@ describe('AI adapter: google', function() {
         }) ]
       }));
       assert.deepEqual(turn.content.map((part) => part.id), [ 'search-0', 'search-1' ]);
+    });
+
+    it('carries part-level thought signatures on the normalized parts', function() {
+      const turn = adapter.parseResponse(fixture({
+        candidates: [ candidate({
+          content: {
+            role: 'model',
+            parts: [
+              {
+                text: 'searching',
+                thoughtSignature: 'sig-text'
+              },
+              {
+                functionCall: {
+                  name: 'find_pages',
+                  args: { title: 'Pricing' }
+                },
+                thoughtSignature: 'sig-call'
+              }
+            ]
+          },
+          finishReason: 'STOP'
+        }) ]
+      }));
+      assert.deepEqual(turn.content, [
+        {
+          type: 'text',
+          text: 'searching',
+          thoughtSignature: 'sig-text'
+        },
+        {
+          type: 'toolCall',
+          id: 'find_pages-0',
+          name: 'find_pages',
+          input: { title: 'Pricing' },
+          thoughtSignature: 'sig-call'
+        }
+      ]);
     });
 
     it('throws the refusal error on a blocked prompt', function() {
@@ -667,6 +776,72 @@ describe('AI adapter: google', function() {
       );
       assert.equal(call.options.headers['x-goog-api-key'], 'sk-gw');
       assert.equal(call.options.body.generationConfig.maxOutputTokens, 65536);
+    });
+
+    it('drives a thinking tool loop end to end, replaying the thought signature', async function() {
+      httpScript = [
+        () => fixture({
+          candidates: [ candidate({
+            content: {
+              role: 'model',
+              parts: [ {
+                functionCall: {
+                  name: 'echo',
+                  args: { value: 'pricing' }
+                },
+                thoughtSignature: 'sig-call'
+              } ]
+            },
+            finishReason: 'STOP'
+          }) ]
+        }),
+        () => fixture({
+          candidates: [ candidate({
+            content: {
+              role: 'model',
+              parts: [ { text: 'done' } ]
+            }
+          }) ]
+        })
+      ];
+      const result = await apos.ai.generate(apos.task.getReq(), 'use the tool', {
+        tools: [ 'echo' ],
+        reasoning: 'high'
+      });
+      assert.equal(result.text, 'done');
+      assert.equal(result.finishReason, 'stop');
+      assert.equal(httpCalls.length, 2);
+      // Thinking was on for both turns of the loop
+      for (const call of httpCalls) {
+        assert.deepEqual(
+          call.options.body.generationConfig.thinkingConfig,
+          { thinkingLevel: 'high' }
+        );
+      }
+      // The second call replays the function call with its thought
+      // signature restored, exactly as received, and pairs the
+      // function response back by name
+      assert.deepEqual(httpCalls[1].options.body.contents.slice(1), [
+        {
+          role: 'model',
+          parts: [ {
+            functionCall: {
+              name: 'echo',
+              args: { value: 'pricing' }
+            },
+            thoughtSignature: 'sig-call'
+          } ]
+        },
+        {
+          role: 'user',
+          parts: [ {
+            functionResponse: {
+              name: 'echo',
+              response: { value: 'pricing' }
+            }
+          } ]
+        }
+      ]);
     });
 
     it('retries a 429 at the RetryInfo delay', async function() {

--- a/packages/apostrophe/test/ai-adapter-google.js
+++ b/packages/apostrophe/test/ai-adapter-google.js
@@ -307,6 +307,35 @@ describe('AI adapter: google', function() {
         }
       });
     });
+
+    it('adds the synthetic final-answer function and forces it for a pure structured call', function() {
+      const schema = {
+        type: 'object',
+        properties: { title: { type: 'string' } },
+        required: [ 'title' ]
+      };
+      const body = adapter.buildBody(request({ schema }));
+      const [ tool ] = body.tools;
+      assert.equal(tool.functionDeclarations.length, 1);
+      assert.equal(tool.functionDeclarations[0].name, '_final_answer');
+      assert.equal(typeof tool.functionDeclarations[0].description, 'string');
+      assert.deepEqual(tool.functionDeclarations[0].parameters, schema);
+      assert.deepEqual(body.toolConfig, {
+        functionCallingConfig: {
+          mode: 'ANY',
+          allowedFunctionNames: [ '_final_answer' ]
+        }
+      });
+    });
+
+    it('does not force the final-answer function when thinking is on', function() {
+      const body = adapter.buildBody(request({
+        schema: { type: 'object' },
+        reasoning: 'high'
+      }));
+      assert.equal(body.tools[0].functionDeclarations[0].name, '_final_answer');
+      assert.equal('toolConfig' in body, false);
+    });
   });
 
   describe('response parsing', function() {
@@ -432,6 +461,39 @@ describe('AI adapter: google', function() {
           return true;
         }
       );
+    });
+
+    it('turns a final-answer function call into a structured stop turn', function() {
+      const object = { title: 'Pricing' };
+      const turn = adapter.parseResponse(
+        fixture({
+          candidates: [ candidate({
+            content: {
+              role: 'model',
+              parts: [ {
+                functionCall: {
+                  name: '_final_answer',
+                  args: object
+                }
+              } ]
+            },
+            finishReason: 'STOP'
+          }) ]
+        }),
+        request({ schema: { type: 'object' } })
+      );
+      assert.deepEqual(turn.object, object);
+      assert.equal(turn.finishReason, 'stop');
+      assert.deepEqual(turn.content, [ text(JSON.stringify(object)) ]);
+    });
+
+    it('leaves a free-text answer without an object for the backstop to retry', function() {
+      const turn = adapter.parseResponse(
+        fixture(),
+        request({ schema: { type: 'object' } })
+      );
+      assert.equal('object' in turn, false);
+      assert.equal(turn.finishReason, 'stop');
     });
   });
 

--- a/packages/apostrophe/test/ai-adapter-google.js
+++ b/packages/apostrophe/test/ai-adapter-google.js
@@ -206,6 +206,107 @@ describe('AI adapter: google', function() {
         );
       }
     });
+
+    it('translates tool definitions to functionDeclarations', function() {
+      const input = {
+        type: 'object',
+        properties: { title: { type: 'string' } }
+      };
+      const body = adapter.buildBody(request({
+        tools: [ {
+          name: 'find_pages',
+          description: 'Find pages',
+          input
+        } ]
+      }));
+      assert.deepEqual(body.tools, [ {
+        functionDeclarations: [ {
+          name: 'find_pages',
+          description: 'Find pages',
+          parameters: input
+        } ]
+      } ]);
+    });
+
+    it('carries tool calls and results, recovering the response name from the call id', function() {
+      const body = adapter.buildBody(request({
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              text('searching'),
+              {
+                type: 'toolCall',
+                id: 'find_pages-0',
+                name: 'find_pages',
+                input: { title: 'Pricing' }
+              }
+            ]
+          },
+          {
+            role: 'tool',
+            content: [ {
+              type: 'toolResult',
+              toolCallId: 'find_pages-0',
+              output: { id: 'p1' }
+            } ]
+          }
+        ]
+      }));
+      assert.deepEqual(body.contents, [
+        {
+          role: 'model',
+          parts: [
+            { text: 'searching' },
+            {
+              functionCall: {
+                name: 'find_pages',
+                args: { title: 'Pricing' }
+              }
+            }
+          ]
+        },
+        {
+          role: 'user',
+          parts: [ {
+            functionResponse: {
+              name: 'find_pages',
+              response: { id: 'p1' }
+            }
+          } ]
+        }
+      ]);
+    });
+
+    it('wraps a tool error result in the functionResponse', function() {
+      const body = adapter.buildBody(request({
+        messages: [
+          {
+            role: 'assistant',
+            content: [ {
+              type: 'toolCall',
+              id: 'x-0',
+              name: 'x',
+              input: {}
+            } ]
+          },
+          {
+            role: 'tool',
+            content: [ {
+              type: 'toolResult',
+              toolCallId: 'x-0',
+              error: 'boom'
+            } ]
+          }
+        ]
+      }));
+      assert.deepEqual(body.contents[1].parts[0], {
+        functionResponse: {
+          name: 'x',
+          response: { error: 'boom' }
+        }
+      });
+    });
   });
 
   describe('response parsing', function() {
@@ -284,11 +385,39 @@ describe('AI adapter: google', function() {
         text('checking'),
         {
           type: 'toolCall',
+          // Synthesized: Gemini function calls carry no id
+          id: 'find_pages-0',
           name: 'find_pages',
           input: { title: 'Pricing' }
         }
       ]);
       assert.equal(turn.finishReason, 'toolCalls');
+    });
+
+    it('synthesizes a distinct id per function call in a turn', function() {
+      const turn = adapter.parseResponse(fixture({
+        candidates: [ candidate({
+          content: {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  name: 'search',
+                  args: { q: 'a' }
+                }
+              },
+              {
+                functionCall: {
+                  name: 'search',
+                  args: { q: 'b' }
+                }
+              }
+            ]
+          },
+          finishReason: 'STOP'
+        }) ]
+      }));
+      assert.deepEqual(turn.content.map((part) => part.id), [ 'search-0', 'search-1' ]);
     });
 
     it('throws the refusal error on a blocked prompt', function() {

--- a/packages/apostrophe/test/ai-adapter-openai-compatible.js
+++ b/packages/apostrophe/test/ai-adapter-openai-compatible.js
@@ -17,6 +17,22 @@ describe('AI adapter: openai-compatible', function() {
     apos = await t.create({
       root: module,
       modules: {
+        'tool-fixtures': {
+          init(self) {
+            self.apos.ai.addTool({
+              name: 'echo',
+              description: 'Echo the value back',
+              access: 'read',
+              input: {
+                type: 'object',
+                properties: { value: { type: 'string' } },
+                required: [ 'value' ]
+              },
+              schema: { value: { type: 'string' } },
+              handler: (req, args) => ({ value: args.value })
+            });
+          }
+        },
         '@apostrophecms/ai': {
           options: {
             provider: 'openai-compatible',
@@ -105,7 +121,9 @@ describe('AI adapter: openai-compatible', function() {
     assert.equal(info.maxOutputTokens, 128000);
     const high = apos.ai.modelInfo({ effort: 'high' });
     assert.equal(high.model, 'gpt-5.6-sol');
-    assert.equal(high.reasoning, 'high');
+    // No reasoning on the native high row: the reasoning path for
+    // OpenAI proper is the openai adapter
+    assert.equal(high.reasoning, undefined);
   });
 
   describe('request translation', function() {
@@ -295,6 +313,25 @@ describe('AI adapter: openai-compatible', function() {
             arguments: '{}'
           }
         } ]
+      });
+    });
+
+    it('skips assistant parts another dialect owns', function() {
+      const body = adapter.buildBody(request({
+        messages: [ {
+          role: 'assistant',
+          content: [
+            {
+              type: 'reasoning',
+              item: { type: 'reasoning' }
+            },
+            text('visible')
+          ]
+        } ]
+      }));
+      assert.deepEqual(body.messages[0], {
+        role: 'assistant',
+        content: 'visible'
       });
     });
 
@@ -585,6 +622,44 @@ describe('AI adapter: openai-compatible', function() {
       assert.equal(call.url, 'https://llm-gateway.example.com/openai/v1/chat/completions');
       assert.equal(call.options.headers.authorization, 'Bearer sk-gw');
       assert.equal(call.options.body.max_completion_tokens, 128000);
+    });
+
+    it('drops reasoning from a native tools request, keeping it everywhere else', async function() {
+      // Native, tools + reasoning: the service rejects the
+      // combination, so reasoning is dropped
+      httpScript = [ () => fixture() ];
+      await apos.ai.generate(apos.task.getReq(), 'p', {
+        tools: [ 'echo' ],
+        reasoning: 'high'
+      });
+      assert(httpCalls[0].options.body.tools);
+      assert.equal('reasoning_effort' in httpCalls[0].options.body, false);
+
+      // Native, tools + the explicit 'none' level: the one value the
+      // service accepts beside tools passes through
+      httpScript = [ () => fixture() ];
+      await apos.ai.generate(apos.task.getReq(), 'p', {
+        tools: [ 'echo' ],
+        reasoning: 'none'
+      });
+      assert.equal(httpCalls[1].options.body.reasoning_effort, 'none');
+
+      // Native, reasoning without tools: nothing to degrade
+      httpScript = [ () => fixture() ];
+      await apos.ai.generate(apos.task.getReq(), 'p', { reasoning: 'high' });
+      assert.equal(httpCalls[2].options.body.reasoning_effort, 'high');
+
+      // An aliased entry describes another service, which accepts the
+      // combination: everything passes through untouched
+      httpScript = [ () => fixture() ];
+      await apos.ai.generate(apos.task.getReq(), 'p', {
+        provider: 'gateway',
+        model: 'gpt-5.6-sol',
+        tools: [ 'echo' ],
+        reasoning: 'high'
+      });
+      assert(httpCalls[3].options.body.tools);
+      assert.equal(httpCalls[3].options.body.reasoning_effort, 'high');
     });
 
     it('returns a validated object for a structured call over the wire', async function() {

--- a/packages/apostrophe/test/ai-adapter-openai-compatible.js
+++ b/packages/apostrophe/test/ai-adapter-openai-compatible.js
@@ -1,7 +1,7 @@
 const t = require('../test-lib/test.js');
 const assert = require('assert/strict');
 
-describe('AI adapter: openai', function() {
+describe('AI adapter: openai-compatible', function() {
   this.timeout(t.timeout);
 
   let apos;
@@ -19,11 +19,11 @@ describe('AI adapter: openai', function() {
       modules: {
         '@apostrophecms/ai': {
           options: {
-            provider: 'openai',
+            provider: 'openai-compatible',
             providers: {
-              openai: { apiKey: 'sk-test' },
+              'openai-compatible': { apiKey: 'sk-test' },
               gateway: {
-                adapter: 'openai',
+                adapter: 'openai-compatible',
                 apiKey: 'sk-gw',
                 baseUrl: 'https://llm-gateway.example.com/openai/v1'
               }
@@ -34,7 +34,7 @@ describe('AI adapter: openai', function() {
         }
       }
     });
-    adapter = apos.modules['@apostrophecms/ai-adapter-openai'];
+    adapter = apos.modules['@apostrophecms/ai-adapter-openai-compatible'];
   });
 
   after(async function() {
@@ -95,11 +95,11 @@ describe('AI adapter: openai', function() {
   );
 
   it('registers the adapter and activates the provider', function() {
-    assert(apos.ai.getAdapter('openai'));
-    assert.equal(apos.ai.getAdapter('openai').envKey, 'APOS_OPENAI_KEY');
+    assert(apos.ai.getAdapter('openai-compatible'));
+    assert.equal(apos.ai.getAdapter('openai-compatible').envKey, 'APOS_OPENAI_KEY');
     assert.equal(apos.ai.active, true);
     const info = apos.ai.modelInfo();
-    assert.equal(info.provider, 'openai');
+    assert.equal(info.provider, 'openai-compatible');
     assert.equal(info.model, 'gpt-5.6-terra');
     assert.equal(info.contextWindow, 1050000);
     assert.equal(info.maxOutputTokens, 128000);
@@ -552,7 +552,7 @@ describe('AI adapter: openai', function() {
       );
       assert.equal(result.text, 'a haiku');
       assert.equal(result.finishReason, 'stop');
-      assert.equal(result.provider, 'openai');
+      assert.equal(result.provider, 'openai-compatible');
       // The model the response named, not the routed alias
       assert.equal(result.model, 'gpt-5.6-terra-2026-06-26');
       assert.deepEqual(result.usage, {
@@ -731,7 +731,7 @@ describe('AI adapter: openai', function() {
           '@apostrophecms/ai': {
             options: {
               providers: {
-                openai: { apiKey: liveKey }
+                'openai-compatible': { apiKey: liveKey }
               }
             }
           }
@@ -757,7 +757,7 @@ describe('AI adapter: openai', function() {
         }
       );
       assert(result.text.length > 0);
-      assert.equal(result.provider, 'openai');
+      assert.equal(result.provider, 'openai-compatible');
       assert.equal(result.finishReason, 'stop');
       assert(Number.isFinite(result.usage.inputTokens));
       assert(Number.isFinite(result.usage.outputTokens));

--- a/packages/apostrophe/test/ai-adapter-openai.js
+++ b/packages/apostrophe/test/ai-adapter-openai.js
@@ -1,0 +1,856 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert/strict');
+
+describe('AI adapter: openai', function() {
+  this.timeout(t.timeout);
+
+  let apos;
+  // The adapter module instance, for unit access to the dialect methods
+  let adapter;
+  let savedLiveKey;
+
+  before(async function() {
+    // A real key in the environment would override the fixture keys
+    // below (envKey); keep the suite hermetic and restore at the end
+    savedLiveKey = process.env.APOS_OPENAI_KEY;
+    delete process.env.APOS_OPENAI_KEY;
+    apos = await t.create({
+      root: module,
+      modules: {
+        'tool-fixtures': {
+          init(self) {
+            self.apos.ai.addTool({
+              name: 'echo',
+              description: 'Echo the value back',
+              access: 'read',
+              input: {
+                type: 'object',
+                properties: { value: { type: 'string' } },
+                required: [ 'value' ]
+              },
+              schema: { value: { type: 'string' } },
+              handler: (req, args) => ({ value: args.value })
+            });
+          }
+        },
+        '@apostrophecms/ai': {
+          options: {
+            provider: 'openai',
+            providers: {
+              openai: { apiKey: 'sk-test' },
+              gateway: {
+                adapter: 'openai',
+                apiKey: 'sk-gw',
+                baseUrl: 'https://llm-gateway.example.com/openai/v1'
+              }
+            },
+            // Keep retried tests fast; the delay engine has its own suite
+            retryBaseDelay: 1
+          }
+        }
+      }
+    });
+    adapter = apos.modules['@apostrophecms/ai-adapter-openai'];
+  });
+
+  after(async function() {
+    if (savedLiveKey !== undefined) {
+      process.env.APOS_OPENAI_KEY = savedLiveKey;
+    }
+    if (apos) {
+      return t.destroy(apos);
+    }
+  });
+
+  const text = (value) => ({
+    type: 'text',
+    text: value
+  });
+  const userMessage = (value) => ({
+    role: 'user',
+    content: [ text(value) ]
+  });
+  // A minimal normalized adapter request, as the engine assembles it
+  const request = (extras = {}) => ({
+    messages: [ userMessage('write a haiku about cats') ],
+    model: 'gpt-5.6-terra',
+    maxTokens: 128000,
+    cache: false,
+    ...extras
+  });
+  // Canned Responses API output items and response body
+  const messageItem = (value) => ({
+    type: 'message',
+    id: 'msg_1',
+    role: 'assistant',
+    status: 'completed',
+    content: [ {
+      type: 'output_text',
+      text: value,
+      annotations: []
+    } ]
+  });
+  const callItem = (extras = {}) => ({
+    type: 'function_call',
+    id: 'fc_1',
+    call_id: 'call_1',
+    name: 'find_pages',
+    arguments: '{"title":"Pricing"}',
+    status: 'completed',
+    ...extras
+  });
+  const reasoningItem = (extras = {}) => ({
+    type: 'reasoning',
+    id: 'rs_1',
+    summary: [],
+    encrypted_content: 'gAAAAB-opaque',
+    ...extras
+  });
+  const fixture = (extras = {}) => ({
+    id: 'resp_1',
+    object: 'response',
+    status: 'completed',
+    model: 'gpt-5.6-terra-2026-06-26',
+    output: [ messageItem('a haiku') ],
+    usage: {
+      input_tokens: 12,
+      output_tokens: 7
+    },
+    ...extras
+  });
+  // An apos.http >= 400 throw: Error with status, headers, body
+  const httpError = (status, headers = {}, body) => Object.assign(
+    new Error(`HTTP error ${status}`),
+    {
+      status,
+      headers,
+      body
+    }
+  );
+
+  it('registers the adapter and activates the provider', function() {
+    assert(apos.ai.getAdapter('openai'));
+    assert.equal(apos.ai.getAdapter('openai').envKey, 'APOS_OPENAI_KEY');
+    assert.equal(apos.ai.active, true);
+    const info = apos.ai.modelInfo();
+    assert.equal(info.provider, 'openai');
+    assert.equal(info.model, 'gpt-5.6-terra');
+    assert.equal(info.contextWindow, 1050000);
+    assert.equal(info.maxOutputTokens, 128000);
+    const high = apos.ai.modelInfo({ effort: 'high' });
+    assert.equal(high.model, 'gpt-5.6-sol');
+    assert.equal(high.reasoning, 'high');
+  });
+
+  describe('request translation', function() {
+    it('builds the minimal stateless body', function() {
+      assert.deepEqual(adapter.buildBody(request()), {
+        model: 'gpt-5.6-terra',
+        store: false,
+        input: [ {
+          role: 'user',
+          content: [ {
+            type: 'input_text',
+            text: 'write a haiku about cats'
+          } ]
+        } ],
+        max_output_tokens: 128000
+      });
+    });
+
+    it('sends the system prompt as instructions', function() {
+      const body = adapter.buildBody(request({ system: 'You help editors.' }));
+      assert.equal(body.instructions, 'You help editors.');
+      assert.equal(body.input.length, 1);
+      assert.equal(body.input[0].role, 'user');
+    });
+
+    it('translates both image forms to input_image parts', function() {
+      const body = adapter.buildBody(request({
+        messages: [ {
+          role: 'user',
+          content: [
+            text('describe these'),
+            {
+              type: 'image',
+              image: { url: 'https://example.com/a.png' }
+            },
+            {
+              type: 'image',
+              image: {
+                data: 'aGk=',
+                mediaType: 'image/png'
+              }
+            }
+          ]
+        } ]
+      }));
+      assert.deepEqual(body.input[0].content, [
+        {
+          type: 'input_text',
+          text: 'describe these'
+        },
+        {
+          type: 'input_image',
+          image_url: 'https://example.com/a.png'
+        },
+        {
+          type: 'input_image',
+          image_url: 'data:image/png;base64,aGk='
+        }
+      ]);
+    });
+
+    it('sends reasoning as the effort object', function() {
+      assert.equal(adapter.buildBody(request()).reasoning, undefined);
+      assert.deepEqual(
+        adapter.buildBody(request({ reasoning: 'high' })).reasoning,
+        { effort: 'high' }
+      );
+    });
+
+    it('asks for encrypted reasoning content only when tools ride along', function() {
+      const tools = [ {
+        name: 'find_pages',
+        description: 'Find pages',
+        input: { type: 'object' }
+      } ];
+      assert.equal(
+        'include' in adapter.buildBody(request({ reasoning: 'high' })),
+        false
+      );
+      assert.equal(
+        'include' in adapter.buildBody(request({ tools })),
+        false
+      );
+      assert.deepEqual(
+        adapter.buildBody(request({
+          reasoning: 'high',
+          tools
+        })).include,
+        [ 'reasoning.encrypted_content' ]
+      );
+    });
+
+    it('omits the token cap when none resolved', function() {
+      const body = adapter.buildBody(request({ maxTokens: undefined }));
+      assert.equal('max_output_tokens' in body, false);
+    });
+
+    it('places nothing for any cache policy', function() {
+      for (const cache of [ { ttl: 'short' }, { ttl: 'long' } ]) {
+        assert.deepEqual(
+          adapter.buildBody(request({ cache })),
+          adapter.buildBody(request())
+        );
+      }
+    });
+
+    it('translates tool definitions to flattened non-strict function tools', function() {
+      const input = {
+        type: 'object',
+        properties: { title: { type: 'string' } }
+      };
+      const body = adapter.buildBody(request({
+        tools: [ {
+          name: 'find_pages',
+          description: 'Find pages',
+          input
+        } ]
+      }));
+      assert.deepEqual(body.tools, [ {
+        type: 'function',
+        name: 'find_pages',
+        description: 'Find pages',
+        parameters: input,
+        strict: false
+      } ]);
+    });
+
+    it('translates an assistant turn part by part, in order', function() {
+      const item = reasoningItem();
+      const body = adapter.buildBody(request({
+        messages: [ {
+          role: 'assistant',
+          content: [
+            {
+              type: 'reasoning',
+              item
+            },
+            text('searching'),
+            {
+              type: 'toolCall',
+              id: 'call_1',
+              name: 'find_pages',
+              input: { title: 'Pricing' }
+            }
+          ]
+        } ]
+      }));
+      assert.deepEqual(body.input, [
+        item,
+        {
+          role: 'assistant',
+          content: [ {
+            type: 'output_text',
+            text: 'searching'
+          } ]
+        },
+        {
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'find_pages',
+          arguments: JSON.stringify({ title: 'Pricing' })
+        }
+      ]);
+    });
+
+    it('skips assistant parts another dialect owns', function() {
+      const body = adapter.buildBody(request({
+        messages: [ {
+          role: 'assistant',
+          content: [
+            {
+              type: 'thinking',
+              thinking: 'hidden',
+              signature: 'sig'
+            },
+            text('visible')
+          ]
+        } ]
+      }));
+      assert.deepEqual(body.input, [ {
+        role: 'assistant',
+        content: [ {
+          type: 'output_text',
+          text: 'visible'
+        } ]
+      } ]);
+    });
+
+    it('fans a tool batch into one function_call_output item per result', function() {
+      const body = adapter.buildBody(request({
+        messages: [ {
+          role: 'tool',
+          content: [
+            {
+              type: 'toolResult',
+              toolCallId: 'call_1',
+              output: { id: 'p1' }
+            },
+            {
+              type: 'toolResult',
+              toolCallId: 'call_2',
+              error: 'not found'
+            }
+          ]
+        } ]
+      }));
+      assert.deepEqual(body.input, [
+        {
+          type: 'function_call_output',
+          call_id: 'call_1',
+          output: JSON.stringify({ id: 'p1' })
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_2',
+          output: 'not found'
+        }
+      ]);
+    });
+
+    it('sends a structured-output schema as the non-strict json_schema text format', function() {
+      const schema = {
+        type: 'object',
+        properties: { title: { type: 'string' } },
+        required: [ 'title' ]
+      };
+      const body = adapter.buildBody(request({ schema }));
+      assert.deepEqual(body.text, {
+        format: {
+          type: 'json_schema',
+          name: 'response',
+          schema,
+          strict: false
+        }
+      });
+    });
+  });
+
+  describe('response parsing', function() {
+    it('parses a text turn', function() {
+      assert.deepEqual(adapter.parseResponse(fixture()), {
+        content: [ text('a haiku') ],
+        finishReason: 'stop',
+        usage: {
+          inputTokens: 12,
+          outputTokens: 7
+        },
+        model: 'gpt-5.6-terra-2026-06-26'
+      });
+    });
+
+    it('derives the finish reason from status and output', function() {
+      for (const [ extras, ours ] of [
+        [ {}, 'stop' ],
+        [ { output: [ callItem() ] }, 'toolCalls' ],
+        [ {
+          status: 'incomplete',
+          incomplete_details: { reason: 'max_output_tokens' }
+        }, 'length' ],
+        [ {
+          status: 'incomplete',
+          incomplete_details: { reason: 'content_filter' }
+        }, 'refusal' ],
+        [ {
+          status: 'incomplete',
+          incomplete_details: { reason: 'weird' }
+        }, undefined ],
+        // Unknown statuses yield none: the engine treats the turn as
+        // malformed and retries, never a truncated success
+        [ { status: 'failed' }, undefined ]
+      ]) {
+        assert.equal(
+          adapter.parseResponse(fixture(extras)).finishReason,
+          ours
+        );
+      }
+    });
+
+    it('translates function calls, parsing their arguments', function() {
+      const turn = adapter.parseResponse(fixture({
+        output: [ callItem() ]
+      }));
+      assert.deepEqual(turn.content, [ {
+        type: 'toolCall',
+        id: 'call_1',
+        name: 'find_pages',
+        input: { title: 'Pricing' }
+      } ]);
+      assert.equal(turn.finishReason, 'toolCalls');
+    });
+
+    it('carries a replayable reasoning item as an opaque part, drops a bare one', function() {
+      const item = reasoningItem();
+      const turn = adapter.parseResponse(fixture({
+        output: [ item, callItem() ]
+      }));
+      assert.deepEqual(turn.content[0], {
+        type: 'reasoning',
+        item
+      });
+      assert.equal(turn.content[1].type, 'toolCall');
+
+      const bare = adapter.parseResponse(fixture({
+        output: [
+          reasoningItem({ encrypted_content: undefined }),
+          messageItem('a haiku')
+        ]
+      }));
+      assert.deepEqual(bare.content, [ text('a haiku') ]);
+    });
+
+    it('throws the refusal error on a refusal part', function() {
+      assert.throws(
+        () => adapter.parseResponse(fixture({
+          output: [ {
+            type: 'message',
+            id: 'msg_1',
+            role: 'assistant',
+            status: 'completed',
+            content: [ {
+              type: 'refusal',
+              refusal: 'I cannot help with that.'
+            } ]
+          } ]
+        })),
+        (e) => {
+          assert.equal(e.name, 'aiRefusal');
+          assert.equal(e.message, 'I cannot help with that.');
+          return true;
+        }
+      );
+    });
+
+    it('parses the structured answer onto the turn object', function() {
+      const object = {
+        title: 'Pricing',
+        description: 'Our plans'
+      };
+      const turn = adapter.parseResponse(
+        fixture({ output: [ messageItem(JSON.stringify(object)) ] }),
+        request({ schema: { type: 'object' } })
+      );
+      assert.deepEqual(turn.object, object);
+      // The JSON also stays on the content so the transcript round-trips
+      assert.deepEqual(turn.content, [ text(JSON.stringify(object)) ]);
+    });
+
+    it('treats malformed structured JSON as a retryable response', function() {
+      assert.throws(
+        () => adapter.parseResponse(
+          fixture({ output: [ messageItem('not json') ] }),
+          request({ schema: { type: 'object' } })
+        ),
+        (e) => {
+          assert.equal(e.name, 'aiRetry');
+          assert.match(e.message, /malformed structured JSON/);
+          return true;
+        }
+      );
+    });
+
+    it('leaves the turn object unset without a schema request', function() {
+      const turn = adapter.parseResponse(fixture({
+        output: [ messageItem('{"a":1}') ]
+      }));
+      assert.equal('object' in turn, false);
+    });
+  });
+
+  describe('error normalization', function() {
+    it('maps the statuses to the normalized codes', function() {
+      for (const [ status, code, kind ] of [
+        [ 429, 'aiRetry', 'rateLimit' ],
+        [ 500, 'aiRetry', 'overload' ],
+        [ 503, 'aiRetry', 'overload' ],
+        [ 401, 'forbidden', undefined ],
+        [ 403, 'forbidden', undefined ],
+        [ 404, 'notfound', undefined ],
+        [ 400, 'invalid', undefined ]
+      ]) {
+        const error = adapter.normalizeError(httpError(status));
+        assert.equal(error.name, code);
+        assert.equal(error.data.status, status);
+        assert.equal(error.data.kind, kind);
+      }
+    });
+
+    it('prefers the provider message and carries the request id', function() {
+      const error = adapter.normalizeError(httpError(401, {
+        'x-request-id': 'req_9'
+      }, {
+        error: {
+          message: 'Incorrect API key provided',
+          type: 'invalid_request_error',
+          code: 'invalid_api_key'
+        }
+      }));
+      assert.equal(error.message, 'Incorrect API key provided');
+      assert.equal(error.data.requestId, 'req_9');
+    });
+
+    it('parses Retry-After as seconds and as an HTTP date', function() {
+      const seconds = adapter.normalizeError(httpError(429, { 'retry-after': '7' }));
+      assert.equal(seconds.data.retryAfter, 7);
+      const date = adapter.normalizeError(httpError(429, {
+        'retry-after': new Date(Date.now() + 30000).toUTCString()
+      }));
+      assert(date.data.retryAfter >= 28 && date.data.retryAfter <= 31);
+      const garbage = adapter.normalizeError(httpError(429, { 'retry-after': 'soon' }));
+      assert.equal(garbage.data.retryAfter, undefined);
+    });
+
+    it('maps timeouts and network failures to the transient code', function() {
+      const timeout = adapter.normalizeError(
+        new DOMException('The operation timed out', 'TimeoutError')
+      );
+      assert.equal(timeout.name, 'aiRetry');
+      assert.equal(timeout.data.kind, 'timeout');
+      const network = adapter.normalizeError(new TypeError('fetch failed'));
+      assert.equal(network.name, 'aiRetry');
+      assert.equal(network.data.kind, 'network');
+      assert.match(network.message, /fetch failed/);
+    });
+
+    it('passes a caller abort through untouched', function() {
+      const abort = new DOMException('The operation was aborted', 'AbortError');
+      assert.equal(adapter.normalizeError(abort), abort);
+    });
+  });
+
+  describe('the wire', function() {
+    // Thunks consumed by the stubbed apos.http.post, one per call
+    let httpScript;
+    let httpCalls;
+    let logRecords;
+    let waits;
+    let originalPost;
+
+    before(function() {
+      originalPost = apos.http.post;
+    });
+
+    after(function() {
+      apos.http.post = originalPost;
+    });
+
+    beforeEach(function() {
+      httpScript = [];
+      httpCalls = [];
+      waits = [];
+      logRecords = [];
+      apos.http.post = async (url, options) => {
+        httpCalls.push({
+          url,
+          options
+        });
+        const step = httpScript.shift();
+        if (step === undefined) {
+          throw new Error('post called beyond its script');
+        }
+        return step();
+      };
+      apos.ai.pause = async (ms) => {
+        waits.push(ms);
+      };
+      for (const severity of [ 'Warn', 'Error' ]) {
+        apos.ai[`log${severity}`] = (req, type, message, data) => {
+          logRecords.push({
+            severity: severity.toLowerCase(),
+            type,
+            message,
+            data
+          });
+        };
+      }
+    });
+
+    it('generates end to end against the dialect', async function() {
+      httpScript = [ () => fixture() ];
+      const result = await apos.ai.generate(
+        apos.task.getReq(),
+        'write a haiku about cats'
+      );
+      assert.equal(result.text, 'a haiku');
+      assert.equal(result.finishReason, 'stop');
+      assert.equal(result.provider, 'openai');
+      // The model the response named, not the routed alias
+      assert.equal(result.model, 'gpt-5.6-terra-2026-06-26');
+      assert.deepEqual(result.usage, {
+        inputTokens: 12,
+        outputTokens: 7
+      });
+
+      const [ call ] = httpCalls;
+      assert.equal(call.url, 'https://api.openai.com/v1/responses');
+      assert.equal(call.options.headers.authorization, 'Bearer sk-test');
+      assert.equal(call.options.timeout, 600000);
+      // The whole body: the default short cache policy adds nothing
+      assert.deepEqual(call.options.body, {
+        model: 'gpt-5.6-terra',
+        store: false,
+        input: [ {
+          role: 'user',
+          content: [ {
+            type: 'input_text',
+            text: 'write a haiku about cats'
+          } ]
+        } ],
+        max_output_tokens: 128000
+      });
+    });
+
+    it('honors an aliased entry: its baseUrl, key and merged model metadata', async function() {
+      httpScript = [ () => fixture() ];
+      await apos.ai.generate(apos.task.getReq(), 'p', {
+        provider: 'gateway',
+        model: 'gpt-5.6-terra'
+      });
+      const [ call ] = httpCalls;
+      assert.equal(call.url, 'https://llm-gateway.example.com/openai/v1/responses');
+      assert.equal(call.options.headers.authorization, 'Bearer sk-gw');
+      assert.equal(call.options.body.max_output_tokens, 128000);
+    });
+
+    it('drives a reasoning tool loop end to end, replaying the reasoning item', async function() {
+      const item = reasoningItem();
+      httpScript = [
+        () => fixture({
+          output: [
+            item,
+            callItem({
+              name: 'echo',
+              arguments: JSON.stringify({ value: 'pricing' })
+            })
+          ]
+        }),
+        () => fixture({ output: [ messageItem('done') ] })
+      ];
+      const result = await apos.ai.generate(apos.task.getReq(), 'use the tool', {
+        tools: [ 'echo' ],
+        reasoning: 'high'
+      });
+      assert.equal(result.text, 'done');
+      assert.equal(result.finishReason, 'stop');
+      assert.deepEqual(result.steps, [ {
+        toolCall: {
+          type: 'toolCall',
+          id: 'call_1',
+          name: 'echo',
+          input: { value: 'pricing' }
+        },
+        result: { value: 'pricing' }
+      } ]);
+      assert.equal(httpCalls.length, 2);
+      // The first wire call asked for the replayable reasoning content
+      assert.deepEqual(
+        httpCalls[0].options.body.include,
+        [ 'reasoning.encrypted_content' ]
+      );
+      // The second replays the whole exchange: the reasoning item
+      // verbatim ahead of its function call, then the result
+      assert.deepEqual(httpCalls[1].options.body.input.slice(1), [
+        item,
+        {
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'echo',
+          arguments: JSON.stringify({ value: 'pricing' })
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_1',
+          output: JSON.stringify({ value: 'pricing' })
+        }
+      ]);
+    });
+
+    it('returns a validated object for a structured call over the wire', async function() {
+      const object = {
+        title: 'Pricing',
+        description: 'Our plans'
+      };
+      httpScript = [ () => fixture({
+        output: [ messageItem(JSON.stringify(object)) ]
+      }) ];
+      const result = await apos.ai.generate(apos.task.getReq(), {
+        messages: [ {
+          role: 'user',
+          content: 'write the metadata'
+        } ],
+        schema: {
+          type: 'object',
+          properties: {
+            title: {
+              type: 'string',
+              maxLength: 60
+            },
+            description: {
+              type: 'string',
+              maxLength: 160
+            }
+          },
+          required: [ 'title', 'description' ]
+        }
+      });
+      assert.deepEqual(result.object, object);
+      // The schema went out as the json_schema text format
+      const { body } = httpCalls[0].options;
+      assert.equal(body.text.format.type, 'json_schema');
+      assert.deepEqual(
+        body.text.format.schema.required,
+        [ 'title', 'description' ]
+      );
+    });
+
+    it('retries a 429 at the Retry-After delay', async function() {
+      httpScript = [
+        () => {
+          throw httpError(429, {
+            'retry-after': '2',
+            'x-request-id': 'req_9'
+          }, {
+            error: {
+              message: 'Rate limit reached',
+              type: 'tokens',
+              code: 'rate_limit_exceeded'
+            }
+          });
+        },
+        () => fixture()
+      ];
+      const result = await apos.ai.generate(apos.task.getReq(), 'p');
+      assert.equal(result.text, 'a haiku');
+      assert.equal(httpCalls.length, 2);
+      assert.deepEqual(waits, [ 2000 ]);
+      const [ record ] = logRecords;
+      assert.equal(record.type, 'retry');
+      assert.equal(record.message, 'Rate limit reached');
+      assert.equal(record.data.kind, 'rateLimit');
+      assert.equal(record.data.status, 429);
+      assert.equal(record.data.retryAfter, 2);
+      assert.equal(record.data.requestId, 'req_9');
+    });
+
+    it('surfaces a refusal part as the refusal error, without a retry', async function() {
+      httpScript = [ () => fixture({
+        output: [ {
+          type: 'message',
+          id: 'msg_1',
+          role: 'assistant',
+          status: 'completed',
+          content: [ {
+            type: 'refusal',
+            refusal: 'I cannot help with that.'
+          } ]
+        } ]
+      }) ];
+      await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
+        assert.equal(e.name, 'aiRefusal');
+        return true;
+      });
+      assert.equal(httpCalls.length, 1);
+    });
+  });
+
+  describe('live smoke', function() {
+    const liveKey = process.env.APOS_OPENAI_KEY;
+    let liveApos;
+
+    before(async function() {
+      if (!liveKey) {
+        this.skip();
+      }
+      await t.destroy(apos);
+      apos = null;
+      liveApos = await t.create({
+        root: module,
+        modules: {
+          '@apostrophecms/ai': {
+            options: {
+              providers: {
+                openai: { apiKey: liveKey }
+              }
+            }
+          }
+        }
+      });
+    });
+
+    after(async function() {
+      if (liveApos) {
+        return t.destroy(liveApos);
+      }
+    });
+
+    it('generates against OpenAI for real', async function() {
+      const result = await liveApos.ai.generate(
+        liveApos.task.getReq(),
+        'write a haiku about cats',
+        {
+          effort: 'low',
+          // Room for the model's reasoning tokens ahead of the text
+          maxTokens: 2000,
+          cache: false
+        }
+      );
+      assert(result.text.length > 0);
+      assert.equal(result.provider, 'openai');
+      assert.equal(result.finishReason, 'stop');
+      assert(Number.isFinite(result.usage.inputTokens));
+      assert(Number.isFinite(result.usage.outputTokens));
+    });
+  });
+});

--- a/packages/apostrophe/test/ai-adapter-openai.js
+++ b/packages/apostrophe/test/ai-adapter-openai.js
@@ -297,6 +297,22 @@ describe('AI adapter: openai', function() {
         } ]
       });
     });
+
+    it('sends a structured-output schema as a json_schema response format', function() {
+      const schema = {
+        type: 'object',
+        properties: { title: { type: 'string' } },
+        required: [ 'title' ]
+      };
+      const body = adapter.buildBody(request({ schema }));
+      assert.deepEqual(body.response_format, {
+        type: 'json_schema',
+        json_schema: {
+          name: 'response',
+          schema
+        }
+      });
+    });
   });
 
   describe('response parsing', function() {
@@ -378,6 +394,45 @@ describe('AI adapter: openai', function() {
           return true;
         }
       );
+    });
+
+    it('parses the structured answer onto the turn object', function() {
+      const object = {
+        title: 'Pricing',
+        description: 'Our plans'
+      };
+      const turn = adapter.parseResponse(
+        fixture({
+          choices: [ choice({ message: { content: JSON.stringify(object) } }) ]
+        }),
+        request({ schema: { type: 'object' } })
+      );
+      assert.deepEqual(turn.object, object);
+      // The JSON also stays on the content so the transcript round-trips
+      assert.deepEqual(turn.content, [ text(JSON.stringify(object)) ]);
+    });
+
+    it('treats malformed structured JSON as a retryable response', function() {
+      assert.throws(
+        () => adapter.parseResponse(
+          fixture({
+            choices: [ choice({ message: { content: 'not json' } }) ]
+          }),
+          request({ schema: { type: 'object' } })
+        ),
+        (e) => {
+          assert.equal(e.name, 'aiRetry');
+          assert.match(e.message, /malformed structured JSON/);
+          return true;
+        }
+      );
+    });
+
+    it('leaves the turn object unset without a schema request', function() {
+      const turn = adapter.parseResponse(fixture({
+        choices: [ choice({ message: { content: '{"a":1}' } }) ]
+      }));
+      assert.equal('object' in turn, false);
     });
   });
 
@@ -530,6 +585,44 @@ describe('AI adapter: openai', function() {
       assert.equal(call.url, 'https://llm-gateway.example.com/openai/v1/chat/completions');
       assert.equal(call.options.headers.authorization, 'Bearer sk-gw');
       assert.equal(call.options.body.max_completion_tokens, 128000);
+    });
+
+    it('returns a validated object for a structured call over the wire', async function() {
+      const object = {
+        title: 'Pricing',
+        description: 'Our plans'
+      };
+      httpScript = [ () => fixture({
+        choices: [ choice({ message: { content: JSON.stringify(object) } }) ]
+      }) ];
+      const result = await apos.ai.generate(apos.task.getReq(), {
+        messages: [ {
+          role: 'user',
+          content: 'write the metadata'
+        } ],
+        schema: {
+          type: 'object',
+          properties: {
+            title: {
+              type: 'string',
+              maxLength: 60
+            },
+            description: {
+              type: 'string',
+              maxLength: 160
+            }
+          },
+          required: [ 'title', 'description' ]
+        }
+      });
+      assert.deepEqual(result.object, object);
+      // The schema went out as the json_schema response format
+      const { body } = httpCalls[0].options;
+      assert.equal(body.response_format.type, 'json_schema');
+      assert.deepEqual(
+        body.response_format.json_schema.schema.required,
+        [ 'title', 'description' ]
+      );
     });
 
     it('retries a 429 at the Retry-After delay', async function() {

--- a/packages/apostrophe/test/ai-adapter-openai.js
+++ b/packages/apostrophe/test/ai-adapter-openai.js
@@ -191,6 +191,112 @@ describe('AI adapter: openai', function() {
         );
       }
     });
+
+    it('translates tool definitions to function tools', function() {
+      const input = {
+        type: 'object',
+        properties: { title: { type: 'string' } }
+      };
+      const body = adapter.buildBody(request({
+        tools: [ {
+          name: 'find_pages',
+          description: 'Find pages',
+          input
+        } ]
+      }));
+      assert.deepEqual(body.tools, [ {
+        type: 'function',
+        function: {
+          name: 'find_pages',
+          description: 'Find pages',
+          parameters: input
+        }
+      } ]);
+    });
+
+    it('carries an assistant tool call and fans a tool batch into one message per result', function() {
+      const body = adapter.buildBody(request({
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              text('searching'),
+              {
+                type: 'toolCall',
+                id: 'c1',
+                name: 'find_pages',
+                input: { title: 'Pricing' }
+              }
+            ]
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'toolResult',
+                toolCallId: 'c1',
+                output: { id: 'p1' }
+              },
+              {
+                type: 'toolResult',
+                toolCallId: 'c2',
+                error: 'not found'
+              }
+            ]
+          }
+        ]
+      }));
+      assert.deepEqual(body.messages, [
+        {
+          role: 'assistant',
+          content: 'searching',
+          tool_calls: [ {
+            id: 'c1',
+            type: 'function',
+            function: {
+              name: 'find_pages',
+              arguments: JSON.stringify({ title: 'Pricing' })
+            }
+          } ]
+        },
+        {
+          role: 'tool',
+          tool_call_id: 'c1',
+          content: JSON.stringify({ id: 'p1' })
+        },
+        {
+          role: 'tool',
+          tool_call_id: 'c2',
+          content: 'not found'
+        }
+      ]);
+    });
+
+    it('sends null content for an assistant turn that is only tool calls', function() {
+      const body = adapter.buildBody(request({
+        messages: [ {
+          role: 'assistant',
+          content: [ {
+            type: 'toolCall',
+            id: 'c1',
+            name: 'ping',
+            input: {}
+          } ]
+        } ]
+      }));
+      assert.deepEqual(body.messages[0], {
+        role: 'assistant',
+        content: null,
+        tool_calls: [ {
+          id: 'c1',
+          type: 'function',
+          function: {
+            name: 'ping',
+            arguments: '{}'
+          }
+        } ]
+      });
+    });
   });
 
   describe('response parsing', function() {

--- a/packages/apostrophe/test/ai-generate.js
+++ b/packages/apostrophe/test/ai-generate.js
@@ -169,18 +169,33 @@ describe('AI generate', function() {
   });
 
   describe('option validation', function() {
-    it('rejects the reserved options as not yet supported', function() {
-      throwsUnimplemented(
-        () => apos.ai.normalizeGenerateOptions('p', { tools: [] }),
-        /"tools" is not yet supported/
-      );
+    it('rejects the reserved schema option as not yet supported', function() {
       throwsUnimplemented(
         () => apos.ai.normalizeGenerateOptions('p', { schema: { type: 'object' } }),
         /"schema" is not yet supported/
       );
-      throwsUnimplemented(
-        () => apos.ai.normalizeGenerateOptions('p', { maxSteps: 3 }),
-        /"maxSteps" is not yet supported/
+    });
+
+    it('validates tools and maxSteps', function() {
+      const canonical = apos.ai.normalizeGenerateOptions('p');
+      assert.deepEqual(canonical.tools, []);
+      // The module option is the default cap
+      assert.equal(canonical.maxSteps, 5);
+      assert.equal(
+        apos.ai.normalizeGenerateOptions('p', { maxSteps: 8 }).maxSteps,
+        8
+      );
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions('p', { maxSteps: 0 }),
+        /"maxSteps" must be a positive integer/
+      );
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions('p', { tools: 'find_pages' }),
+        /"tools" must be an array of registered tool names/
+      );
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions('p', { tools: [ 'ghost' ] }),
+        /"tools" names unknown tool "ghost"/
       );
     });
 
@@ -284,25 +299,105 @@ describe('AI generate', function() {
       } ]);
     });
 
-    it('rejects tool messages and tool parts as not yet supported', function() {
-      throwsUnimplemented(
+    it('normalizes tool messages and tool parts', function() {
+      const messages = apos.ai.normalizeMessages([
+        {
+          role: 'assistant',
+          content: [ {
+            type: 'toolCall',
+            id: 'call_1',
+            name: 'find_pages',
+            input: { query: 'pricing' },
+            extra: 'dropped'
+          } ]
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'toolResult',
+              toolCallId: 'call_1',
+              output: { found: true }
+            },
+            {
+              type: 'toolResult',
+              toolCallId: 'call_2',
+              error: 'unknown tool "ghost"'
+            }
+          ]
+        }
+      ]);
+      assert.deepEqual(messages, [
+        {
+          role: 'assistant',
+          content: [ {
+            type: 'toolCall',
+            id: 'call_1',
+            name: 'find_pages',
+            input: { query: 'pricing' }
+          } ]
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'toolResult',
+              toolCallId: 'call_1',
+              output: { found: true }
+            },
+            {
+              type: 'toolResult',
+              toolCallId: 'call_2',
+              error: 'unknown tool "ghost"'
+            }
+          ]
+        }
+      ]);
+    });
+
+    it('rejects tool parts in the wrong role and malformed tool parts', function() {
+      throwsInvalid(
+        () => apos.ai.normalizeMessages([ {
+          role: 'user',
+          content: [ {
+            type: 'toolCall',
+            id: 'x',
+            name: 'y',
+            input: {}
+          } ]
+        } ]),
+        /a "toolCall" part is not valid in a "user" message/
+      );
+      throwsInvalid(
         () => apos.ai.normalizeMessages([ {
           role: 'tool',
           content: 'result'
         } ]),
-        /"tool" messages are not yet supported/
+        /a "text" part is not valid in a "tool" message/
       );
-      throwsUnimplemented(
+      throwsInvalid(
         () => apos.ai.normalizeMessages([ {
           role: 'assistant',
           content: [ {
             type: 'toolCall',
-            id: 'x',
-            name: 'find_pages',
+            id: '',
+            name: 'y',
             input: {}
           } ]
         } ]),
-        /"toolCall" parts are not yet supported/
+        /must be an object like \{ type, id, name, input \}/
+      );
+      throwsInvalid(
+        () => apos.ai.normalizeMessages([ {
+          role: 'tool',
+          content: [ {
+            type: 'toolResult',
+            toolCallId: 'x',
+            output: { a: 1 },
+            error: 'both'
+          } ]
+        } ]),
+        /must carry an object "output" or a string "error", not both/
       );
     });
 
@@ -320,7 +415,7 @@ describe('AI generate', function() {
           role: 'system',
           content: 'x'
         } ]),
-        /messages\[0\]\.role must be "user" or "assistant"/
+        /messages\[0\]\.role must be "user", "assistant" or "tool"/
       );
       throwsInvalid(
         () => apos.ai.normalizeMessages([ {
@@ -465,7 +560,11 @@ describe('AI generate', function() {
             init(self) {
               self.apos.ai.addAdapter(fakeAdapter('fake', {
                 async chat(req, request) {
-                  chatCalls.push(request);
+                  // Snapshot: the loop keeps growing request.messages
+                  chatCalls.push({
+                    ...request,
+                    messages: [ ...request.messages ]
+                  });
                   const step = chatScript.shift();
                   if (step === undefined) {
                     throw new Error('chat called beyond its script');
@@ -733,7 +832,15 @@ describe('AI generate', function() {
     });
 
     it('rejects unexpected tool calls from the adapter', async function() {
-      chatScript = [ () => turn({ finishReason: 'toolCalls' }) ];
+      chatScript = [ () => turn({
+        content: [ {
+          type: 'toolCall',
+          id: 'c1',
+          name: 'find_pages',
+          input: {}
+        } ],
+        finishReason: 'toolCalls'
+      }) ];
       await assert.rejects(apos.ai.generate(apos.task.getReq(), 'p'), (e) => {
         assert.equal(e.name, 'invalid');
         assert.match(e.message, /tool calls/);

--- a/packages/apostrophe/test/ai-generate.js
+++ b/packages/apostrophe/test/ai-generate.js
@@ -962,11 +962,15 @@ describe('AI generate', function() {
         schema,
         ...extras
       });
+      // The adapter extracts the structured answer onto the turn's
+      // `object` ([D35]); its JSON also stays in the content so the
+      // transcript round-trips
       const jsonTurn = (object) => turn({
         content: [ {
           type: 'text',
           text: JSON.stringify(object)
-        } ]
+        } ],
+        object
       });
 
       it('returns the validated object and sends the schema on the request', async function() {
@@ -977,7 +981,7 @@ describe('AI generate', function() {
         chatScript = [ () => jsonTurn(object) ];
         const result = await structuredCall();
         assert.deepEqual(result.object, object);
-        // The raw JSON stays on text; no tools means no steps/toolCalls
+        // The JSON stays on text; no tools means no steps/toolCalls
         assert.equal(result.text, JSON.stringify(object));
         assert.equal(result.finishReason, 'stop');
         assert.equal('steps' in result, false);
@@ -1007,14 +1011,14 @@ describe('AI generate', function() {
           description: 'good'
         };
         chatScript = [
-          // Not JSON at all
+          // A stop turn that produced no structured object
           () => turn({
             content: [ {
               type: 'text',
               text: 'here is your metadata'
             } ]
           }),
-          // JSON, but missing a required field
+          // An object missing a required field
           () => jsonTurn({ title: 'ok' }),
           () => jsonTurn(object)
         ];
@@ -1025,21 +1029,21 @@ describe('AI generate', function() {
         assert.equal(logRecords.filter((r) => r.type === 'retry').length, 2);
       });
 
-      it('gives up when the response never parses as JSON', async function() {
+      it('gives up when no structured object is ever returned', async function() {
         chatScript = Array.from({ length: 5 }, () => () => turn({
           content: [ {
             type: 'text',
-            text: 'not json'
+            text: 'not structured'
           } ]
         }));
         await assert.rejects(structuredCall(), (e) => {
           assert.equal(e.name, 'aiRetry');
-          assert.match(e.message, /not valid JSON/);
+          assert.match(e.message, /no structured output/);
           return true;
         });
       });
 
-      it('treats a schema-mismatching response as transient', async function() {
+      it('treats a schema-mismatching object as transient', async function() {
         chatScript = Array.from({ length: 5 }, () => () => jsonTurn({ title: 'only a title' }));
         await assert.rejects(structuredCall(), (e) => {
           assert.equal(e.name, 'aiRetry');

--- a/packages/apostrophe/test/ai-generate.js
+++ b/packages/apostrophe/test/ai-generate.js
@@ -61,6 +61,21 @@ describe('AI generate', function() {
             self.apos.ai.addAdapter(fakeAdapter('fake'));
           }
         },
+        'tool-fixtures': {
+          init(self) {
+            self.apos.ai.addTool({
+              name: 'echo',
+              description: 'Echo the text back',
+              access: 'read',
+              input: {
+                type: 'object',
+                properties: { text: { type: 'string' } }
+              },
+              schema: { text: { type: 'string' } },
+              handler: (req, args) => ({ text: args.text })
+            });
+          }
+        },
         '@apostrophecms/ai': {
           options: {
             providers: {
@@ -84,14 +99,6 @@ describe('AI generate', function() {
       return true;
     });
   };
-  const throwsUnimplemented = (fn, pattern) => {
-    assert.throws(fn, (e) => {
-      assert.equal(e.name, 'unimplemented');
-      assert.match(e.message, pattern);
-      return true;
-    });
-  };
-
   describe('argument sugar', function() {
     it('turns a string positional into the sole user message', function() {
       const canonical = apos.ai.normalizeGenerateOptions('write a haiku about cats');
@@ -169,11 +176,52 @@ describe('AI generate', function() {
   });
 
   describe('option validation', function() {
-    it('rejects the reserved schema option as not yet supported', function() {
-      throwsUnimplemented(
-        () => apos.ai.normalizeGenerateOptions('p', { schema: { type: 'object' } }),
-        /"schema" is not yet supported/
+    it('accepts a structured-output schema and compiles a backstop validator', function() {
+      const canonical = apos.ai.normalizeGenerateOptions('p', {
+        schema: {
+          type: 'object',
+          properties: { title: { type: 'string' } },
+          required: [ 'title' ]
+        }
+      });
+      assert.equal(canonical.schema.type, 'object');
+      assert.equal(typeof canonical.validateObject, 'function');
+      // The compiled backstop validates against that schema
+      assert.equal(canonical.validateObject({ title: 'ok' }), true);
+      assert.equal(canonical.validateObject({}), false);
+    });
+
+    it('rejects a schema without an object root', function() {
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions('p', { schema: { type: 'string' } }),
+        /"schema" must be a JSON Schema with an object root/
       );
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions('p', { schema: 'nope' }),
+        /"schema" must be a JSON Schema with an object root/
+      );
+    });
+
+    it('rejects a malformed JSON Schema', function() {
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions('p', {
+          schema: {
+            type: 'object',
+            properties: 'not an object'
+          }
+        }),
+        /"schema" is not a valid JSON Schema/
+      );
+    });
+
+    it('combines tools and schema', function() {
+      const canonical = apos.ai.normalizeGenerateOptions('p', {
+        tools: [ 'echo' ],
+        schema: { type: 'object' }
+      });
+      assert.equal(canonical.tools.length, 1);
+      assert.equal(canonical.tools[0].name, 'echo');
+      assert.equal(typeof canonical.validateObject, 'function');
     });
 
     it('validates tools and maxSteps', function() {
@@ -511,6 +559,16 @@ describe('AI generate', function() {
       assert.equal(request.signal, controller.signal);
     });
 
+    it('passes a structured-output schema through to the adapter request', function() {
+      const schema = {
+        type: 'object',
+        properties: { title: { type: 'string' } },
+        required: [ 'title' ]
+      };
+      const { request } = apos.ai.buildRequest(canonical('p', { schema }));
+      assert.deepEqual(request.schema, schema);
+    });
+
     it('throws the routing errors a real call would', function() {
       assert.throws(
         () => apos.ai.buildRequest(canonical('p', { effort: 'extreme' })),
@@ -616,6 +674,11 @@ describe('AI generate', function() {
                   adapter: 'fake',
                   apiKey: 'k2',
                   capabilities: { text: false }
+                },
+                nostructured: {
+                  adapter: 'fake',
+                  apiKey: 'k3',
+                  capabilities: { structured: false }
                 }
               },
               // Keep retried tests fast; the delay engine has its own suite
@@ -874,6 +937,150 @@ describe('AI generate', function() {
       );
       assert.equal(chatCalls.length, 0);
       assert.equal(events.length, 0);
+    });
+
+    describe('structured output', function() {
+      const schema = {
+        type: 'object',
+        properties: {
+          title: {
+            type: 'string',
+            maxLength: 60
+          },
+          description: {
+            type: 'string',
+            maxLength: 160
+          }
+        },
+        required: [ 'title', 'description' ]
+      };
+      const structuredCall = (extras) => apos.ai.generate(apos.task.getReq(), {
+        messages: [ {
+          role: 'user',
+          content: 'write the metadata'
+        } ],
+        schema,
+        ...extras
+      });
+      const jsonTurn = (object) => turn({
+        content: [ {
+          type: 'text',
+          text: JSON.stringify(object)
+        } ]
+      });
+
+      it('returns the validated object and sends the schema on the request', async function() {
+        const object = {
+          title: 'Pricing',
+          description: 'Our plans'
+        };
+        chatScript = [ () => jsonTurn(object) ];
+        const result = await structuredCall();
+        assert.deepEqual(result.object, object);
+        // The raw JSON stays on text; no tools means no steps/toolCalls
+        assert.equal(result.text, JSON.stringify(object));
+        assert.equal(result.finishReason, 'stop');
+        assert.equal('steps' in result, false);
+        assert.equal('toolCalls' in result, false);
+        // The adapter received the schema to constrain its provider
+        assert.deepEqual(chatCalls[0].schema, schema);
+      });
+
+      it('refuses a structured call to a provider without the capability', async function() {
+        await assert.rejects(
+          structuredCall({
+            provider: 'nostructured',
+            model: 'fake-medium'
+          }),
+          (e) => {
+            assert.equal(e.name, 'invalid');
+            assert.match(e.message, /does not declare the "structured" capability/);
+            return true;
+          }
+        );
+        assert.equal(chatCalls.length, 0);
+      });
+
+      it('retries a non-conforming response through the backstop, then succeeds', async function() {
+        const object = {
+          title: 'ok',
+          description: 'good'
+        };
+        chatScript = [
+          // Not JSON at all
+          () => turn({
+            content: [ {
+              type: 'text',
+              text: 'here is your metadata'
+            } ]
+          }),
+          // JSON, but missing a required field
+          () => jsonTurn({ title: 'ok' }),
+          () => jsonTurn(object)
+        ];
+        const result = await structuredCall();
+        assert.deepEqual(result.object, object);
+        assert.equal(chatCalls.length, 3);
+        // Each backstop failure travelled the normal retry path
+        assert.equal(logRecords.filter((r) => r.type === 'retry').length, 2);
+      });
+
+      it('gives up when the response never parses as JSON', async function() {
+        chatScript = Array.from({ length: 5 }, () => () => turn({
+          content: [ {
+            type: 'text',
+            text: 'not json'
+          } ]
+        }));
+        await assert.rejects(structuredCall(), (e) => {
+          assert.equal(e.name, 'aiRetry');
+          assert.match(e.message, /not valid JSON/);
+          return true;
+        });
+      });
+
+      it('treats a schema-mismatching response as transient', async function() {
+        chatScript = Array.from({ length: 5 }, () => () => jsonTurn({ title: 'only a title' }));
+        await assert.rejects(structuredCall(), (e) => {
+          assert.equal(e.name, 'aiRetry');
+          assert.match(e.message, /does not match the schema/);
+          return true;
+        });
+      });
+
+      it('surfaces a refusal rather than a backstop retry', async function() {
+        chatScript = [ () => turn({
+          finishReason: 'refusal',
+          content: [ {
+            type: 'text',
+            text: 'I cannot help with that'
+          } ]
+        }) ];
+        await assert.rejects(structuredCall(), (e) => {
+          assert.equal(e.name, 'aiRefusal');
+          return true;
+        });
+        // The non-JSON refusal was not retried as a malformed response
+        assert.equal(chatCalls.length, 1);
+      });
+
+      it('returns a length finish without an object and without retrying', async function() {
+        // Truncated output: re-asking cannot fix a too-small maxTokens,
+        // so the backstop must not treat it as malformed
+        chatScript = [ () => turn({
+          finishReason: 'length',
+          content: [ {
+            type: 'text',
+            text: '{"title": "Pric'
+          } ]
+        }) ];
+        const result = await structuredCall();
+        assert.equal(result.finishReason, 'length');
+        assert.equal('object' in result, false);
+        assert.equal(result.text, '{"title": "Pric');
+        assert.equal(chatCalls.length, 1);
+        assert.equal(logRecords.length, 0);
+      });
     });
 
     describe('retry policy', function() {
@@ -1310,6 +1517,41 @@ describe('AI generate', function() {
         );
         assert.equal(result.messages.length, 4);
         assert.equal(result.text, '[mock] Create one from the standard template.');
+      });
+
+      it('synthesizes a schema-conforming object for a structured call', async function() {
+        const result = await apos.ai.generate(apos.task.getReq(), {
+          messages: [ {
+            role: 'user',
+            content: 'write the metadata'
+          } ],
+          schema: {
+            type: 'object',
+            properties: {
+              title: { type: 'string' },
+              count: {
+                type: 'integer',
+                minimum: 3
+              },
+              tags: {
+                type: 'array',
+                items: { type: 'string' },
+                minItems: 1
+              },
+              kind: { enum: [ 'a', 'b' ] }
+            },
+            required: [ 'title', 'count', 'tags', 'kind' ]
+          }
+        });
+        // Deterministic: '' string, the minimum integer, one item at
+        // minItems, the first enum value — and it passed the backstop
+        assert.deepEqual(result.object, {
+          title: '',
+          count: 3,
+          tags: [ '' ],
+          kind: 'a'
+        });
+        assert.equal(result.provider, 'mock');
       });
     });
   });

--- a/packages/apostrophe/test/ai-providers.js
+++ b/packages/apostrophe/test/ai-providers.js
@@ -3,7 +3,7 @@ const t = require('../test-lib/test.js');
 const assert = require('assert/strict');
 
 // The provider ecosystem story, end to end: a free-named provider entry
-// over the openai adapter runs against any host speaking the Chat
+// over the openai-compatible adapter runs against any host speaking the Chat
 // Completions dialect — here a real local HTTP server standing in for
 // Groq, Ollama, vLLM or an internal gateway — with zero adapter code.
 // Unlike the adapter suites, nothing is stubbed: the request travels
@@ -77,7 +77,7 @@ describe('AI: named providers and baseUrl', function() {
               // The named-provider recipe: the entry describes the
               // actual service, the adapter supplies the dialect
               groq: {
-                adapter: 'openai',
+                adapter: 'openai-compatible',
                 baseUrl,
                 apiKey: 'gsk-test',
                 models: {
@@ -124,9 +124,9 @@ describe('AI: named providers and baseUrl', function() {
     hits.length = 0;
   });
 
-  it('activates the free-named entry over the openai adapter', function() {
+  it('activates the free-named entry over the openai-compatible adapter', function() {
     assert.equal(apos.ai.active, true);
-    assert.equal(apos.ai.providers.groq.adapterName, 'openai');
+    assert.equal(apos.ai.providers.groq.adapterName, 'openai-compatible');
     assert.equal(apos.ai.providers.groq.adapter.apiKey, 'gsk-test');
   });
 
@@ -219,7 +219,7 @@ describe('AI: named providers and baseUrl', function() {
             options: {
               providers: {
                 // Same service, different door: only the endpoint moves
-                openai: {
+                'openai-compatible': {
                   apiKey: 'sk-test',
                   baseUrl
                 }
@@ -232,7 +232,7 @@ describe('AI: named providers and baseUrl', function() {
 
     it('keeps the native defaults: effort table and model metadata', function() {
       const info = apos.ai.modelInfo();
-      assert.equal(info.provider, 'openai');
+      assert.equal(info.provider, 'openai-compatible');
       assert.equal(info.model, 'gpt-5.6-terra');
       assert.equal(info.contextWindow, 1050000);
       assert.equal(info.maxOutputTokens, 128000);
@@ -241,7 +241,7 @@ describe('AI: named providers and baseUrl', function() {
 
     it('sends the native-routed call through the gateway door', async function() {
       const result = await apos.ai.generate(apos.task.getReq(), 'p');
-      assert.equal(result.provider, 'openai');
+      assert.equal(result.provider, 'openai-compatible');
       assert.equal(result.model, 'gpt-5.6-terra');
       const [ hit ] = hits;
       assert.equal(hit.url, '/v1/chat/completions');

--- a/packages/apostrophe/test/ai-tools.js
+++ b/packages/apostrophe/test/ai-tools.js
@@ -1,0 +1,491 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert/strict');
+
+describe('AI tools', function() {
+  this.timeout(t.timeout);
+
+  let apos;
+  // Written by the recording fixture handlers
+  const seen = {};
+
+  before(async function() {
+    apos = await t.create({
+      root: module,
+      modules: {
+        'tool-handlers': {
+          init(self) {
+            self.apos.ai.addTool({
+              name: 'find_pages',
+              description: 'Search pages. Use when the user asks about existing content.',
+              tags: [ 'content', 'pages' ],
+              access: 'read',
+              input: {
+                type: 'object',
+                properties: {
+                  query: { type: 'string' },
+                  limit: { type: 'integer' }
+                },
+                required: [ 'query' ]
+              },
+              schema: {
+                found: { type: 'boolean' },
+                summary: { type: 'string' }
+              },
+              handler: 'tool-handlers:findPages'
+            });
+            self.apos.ai.addTool({
+              name: 'create_page',
+              label: 'Add a page',
+              description: 'Create a page.',
+              tags: [ 'content' ],
+              input: {
+                type: 'object',
+                properties: {
+                  title: { type: 'string' }
+                }
+              },
+              schema: {
+                ok: { type: 'boolean' }
+              },
+              handler: async () => ({ ok: true })
+            });
+            // Replaced by the tool-overrides module, which inits later
+            self.apos.ai.addTool({
+              name: 'send_email',
+              description: 'First registration, replaced.',
+              input: {
+                type: 'object',
+                properties: {}
+              },
+              schema: {
+                ok: { type: 'boolean' }
+              },
+              handler: async () => ({ ok: 'original' })
+            });
+            self.apos.ai.addTool({
+              name: 'normalizer',
+              description: 'Returns a result needing coercion.',
+              input: {
+                type: 'object',
+                properties: {}
+              },
+              schema: {
+                count: { type: 'integer' }
+              },
+              handler: async () => ({
+                count: '5',
+                leaked: 'never'
+              })
+            });
+            self.apos.ai.addTool({
+              name: 'tool_trouble',
+              description: 'Throws the recoverable code.',
+              input: {
+                type: 'object',
+                properties: {}
+              },
+              schema: {
+                ok: { type: 'boolean' }
+              },
+              handler: async () => {
+                throw self.apos.error('aiToolError', 'the search index is rebuilding');
+              }
+            });
+            self.apos.ai.addTool({
+              name: 'forbidden_tool',
+              description: 'Throws a standard code.',
+              input: {
+                type: 'object',
+                properties: {}
+              },
+              schema: {
+                ok: { type: 'boolean' }
+              },
+              handler: async () => {
+                throw self.apos.error('forbidden', 'not for you');
+              }
+            });
+            self.apos.ai.addTool({
+              name: 'no_object',
+              description: 'Returns a non-object result.',
+              input: {
+                type: 'object',
+                properties: {}
+              },
+              schema: {
+                ok: { type: 'boolean' }
+              },
+              handler: async () => 'not an object'
+            });
+            self.apos.ai.addTool({
+              name: 'wrong_shape',
+              description: 'Returns a result its schema rejects.',
+              input: {
+                type: 'object',
+                properties: {}
+              },
+              schema: {
+                count: {
+                  type: 'integer',
+                  required: true
+                }
+              },
+              handler: async () => ({ wrong: true })
+            });
+          },
+          methods(self) {
+            return {
+              async findPages(req, args) {
+                seen.req = req;
+                seen.args = args;
+                return {
+                  found: 'yes',
+                  summary: 'one match'
+                };
+              }
+            };
+          }
+        },
+        'tool-overrides': {
+          init(self) {
+            self.apos.ai.addTool({
+              name: 'send_email',
+              label: 'Send an email',
+              description: 'Send an email to an editor.',
+              input: {
+                type: 'object',
+                properties: {}
+              },
+              schema: {
+                ok: { type: 'string' }
+              },
+              handler: async () => ({ ok: 'replaced' })
+            });
+          }
+        }
+      }
+    });
+  });
+
+  after(async function() {
+    return t.destroy(apos);
+  });
+
+  describe('the registry', function() {
+    it('activates canonical definitions', function() {
+      const tool = apos.ai.getTool('find_pages');
+      assert.deepEqual(Object.keys(tool).sort(), [
+        'access', 'description', 'handler', 'input', 'label',
+        'name', 'schema', 'tags', 'validateArgs'
+      ]);
+      assert.equal(tool.label, 'Find Pages');
+      assert.deepEqual(tool.tags, [ 'content', 'pages' ]);
+      assert.equal(tool.access, 'read');
+      assert.equal(typeof tool.handler, 'function');
+      assert.equal(typeof tool.validateArgs, 'function');
+      assert.deepEqual(
+        tool.schema.map(field => [ field.name, field.type ]),
+        [ [ 'found', 'boolean' ], [ 'summary', 'string' ] ]
+      );
+    });
+
+    it('keeps an explicit label, defaults access to write and tags to none', function() {
+      const tool = apos.ai.getTool('create_page');
+      assert.equal(tool.label, 'Add a page');
+      assert.equal(tool.access, 'write');
+      const plain = apos.ai.getTool('no_object');
+      assert.deepEqual(plain.tags, []);
+    });
+
+    it('the last registration of a name wins', async function() {
+      const tool = apos.ai.getTool('send_email');
+      assert.equal(tool.label, 'Send an email');
+      const result = await tool.handler(apos.task.getReq(), {});
+      assert.deepEqual(result, { ok: 'replaced' });
+    });
+
+    it('queries by name and by tags', function() {
+      assert.equal(apos.ai.getTool('ghost'), undefined);
+      assert.equal(apos.ai.hasTool('find_pages'), true);
+      assert.equal(apos.ai.hasTool('ghost'), false);
+      // Prototype-chain names never resolve to anything
+      assert.equal(apos.ai.getTool('constructor'), undefined);
+      assert.equal(apos.ai.hasTool('toString'), false);
+      // The no-criteria list is cached — one array, no per-call
+      // allocation
+      assert.equal(apos.ai.getTools(), apos.ai.getTools());
+      // A tool matching several of the given tags appears once
+      assert.deepEqual(
+        apos.ai.getTools({ tags: [ 'content', 'pages' ] })
+          .map(tool => tool.name).sort(),
+        [ 'create_page', 'find_pages' ]
+      );
+      assert.deepEqual(
+        apos.ai.getTools().map(tool => tool.name).sort(),
+        [
+          'create_page', 'find_pages', 'forbidden_tool', 'no_object',
+          'normalizer', 'send_email', 'tool_trouble', 'wrong_shape'
+        ]
+      );
+      assert.deepEqual(
+        apos.ai.getTools({ tags: [ 'content' ] }).map(tool => tool.name).sort(),
+        [ 'create_page', 'find_pages' ]
+      );
+      assert.deepEqual(
+        apos.ai.getTools({ tags: [ 'pages', 'ghost' ] }).map(tool => tool.name),
+        [ 'find_pages' ]
+      );
+      // A single tag may be a plain string
+      assert.deepEqual(
+        apos.ai.getTools({ tags: 'pages' }).map(tool => tool.name),
+        [ 'find_pages' ]
+      );
+      assert.deepEqual(apos.ai.getTools({ tags: [] }), []);
+      assert.throws(() => apos.ai.getTools({ tags: 42 }), (e) => {
+        assert.equal(e.name, 'invalid');
+        assert.match(e.message, /"tags" must be an array/);
+        return true;
+      });
+    });
+
+    it('is frozen after startup', function() {
+      assert.throws(
+        () => apos.ai.addTool({ name: 'too_late' }),
+        /tools must be registered before "apostrophe:ready"/
+      );
+    });
+  });
+
+  describe('definition failures', function() {
+    // Registration happens in init; validation panics on ready, after
+    // every init has run, so the partially booted instance can be
+    // captured and destroyed
+    const failsToBoot = async (tool, pattern) => {
+      let captured;
+      try {
+        await assert.rejects(t.create({
+          root: module,
+          exit: 'throw',
+          modules: {
+            'bad-tools': {
+              init(self) {
+                captured = self.apos;
+                self.apos.ai.addTool(tool);
+              }
+            }
+          }
+        }), pattern);
+      } finally {
+        await t.destroy(captured);
+      }
+    };
+
+    const minimal = (extras = {}) => ({
+      name: 'minimal_tool',
+      description: 'A minimal valid tool.',
+      input: {
+        type: 'object',
+        properties: {}
+      },
+      schema: {
+        ok: { type: 'boolean' }
+      },
+      handler: async () => ({ ok: true }),
+      ...extras
+    });
+
+    it('panics on a missing or provider-unsafe name', async function() {
+      for (const name of [ undefined, 'bad name', 'x'.repeat(65) ]) {
+        await failsToBoot(minimal({ name }), /addTool requires a definition with a "name"/);
+      }
+    });
+
+    it('panics on a missing description or a bad label', async function() {
+      await failsToBoot(minimal({ description: '' }), /"description" must be a non-empty string/);
+      await failsToBoot(minimal({ label: 42 }), /"label" must be a non-empty string/);
+      await failsToBoot(minimal({ tags: [ '' ] }), /"tags" must be an array of tag strings/);
+    });
+
+    it('panics on a bad input schema', async function() {
+      await failsToBoot(minimal({ input: { type: 'array' } }), /"input" must be a JSON Schema with an object root/);
+      await failsToBoot(minimal({
+        input: {
+          type: 'object',
+          propreties: {}
+        }
+      }), /"input" is not a valid JSON Schema.*propreties/);
+    });
+
+    it('panics on a bad result schema', async function() {
+      await failsToBoot(minimal({ schema: undefined }), /"schema" must be an object of schema fields/);
+      await failsToBoot(minimal({
+        schema: {
+          found: { type: 'nonsense' }
+        }
+      }), /Unknown schema field type/);
+      await failsToBoot(minimal({
+        schema: {
+          docs: {
+            type: 'array',
+            fields: {
+              add: {
+                title: { type: 'nonsense' }
+              }
+            }
+          }
+        }
+      }), /Unknown schema field type/);
+    });
+
+    it('panics on a bad access value', async function() {
+      await failsToBoot(minimal({ access: 'delete' }), /"access" must be "read" or "write"/);
+    });
+
+    it('panics on an unresolvable handler', async function() {
+      await failsToBoot(minimal({ handler: 42 }), /"handler" must be a function or a "moduleName:methodName" string/);
+      await failsToBoot(minimal({ handler: 'findPages' }), /must name a module and a method/);
+      await failsToBoot(minimal({ handler: 'ghost-module:findPages' }), /handler names unknown module "ghost-module"/);
+      await failsToBoot(minimal({ handler: 'bad-tools:ghost' }), /handler names unknown method "ghost" of "bad-tools"/);
+      // References must not resolve through the prototype chain
+      await failsToBoot(minimal({ handler: 'constructor:assign' }), /handler names unknown module "constructor"/);
+      await failsToBoot(minimal({ handler: 'bad-tools:toString' }), /handler names unknown method "toString" of "bad-tools"/);
+    });
+  });
+
+  describe('executing a tool call', function() {
+    it('runs the handler with req and validated args, returns the converted result', async function() {
+      const req = apos.task.getReq();
+      const result = await apos.ai.executeToolCall(req, apos.ai.getTool('find_pages'), {
+        id: 'call_1',
+        name: 'find_pages',
+        input: {
+          query: 'pricing',
+          limit: 3
+        }
+      });
+      assert.equal(seen.req, req);
+      assert.deepEqual(seen.args, {
+        query: 'pricing',
+        limit: 3,
+        _context: {}
+      });
+      // Converted: laundered to the schema's types, every field present
+      assert.deepEqual(result, {
+        found: true,
+        summary: 'one match'
+      });
+    });
+
+    it('normalizes the result and drops what the schema does not declare', async function() {
+      const req = apos.task.getReq();
+      const result = await apos.ai.executeToolCall(req, apos.ai.getTool('normalizer'), {
+        id: 'call_1',
+        name: 'normalizer',
+        input: {}
+      });
+      assert.deepEqual(result, { count: 5 });
+    });
+
+    it('injects _context after validation, replacing any model-provided value', async function() {
+      const req = apos.task.getReq();
+      const call = {
+        id: 'call_1',
+        name: 'find_pages',
+        input: {
+          query: 'pricing',
+          _context: 'evil'
+        }
+      };
+      const context = { signal: 'the abort signal' };
+      await apos.ai.executeToolCall(req, apos.ai.getTool('find_pages'), call, context);
+      assert.deepEqual(seen.args._context, context);
+      // The transcript's own part is never mutated
+      assert.equal(call.input._context, 'evil');
+    });
+
+    it('rejects invalid arguments before the handler runs', async function() {
+      const req = apos.task.getReq();
+      seen.args = null;
+      await assert.rejects(
+        apos.ai.executeToolCall(req, apos.ai.getTool('find_pages'), {
+          id: 'call_1',
+          name: 'find_pages',
+          input: { limit: 'many' }
+        }),
+        (e) => {
+          assert.equal(e.name, 'aiToolError');
+          assert.match(e.message, /invalid arguments for tool "find_pages"/);
+          assert.match(e.message, /query/);
+          assert.match(e.message, /limit must be integer/);
+          return true;
+        }
+      );
+      assert.equal(seen.args, null);
+    });
+
+    it('passes a handler aiToolError through for the model', async function() {
+      const req = apos.task.getReq();
+      await assert.rejects(
+        apos.ai.executeToolCall(req, apos.ai.getTool('tool_trouble'), {
+          id: 'call_1',
+          name: 'tool_trouble',
+          input: {}
+        }),
+        (e) => {
+          assert.equal(e.name, 'aiToolError');
+          assert.equal(e.message, 'the search index is rebuilding');
+          return true;
+        }
+      );
+    });
+
+    it('passes a standard code through untouched', async function() {
+      const req = apos.task.getReq();
+      await assert.rejects(
+        apos.ai.executeToolCall(req, apos.ai.getTool('forbidden_tool'), {
+          id: 'call_1',
+          name: 'forbidden_tool',
+          input: {}
+        }),
+        (e) => {
+          assert.equal(e.name, 'forbidden');
+          assert.equal(e.message, 'not for you');
+          return true;
+        }
+      );
+    });
+
+    it('treats a non-object result as a handler bug', async function() {
+      const req = apos.task.getReq();
+      await assert.rejects(
+        apos.ai.executeToolCall(req, apos.ai.getTool('no_object'), {
+          id: 'call_1',
+          name: 'no_object',
+          input: {}
+        }),
+        (e) => {
+          assert.equal(e.name, 'invalid');
+          assert.match(e.message, /tool "no_object" must return an object/);
+          return true;
+        }
+      );
+    });
+
+    it('treats a result the schema rejects as a handler bug', async function() {
+      const req = apos.task.getReq();
+      await assert.rejects(
+        apos.ai.executeToolCall(req, apos.ai.getTool('wrong_shape'), {
+          id: 'call_1',
+          name: 'wrong_shape',
+          input: {}
+        }),
+        (e) => {
+          assert.equal(e.name, 'invalid');
+          assert.match(e.message, /tool "wrong_shape" returned a result that does not match its schema/);
+          assert.match(e.message, /count/);
+          return true;
+        }
+      );
+    });
+  });
+});

--- a/packages/apostrophe/test/ai-tools.js
+++ b/packages/apostrophe/test/ai-tools.js
@@ -338,7 +338,7 @@ describe('AI tools', function() {
     });
 
     it('panics on a bad access value', async function() {
-      await failsToBoot(minimal({ access: 'delete' }), /"access" must be "read" or "write"/);
+      await failsToBoot(minimal({ access: 'delete' }), /"access" must be "read", "write" or "agent"/);
     });
 
     it('panics on an unresolvable handler', async function() {
@@ -486,6 +486,686 @@ describe('AI tools', function() {
           return true;
         }
       );
+    });
+  });
+
+  describe('the agent loop', function() {
+    // Each test scripts the fake adapter's chat: an array of thunks,
+    // one consumed per call
+    let chatScript;
+    let chatCalls;
+    // Handler activity: 'start:<tool>' / 'end:<tool>' entries
+    const log = [];
+    // [ [ toolName, args._context.depth ] ]
+    const depths = [];
+    // Set by the scheduling test: reads block until all expected
+    // reads have started, proving they overlap
+    let readGate = null;
+    // [ [ 'before' | 'after', toolName, resultOrError ] ]
+    const toolEvents = [];
+
+    const toolCall = (id, name, input = {}) => ({
+      type: 'toolCall',
+      id,
+      name,
+      input
+    });
+    const toolTurn = (...calls) => () => ({
+      content: calls,
+      finishReason: 'toolCalls',
+      usage: {
+        inputTokens: 10,
+        outputTokens: 5
+      },
+      model: 'fake-medium'
+    });
+    const textTurn = (text = 'done') => () => ({
+      content: [ {
+        type: 'text',
+        text
+      } ],
+      finishReason: 'stop',
+      usage: {
+        inputTokens: 20,
+        outputTokens: 3
+      },
+      model: 'fake-medium'
+    });
+    const okSchema = { ok: { type: 'boolean' } };
+    const okInput = {
+      type: 'object',
+      properties: {}
+    };
+
+    const track = (name) => async () => {
+      log.push(`start:${name}`);
+      if (readGate && name.startsWith('read')) {
+        readGate.started++;
+        if (readGate.started === readGate.expected) {
+          readGate.release();
+        }
+        await readGate.opened;
+      }
+      log.push(`end:${name}`);
+      return { ok: true };
+    };
+
+    before(async function() {
+      await t.destroy(apos);
+      apos = await t.create({
+        root: module,
+        modules: {
+          'fake-adapters': {
+            init(self) {
+              self.apos.ai.addAdapter({
+                name: 'fake',
+                label: 'Fake',
+                capabilities: {
+                  text: true,
+                  tools: true
+                },
+                effort: {
+                  medium: { model: 'fake-medium' }
+                },
+                models: {
+                  'fake-medium': {
+                    contextWindow: 200000,
+                    maxOutputTokens: 16000
+                  }
+                },
+                validate() {},
+                async chat(req, request) {
+                  // Snapshot: the loop keeps growing request.messages
+                  chatCalls.push({
+                    ...request,
+                    messages: [ ...request.messages ]
+                  });
+                  const step = chatScript.shift();
+                  if (step === undefined) {
+                    throw new Error('chat called beyond its script');
+                  }
+                  return step();
+                },
+                normalizeError(err) {
+                  return err;
+                }
+              });
+            }
+          },
+          'loop-tools': {
+            init(self) {
+              const add = (tool) => self.apos.ai.addTool({
+                description: `The ${tool.name} tool.`,
+                input: okInput,
+                schema: okSchema,
+                ...tool
+              });
+              add({
+                name: 'read_a',
+                access: 'read',
+                handler: track('read_a')
+              });
+              add({
+                name: 'read_b',
+                access: 'read',
+                handler: track('read_b')
+              });
+              add({
+                name: 'write_a',
+                handler: track('write_a')
+              });
+              add({
+                name: 'write_b',
+                handler: track('write_b')
+              });
+              add({
+                name: 'agent_a',
+                access: 'agent',
+                handler: track('agent_a')
+              });
+              add({
+                name: 'echo',
+                input: {
+                  type: 'object',
+                  properties: {
+                    value: { type: 'string' }
+                  },
+                  required: [ 'value' ]
+                },
+                schema: {
+                  value: { type: 'string' }
+                },
+                handler: async (req, args) => {
+                  log.push('start:echo');
+                  depths.push([ 'echo', args._context.depth ]);
+                  return { value: args.value };
+                }
+              });
+              add({
+                name: 'sub_agent',
+                access: 'agent',
+                schema: {
+                  value: { type: 'string' }
+                },
+                handler: async (req, args) => {
+                  depths.push([ 'sub_agent', args._context.depth ]);
+                  const inner = await self.apos.ai.generate(req, 'inner question', {
+                    tools: [ 'echo' ]
+                  });
+                  return { value: inner.text };
+                }
+              });
+              add({
+                name: 'sub_sub',
+                access: 'agent',
+                schema: {
+                  value: { type: 'string' }
+                },
+                handler: async (req) => {
+                  const inner = await self.apos.ai.generate(req, 'nested', {
+                    tools: [ 'sub_agent', 'echo' ]
+                  });
+                  return { value: inner.text };
+                }
+              });
+              add({
+                name: 'spawner',
+                handler: async (req) => {
+                  await self.apos.ai.generate(req, 'too deep');
+                  return { ok: true };
+                }
+              });
+              add({
+                name: 'sub_deep',
+                access: 'agent',
+                handler: async (req) => {
+                  await self.apos.ai.generate(req, 'inner', {
+                    tools: [ 'spawner' ]
+                  });
+                  return { ok: true };
+                }
+              });
+              add({
+                name: 'boom_recover',
+                handler: async () => {
+                  throw self.apos.error('aiToolError', 'the search index is rebuilding');
+                }
+              });
+              add({
+                name: 'boom_forbidden',
+                handler: async () => {
+                  throw self.apos.error('forbidden', 'not for you');
+                }
+              });
+              add({
+                name: 'bad_shape',
+                schema: {
+                  count: {
+                    type: 'integer',
+                    required: true
+                  }
+                },
+                handler: async () => ({ wrong: true })
+              });
+            }
+          },
+          'ai-events': {
+            handlers(self) {
+              return {
+                '@apostrophecms/ai:beforeToolCall': {
+                  record(req, payload) {
+                    toolEvents.push([ 'before', payload.tool.name ]);
+                  }
+                },
+                '@apostrophecms/ai:afterToolCall': {
+                  record(req, payload) {
+                    toolEvents.push([ 'after', payload.tool.name, payload.result ?? payload.error ]);
+                  }
+                }
+              };
+            }
+          },
+          '@apostrophecms/ai': {
+            options: {
+              provider: 'fake',
+              providers: {
+                fake: { apiKey: 'k1' }
+              },
+              retryBaseDelay: 1
+            }
+          }
+        }
+      });
+    });
+
+    beforeEach(function() {
+      chatScript = [];
+      chatCalls = [];
+      log.length = 0;
+      depths.length = 0;
+      toolEvents.length = 0;
+      readGate = null;
+    });
+
+    it('runs the loop to completion with transcript, steps and aggregated usage', async function() {
+      const req = apos.task.getReq();
+      chatScript = [
+        toolTurn(toolCall('c1', 'echo', { value: 'pricing' })),
+        textTurn('all done')
+      ];
+      const result = await apos.ai.generate(req, 'find it', { tools: [ 'echo' ] });
+
+      assert.equal(result.text, 'all done');
+      assert.equal(result.finishReason, 'stop');
+      assert.equal(result.toolCalls, undefined);
+      assert.deepEqual(result.steps, [ {
+        toolCall: toolCall('c1', 'echo', { value: 'pricing' }),
+        result: { value: 'pricing' }
+      } ]);
+      assert.deepEqual(result.usage, {
+        inputTokens: 30,
+        outputTokens: 8
+      });
+      assert.deepEqual(result.messages.map(message => message.role),
+        [ 'user', 'assistant', 'tool', 'assistant' ]);
+      assert.deepEqual(result.messages[2].content, [ {
+        type: 'toolResult',
+        toolCallId: 'c1',
+        output: { value: 'pricing' }
+      } ]);
+      // The adapter sees only the model-facing face of a tool
+      assert.deepEqual(chatCalls[0].tools, [ {
+        name: 'echo',
+        description: 'The echo tool.',
+        input: apos.ai.getTool('echo').input
+      } ]);
+      // The second call carried the grown transcript
+      assert.equal(chatCalls[1].messages.length, 3);
+      assert.deepEqual(toolEvents, [
+        [ 'before', 'echo' ],
+        [ 'after', 'echo', { value: 'pricing' } ]
+      ]);
+    });
+
+    it('runs reads in parallel first, then writes serially in model order', async function() {
+      const req = apos.task.getReq();
+      let release;
+      const opened = new Promise((resolve) => {
+        release = resolve;
+      });
+      readGate = {
+        expected: 2,
+        started: 0,
+        release,
+        opened
+      };
+      chatScript = [
+        toolTurn(
+          toolCall('c1', 'read_a'),
+          toolCall('c2', 'write_a'),
+          toolCall('c3', 'agent_a'),
+          toolCall('c4', 'read_b'),
+          toolCall('c5', 'write_b')
+        ),
+        textTurn()
+      ];
+      const result = await apos.ai.generate(req, 'go', {
+        tools: [ 'read_a', 'read_b', 'write_a', 'write_b', 'agent_a' ]
+      });
+
+      // Both reads started before either finished; writes and agents
+      // followed, one at a time, in the order the model asked
+      assert.deepEqual(log.slice(0, 2).sort(), [ 'start:read_a', 'start:read_b' ]);
+      assert.deepEqual(log.slice(2, 4).sort(), [ 'end:read_a', 'end:read_b' ]);
+      assert.deepEqual(log.slice(4), [
+        'start:write_a', 'end:write_a', 'start:agent_a', 'end:agent_a',
+        'start:write_b', 'end:write_b'
+      ]);
+      // Steps stay in model order regardless of scheduling
+      assert.deepEqual(
+        result.steps.map(step => step.toolCall.name),
+        [ 'read_a', 'write_a', 'agent_a', 'read_b', 'write_b' ]
+      );
+    });
+
+    it('feeds recoverable failures back and leaves siblings unaffected', async function() {
+      const req = apos.task.getReq();
+      chatScript = [
+        toolTurn(
+          toolCall('c1', 'boom_recover'),
+          toolCall('c2', 'echo', { value: 'still runs' })
+        ),
+        textTurn()
+      ];
+      const result = await apos.ai.generate(req, 'go', {
+        tools: [ 'boom_recover', 'echo' ]
+      });
+
+      assert.deepEqual(result.steps, [
+        {
+          toolCall: toolCall('c1', 'boom_recover'),
+          error: 'the search index is rebuilding'
+        },
+        {
+          toolCall: toolCall('c2', 'echo', { value: 'still runs' }),
+          result: { value: 'still runs' }
+        }
+      ]);
+      // The model read the error back
+      assert.deepEqual(chatCalls[1].messages.at(-1).content[0], {
+        type: 'toolResult',
+        toolCallId: 'c1',
+        error: 'the search index is rebuilding'
+      });
+    });
+
+    it('feeds invalid arguments and unknown tools back without running anything', async function() {
+      const req = apos.task.getReq();
+      chatScript = [
+        toolTurn(
+          toolCall('c1', 'echo', { value: 42 }),
+          toolCall('c2', 'ghost')
+        ),
+        textTurn()
+      ];
+      const result = await apos.ai.generate(req, 'go', { tools: [ 'echo' ] });
+
+      assert.match(result.steps[0].error, /invalid arguments for tool "echo"/);
+      assert.match(result.steps[0].error, /value must be string/);
+      assert.equal(result.steps[1].error, 'unknown tool "ghost"');
+      // No handler ran
+      assert.deepEqual(log, []);
+    });
+
+    it('hard-stops on a standard code with nothing model-bound', async function() {
+      const req = apos.task.getReq();
+      chatScript = [
+        toolTurn(
+          toolCall('c1', 'boom_forbidden'),
+          toolCall('c2', 'echo', { value: 'never' })
+        )
+      ];
+      await assert.rejects(
+        apos.ai.generate(req, 'go', { tools: [ 'boom_forbidden', 'echo' ] }),
+        (e) => {
+          assert.equal(e.name, 'forbidden');
+          assert.equal(e.message, 'not for you');
+          return true;
+        }
+      );
+      // The batch aborted: the later write never ran, the model was
+      // never called again
+      assert.deepEqual(log, []);
+      assert.equal(chatCalls.length, 1);
+    });
+
+    it('hard-stops on a handler bug', async function() {
+      const req = apos.task.getReq();
+      chatScript = [
+        toolTurn(toolCall('c1', 'bad_shape'))
+      ];
+      await assert.rejects(
+        apos.ai.generate(req, 'go', { tools: [ 'bad_shape' ] }),
+        (e) => {
+          assert.equal(e.name, 'invalid');
+          assert.match(e.message, /does not match its schema/);
+          return true;
+        }
+      );
+      assert.equal(chatCalls.length, 1);
+    });
+
+    it('returns pending tool calls unexecuted when maxSteps is spent', async function() {
+      const req = apos.task.getReq();
+      chatScript = [
+        toolTurn(toolCall('c1', 'echo', { value: 'first' })),
+        toolTurn(toolCall('c2', 'echo', { value: 'second' }))
+      ];
+      const result = await apos.ai.generate(req, 'go', {
+        tools: [ 'echo' ],
+        maxSteps: 2
+      });
+
+      assert.equal(result.finishReason, 'maxSteps');
+      // The first round executed, the second is pending, untouched
+      assert.deepEqual(result.steps, [ {
+        toolCall: toolCall('c1', 'echo', { value: 'first' }),
+        result: { value: 'first' }
+      } ]);
+      assert.deepEqual(result.toolCalls, [
+        toolCall('c2', 'echo', { value: 'second' })
+      ]);
+      assert.deepEqual(log, [ 'start:echo' ]);
+      assert.equal(result.messages.at(-1).role, 'assistant');
+    });
+
+    it('maxSteps: 1 is manual mode', async function() {
+      const req = apos.task.getReq();
+      chatScript = [
+        toolTurn(toolCall('c1', 'echo', { value: 'manual' }))
+      ];
+      const result = await apos.ai.generate(req, 'go', {
+        tools: [ 'echo' ],
+        maxSteps: 1
+      });
+
+      assert.equal(result.finishReason, 'maxSteps');
+      assert.deepEqual(result.steps, []);
+      assert.deepEqual(result.toolCalls, [
+        toolCall('c1', 'echo', { value: 'manual' })
+      ]);
+      assert.deepEqual(log, []);
+    });
+
+    it('resumes from a returned transcript with hand-run tool results', async function() {
+      const req = apos.task.getReq();
+      chatScript = [
+        toolTurn(toolCall('c1', 'echo', { value: 'manual' }))
+      ];
+      const first = await apos.ai.generate(req, 'go', {
+        tools: [ 'echo' ],
+        maxSteps: 1
+      });
+
+      chatScript = [ textTurn('resumed') ];
+      const second = await apos.ai.generate(req, {
+        messages: [
+          ...first.messages,
+          {
+            role: 'tool',
+            content: [ {
+              type: 'toolResult',
+              toolCallId: 'c1',
+              output: { value: 'ran by hand' }
+            } ]
+          }
+        ],
+        tools: [ 'echo' ]
+      });
+
+      assert.equal(second.text, 'resumed');
+      // The adapter received the full round-tripped transcript
+      assert.deepEqual(
+        chatCalls.at(-1).messages.map(message => message.role),
+        [ 'user', 'assistant', 'tool' ]
+      );
+    });
+
+    it('an agent tool runs a subagent, one level deep', async function() {
+      const req = apos.task.getReq();
+      chatScript = [
+        // Outer turn: request the agent tool
+        toolTurn(toolCall('c1', 'sub_agent')),
+        // Inner conversation: request echo, then answer
+        toolTurn(toolCall('c2', 'echo', { value: 'from below' })),
+        textTurn('inner done'),
+        // Outer conversation resumes
+        textTurn('outer done')
+      ];
+      const result = await apos.ai.generate(req, 'go', { tools: [ 'sub_agent' ] });
+
+      assert.equal(result.text, 'outer done');
+      assert.deepEqual(result.steps, [ {
+        toolCall: toolCall('c1', 'sub_agent'),
+        result: { value: 'inner done' }
+      } ]);
+      // The handler ran at depth 1, the subagent's own handler at 2
+      assert.deepEqual(depths, [
+        [ 'sub_agent', 1 ],
+        [ 'echo', 2 ]
+      ]);
+      // Handlers run on stamped clones; the caller's req is untouched
+      assert.equal(req.aposAiDepth, undefined);
+    });
+
+    it('a subagent silently drops agent tools from its set', async function() {
+      const req = apos.task.getReq();
+      chatScript = [
+        toolTurn(toolCall('c1', 'sub_sub')),
+        // The nested conversation: only the non-agent tool survived
+        toolTurn(toolCall('c2', 'echo', { value: 'kept' })),
+        textTurn('inner done'),
+        textTurn('outer done')
+      ];
+      const result = await apos.ai.generate(req, 'go', { tools: [ 'sub_sub' ] });
+
+      assert.equal(result.text, 'outer done');
+      assert.deepEqual(result.steps[0].result, { value: 'inner done' });
+      // The nested request offered the model only the non-agent tool
+      assert.deepEqual(
+        chatCalls[1].tools.map(tool => tool.name),
+        [ 'echo' ]
+      );
+    });
+
+    it('limits generation to one level of nesting', async function() {
+      const req = apos.task.getReq();
+      chatScript = [
+        toolTurn(toolCall('c1', 'sub_deep')),
+        // The subagent's conversation requests a plain write tool,
+        // whose handler tries to generate again
+        toolTurn(toolCall('c2', 'spawner'))
+      ];
+      await assert.rejects(
+        apos.ai.generate(req, 'go', { tools: [ 'sub_deep' ] }),
+        (e) => {
+          assert.equal(e.name, 'invalid');
+          assert.match(e.message, /one level of nesting/);
+          return true;
+        }
+      );
+      assert.equal(chatCalls.length, 2);
+    });
+
+    it('rejects malformed tool turns into the retry path', function() {
+      const usage = {
+        inputTokens: 1,
+        outputTokens: 1
+      };
+      assert.throws(() => apos.ai.validateTurn({
+        content: [ {
+          type: 'text',
+          text: 'x'
+        } ],
+        finishReason: 'toolCalls',
+        usage
+      }), (e) => {
+        assert.equal(e.name, 'aiRetry');
+        assert.match(e.message, /"toolCalls" finish reason without toolCall parts/);
+        return true;
+      });
+      assert.throws(() => apos.ai.validateTurn({
+        content: [ {
+          type: 'toolCall',
+          name: 'echo',
+          input: {}
+        } ],
+        finishReason: 'toolCalls',
+        usage
+      }), (e) => {
+        assert.equal(e.name, 'aiRetry');
+        assert.match(e.message, /toolCall parts must carry/);
+        return true;
+      });
+    });
+  });
+
+  describe('the agent loop under APOS_AI_MOCK', function() {
+    const log = [];
+
+    before(async function() {
+      process.env.APOS_AI_MOCK = '1';
+      await t.destroy(apos);
+      apos = await t.create({
+        root: module,
+        modules: {
+          'loop-tools': {
+            init(self) {
+              self.apos.ai.addTool({
+                name: 'echo',
+                description: 'Echo a value.',
+                input: {
+                  type: 'object',
+                  properties: {
+                    value: { type: 'string' }
+                  },
+                  required: [ 'value' ]
+                },
+                schema: {
+                  value: { type: 'string' }
+                },
+                handler: async (req, args) => {
+                  log.push(args.value);
+                  return { value: args.value };
+                }
+              });
+            }
+          },
+          '@apostrophecms/ai': {
+            options: {
+              // A scripted model: request a tool once, then answer
+              mock(request) {
+                if (request.messages.at(-1).role !== 'tool') {
+                  return {
+                    content: [ {
+                      type: 'toolCall',
+                      id: 'c1',
+                      name: 'echo',
+                      input: { value: 'offline' }
+                    } ],
+                    finishReason: 'toolCalls',
+                    usage: {
+                      inputTokens: 1,
+                      outputTokens: 1
+                    }
+                  };
+                }
+                return { text: 'offline done' };
+              }
+            }
+          }
+        }
+      });
+    });
+
+    after(async function() {
+      delete process.env.APOS_AI_MOCK;
+    });
+
+    it('scripted mock tool calls run the real handlers offline', async function() {
+      const req = apos.task.getReq();
+      const result = await apos.ai.generate(req, 'go', { tools: [ 'echo' ] });
+      assert.equal(result.text, 'offline done');
+      assert.deepEqual(log, [ 'offline' ]);
+      assert.deepEqual(result.steps, [ {
+        toolCall: {
+          type: 'toolCall',
+          id: 'c1',
+          name: 'echo',
+          input: { value: 'offline' }
+        },
+        result: { value: 'offline' }
+      } ]);
     });
   });
 });

--- a/packages/apostrophe/test/ai-tools.js
+++ b/packages/apostrophe/test/ai-tools.js
@@ -793,9 +793,22 @@ describe('AI tools', function() {
       const object = { found: 'pricing' };
       chatScript = [
         // The tool turn is not the answer and must never reach the
-        // backstop — it has no JSON to offer
+        // backstop — it has no object to offer
         toolTurn(toolCall('c1', 'echo', { value: 'pricing' })),
-        textTurn(JSON.stringify(object))
+        // The final answer: the adapter placed the object on the turn
+        () => ({
+          content: [ {
+            type: 'text',
+            text: JSON.stringify(object)
+          } ],
+          object,
+          finishReason: 'stop',
+          usage: {
+            inputTokens: 20,
+            outputTokens: 3
+          },
+          model: 'fake-medium'
+        })
       ];
       const result = await apos.ai.generate(req, 'find it', {
         tools: [ 'echo' ],

--- a/packages/apostrophe/test/ai-tools.js
+++ b/packages/apostrophe/test/ai-tools.js
@@ -562,7 +562,8 @@ describe('AI tools', function() {
                 label: 'Fake',
                 capabilities: {
                   text: true,
-                  tools: true
+                  tools: true,
+                  structured: true
                 },
                 effort: {
                   medium: { model: 'fake-medium' }
@@ -785,6 +786,34 @@ describe('AI tools', function() {
         [ 'before', 'echo' ],
         [ 'after', 'echo', { value: 'pricing' } ]
       ]);
+    });
+
+    it('combines tools and schema: the loop runs free, the final answer validates', async function() {
+      const req = apos.task.getReq();
+      const object = { found: 'pricing' };
+      chatScript = [
+        // The tool turn is not the answer and must never reach the
+        // backstop — it has no JSON to offer
+        toolTurn(toolCall('c1', 'echo', { value: 'pricing' })),
+        textTurn(JSON.stringify(object))
+      ];
+      const result = await apos.ai.generate(req, 'find it', {
+        tools: [ 'echo' ],
+        schema: {
+          type: 'object',
+          properties: {
+            found: { type: 'string' }
+          },
+          required: [ 'found' ]
+        }
+      });
+
+      assert.deepEqual(result.object, object);
+      assert.equal(result.finishReason, 'stop');
+      assert.equal(result.steps.length, 1);
+      // The adapter request carried both faces
+      assert.equal(chatCalls[0].tools.length, 1);
+      assert.equal(chatCalls[0].schema.type, 'object');
     });
 
     it('runs reads in parallel first, then writes serially in model order', async function() {

--- a/packages/apostrophe/test/ai.js
+++ b/packages/apostrophe/test/ai.js
@@ -782,6 +782,49 @@ describe('AI engine', function() {
     });
   });
 
+  describe('the permission seam', function() {
+    it('answers exactly as apos.permission.can does', function() {
+      const admin = apos.task.getReq();
+      const anon = apos.task.getAnonReq();
+      for (const [ req, action, docOrType ] of [
+        [ admin, 'edit', '@apostrophecms/any-page-type' ],
+        [ anon, 'edit', '@apostrophecms/any-page-type' ],
+        [ anon, 'view', '@apostrophecms/any-page-type' ]
+      ]) {
+        assert.equal(
+          apos.ai.can(req, action, docOrType),
+          apos.permission.can(req, action, docOrType)
+        );
+      }
+      // Sanity that the tuples above exercise both outcomes
+      assert.equal(apos.ai.can(admin, 'edit', '@apostrophecms/any-page-type'), true);
+      assert.equal(apos.ai.can(anon, 'edit', '@apostrophecms/any-page-type'), false);
+    });
+
+    it('proxies every argument and the return value verbatim', function() {
+      const original = apos.permission.can;
+      const calls = [];
+      const sentinel = Symbol('answer');
+      try {
+        apos.permission.can = (...args) => {
+          calls.push(args);
+          return sentinel;
+        };
+        const req = apos.task.getReq();
+        const doc = { _id: 'd1' };
+        assert.equal(apos.ai.can(req, 'edit', doc, 'draft'), sentinel);
+        assert.equal(calls.length, 1);
+        assert.equal(calls[0].length, 4);
+        assert.equal(calls[0][0], req);
+        assert.equal(calls[0][1], 'edit');
+        assert.equal(calls[0][2], doc);
+        assert.equal(calls[0][3], 'draft');
+      } finally {
+        apos.permission.can = original;
+      }
+    });
+  });
+
   it('fails fast at startup on a malformed configuration', function(done) {
     const child = spawn('node', [ './test/ai-children/ai-malformed-child.js' ]);
     let stderr = '';


### PR DESCRIPTION
`generate` accepts `tools` and runs a core-owned
agent loop (tool-call → execute → continue), and accepts `schema` for
structured output.