### PR TITLE
Image generation

### DIFF
--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-anthropic/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-anthropic/index.js
@@ -7,6 +7,15 @@
 // The transport is `apos.http`, no SDK. Projects can adjust the dialect
 // by extending this module and overriding its methods.
 
+// Anthropic has no response-schema mode, so structured output is
+// delivered through tool use: a synthetic tool whose input schema is
+// the request's `schema`. The model calls it to answer; parseResponse
+// turns that call back into a plain structured answer. Its name leads
+// with an underscore, which the engine's tool-name rule forbids, so
+// it can never collide with a real tool.
+const FINAL_ANSWER = '_final_answer';
+const FINAL_ANSWER_DESCRIPTION = 'Provide your final answer by calling this tool with the required fields. This is the only way to return your response.';
+
 module.exports = {
   options: {
     // The anthropic-version request header
@@ -26,14 +35,6 @@ module.exports = {
     self.apos.ai.addAdapter(self.adapter());
   },
   methods(self) {
-    // Anthropic has no response-schema mode, so structured output is
-    // delivered through tool use: a synthetic tool whose input schema is
-    // the request's `schema`. The model calls it to answer; parseResponse
-    // turns that call back into a plain structured answer. Its name leads
-    // with an underscore, which the engine's tool-name rule forbids, so
-    // it can never collide with a real tool.
-    const FINAL_ANSWER = '_final_answer';
-    const FINAL_ANSWER_DESCRIPTION = 'Provide your final answer by calling this tool with the required fields. This is the only way to return your response.';
     return {
       // The adapter definition registered with `apos.ai`. The engine
       // instantiates it per configured provider entry, assigning

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-google/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-google/index.js
@@ -2,7 +2,10 @@
 // itself with the AI engine at startup; configure the provider with
 // just a key under the engine's `providers.google` entry to use it.
 // All knowledge of the Gemini generateContent dialect — request
-// translation, response parsing, error mapping — lives here.
+// translation, response parsing, error mapping — lives here. Image
+// generation and editing ride the same surface: an image-capable
+// Gemini model returns inline image parts, so one dialect covers
+// text and images.
 //
 // Url-form image parts translate to the dialect's `fileData.fileUri`,
 // which the service accepts for its own Files API URIs, not for
@@ -11,6 +14,40 @@
 //
 // The transport is `apos.http`, no SDK. Projects can adjust the dialect
 // by extending this module and overriding its methods.
+
+// Gemini forbids a response schema alongside function calling, so
+// structured output is delivered through a synthetic tool whose
+// parameters are the request's `schema`. The model calls it to
+// answer; parseResponse turns that call back into a plain structured
+// answer. Its name leads with an underscore, which the engine's
+// tool-name rule forbids, so it can never collide with a real tool.
+const FINAL_ANSWER = '_final_answer';
+const FINAL_ANSWER_DESCRIPTION = 'Provide your final answer by calling this function with the required fields. This is the only way to return your response.';
+// The dialect's finish reasons → the normalized vocabulary; the
+// whole safety family maps to refusal, which always arrives as an
+// error
+const FINISH_REASONS = {
+  STOP: 'stop',
+  MAX_TOKENS: 'length',
+  SAFETY: 'refusal',
+  RECITATION: 'refusal',
+  PROHIBITED_CONTENT: 'refusal',
+  BLOCKLIST: 'refusal',
+  SPII: 'refusal',
+  IMAGE_SAFETY: 'refusal'
+};
+// The ratio set every current image model takes — what the core's
+// nearest-match resolves against
+const ASPECTS = [
+  '1:1', '3:2', '2:3', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9'
+];
+// The normalized quality tiers → the dialect's output resolution
+// (the uppercase K is required)
+const IMAGE_SIZES = {
+  low: '1K',
+  medium: '1K',
+  high: '2K'
+};
 
 module.exports = {
   options: {
@@ -22,14 +59,7 @@ module.exports = {
     self.apos.ai.addAdapter(self.adapter());
   },
   methods(self) {
-    // Gemini forbids a response schema alongside function calling, so
-    // structured output is delivered through a synthetic tool whose
-    // parameters are the request's `schema`. The model calls it to
-    // answer; parseResponse turns that call back into a plain structured
-    // answer. Its name leads with an underscore, which the engine's
-    // tool-name rule forbids, so it can never collide with a real tool.
-    const FINAL_ANSWER = '_final_answer';
-    const FINAL_ANSWER_DESCRIPTION = 'Provide your final answer by calling this function with the required fields. This is the only way to return your response.';
+
     return {
       // The adapter definition registered with `apos.ai`. The engine
       // instantiates it per configured provider entry, assigning
@@ -67,6 +97,15 @@ module.exports = {
             'gemini-3.5-flash': {
               contextWindow: 1048576,
               maxOutputTokens: 65536
+            },
+            'gemini-3.1-flash-image': {
+              aspects: ASPECTS
+            },
+            'gemini-3-pro-image': {
+              aspects: ASPECTS
+            },
+            'gemini-3.1-flash-lite-image': {
+              aspects: ASPECTS
             }
           },
           validate() {
@@ -87,6 +126,51 @@ module.exports = {
               }
             );
             return self.parseResponse(response, request);
+          },
+          // text → image and image(s) + text → image, on the same
+          // generateContent surface; the core resolved `aspect` to a
+          // declared ratio the dialect takes verbatim. The dialect
+          // returns one image per call — no count knob — so `count`
+          // fans out as that many concurrent requests. A partial
+          // failure does not scrap the survivors: what generated is
+          // delivered (possibly fewer than `count`) and each lost
+          // request is logged; only losing every request throws.
+          async image(req, request) {
+            const body = await self.buildImageBody(request, this.baseUrl);
+            const settled = await Promise.allSettled(
+              Array.from({ length: request.count }, () => self.apos.http.post(
+                `${this.baseUrl}/v1beta/models/${request.model}:generateContent`,
+                {
+                  headers: {
+                    'x-goog-api-key': this.apiKey
+                  },
+                  body,
+                  timeout: self.options.timeout,
+                  ...(request.signal && { signal: request.signal })
+                }
+              ))
+            );
+            const responses = settled
+              .filter((outcome) => outcome.status === 'fulfilled')
+              .map((outcome) => outcome.value);
+            if (!responses.length) {
+              throw settled[0].reason;
+            }
+            for (const outcome of settled) {
+              if (outcome.status === 'rejected') {
+                const error = self.normalizeError(outcome.reason);
+                self.apos.ai.logError(req, 'imagePartial', error.message, {
+                  provider: this.provider,
+                  model: request.model,
+                  code: error.name,
+                  status: error.data?.status,
+                  kind: error.data?.kind,
+                  requested: request.count,
+                  delivered: responses.length
+                });
+              }
+            }
+            return self.parseImageResponses(responses);
           },
           normalizeError(error) {
             return self.normalizeError(error);
@@ -257,13 +341,7 @@ module.exports = {
           .filter((part) => !part.thought)
           .map(fromPart)
           .filter(Boolean);
-        const usage = response.usageMetadata;
-        const usageTokens = {
-          inputTokens: usage?.promptTokenCount,
-          outputTokens: usage?.candidatesTokenCount === undefined
-            ? undefined
-            : usage.candidatesTokenCount + (usage.thoughtsTokenCount || 0)
-        };
+        const usageTokens = self.normalizeUsage(response);
         if (request.schema) {
           const answer = content.find(
             (part) => part.type === 'toolCall' && part.name === FINAL_ANSWER
@@ -285,16 +363,7 @@ module.exports = {
           content,
           finishReason: content.some((part) => part.type === 'toolCall')
             ? 'toolCalls'
-            : {
-              STOP: 'stop',
-              MAX_TOKENS: 'length',
-              SAFETY: 'refusal',
-              RECITATION: 'refusal',
-              PROHIBITED_CONTENT: 'refusal',
-              BLOCKLIST: 'refusal',
-              SPII: 'refusal',
-              IMAGE_SAFETY: 'refusal'
-            }[candidate?.finishReason],
+            : FINISH_REASONS[candidate?.finishReason],
           usage: usageTokens,
           model: response.modelVersion
         };
@@ -324,6 +393,138 @@ module.exports = {
           }
           return null;
         }
+      },
+      // Translate a normalized image request { prompt, aspect,
+      // quality, images? } to a generateContent body: one user turn,
+      // the prompt first and any edit sources after it. The dials ride
+      // `generationConfig.imageConfig` — the resolved aspect verbatim
+      // as `aspectRatio`, quality as the `imageSize` resolution — each
+      // omitted when unset, so the provider default applies. An
+      // image-capable model wants TEXT beside IMAGE in
+      // `responseModalities`.
+      async buildImageBody(request, baseUrl) {
+        const imageConfig = {
+          ...(request.aspect !== undefined && { aspectRatio: request.aspect }),
+          ...(request.quality !== undefined && {
+            imageSize: IMAGE_SIZES[request.quality]
+          })
+        };
+        const sources = request.images
+          ? await self.resolveImageSources(request.images, baseUrl, request.signal)
+          : [];
+        return {
+          contents: [ {
+            role: 'user',
+            parts: [
+              { text: request.prompt },
+              ...sources
+            ]
+          } ],
+          generationConfig: {
+            responseModalities: [ 'TEXT', 'IMAGE' ],
+            ...(Object.keys(imageConfig).length && { imageConfig })
+          }
+        };
+      },
+      // The normalized source refs → the parts an edit sends. Inline
+      // data travels as `inlineData`; a url on the service's own
+      // endpoint (a Files API upload) passes through as `fileData`;
+      // any other url is fetched and inlined, since the service does
+      // not load arbitrary web URLs (built-in fetch — apos.http reads
+      // text only). A source that will not load is a caller error, not
+      // a provider one — a hard stop, no retry.
+      resolveImageSources(images, baseUrl, signal) {
+        return Promise.all(images.map(async (source) => {
+          if (source.data !== undefined) {
+            return {
+              inlineData: {
+                mimeType: source.mediaType,
+                data: source.data
+              }
+            };
+          }
+          if (source.url.startsWith(baseUrl)) {
+            return {
+              fileData: { fileUri: source.url }
+            };
+          }
+          const response = await fetch(source.url, {
+            ...(signal && { signal })
+          });
+          if (!response.ok) {
+            throw self.apos.error('invalid', `could not fetch image source "${source.url}": HTTP ${response.status}`);
+          }
+          return {
+            inlineData: {
+              mimeType: response.headers.get('content-type') || 'application/octet-stream',
+              data: Buffer.from(await response.arrayBuffer()).toString('base64')
+            }
+          };
+        }));
+      },
+      // Translate the fanned-out generateContent responses to the
+      // normalized image result { images, model, usage }: the inline
+      // image parts across all responses and candidates, each typed by
+      // its mime subtype; commentary text parts are not images and do
+      // not travel. Refusals — a blocked prompt, a safety-family
+      // finish — throw only when NOTHING was produced: anything that
+      // survived is delivered. Token usage sums across the requests.
+      // No pixel `size`: this dialect works in ratios, which the core
+      // echoes as `aspect`.
+      parseImageResponses(responses) {
+        const candidates = responses.flatMap(
+          (response) => response.candidates || []
+        );
+        const images = candidates.flatMap((candidate) =>
+          (candidate.content?.parts || [])
+            .filter((part) => part.inlineData)
+            .map((part) => ({
+              type: (part.inlineData.mimeType || 'image/png').replace('image/', ''),
+              data: part.inlineData.data
+            }))
+        );
+        if (!images.length) {
+          const blocked = responses.find(
+            (response) => response.promptFeedback?.blockReason
+          );
+          if (blocked) {
+            throw self.apos.error('aiRefusal', `the model blocked this request: ${blocked.promptFeedback.blockReason}`);
+          }
+          const refusal = candidates.find(
+            (candidate) => FINISH_REASONS[candidate.finishReason] === 'refusal'
+          );
+          if (refusal) {
+            throw self.apos.error('aiRefusal', `the model blocked this request: ${refusal.finishReason}`);
+          }
+        }
+        const usages = responses.map((response) => self.normalizeUsage(response));
+        return {
+          images,
+          model: responses[0]?.modelVersion,
+          usage: {
+            inputTokens: total(usages.map((usage) => usage.inputTokens)),
+            outputTokens: total(usages.map((usage) => usage.outputTokens))
+          }
+        };
+
+        function total(values) {
+          const defined = values.filter((value) => value !== undefined);
+          return defined.length
+            ? defined.reduce((sum, value) => sum + value, 0)
+            : undefined;
+        }
+      },
+      // The response's usageMetadata → normalized token counts;
+      // thinking tokens are billed as output, so they add into
+      // outputTokens
+      normalizeUsage(response) {
+        const usage = response.usageMetadata;
+        return {
+          inputTokens: usage?.promptTokenCount,
+          outputTokens: usage?.candidatesTokenCount === undefined
+            ? undefined
+            : usage.candidatesTokenCount + (usage.thoughtsTokenCount || 0)
+        };
       },
       // Map any error the transport produced to a normalized apos
       // error, the only shape the engine reacts to. Transient failures

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-google/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-google/index.js
@@ -53,7 +53,11 @@ module.exports = {
   options: {
     // Per-request timeout in milliseconds; a timed-out call is a
     // transient failure the engine retries
-    timeout: 600000
+    timeout: 600000,
+    // Milliseconds between the starts of the fanned-out image
+    // requests a count > 1 spawns, jittered per request, so a burst
+    // does not trip the provider's rate limit
+    imageStagger: 500
   },
   init(self) {
     self.apos.ai.addAdapter(self.adapter());
@@ -131,24 +135,33 @@ module.exports = {
           // generateContent surface; the core resolved `aspect` to a
           // declared ratio the dialect takes verbatim. The dialect
           // returns one image per call — no count knob — so `count`
-          // fans out as that many concurrent requests. A partial
-          // failure does not scrap the survivors: what generated is
-          // delivered (possibly fewer than `count`) and each lost
-          // request is logged; only losing every request throws.
+          // fans out as that many concurrent requests, their starts
+          // staggered with jitter (imageStagger) so the burst does
+          // not trip the rate limit. A partial failure does not scrap
+          // the survivors: what generated is delivered (possibly
+          // fewer than `count`) and each lost request is logged; only
+          // losing every request throws.
           async image(req, request) {
             const body = await self.buildImageBody(request, this.baseUrl);
             const settled = await Promise.allSettled(
-              Array.from({ length: request.count }, () => self.apos.http.post(
-                `${this.baseUrl}/v1beta/models/${request.model}:generateContent`,
-                {
-                  headers: {
-                    'x-goog-api-key': this.apiKey
-                  },
-                  body,
-                  timeout: self.options.timeout,
-                  ...(request.signal && { signal: request.signal })
+              Array.from({ length: request.count }, async (item, index) => {
+                if (index) {
+                  await self.apos.ai.pause(
+                    (index + Math.random()) * self.options.imageStagger
+                  );
                 }
-              ))
+                return self.apos.http.post(
+                  `${this.baseUrl}/v1beta/models/${request.model}:generateContent`,
+                  {
+                    headers: {
+                      'x-goog-api-key': this.apiKey
+                    },
+                    body,
+                    timeout: self.options.timeout,
+                    ...(request.signal && { signal: request.signal })
+                  }
+                );
+              })
             );
             const responses = settled
               .filter((outcome) => outcome.status === 'fulfilled')

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai-compatible/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai-compatible/index.js
@@ -249,7 +249,7 @@ module.exports = {
       // empty turn. Tool calls carry their arguments as a JSON string,
       // parsed into the normalized input object. When the request asked
       // for structured output, the final answer's text is the JSON
-      // object: it is parsed onto the turn's `object` ([D35]), which the
+      // object: it is parsed onto the turn's `object`, which the
       // engine backstop-validates; malformed JSON is a retryable
       // response. An unknown finish reason maps to no finishReason — the
       // engine's turn validation treats that as a malformed (retryable)

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai-compatible/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai-compatible/index.js
@@ -13,8 +13,14 @@
 // the combination in this dialect). Aliased entries describe other
 // services, which accept it, and pass through untouched.
 //
+// Image generation uses the OpenAI Images API — a REST surface separate
+// from Chat Completions, shared with the openai adapter (its lib/image.js)
+// since it does not depend on the chat dialect.
+//
 // The transport is `apos.http`, no SDK. Projects can adjust the dialect
 // by extending this module and overriding its methods.
+
+const image = require('../ai-adapter-openai/lib/image');
 
 module.exports = {
   options: {
@@ -70,7 +76,8 @@ module.exports = {
             'gpt-5.6-sol': {
               contextWindow: 1050000,
               maxOutputTokens: 128000
-            }
+            },
+            ...image.models
           },
           validate() {
             if (!this.apiKey) {
@@ -90,6 +97,19 @@ module.exports = {
               ...(request.signal && { signal: request.signal })
             });
             return self.parseResponse(response, request);
+          },
+          // Image generation is the Images API, a REST surface
+          // independent of the Chat Completions dialect, so it is the
+          // same call the openai adapter makes. The default target is
+          // OpenAI proper, which serves it; an aliased host that cannot
+          // declares `capabilities.image: false`.
+          async image(req, request) {
+            return image({
+              apos: self.apos,
+              apiKey: this.apiKey,
+              baseUrl: this.baseUrl,
+              timeout: self.options.timeout
+            }, request);
           },
           normalizeError(error) {
             return self.normalizeError(error);

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai/index.js
@@ -4,16 +4,20 @@
 // of the OpenAI dialect — request translation, response parsing, error
 // mapping — lives here.
 //
-// The adapter speaks the Responses API, OpenAI's first-class surface,
-// where function tools and reasoning work together. Requests are
-// stateless (`store: false`): the engine drives its own loop and owns
-// the transcript, so no server-side conversation state is created. For
+// Chat uses the Responses API, OpenAI's first-class surface, where
+// function tools and reasoning work together; requests are stateless
+// (`store: false`) since the engine drives its own loop and owns the
+// transcript. Image generation uses the Images API, a separate REST
+// surface under the same endpoint — shared with the openai-compatible
+// adapter (lib/image.js), as it does not depend on the chat dialect. For
 // the OpenAI-compatible ecosystem (Groq, Mistral, Ollama, vLLM, …) use
 // the `openai-compatible` adapter, which speaks the Chat Completions
 // dialect those hosts implement.
 //
 // The transport is `apos.http`, no SDK. Projects can adjust the dialect
 // by extending this module and overriding its methods.
+
+const image = require('./lib/image');
 
 module.exports = {
   options: {
@@ -66,7 +70,8 @@ module.exports = {
             'gpt-5.6-sol': {
               contextWindow: 1050000,
               maxOutputTokens: 128000
-            }
+            },
+            ...image.models
           },
           validate() {
             if (!this.apiKey) {
@@ -83,6 +88,17 @@ module.exports = {
               ...(request.signal && { signal: request.signal })
             });
             return self.parseResponse(response, request);
+          },
+          // text → image and image(s) + text → image, via the shared
+          // Images API; the core resolved `aspect` to a declared 'W:H'
+          // and the lib maps it to the size string
+          async image(req, request) {
+            return image({
+              apos: self.apos,
+              apiKey: this.apiKey,
+              baseUrl: this.baseUrl,
+              timeout: self.options.timeout
+            }, request);
           },
           normalizeError(error) {
             return self.normalizeError(error);

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai/index.js
@@ -239,7 +239,7 @@ module.exports = {
       // validation treats that as a malformed (retryable) response,
       // never a truncated success. When the request asked for structured
       // output, the final answer's text is the JSON object: it is parsed
-      // onto the turn's `object` ([D35]), which the engine
+      // onto the turn's `object`, which the engine
       // backstop-validates; malformed JSON is a retryable response.
       parseResponse(response, request = {}) {
         const content = [];

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai/lib/image.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai/lib/image.js
@@ -1,0 +1,156 @@
+// The OpenAI Images API, shared by the openai and openai-compatible
+// adapters — one REST surface whichever chat dialect an adapter speaks.
+// It generates images from a prompt, or edits one or more source images
+// with a prompt, and returns the normalized image result the engine
+// assembles into its standard return shape:
+// { images: [ { type, data } ], model, usage, size }.
+
+// The aspect the core resolved — always one the model declares — mapped
+// to the pixel-size string this API takes. An aspect with no mapping and
+// an omitted aspect both leave the size unset, so the service picks.
+// Every size satisfies gpt-image-2's constraints (dimensions divisible
+// by 16, ratio within 1:3 to 3:1); the first three are exactly
+// gpt-image-1's fixed sizes, the only ones it accepts.
+const SIZES = {
+  '1:1': '1024x1024',
+  '3:2': '1536x1024',
+  '2:3': '1024x1536',
+  '4:3': '1152x864',
+  '3:4': '864x1152',
+  '16:9': '1536x864',
+  '9:16': '864x1536'
+};
+
+// Extensions for the source media types an edit can carry, so uploaded
+// files are named plausibly; anything else uploads as .png.
+const EXTENSIONS = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp'
+};
+
+// Run one image request. `deps` carries the calling adapter's transport
+// and config — { apos, apiKey, baseUrl, timeout } — so the same logic
+// serves either adapter instance; `request` is the normalized image
+// request { prompt, count, aspect, quality, images?, model, signal }.
+// `images` present means an edit (the prompt instructs, the sources are
+// edited); absent means generation.
+module.exports = async function image(deps, request) {
+  const size = SIZES[request.aspect];
+  const response = request.images
+    ? await edit(deps, request, size)
+    : await generate(deps, request, size);
+  return parse(response, request.model, size);
+};
+
+// The image models both adapters declare, with the aspects the core
+// resolves against — derived from the size table, one source of truth,
+// so a resolved aspect is always mappable here. gpt-image-2 takes
+// near-arbitrary sizes and declares the whole table; gpt-image-1 is
+// fixed to its three.
+module.exports.models = {
+  'gpt-image-2': {
+    aspects: Object.keys(SIZES)
+  },
+  'gpt-image-1': {
+    aspects: [ '1:1', '3:2', '2:3' ]
+  }
+};
+
+// text → image: a JSON body to /images/generations
+function generate(deps, request, size) {
+  return post(deps, 'images/generations', {
+    model: request.model,
+    prompt: request.prompt,
+    n: request.count,
+    ...(size !== undefined && { size }),
+    ...(request.quality !== undefined && { quality: request.quality })
+  }, request.signal);
+}
+
+// image(s) + text → image: a multipart body to /images/edits, the source
+// images uploaded as files beside the same dial fields
+async function edit(deps, request, size) {
+  const form = new FormData();
+  form.set('model', request.model);
+  form.set('prompt', request.prompt);
+  form.set('n', String(request.count));
+  if (size !== undefined) {
+    form.set('size', size);
+  }
+  if (request.quality !== undefined) {
+    form.set('quality', request.quality);
+  }
+  const sources = await resolveSources(deps, request.images, request.signal);
+  for (const source of sources) {
+    form.append(
+      'image[]',
+      new Blob([ source.buffer ], { type: source.contentType }),
+      source.filename
+    );
+  }
+  return post(deps, 'images/edits', form, request.signal);
+}
+
+function post(deps, path, body, signal) {
+  return deps.apos.http.post(`${deps.baseUrl}/${path}`, {
+    headers: {
+      authorization: `Bearer ${deps.apiKey}`
+    },
+    body,
+    timeout: deps.timeout,
+    ...(signal && { signal })
+  });
+}
+
+// The normalized source refs → the bytes an edit uploads. Inline data
+// decodes directly; a url is fetched (built-in fetch, since apos.http
+// reads text only), and a source that will not load is a caller error,
+// not a provider one — a hard stop, no retry.
+function resolveSources(deps, images, signal) {
+  return Promise.all(images.map(async (source, index) => {
+    if (source.data !== undefined) {
+      return {
+        buffer: Buffer.from(source.data, 'base64'),
+        contentType: source.mediaType,
+        filename: `source-${index}.${extension(source.mediaType)}`
+      };
+    }
+    const response = await fetch(source.url, {
+      ...(signal && { signal })
+    });
+    if (!response.ok) {
+      throw deps.apos.error('invalid', `could not fetch image source "${source.url}": HTTP ${response.status}`);
+    }
+    const contentType = response.headers.get('content-type') || 'application/octet-stream';
+    return {
+      buffer: Buffer.from(await response.arrayBuffer()),
+      contentType,
+      filename: `source-${index}.${extension(contentType)}`
+    };
+  }));
+}
+
+// A response's base64 images plus what the core echoes in metadata: the
+// model, normalized token usage when the service reports it, and the
+// native pixel size when one was set.
+function parse(response, model, size) {
+  return {
+    images: (response.data || []).map((item) => ({
+      type: 'png',
+      data: item.b64_json
+    })),
+    model,
+    ...(response.usage && {
+      usage: {
+        inputTokens: response.usage.input_tokens,
+        outputTokens: response.usage.output_tokens
+      }
+    }),
+    ...(size !== undefined && { size })
+  };
+}
+
+function extension(contentType) {
+  return EXTENSIONS[contentType] || 'png';
+}

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -75,6 +75,21 @@ module.exports = {
       return Boolean(value) && typeof value === 'object' &&
         !Array.isArray(value);
     }
+    // A 'W:H' aspect string → its [ width, height ] positive numbers, or
+    // null when it is not a well-formed ratio. Named tokens are not
+    // accepted here.
+    function parseAspect(value) {
+      if (typeof value !== 'string') {
+        return null;
+      }
+      const match = /^(\d+(?:\.\d+)?):(\d+(?:\.\d+)?)$/.exec(value);
+      if (!match) {
+        return null;
+      }
+      const w = Number(match[1]);
+      const h = Number(match[2]);
+      return w > 0 && h > 0 ? [ w, h ] : null;
+    }
 
     return {
       // Register a provider adapter. Adapters self-register in their own
@@ -142,6 +157,7 @@ module.exports = {
                 ...entry.effort
               }
           };
+          self.validateAspects(name, self.providers[name].models);
         }
 
         if (Object.keys(providers).length &&
@@ -559,6 +575,177 @@ module.exports = {
           });
         }
       },
+      // Parse and validate generateImage's `(prompt, options)` arguments
+      // into one canonical options object `{ prompt, count, aspect,
+      // quality, images, provider, model, signal }`. `prompt` is the
+      // required instruction — the subject to generate, or the edit to
+      // apply when `images` are present. Unknown options are rejected as
+      // "invalid"; `aspect` is checked as a recognized dial here (a named
+      // token or a 'W:H' ratio) but resolved against the routed model's
+      // declared aspects later, at call time. Unset options are left
+      // undefined so buildImageRequest omits them and the provider's own
+      // default applies.
+      normalizeImageOptions(prompt, options) {
+        const invalid = (message) => {
+          throw self.apos.error('invalid', message);
+        };
+        if (typeof prompt !== 'string' || !prompt) {
+          invalid('the image prompt must be a non-empty string');
+        }
+        options = options === undefined ? {} : options;
+        if (!isObject(options)) {
+          invalid('"options" must be an object');
+        }
+        const known = [
+          'count', 'aspect', 'quality', 'images', 'provider', 'model', 'signal'
+        ];
+        for (const name of Object.keys(options)) {
+          if (!known.includes(name)) {
+            invalid(`unknown option "${name}"`);
+          }
+        }
+        const {
+          count = 1, aspect, quality, provider, model, signal
+        } = options;
+        if (!Number.isInteger(count) || count < 1) {
+          invalid('"count" must be a positive integer');
+        }
+        if (aspect !== undefined) {
+          if (typeof aspect !== 'string') {
+            invalid('"aspect" must be a string');
+          }
+          // Reject a malformed dial now; the nearest-match resolution
+          // against the routed model happens at call time
+          self.canonicalAspect(aspect);
+        }
+        if (quality !== undefined &&
+          ![ 'low', 'medium', 'high' ].includes(quality)) {
+          invalid('"quality" must be "low", "medium" or "high"');
+        }
+        if ((provider === undefined) !== (model === undefined)) {
+          invalid('"provider" and "model" must be given together');
+        }
+        for (const [ name, value ] of Object.entries({
+          provider,
+          model
+        })) {
+          if (value !== undefined && typeof value !== 'string') {
+            invalid(`"${name}" must be a string`);
+          }
+        }
+        if (signal !== undefined && !(signal instanceof AbortSignal)) {
+          invalid('"signal" must be an AbortSignal');
+        }
+        return {
+          prompt,
+          count,
+          aspect,
+          quality,
+          images: imageSources(options.images),
+          provider,
+          model,
+          signal
+        };
+
+        // The images option → normalized source refs, or undefined when
+        // absent (a plain text→image generation). Its presence is what
+        // makes the call an edit. Each source is a public url or
+        // inline base64 data with its media type — the same two shapes an
+        // image content part accepts (normalizeMessages).
+        function imageSources(sources) {
+          if (sources === undefined) {
+            return undefined;
+          }
+          if (!Array.isArray(sources) || !sources.length) {
+            invalid('"images" must be a non-empty array of image sources');
+          }
+          return sources.map((source, index) => {
+            const name = `images[${index}]`;
+            if (isObject(source) && typeof source.url === 'string') {
+              return { url: source.url };
+            }
+            if (isObject(source) && typeof source.data === 'string' &&
+              typeof source.mediaType === 'string') {
+              return {
+                data: source.data,
+                mediaType: source.mediaType
+              };
+            }
+            throw self.apos.error(
+              'invalid',
+              `${name} must be an object like { url } or { data, mediaType }`
+            );
+          });
+        }
+      },
+      // Normalize an aspect dial to its canonical 'W:H' string. The named
+      // tokens square, portrait and landscape ground to the conventional
+      // photo ratios (1:1, 3:4, 4:3); an explicit 'W:H' of two positive
+      // numbers is returned as given. Throws "invalid" on anything else.
+      // Every aspect the core hands an adapter passes through here, so an
+      // adapter only ever sees 'W:H', never a named token.
+      canonicalAspect(aspect) {
+        const named = {
+          square: '1:1',
+          portrait: '3:4',
+          landscape: '4:3'
+        };
+        if (Object.hasOwn(named, aspect)) {
+          return named[aspect];
+        }
+        if (parseAspect(aspect)) {
+          return aspect;
+        }
+        throw self.apos.error('invalid', `"${aspect}" is not a valid aspect: use "square", "portrait", "landscape" or a "W:H" ratio`);
+      },
+      // The numeric width/height ratio of an aspect dial.
+      aspectRatio(aspect) {
+        const [ w, h ] = parseAspect(self.canonicalAspect(aspect));
+        return w / h;
+      },
+      // Resolve a requested aspect dial to the nearest aspect the routed
+      // model declares, returning that declared string verbatim — echoed
+      // to the caller in metadata and translated to the provider's dialect
+      // by the adapter. `requested` is the call's `aspect` option (a named
+      // token or 'W:H'), or undefined to leave the dial unset (returns
+      // undefined; the provider default applies). `declared` is the
+      // model's supported aspect strings (modelInfo). Nearest match
+      // minimizes the log-ratio distance to the requested ratio; a tie
+      // resolves to the larger ratio, then to declaration order. A model
+      // that declares no aspects (an unknown model) is a pass-through: the
+      // requested ratio returns as its canonical 'W:H' — never a named
+      // token, so the adapter's input is uniform — for the adapter to
+      // best-effort, and the provider may reject it.
+      resolveAspect(requested, declared) {
+        if (requested === undefined) {
+          return undefined;
+        }
+        const target = self.aspectRatio(requested);
+        if (!Array.isArray(declared) || !declared.length) {
+          return self.canonicalAspect(requested);
+        }
+        let best = describe(declared[0]);
+        for (const aspect of declared) {
+          const candidate = describe(aspect);
+          if (candidate.distance < best.distance - 1e-9 ||
+            (Math.abs(candidate.distance - best.distance) <= 1e-9 &&
+              candidate.ratio > best.ratio)) {
+            best = candidate;
+          }
+        }
+        return best.aspect;
+
+        // An aspect string with its ratio and its log-ratio distance from
+        // the requested target
+        function describe(aspect) {
+          const ratio = self.aspectRatio(aspect);
+          return {
+            aspect,
+            ratio,
+            distance: Math.abs(Math.log(target / ratio))
+          };
+        }
+      },
       // Register an AI tool definition. Feature modules call this in
       // their own init; core, project and third-party modules all use
       // the same call. Re-registering an existing name overrides (last
@@ -902,7 +1089,7 @@ module.exports = {
       // the deterministic default. That default is request-aware: for a
       // structured request (`request.schema`) it synthesizes a
       // schema-conforming object and returns it on the turn's `object`,
-      // as a real adapter would ([D35]) — the pipeline backstop-validates
+      // as a real adapter would — the pipeline backstop-validates
       // it like a real one — otherwise canned text echoing the
       // conversation's final message; usage is estimated from the text
       // sizes. Runs inside the same retry and validation seam as a real
@@ -933,7 +1120,7 @@ module.exports = {
 
         // A canned assistant turn. `text` is the answer's text; a
         // structured call passes the synthesized `object` too, which
-        // rides the turn ([D35]). The text stays in the content — for a
+        // rides the turn. The text stays in the content — for a
         // structured turn it is the object's JSON, so the transcript's
         // assistant message is non-empty and re-normalizes on resume,
         // as a real provider's structured answer would.
@@ -1478,7 +1665,7 @@ module.exports = {
       },
       // The anti-hallucination backstop for structured output. The
       // adapter has already extracted the final answer into `turn.object`
-      // from its provider's structured mode ([D35] — an adapter concern,
+      // from its provider's structured mode (an adapter concern,
       // since only the dialect knows where the object lives); this
       // validates it against `validate`, the compiled validator for the
       // call's `schema` (normalizeGenerateOptions). The provider's
@@ -1527,6 +1714,26 @@ module.exports = {
           model: turn.model || context.request.model,
           provider: context.provider
         };
+      },
+      // Fail startup when a model's declared image `aspects` are
+      // malformed. resolveAspect trusts these to be well-formed 'W:H'
+      // strings at call time, so a bad declaration — from an adapter or a
+      // provider entry — is caught here, once, with a clear message,
+      // rather than surfacing as a caller-facing error on a real call.
+      validateAspects(providerName, models) {
+        for (const [ model, meta ] of Object.entries(models)) {
+          if (meta.aspects === undefined) {
+            continue;
+          }
+          if (!Array.isArray(meta.aspects) || !meta.aspects.length) {
+            fail(`"providers.${providerName}" model "${model}": "aspects" must be a non-empty array of "W:H" ratios`);
+          }
+          for (const aspect of meta.aspects) {
+            if (!parseAspect(aspect)) {
+              fail(`"providers.${providerName}" model "${model}" declares an invalid aspect "${aspect}"; use a "W:H" ratio`);
+            }
+          }
+        }
       },
       // Union of the adapter's and the entry's model metadata,
       // merged per model id with the entry's fields winning

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -18,7 +18,10 @@ module.exports = {
     // provider: the default provider name; inferred when only one is configured
     // effort: { default, levels: { name: { provider, model, reasoning } } }
     // image: { provider, model, aspect, quality }
-    // mock: (request) => assistant turn, consulted only under APOS_AI_MOCK
+    // mock: (req, request) => assistant turn, consulted only under
+    //   APOS_AI_MOCK
+    // mockImage: (req, request) => adapter image result, consulted only
+    //   under APOS_AI_MOCK
     // Conservative agent-loop cap; any call may override it
     maxSteps: 5,
     // Transient-failure retry cap, counting calls
@@ -1108,9 +1111,11 @@ module.exports = {
       },
       // The built-in mock standing in for every adapter chat under
       // APOS_AI_MOCK. Consults the "mock" option first when the module
-      // has one: it may return a complete assistant turn, a { text }
-      // shorthand filled out into one, or undefined to fall through to
-      // the deterministic default. That default is request-aware: for a
+      // has one — called (req, request), req-first like every AI
+      // surface, so a mock can answer per current user: it may return
+      // a complete assistant turn, a { text } shorthand filled out
+      // into one, or undefined to fall through to the deterministic
+      // default. That default is request-aware: for a
       // structured request (`request.schema`) it synthesizes a
       // schema-conforming object and returns it on the turn's `object`,
       // as a real adapter would — the pipeline backstop-validates
@@ -1121,7 +1126,7 @@ module.exports = {
       // the real error paths.
       async mockChat(req, request) {
         const custom = self.options.mock
-          ? await self.options.mock(request)
+          ? await self.options.mock(req, request)
           : undefined;
         if (custom == null) {
           if (request.schema) {
@@ -1225,23 +1230,50 @@ module.exports = {
         return error;
       },
       // The built-in mock standing in for every adapter image call
-      // under APOS_AI_MOCK: `count` copies of a placeholder pixel in
-      // the adapter's return shape, no network or keys. Runs inside
-      // the same retry and validation seam as a real call. Usage is
-      // the chat mock's text ballpark for the prompt plus a flat
-      // per-image output, the order images bill at.
+      // under APOS_AI_MOCK. Consults the "mockImage" option first when
+      // the module has one — called (req, request), req-first like
+      // every AI surface, so a mock can answer per current user: it
+      // may return a complete adapter image result ({ images, model?,
+      // usage?, size? }), an images array shorthand filled out into
+      // one, or undefined to fall through to the deterministic
+      // default — `count` copies of a placeholder pixel, no network
+      // or keys. Filled-in usage is the chat mock's
+      // text ballpark for the prompt plus a flat per-image output, the
+      // order images bill at. Runs inside the same retry and
+      // validation seam as a real call.
       async mockImage(req, request) {
-        return {
-          images: Array.from({ length: request.count }, () => ({
+        const custom = self.options.mockImage
+          ? await self.options.mockImage(req, request)
+          : undefined;
+        if (custom == null) {
+          return result(Array.from({ length: request.count }, () => ({
             type: 'png',
             data: MOCK_PIXEL
-          })),
-          model: request.model,
-          usage: {
-            inputTokens: Math.max(1, Math.round(request.prompt.length / 4)),
-            outputTokens: 1000 * request.count
-          }
-        };
+          })));
+        }
+        if (isObject(custom) && Array.isArray(custom.images)) {
+          return custom;
+        }
+        if (Array.isArray(custom)) {
+          return result(custom);
+        }
+        throw self.apos.error(
+          'invalid',
+          '"mockImage" must return an image result, an images array or undefined'
+        );
+
+        // The adapter return shape around `images`, with the model and
+        // a plausible usage supplied
+        function result(images) {
+          return {
+            images,
+            model: request.model,
+            usage: {
+              inputTokens: Math.max(1, Math.round(request.prompt.length / 4)),
+              outputTokens: 1000 * images.length
+            }
+          };
+        }
       },
       // The language method: text, multi-turn chat, the tool-calling
       // agent loop and structured output against the routed provider.
@@ -1480,7 +1512,8 @@ module.exports = {
       // `size` the native pixel size when the provider works in
       // pixels. Throws the same normalized codes as generate, with
       // the same retries, log records and mock behavior (placeholder
-      // images, no network). Emits `beforeGenerateImage` and
+      // images, no network — scriptable via the `mockImage` option,
+      // see mockImage). Emits `beforeGenerateImage` and
       // `afterGenerateImage` around the call, sharing one mutable
       // context.
       async generateImage(req, prompt, options) {
@@ -1968,7 +2001,7 @@ module.exports = {
         };
 
         const {
-          providers, provider, effort, image, maxSteps, mock,
+          providers, provider, effort, image, maxSteps, mock, mockImage,
           retryAttempts, retryBaseDelay, retryMaxElapsed
         } = options;
 
@@ -2065,6 +2098,10 @@ module.exports = {
 
         if (mock !== undefined && typeof mock !== 'function') {
           fail('"mock" must be a function');
+        }
+
+        if (mockImage !== undefined && typeof mockImage !== 'function') {
+          fail('"mockImage" must be a function');
         }
 
         for (const [ name, value ] of Object.entries({

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -75,6 +75,9 @@ module.exports = {
       return Boolean(value) && typeof value === 'object' &&
         !Array.isArray(value);
     }
+    // A 1×1 transparent PNG, the placeholder pixel mock image calls
+    // return
+    const MOCK_PIXEL = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
     // A 'W:H' aspect string → its [ width, height ] positive numbers, or
     // null when it is not a well-formed ratio. Named tokens are not
     // accepted here.
@@ -170,8 +173,13 @@ module.exports = {
             fail(`"effort.levels.${level}" references unconfigured provider "${row.provider}"`);
           }
         }
-        if (image && !self.providers[image.provider]) {
-          fail(`"image" references unconfigured provider "${image.provider}"`);
+        if (image) {
+          if (!self.providers[image.provider]) {
+            fail(`"image" references unconfigured provider "${image.provider}"`);
+          }
+          if (!self.providers[image.provider].capabilities.image) {
+            fail(`"image" references provider "${image.provider}" which does not declare the "image" capability`);
+          }
         }
 
         self.effortTable = self.buildEffortTable();
@@ -1216,6 +1224,25 @@ module.exports = {
       mockNormalizeError(error) {
         return error;
       },
+      // The built-in mock standing in for every adapter image call
+      // under APOS_AI_MOCK: `count` copies of a placeholder pixel in
+      // the adapter's return shape, no network or keys. Runs inside
+      // the same retry and validation seam as a real call. Usage is
+      // the chat mock's text ballpark for the prompt plus a flat
+      // per-image output, the order images bill at.
+      async mockImage(req, request) {
+        return {
+          images: Array.from({ length: request.count }, () => ({
+            type: 'png',
+            data: MOCK_PIXEL
+          })),
+          model: request.model,
+          usage: {
+            inputTokens: Math.max(1, Math.round(request.prompt.length / 4)),
+            outputTokens: 1000 * request.count
+          }
+        };
+      },
       // The language method: text, multi-turn chat, the tool-calling
       // agent loop and structured output against the routed provider.
       //
@@ -1414,6 +1441,131 @@ module.exports = {
           hadTools: tools.size > 0
         });
         await self.emit('afterGenerate', req, context);
+        return context.result;
+      },
+      // The image method: text → image against the routed image
+      // provider, or image(s) + text → image (editing) when `images`
+      // sources are passed — `prompt` is then the edit instruction and
+      // the images are the source.
+      //
+      // Options:
+      // `count` (positive integer, default 1): how many images;
+      // `aspect` ('square' | 'portrait' | 'landscape', or a 'W:H'
+      //   ratio): the shape dial, resolved to the nearest aspect the
+      //   routed model declares (resolveAspect); the adapter
+      //   translates the resolved ratio to its dialect. Omitted ⇒ not
+      //   sent, the provider default applies;
+      // `quality` ('low' | 'medium' | 'high'): the spend dial, mapped
+      //   to the provider's native knob; providers without one ignore
+      //   it. Omitted ⇒ not sent;
+      // `images` (array of { url } | { data, mediaType } sources):
+      //   the presence of sources makes the call an edit;
+      // `provider`, `model` (strings, only together): the explicit
+      //   target, bypassing the `image` routing entry — the entry's
+      //   default dials do not apply then;
+      // `signal` (AbortSignal): aborts the in-flight provider call.
+      //
+      // Routing: the module's `image` option ({ provider, model,
+      // aspect, quality }) names the project's image route and its
+      // default dials; per-call dials win. Capability-gated on
+      // `image`: routing image work to a provider that cannot
+      // generate images is a clear error, never a silent re-route.
+      //
+      // Returns one call-level result object, like generate:
+      // { images, provider, model, usage, aspect?, size? }. `images`
+      // is [ { type, data } ], `data` base64 and `type` its format;
+      // everything else is said once on the envelope — `usage` is the
+      // whole call's token total (providers bill the batch, not the
+      // image), `aspect` the resolved native ratio when a dial ran,
+      // `size` the native pixel size when the provider works in
+      // pixels. Throws the same normalized codes as generate, with
+      // the same retries, log records and mock behavior (placeholder
+      // images, no network). Emits `beforeGenerateImage` and
+      // `afterGenerateImage` around the call, sharing one mutable
+      // context.
+      async generateImage(req, prompt, options) {
+        const canonical = self.normalizeImageOptions(prompt, options);
+        // Mock answers unconditionally: real routing still applies
+        // under mock when it can resolve — the configuration stays
+        // exercised — but a missing image route (an optional entry,
+        // unlike the always-present effort table) or missing providers
+        // never block a mock call; placeholder routing stands in
+        let route;
+        if (self.mockMode && (
+          !Object.keys(self.providers).length ||
+          (!canonical.provider && !self.options.image)
+        )) {
+          route = {
+            provider: canonical.provider ?? 'mock',
+            model: canonical.model ?? 'mock'
+          };
+        } else {
+          route = self.resolve({
+            provider: canonical.provider,
+            model: canonical.model,
+            capability: 'image'
+          });
+          self.checkCapability(route.provider, 'image');
+        }
+        const {
+          provider, model, aspect: routeAspect, quality: routeQuality,
+          ...inline
+        } = route;
+        // The routed model's metadata, inline routing-entry fields
+        // winning — its declared aspects ground the nearest-match
+        const metadata = {
+          ...self.providers[provider]?.models?.[model],
+          ...inline
+        };
+        const aspect = self.resolveAspect(
+          canonical.aspect ?? routeAspect,
+          metadata.aspects
+        );
+        const quality = canonical.quality ?? routeQuality;
+        const request = {
+          prompt: canonical.prompt,
+          count: canonical.count,
+          ...(aspect !== undefined && { aspect }),
+          ...(quality !== undefined && { quality }),
+          ...(canonical.images && { images: canonical.images }),
+          model,
+          ...(canonical.signal && { signal: canonical.signal })
+        };
+        const record = self.mockMode
+          ? {
+            name: provider,
+            adapter: {
+              image: self.mockImage,
+              normalizeError: self.mockNormalizeError
+            }
+          }
+          : self.providers[provider];
+        const context = {
+          provider,
+          request
+        };
+        await self.emit('beforeGenerateImage', req, context);
+        const result = await self.callAdapter(req, record, context.request, async () =>
+          self.validateImageResult(
+            await record.adapter.image(req, context.request)
+          )
+        );
+        // The envelope: the adapter's minimal result plus what the
+        // core knows — the provider and the resolved aspect it sent;
+        // the pixel size only when the adapter reported one
+        context.result = {
+          images: result.images.map((image) => ({
+            type: image.type,
+            data: image.data
+          })),
+          provider: context.provider,
+          model: result.model || context.request.model,
+          ...(result.usage && { usage: { ...result.usage } }),
+          ...(context.request.aspect !== undefined &&
+            { aspect: context.request.aspect }),
+          ...(result.size !== undefined && { size: result.size })
+        };
+        await self.emit('afterGenerateImage', req, context);
         return context.result;
       },
       // Execute one batch of model-requested tool calls — the toolCall
@@ -1679,6 +1831,32 @@ module.exports = {
         }
         return turn;
       },
+      // Enforce the adapter image contract on `result` ({ images,
+      // model?, usage?, size? }) and return it unchanged. A missing or
+      // empty image list, or a malformed image, is a malformed
+      // response: it throws the transient code so the call travels
+      // the retry path — a model whim never returns an empty success.
+      validateImageResult(result) {
+        const malformed = (detail) => {
+          throw self.apos.error('aiRetry', `malformed image result: ${detail}`);
+        };
+        if (!isObject(result)) {
+          malformed('not an object');
+        }
+        if (!Array.isArray(result.images) || !result.images.length) {
+          malformed('"images" must be a non-empty array');
+        }
+        for (const image of result.images) {
+          if (!isObject(image) || typeof image.type !== 'string' ||
+            typeof image.data !== 'string' || !image.data) {
+            malformed('images must carry a string "type" and a non-empty "data"');
+          }
+        }
+        if (result.usage !== undefined && !isObject(result.usage)) {
+          malformed('"usage" must be an object');
+        }
+        return result;
+      },
       // The anti-hallucination backstop for structured output. The
       // adapter has already extracted the final answer into `turn.object`
       // from its provider's structured mode (an adapter concern,
@@ -1861,8 +2039,24 @@ module.exports = {
 
         if (image !== undefined) {
           checkEffortRow(image, 'image', { provider: true });
-          checkString(image.aspect, 'image.aspect');
-          checkString(image.quality, 'image.quality');
+          if (image.aspect !== undefined &&
+            ![ 'square', 'portrait', 'landscape' ].includes(image.aspect) &&
+            !parseAspect(image.aspect)) {
+            fail('"image.aspect" must be "square", "portrait", "landscape" or a "W:H" ratio');
+          }
+          if (image.quality !== undefined &&
+            ![ 'low', 'medium', 'high' ].includes(image.quality)) {
+            fail('"image.quality" must be "low", "medium" or "high"');
+          }
+          // Inline model metadata on the routing entry participates in
+          // aspect resolution (metadata merge), so it gets the same
+          // startup vetting as a declared model's
+          if (image.aspects !== undefined && (
+            !Array.isArray(image.aspects) || !image.aspects.length ||
+            image.aspects.some((aspect) => !parseAspect(aspect))
+          )) {
+            fail('"image.aspects" must be a non-empty array of "W:H" ratios');
+          }
         }
 
         if (!Number.isInteger(maxSteps) || maxSteps < 1) {

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -662,6 +662,13 @@ module.exports = {
           return sources.map((source, index) => {
             const name = `images[${index}]`;
             if (isObject(source) && typeof source.url === 'string') {
+              // The adapter fetches this server-side, so only web urls
+              // pass — no data:, file: or relative forms. Vetting and
+              // authorizing a user-supplied url is the caller's job
+              // before it reaches this surface.
+              if (![ 'http:', 'https:' ].includes(urlProtocol(source.url))) {
+                throw self.apos.error('invalid', `${name}.url must be an absolute http(s) url`);
+              }
               return { url: source.url };
             }
             if (isObject(source) && typeof source.data === 'string' &&
@@ -676,6 +683,15 @@ module.exports = {
               `${name} must be an object like { url } or { data, mediaType }`
             );
           });
+        }
+
+        // The parsed protocol of an absolute url, or undefined
+        function urlProtocol(url) {
+          try {
+            return new URL(url).protocol;
+          } catch (e) {
+            return undefined;
+          }
         }
       },
       // Normalize an aspect dial to its canonical 'W:H' string. The named

--- a/packages/apostrophe/test/ai-adapter-google.js
+++ b/packages/apostrophe/test/ai-adapter-google.js
@@ -933,6 +933,7 @@ describe('AI adapter: google', function() {
     let httpScript;
     let httpCalls;
     let logRecords;
+    let waits;
     let originalPost;
     let originalFetch;
     let fetchCalls;
@@ -952,6 +953,7 @@ describe('AI adapter: google', function() {
       httpCalls = [];
       fetchCalls = [];
       logRecords = [];
+      waits = [];
       apos.http.post = async (url, options) => {
         httpCalls.push({
           url,
@@ -962,6 +964,9 @@ describe('AI adapter: google', function() {
           throw new Error('post called beyond its script');
         }
         return step();
+      };
+      apos.ai.pause = async (ms) => {
+        waits.push(ms);
       };
       for (const severity of [ 'Warn', 'Error' ]) {
         apos.ai[`log${severity}`] = (req, type, message, data) => {
@@ -1099,6 +1104,10 @@ describe('AI adapter: google', function() {
         model: 'gemini-3.1-flash-image'
       });
       assert.equal(httpCalls.length, 2);
+      // The second request start is staggered with jitter into its
+      // own imageStagger slot; the first fires immediately
+      assert.equal(waits.length, 1);
+      assert(waits[0] >= 500 && waits[0] < 1000);
       // One image per request, the same body each time; commentary
       // text parts do not travel
       assert.deepEqual(httpCalls[0].options.body, httpCalls[1].options.body);
@@ -1314,6 +1323,10 @@ describe('AI adapter: google', function() {
             options: {
               providers: {
                 google: { apiKey: liveKey }
+              },
+              image: {
+                provider: 'google',
+                model: 'gemini-3.1-flash-image'
               }
             }
           }
@@ -1345,20 +1358,37 @@ describe('AI adapter: google', function() {
       assert(Number.isFinite(result.usage.outputTokens));
     });
 
-    it('generates an image against Google for real', async function() {
-      const result = await liveApos.ai.providers.google.adapter.image(
+    it('generates and edits an image against Google for real', async function() {
+      const result = await liveApos.ai.generateImage(
         liveApos.task.getReq(),
+        'a small watercolor fox',
         {
-          prompt: 'a small watercolor fox',
-          count: 1,
           aspect: '1:1',
-          quality: 'low',
-          model: 'gemini-3.1-flash-image'
+          quality: 'low'
         }
       );
-      assert.equal(result.images.length, 1);
-      assert(result.images[0].data.length > 0);
+      const [ image ] = result.images;
+      assert(image.data.length > 0);
+      assert.equal(result.provider, 'google');
+      assert.equal(result.aspect, '1:1');
+      // No pixel size: this dialect works in ratios
+      assert.equal(result.size, undefined);
       assert(Number.isFinite(result.usage.outputTokens));
+      // The generated image comes back as the edit's source
+      const { images: [ edited ], aspect } = await liveApos.ai.generateImage(
+        liveApos.task.getReq(),
+        'make the fox wear a red scarf',
+        {
+          images: [ {
+            data: image.data,
+            mediaType: `image/${image.type}`
+          } ],
+          aspect: 'square',
+          quality: 'low'
+        }
+      );
+      assert(edited.data.length > 0);
+      assert.equal(aspect, '1:1');
     });
   });
 });

--- a/packages/apostrophe/test/ai-adapter-google.js
+++ b/packages/apostrophe/test/ai-adapter-google.js
@@ -929,6 +929,374 @@ describe('AI adapter: google', function() {
     });
   });
 
+  describe('image', function() {
+    let httpScript;
+    let httpCalls;
+    let logRecords;
+    let originalPost;
+    let originalFetch;
+    let fetchCalls;
+
+    before(function() {
+      originalPost = apos.http.post;
+      originalFetch = global.fetch;
+    });
+
+    after(function() {
+      apos.http.post = originalPost;
+      global.fetch = originalFetch;
+    });
+
+    beforeEach(function() {
+      httpScript = [];
+      httpCalls = [];
+      fetchCalls = [];
+      logRecords = [];
+      apos.http.post = async (url, options) => {
+        httpCalls.push({
+          url,
+          options
+        });
+        const step = httpScript.shift();
+        if (step === undefined) {
+          throw new Error('post called beyond its script');
+        }
+        return step();
+      };
+      for (const severity of [ 'Warn', 'Error' ]) {
+        apos.ai[`log${severity}`] = (req, type, message, data) => {
+          logRecords.push({
+            severity: severity.toLowerCase(),
+            type,
+            message,
+            data
+          });
+        };
+      }
+    });
+
+    // The provider instance the engine bound with this suite's config
+    const instance = () => apos.ai.providers.google.adapter;
+    const imagePart = (extras = {}) => ({
+      inlineData: {
+        mimeType: 'image/png',
+        data: 'aW1n'
+      },
+      ...extras
+    });
+    const imageResponse = (extras = {}) => ({
+      candidates: [ {
+        content: {
+          role: 'model',
+          parts: [ imagePart() ]
+        },
+        finishReason: 'STOP',
+        index: 0
+      } ],
+      usageMetadata: {
+        promptTokenCount: 9,
+        candidatesTokenCount: 1290
+      },
+      modelVersion: 'gemini-3.1-flash-image',
+      ...extras
+    });
+
+    it('declares the current image models and their shared ratio set', function() {
+      const { models } = apos.ai.getAdapter('google');
+      const aspects = [
+        '1:1', '3:2', '2:3', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9'
+      ];
+      assert.deepEqual(models['gemini-3.1-flash-image'].aspects, aspects);
+      assert.deepEqual(models['gemini-3-pro-image'].aspects, aspects);
+      assert.deepEqual(models['gemini-3.1-flash-lite-image'].aspects, aspects);
+    });
+
+    it('generates from a prompt, mapping aspect and quality to the dialect', async function() {
+      httpScript = [ () => imageResponse() ];
+      const result = await instance().image(apos.task.getReq(), {
+        prompt: 'a watercolor fox',
+        count: 1,
+        // The core resolved the requested aspect to a declared ratio
+        aspect: '16:9',
+        quality: 'high',
+        model: 'gemini-3.1-flash-image'
+      });
+      const [ call ] = httpCalls;
+      assert.equal(
+        call.url,
+        'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image:generateContent'
+      );
+      assert.equal(call.options.headers['x-goog-api-key'], 'sk-test');
+      assert.equal(call.options.timeout, 600000);
+      assert.deepEqual(call.options.body, {
+        contents: [ {
+          role: 'user',
+          parts: [ { text: 'a watercolor fox' } ]
+        } ],
+        generationConfig: {
+          responseModalities: [ 'TEXT', 'IMAGE' ],
+          imageConfig: {
+            aspectRatio: '16:9',
+            imageSize: '2K'
+          }
+        }
+      });
+      assert.deepEqual(result, {
+        images: [ {
+          type: 'png',
+          data: 'aW1n'
+        } ],
+        model: 'gemini-3.1-flash-image',
+        usage: {
+          inputTokens: 9,
+          outputTokens: 1290
+        }
+      });
+    });
+
+    it('maps the lower quality tiers to the 1K resolution', async function() {
+      httpScript = [ () => imageResponse() ];
+      await instance().image(apos.task.getReq(), {
+        prompt: 'a fox',
+        count: 1,
+        quality: 'medium',
+        model: 'gemini-3.1-flash-image'
+      });
+      assert.deepEqual(httpCalls[0].options.body.generationConfig.imageConfig, {
+        imageSize: '1K'
+      });
+    });
+
+    it('fans a count out as concurrent requests, summing usage', async function() {
+      httpScript = [
+        () => imageResponse(),
+        () => imageResponse({
+          candidates: [ {
+            content: {
+              role: 'model',
+              parts: [
+                { text: 'here is your fox' },
+                imagePart({
+                  inlineData: {
+                    mimeType: 'image/jpeg',
+                    data: 'aW1nMg=='
+                  }
+                })
+              ]
+            },
+            finishReason: 'STOP',
+            index: 0
+          } ],
+          usageMetadata: {
+            promptTokenCount: 9,
+            candidatesTokenCount: 1300
+          }
+        })
+      ];
+      const result = await instance().image(apos.task.getReq(), {
+        prompt: 'a fox',
+        count: 2,
+        model: 'gemini-3.1-flash-image'
+      });
+      assert.equal(httpCalls.length, 2);
+      // One image per request, the same body each time; commentary
+      // text parts do not travel
+      assert.deepEqual(httpCalls[0].options.body, httpCalls[1].options.body);
+      assert.deepEqual(result.images, [
+        {
+          type: 'png',
+          data: 'aW1n'
+        },
+        {
+          type: 'jpeg',
+          data: 'aW1nMg=='
+        }
+      ]);
+      assert.deepEqual(result.usage, {
+        inputTokens: 18,
+        outputTokens: 2590
+      });
+      assert.deepEqual(logRecords, []);
+    });
+
+    it('delivers the survivors of a partial fan-out, logging the losses', async function() {
+      httpScript = [
+        () => imageResponse(),
+        () => {
+          throw httpError(500, {}, {
+            error: { message: 'internal error' }
+          });
+        },
+        () => imageResponse()
+      ];
+      const result = await instance().image(apos.task.getReq(), {
+        prompt: 'a fox',
+        count: 3,
+        model: 'gemini-3.1-flash-image'
+      });
+      assert.equal(result.images.length, 2);
+      // Usage sums over the surviving requests only
+      assert.deepEqual(result.usage, {
+        inputTokens: 18,
+        outputTokens: 2580
+      });
+      const [ record ] = logRecords;
+      assert.equal(logRecords.length, 1);
+      assert.equal(record.severity, 'error');
+      assert.equal(record.type, 'imagePartial');
+      assert.equal(record.message, 'internal error');
+      assert.equal(record.data.provider, 'google');
+      assert.equal(record.data.model, 'gemini-3.1-flash-image');
+      assert.equal(record.data.code, 'aiRetry');
+      assert.equal(record.data.kind, 'overload');
+      assert.equal(record.data.requested, 3);
+      assert.equal(record.data.delivered, 2);
+    });
+
+    it('throws when every fanned-out request fails, leaving the engine to react', async function() {
+      httpScript = [
+        () => {
+          throw httpError(500);
+        },
+        () => {
+          throw httpError(500);
+        }
+      ];
+      await assert.rejects(instance().image(apos.task.getReq(), {
+        prompt: 'a fox',
+        count: 2,
+        model: 'gemini-3.1-flash-image'
+      }), (e) => {
+        // Raw, not normalized — the engine's retry wrapper owns that
+        assert.equal(e.status, 500);
+        return true;
+      });
+      assert.deepEqual(logRecords, []);
+    });
+
+    it('omits unset dials, and leaves usage the service never reported unset', async function() {
+      httpScript = [ () => imageResponse({ usageMetadata: undefined }) ];
+      const result = await instance().image(apos.task.getReq(), {
+        prompt: 'a fox',
+        count: 1,
+        model: 'gemini-3-pro-image'
+      });
+      assert.deepEqual(httpCalls[0].options.body.generationConfig, {
+        responseModalities: [ 'TEXT', 'IMAGE' ]
+      });
+      assert.deepEqual(result.usage, {
+        inputTokens: undefined,
+        outputTokens: undefined
+      });
+    });
+
+    it('edits with inline and service-hosted sources as parts after the prompt', async function() {
+      httpScript = [ () => imageResponse() ];
+      await instance().image(apos.task.getReq(), {
+        prompt: 'make the fox wear a red scarf',
+        count: 1,
+        aspect: '1:1',
+        model: 'gemini-3.1-flash-image',
+        images: [
+          {
+            data: 'aGk=',
+            mediaType: 'image/png'
+          },
+          { url: 'https://generativelanguage.googleapis.com/v1beta/files/f1' }
+        ]
+      });
+      assert.deepEqual(httpCalls[0].options.body.contents, [ {
+        role: 'user',
+        parts: [
+          { text: 'make the fox wear a red scarf' },
+          {
+            inlineData: {
+              mimeType: 'image/png',
+              data: 'aGk='
+            }
+          },
+          {
+            fileData: { fileUri: 'https://generativelanguage.googleapis.com/v1beta/files/f1' }
+          }
+        ]
+      } ]);
+    });
+
+    it('fetches an external url source and inlines it', async function() {
+      global.fetch = async (url, options) => {
+        fetchCalls.push({
+          url,
+          options
+        });
+        return {
+          ok: true,
+          status: 200,
+          headers: { get: (name) => (name === 'content-type' ? 'image/jpeg' : null) },
+          arrayBuffer: async () => new Uint8Array([ 1, 2, 3 ]).buffer
+        };
+      };
+      httpScript = [ () => imageResponse() ];
+      await instance().image(apos.task.getReq(), {
+        prompt: 'edit',
+        count: 1,
+        model: 'gemini-3.1-flash-image',
+        images: [ { url: 'https://example.com/fox.jpg' } ]
+      });
+      assert.equal(fetchCalls[0].url, 'https://example.com/fox.jpg');
+      assert.deepEqual(httpCalls[0].options.body.contents[0].parts[1], {
+        inlineData: {
+          mimeType: 'image/jpeg',
+          data: 'AQID'
+        }
+      });
+    });
+
+    it('rejects a url source that will not load', async function() {
+      global.fetch = async () => ({
+        ok: false,
+        status: 404,
+        headers: { get: () => null }
+      });
+      await assert.rejects(instance().image(apos.task.getReq(), {
+        prompt: 'edit',
+        count: 1,
+        model: 'gemini-3.1-flash-image',
+        images: [ { url: 'https://example.com/missing.png' } ]
+      }), (e) => e.name === 'invalid');
+      assert.equal(httpCalls.length, 0);
+    });
+
+    it('throws the refusal error on a blocked prompt', async function() {
+      httpScript = [ () => ({
+        promptFeedback: { blockReason: 'SAFETY' },
+        usageMetadata: { promptTokenCount: 9 }
+      }) ];
+      await assert.rejects(instance().image(apos.task.getReq(), {
+        prompt: 'p',
+        count: 1,
+        model: 'gemini-3.1-flash-image'
+      }), (e) => e.name === 'aiRefusal');
+    });
+
+    it('throws the refusal error on a safety finish that produced no image', async function() {
+      httpScript = [ () => imageResponse({
+        candidates: [ {
+          content: {
+            role: 'model',
+            parts: []
+          },
+          finishReason: 'IMAGE_SAFETY',
+          index: 0
+        } ]
+      }) ];
+      await assert.rejects(instance().image(apos.task.getReq(), {
+        prompt: 'p',
+        count: 1,
+        model: 'gemini-3.1-flash-image'
+      }), (e) => e.name === 'aiRefusal');
+    });
+  });
+
   describe('live smoke', function() {
     const liveKey = process.env.APOS_GEMINI_KEY;
     let liveApos;
@@ -974,6 +1342,22 @@ describe('AI adapter: google', function() {
       assert.equal(result.provider, 'google');
       assert.equal(result.finishReason, 'stop');
       assert(Number.isFinite(result.usage.inputTokens));
+      assert(Number.isFinite(result.usage.outputTokens));
+    });
+
+    it('generates an image against Google for real', async function() {
+      const result = await liveApos.ai.providers.google.adapter.image(
+        liveApos.task.getReq(),
+        {
+          prompt: 'a small watercolor fox',
+          count: 1,
+          aspect: '1:1',
+          quality: 'low',
+          model: 'gemini-3.1-flash-image'
+        }
+      );
+      assert.equal(result.images.length, 1);
+      assert(result.images[0].data.length > 0);
       assert(Number.isFinite(result.usage.outputTokens));
     });
   });

--- a/packages/apostrophe/test/ai-adapter-openai-compatible.js
+++ b/packages/apostrophe/test/ai-adapter-openai-compatible.js
@@ -126,6 +126,15 @@ describe('AI adapter: openai-compatible', function() {
     assert.equal(high.reasoning, undefined);
   });
 
+  it('declares the same image models as the openai adapter', function() {
+    const { models } = apos.ai.getAdapter('openai-compatible');
+    assert.deepEqual(
+      models['gpt-image-2'].aspects,
+      [ '1:1', '3:2', '2:3', '4:3', '3:4', '16:9', '9:16' ]
+    );
+    assert.deepEqual(models['gpt-image-1'].aspects, [ '1:1', '3:2', '2:3' ]);
+  });
+
   describe('request translation', function() {
     it('builds the minimal body, collapsing one text part to a string', function() {
       assert.deepEqual(adapter.buildBody(request()), {
@@ -787,6 +796,66 @@ describe('AI adapter: openai-compatible', function() {
         return true;
       });
       assert.equal(httpCalls.length, 1);
+    });
+  });
+
+  // Image generation is the shared OpenAI Images API (lib/image.js), the
+  // same call the openai adapter makes — so this adapter reaches it too,
+  // under its own baseUrl
+  describe('image', function() {
+    let httpCalls;
+    let originalPost;
+
+    before(function() {
+      originalPost = apos.http.post;
+    });
+
+    after(function() {
+      apos.http.post = originalPost;
+    });
+
+    beforeEach(function() {
+      httpCalls = [];
+      apos.http.post = async (url, options) => {
+        httpCalls.push({
+          url,
+          options
+        });
+        return {
+          data: [ { b64_json: 'aW1n' } ],
+          usage: {
+            input_tokens: 3,
+            output_tokens: 8
+          }
+        };
+      };
+    });
+
+    it('generates through the shared Images API', async function() {
+      const result = await apos.ai.providers['openai-compatible'].adapter.image(
+        apos.task.getReq(),
+        {
+          prompt: 'a watercolor fox',
+          count: 1,
+          aspect: '2:3',
+          model: 'gpt-image-1'
+        }
+      );
+      const [ call ] = httpCalls;
+      assert.equal(call.url, 'https://api.openai.com/v1/images/generations');
+      assert.equal(call.options.body.size, '1024x1536');
+      assert.deepEqual(result, {
+        images: [ {
+          type: 'png',
+          data: 'aW1n'
+        } ],
+        model: 'gpt-image-1',
+        usage: {
+          inputTokens: 3,
+          outputTokens: 8
+        },
+        size: '1024x1536'
+      });
     });
   });
 

--- a/packages/apostrophe/test/ai-adapter-openai.js
+++ b/packages/apostrophe/test/ai-adapter-openai.js
@@ -142,6 +142,25 @@ describe('AI adapter: openai', function() {
     assert.equal(high.reasoning, 'high');
   });
 
+  it('declares the image models and their aspects', function() {
+    const { models } = apos.ai.getAdapter('openai');
+    assert.deepEqual(
+      models['gpt-image-2'].aspects,
+      [ '1:1', '3:2', '2:3', '4:3', '3:4', '16:9', '9:16' ]
+    );
+    assert.deepEqual(models['gpt-image-1'].aspects, [ '1:1', '3:2', '2:3' ]);
+    // What the core's aspect resolution sees for an image call
+    const info = apos.ai.modelInfo({
+      provider: 'openai',
+      model: 'gpt-image-2',
+      capability: 'image'
+    });
+    assert.deepEqual(
+      info.aspects,
+      [ '1:1', '3:2', '2:3', '4:3', '3:4', '16:9', '9:16' ]
+    );
+  });
+
   describe('request translation', function() {
     it('builds the minimal stateless body', function() {
       assert.deepEqual(adapter.buildBody(request()), {
@@ -805,6 +824,193 @@ describe('AI adapter: openai', function() {
     });
   });
 
+  describe('image', function() {
+    let httpScript;
+    let httpCalls;
+    let originalPost;
+    let originalFetch;
+    let fetchCalls;
+
+    before(function() {
+      originalPost = apos.http.post;
+      originalFetch = global.fetch;
+    });
+
+    after(function() {
+      apos.http.post = originalPost;
+      global.fetch = originalFetch;
+    });
+
+    beforeEach(function() {
+      httpScript = [];
+      httpCalls = [];
+      fetchCalls = [];
+      apos.http.post = async (url, options) => {
+        httpCalls.push({
+          url,
+          options
+        });
+        const step = httpScript.shift();
+        if (step === undefined) {
+          throw new Error('post called beyond its script');
+        }
+        return step();
+      };
+    });
+
+    // The provider instance the engine bound with this suite's config
+    const instance = () => apos.ai.providers.openai.adapter;
+    const imageResponse = (extras = {}) => ({
+      created: 1,
+      data: [ { b64_json: 'aW1n' } ],
+      usage: {
+        input_tokens: 9,
+        output_tokens: 42
+      },
+      ...extras
+    });
+
+    it('generates from a prompt, mapping aspect and quality to the dialect', async function() {
+      httpScript = [ () => imageResponse() ];
+      const result = await instance().image(apos.task.getReq(), {
+        prompt: 'a watercolor fox',
+        count: 1,
+        // The core resolved the requested aspect to a declared 'W:H'
+        aspect: '3:2',
+        quality: 'high',
+        model: 'gpt-image-1'
+      });
+      const [ call ] = httpCalls;
+      assert.equal(call.url, 'https://api.openai.com/v1/images/generations');
+      assert.equal(call.options.headers.authorization, 'Bearer sk-test');
+      assert.equal(call.options.timeout, 600000);
+      assert.deepEqual(call.options.body, {
+        model: 'gpt-image-1',
+        prompt: 'a watercolor fox',
+        n: 1,
+        size: '1536x1024',
+        quality: 'high'
+      });
+      assert.deepEqual(result, {
+        images: [ {
+          type: 'png',
+          data: 'aW1n'
+        } ],
+        model: 'gpt-image-1',
+        usage: {
+          inputTokens: 9,
+          outputTokens: 42
+        },
+        size: '1536x1024'
+      });
+    });
+
+    it('maps the wide aspects gpt-image-2 declares', async function() {
+      httpScript = [ () => imageResponse() ];
+      const result = await instance().image(apos.task.getReq(), {
+        prompt: 'a fox',
+        count: 1,
+        aspect: '16:9',
+        model: 'gpt-image-2'
+      });
+      assert.equal(httpCalls[0].options.body.size, '1536x864');
+      assert.equal(result.size, '1536x864');
+    });
+
+    it('omits an unset aspect and quality, and usage the service never reported', async function() {
+      httpScript = [ () => imageResponse({ usage: undefined }) ];
+      const result = await instance().image(apos.task.getReq(), {
+        prompt: 'a fox',
+        count: 2,
+        model: 'gpt-image-1'
+      });
+      assert.deepEqual(httpCalls[0].options.body, {
+        model: 'gpt-image-1',
+        prompt: 'a fox',
+        n: 2
+      });
+      assert.deepEqual(result, {
+        images: [ {
+          type: 'png',
+          data: 'aW1n'
+        } ],
+        model: 'gpt-image-1'
+      });
+    });
+
+    it('edits inline source images as a multipart upload', async function() {
+      httpScript = [ () => imageResponse() ];
+      const result = await instance().image(apos.task.getReq(), {
+        prompt: 'make the fox wear a red scarf',
+        count: 1,
+        aspect: '1:1',
+        model: 'gpt-image-1',
+        images: [ {
+          data: 'aGk=',
+          mediaType: 'image/png'
+        } ]
+      });
+      const [ call ] = httpCalls;
+      assert.equal(call.url, 'https://api.openai.com/v1/images/edits');
+      assert(call.options.body instanceof FormData);
+      const form = call.options.body;
+      assert.equal(form.get('model'), 'gpt-image-1');
+      assert.equal(form.get('prompt'), 'make the fox wear a red scarf');
+      assert.equal(form.get('n'), '1');
+      assert.equal(form.get('size'), '1024x1024');
+      const files = form.getAll('image[]');
+      assert.equal(files.length, 1);
+      assert.equal(files[0].type, 'image/png');
+      assert.equal(files[0].name, 'source-0.png');
+      assert.deepEqual(result.images, [ {
+        type: 'png',
+        data: 'aW1n'
+      } ]);
+    });
+
+    it('fetches a url source before uploading it', async function() {
+      global.fetch = async (url, options) => {
+        fetchCalls.push({
+          url,
+          options
+        });
+        return {
+          ok: true,
+          status: 200,
+          headers: { get: (name) => (name === 'content-type' ? 'image/jpeg' : null) },
+          arrayBuffer: async () => new Uint8Array([ 1, 2, 3 ]).buffer
+        };
+      };
+      httpScript = [ () => imageResponse() ];
+      await instance().image(apos.task.getReq(), {
+        prompt: 'edit',
+        count: 1,
+        model: 'gpt-image-1',
+        images: [ { url: 'https://example.com/fox.png' } ]
+      });
+      assert.equal(fetchCalls[0].url, 'https://example.com/fox.png');
+      const files = httpCalls[0].options.body.getAll('image[]');
+      assert.equal(files.length, 1);
+      assert.equal(files[0].type, 'image/jpeg');
+      assert.equal(files[0].name, 'source-0.jpg');
+    });
+
+    it('rejects a url source that will not load', async function() {
+      global.fetch = async () => ({
+        ok: false,
+        status: 404,
+        headers: { get: () => null }
+      });
+      await assert.rejects(instance().image(apos.task.getReq(), {
+        prompt: 'edit',
+        count: 1,
+        model: 'gpt-image-1',
+        images: [ { url: 'https://example.com/missing.png' } ]
+      }), (e) => e.name === 'invalid');
+      assert.equal(httpCalls.length, 0);
+    });
+  });
+
   describe('live smoke', function() {
     const liveKey = process.env.APOS_OPENAI_KEY;
     let liveApos;
@@ -851,6 +1057,23 @@ describe('AI adapter: openai', function() {
       assert.equal(result.finishReason, 'stop');
       assert(Number.isFinite(result.usage.inputTokens));
       assert(Number.isFinite(result.usage.outputTokens));
+    });
+
+    it('generates an image against OpenAI for real', async function() {
+      const result = await liveApos.ai.providers.openai.adapter.image(
+        liveApos.task.getReq(),
+        {
+          prompt: 'a small watercolor fox',
+          count: 1,
+          aspect: '1:1',
+          quality: 'low',
+          model: 'gpt-image-2'
+        }
+      );
+      assert.equal(result.images.length, 1);
+      assert.equal(result.images[0].type, 'png');
+      assert(result.images[0].data.length > 0);
+      assert.equal(result.size, '1024x1024');
     });
   });
 });

--- a/packages/apostrophe/test/ai-adapter-openai.js
+++ b/packages/apostrophe/test/ai-adapter-openai.js
@@ -1028,6 +1028,10 @@ describe('AI adapter: openai', function() {
             options: {
               providers: {
                 openai: { apiKey: liveKey }
+              },
+              image: {
+                provider: 'openai',
+                model: 'gpt-image-2'
               }
             }
           }
@@ -1059,21 +1063,36 @@ describe('AI adapter: openai', function() {
       assert(Number.isFinite(result.usage.outputTokens));
     });
 
-    it('generates an image against OpenAI for real', async function() {
-      const result = await liveApos.ai.providers.openai.adapter.image(
+    it('generates and edits an image against OpenAI for real', async function() {
+      const result = await liveApos.ai.generateImage(
         liveApos.task.getReq(),
+        'a small watercolor fox',
         {
-          prompt: 'a small watercolor fox',
-          count: 1,
           aspect: '1:1',
-          quality: 'low',
-          model: 'gpt-image-2'
+          quality: 'low'
         }
       );
-      assert.equal(result.images.length, 1);
-      assert.equal(result.images[0].type, 'png');
-      assert(result.images[0].data.length > 0);
+      const [ image ] = result.images;
+      assert.equal(image.type, 'png');
+      assert(image.data.length > 0);
+      assert.equal(result.provider, 'openai');
+      assert.equal(result.aspect, '1:1');
       assert.equal(result.size, '1024x1024');
+      // The generated image comes back as the edit's source
+      const { images: [ edited ], aspect } = await liveApos.ai.generateImage(
+        liveApos.task.getReq(),
+        'make the fox wear a red scarf',
+        {
+          images: [ {
+            data: image.data,
+            mediaType: 'image/png'
+          } ],
+          aspect: 'square',
+          quality: 'low'
+        }
+      );
+      assert(edited.data.length > 0);
+      assert.equal(aspect, '1:1');
     });
   });
 });

--- a/packages/apostrophe/test/ai-generate.js
+++ b/packages/apostrophe/test/ai-generate.js
@@ -1293,7 +1293,7 @@ describe('AI generate', function() {
                   }
                 },
                 retryBaseDelay: 1,
-                mock(request) {
+                mock(req, request) {
                   const step = mockScript.shift();
                   return step && step(request);
                 }

--- a/packages/apostrophe/test/ai-generate.js
+++ b/packages/apostrophe/test/ai-generate.js
@@ -963,7 +963,7 @@ describe('AI generate', function() {
         ...extras
       });
       // The adapter extracts the structured answer onto the turn's
-      // `object` ([D35]); its JSON also stays in the content so the
+      // `object`; its JSON also stays in the content so the
       // transcript round-trips
       const jsonTurn = (object) => turn({
         content: [ {

--- a/packages/apostrophe/test/ai-image.js
+++ b/packages/apostrophe/test/ai-image.js
@@ -5,7 +5,9 @@ const assert = require('assert/strict');
 // nearest-match resolves against
 const GPT_IMAGE_1 = [ '1:1', '3:2', '2:3' ];
 const GPT_IMAGE_2 = [ '1:1', '3:2', '2:3', '4:3', '3:4', '16:9', '9:16' ];
-const GOOGLE = [ '1:1', '3:4', '4:3', '9:16', '16:9' ];
+const GOOGLE = [
+  '1:1', '3:2', '2:3', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9'
+];
 
 describe('AI image dials', function() {
   this.timeout(t.timeout);
@@ -68,10 +70,11 @@ describe('AI image dials', function() {
       [ '9:16', GPT_IMAGE_1, '2:3' ],
       [ '9:16', GOOGLE, '9:16' ],
       [ '3:2', GPT_IMAGE_1, '3:2' ],
-      [ '3:2', GOOGLE, '4:3' ],
+      [ '3:2', GOOGLE, '3:2' ],
       [ '2:1', GPT_IMAGE_1, '3:2' ],
       [ '2:1', GPT_IMAGE_2, '16:9' ],
       [ '2:1', GOOGLE, '16:9' ],
+      [ '2.39:1', GOOGLE, '21:9' ],
       // reciprocal tie → the larger ratio wins
       [ '1:1', [ '3:2', '2:3' ], '3:2' ],
       // larger beats declaration order (2:3 declared first, 3:2 still wins)

--- a/packages/apostrophe/test/ai-image.js
+++ b/packages/apostrophe/test/ai-image.js
@@ -1,9 +1,10 @@
 const t = require('../test-lib/test.js');
 const assert = require('assert/strict');
 
-// The two standard image adapters' declared aspect sets — what the core's
+// The standard image models' declared aspect sets — what the core's
 // nearest-match resolves against
-const OPENAI = [ '1:1', '3:2', '2:3' ];
+const GPT_IMAGE_1 = [ '1:1', '3:2', '2:3' ];
+const GPT_IMAGE_2 = [ '1:1', '3:2', '2:3', '4:3', '3:4', '16:9', '9:16' ];
 const GOOGLE = [ '1:1', '3:4', '4:3', '9:16', '16:9' ];
 
 describe('AI image dials', function() {
@@ -48,23 +49,28 @@ describe('AI image dials', function() {
   describe('resolveAspect nearest-match', function() {
     // [ requested, declared aspects, resolved native aspect ]
     const cases = [
-      // named tokens against each standard adapter's set
-      [ 'square', OPENAI, '1:1' ],
-      [ 'portrait', OPENAI, '2:3' ],
-      [ 'landscape', OPENAI, '3:2' ],
+      // named tokens against each standard model's set
+      [ 'square', GPT_IMAGE_1, '1:1' ],
+      [ 'portrait', GPT_IMAGE_1, '2:3' ],
+      [ 'landscape', GPT_IMAGE_1, '3:2' ],
+      [ 'square', GPT_IMAGE_2, '1:1' ],
+      [ 'portrait', GPT_IMAGE_2, '3:4' ],
+      [ 'landscape', GPT_IMAGE_2, '4:3' ],
       [ 'square', GOOGLE, '1:1' ],
       [ 'portrait', GOOGLE, '3:4' ],
       [ 'landscape', GOOGLE, '4:3' ],
       // explicit W:H — exact when declared, nearest otherwise
-      [ '1:1', OPENAI, '1:1' ],
+      [ '1:1', GPT_IMAGE_1, '1:1' ],
       [ '1:1', GOOGLE, '1:1' ],
-      [ '16:9', OPENAI, '3:2' ],
+      [ '16:9', GPT_IMAGE_1, '3:2' ],
+      [ '16:9', GPT_IMAGE_2, '16:9' ],
       [ '16:9', GOOGLE, '16:9' ],
-      [ '9:16', OPENAI, '2:3' ],
+      [ '9:16', GPT_IMAGE_1, '2:3' ],
       [ '9:16', GOOGLE, '9:16' ],
-      [ '3:2', OPENAI, '3:2' ],
+      [ '3:2', GPT_IMAGE_1, '3:2' ],
       [ '3:2', GOOGLE, '4:3' ],
-      [ '2:1', OPENAI, '3:2' ],
+      [ '2:1', GPT_IMAGE_1, '3:2' ],
+      [ '2:1', GPT_IMAGE_2, '16:9' ],
       [ '2:1', GOOGLE, '16:9' ],
       // reciprocal tie → the larger ratio wins
       [ '1:1', [ '3:2', '2:3' ], '3:2' ],
@@ -80,7 +86,7 @@ describe('AI image dials', function() {
     }
 
     it('an omitted dial resolves to undefined', function() {
-      assert.equal(apos.ai.resolveAspect(undefined, OPENAI), undefined);
+      assert.equal(apos.ai.resolveAspect(undefined, GPT_IMAGE_1), undefined);
     });
 
     it('a model with no declared aspects passes the canonical ratio through', function() {
@@ -163,6 +169,9 @@ describe('AI image dials', function() {
       [ 'an unknown quality', 'a fox', { quality: 'ultra' } ],
       [ 'an empty images array', 'a fox', { images: [] } ],
       [ 'a malformed image source', 'a fox', { images: [ { path: 'x' } ] } ],
+      [ 'a non-http(s) source url', 'a fox', { images: [ { url: 'file:///etc/passwd' } ] } ],
+      [ 'a data: source url', 'a fox', { images: [ { url: 'data:image/png;base64,aGk=' } ] } ],
+      [ 'a relative source url', 'a fox', { images: [ { url: '/uploads/fox.png' } ] } ],
       [ 'provider without model', 'a fox', { provider: 'openai' } ],
       [ 'model without provider', 'a fox', { model: 'gpt-image-1' } ],
       [ 'a non-AbortSignal signal', 'a fox', { signal: {} } ]

--- a/packages/apostrophe/test/ai-image.js
+++ b/packages/apostrophe/test/ai-image.js
@@ -1,0 +1,179 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert/strict');
+
+// The two standard image adapters' declared aspect sets — what the core's
+// nearest-match resolves against
+const OPENAI = [ '1:1', '3:2', '2:3' ];
+const GOOGLE = [ '1:1', '3:4', '4:3', '9:16', '16:9' ];
+
+describe('AI image dials', function() {
+  this.timeout(t.timeout);
+
+  let apos;
+
+  before(async function() {
+    apos = await t.create({
+      root: module
+    });
+  });
+
+  after(async function() {
+    await t.destroy(apos);
+  });
+
+  describe('aspectRatio', function() {
+    const valid = [
+      [ 'square', 1 ],
+      [ 'portrait', 3 / 4 ],
+      [ 'landscape', 4 / 3 ],
+      [ '1:1', 1 ],
+      [ '16:9', 16 / 9 ],
+      [ '2:3', 2 / 3 ],
+      [ '1.91:1', 1.91 ]
+    ];
+    for (const [ aspect, ratio ] of valid) {
+      it(`parses "${aspect}"`, function() {
+        assert.equal(apos.ai.aspectRatio(aspect), ratio);
+      });
+    }
+
+    const invalid = [ 'wide', '', '16x9', '16:', ':9', '0:1', '1:0', '-1:2', '16:9:1' ];
+    for (const aspect of invalid) {
+      it(`rejects ${JSON.stringify(aspect)}`, function() {
+        assert.throws(() => apos.ai.aspectRatio(aspect), (e) => e.name === 'invalid');
+      });
+    }
+  });
+
+  describe('resolveAspect nearest-match', function() {
+    // [ requested, declared aspects, resolved native aspect ]
+    const cases = [
+      // named tokens against each standard adapter's set
+      [ 'square', OPENAI, '1:1' ],
+      [ 'portrait', OPENAI, '2:3' ],
+      [ 'landscape', OPENAI, '3:2' ],
+      [ 'square', GOOGLE, '1:1' ],
+      [ 'portrait', GOOGLE, '3:4' ],
+      [ 'landscape', GOOGLE, '4:3' ],
+      // explicit W:H — exact when declared, nearest otherwise
+      [ '1:1', OPENAI, '1:1' ],
+      [ '1:1', GOOGLE, '1:1' ],
+      [ '16:9', OPENAI, '3:2' ],
+      [ '16:9', GOOGLE, '16:9' ],
+      [ '9:16', OPENAI, '2:3' ],
+      [ '9:16', GOOGLE, '9:16' ],
+      [ '3:2', OPENAI, '3:2' ],
+      [ '3:2', GOOGLE, '4:3' ],
+      [ '2:1', OPENAI, '3:2' ],
+      [ '2:1', GOOGLE, '16:9' ],
+      // reciprocal tie → the larger ratio wins
+      [ '1:1', [ '3:2', '2:3' ], '3:2' ],
+      // larger beats declaration order (2:3 declared first, 3:2 still wins)
+      [ '1:1', [ '2:3', '3:2' ], '3:2' ],
+      // exact duplicate ratios → declaration order (the first wins)
+      [ 'square', [ '1:1', '1:1' ], '1:1' ]
+    ];
+    for (const [ requested, declared, resolved ] of cases) {
+      it(`${requested} in [${declared.join(', ')}] → ${resolved}`, function() {
+        assert.equal(apos.ai.resolveAspect(requested, declared), resolved);
+      });
+    }
+
+    it('an omitted dial resolves to undefined', function() {
+      assert.equal(apos.ai.resolveAspect(undefined, OPENAI), undefined);
+    });
+
+    it('a model with no declared aspects passes the canonical ratio through', function() {
+      // an explicit ratio unchanged, a named token as its canonical 'W:H'
+      // — never a named token an adapter would have to decode
+      assert.equal(apos.ai.resolveAspect('16:9', undefined), '16:9');
+      assert.equal(apos.ai.resolveAspect('portrait', []), '3:4');
+      assert.equal(apos.ai.resolveAspect('square', []), '1:1');
+    });
+  });
+
+  describe('normalizeImageOptions', function() {
+    it('defaults count to 1 and leaves unset dials undefined', function() {
+      assert.deepEqual(apos.ai.normalizeImageOptions('a watercolor fox'), {
+        prompt: 'a watercolor fox',
+        count: 1,
+        aspect: undefined,
+        quality: undefined,
+        images: undefined,
+        provider: undefined,
+        model: undefined,
+        signal: undefined
+      });
+    });
+
+    it('carries the full dial set', function() {
+      const result = apos.ai.normalizeImageOptions('a watercolor fox', {
+        count: 2,
+        aspect: '16:9',
+        quality: 'high'
+      });
+      assert.equal(result.count, 2);
+      assert.equal(result.aspect, '16:9');
+      assert.equal(result.quality, 'high');
+    });
+
+    it('normalizes url and inline image sources for an edit', function() {
+      const result = apos.ai.normalizeImageOptions('make the fox wear a red scarf', {
+        images: [
+          { url: 'https://example.com/fox.png' },
+          {
+            data: 'aGVsbG8=',
+            mediaType: 'image/png',
+            extra: 'stripped'
+          }
+        ]
+      });
+      assert.deepEqual(result.images, [
+        { url: 'https://example.com/fox.png' },
+        {
+          data: 'aGVsbG8=',
+          mediaType: 'image/png'
+        }
+      ]);
+    });
+
+    it('accepts provider and model together', function() {
+      const result = apos.ai.normalizeImageOptions('a fox', {
+        provider: 'openai',
+        model: 'gpt-image-1'
+      });
+      assert.equal(result.provider, 'openai');
+      assert.equal(result.model, 'gpt-image-1');
+    });
+
+    it('carries an AbortSignal', function() {
+      const { signal } = new AbortController();
+      const result = apos.ai.normalizeImageOptions('a fox', { signal });
+      assert.equal(result.signal, signal);
+    });
+
+    const rejects = [
+      [ 'an empty prompt', '', {} ],
+      [ 'a non-string prompt', 42, {} ],
+      [ 'a non-object options argument', 'a fox', 42 ],
+      [ 'an unknown option', 'a fox', { size: '1024x1024' } ],
+      [ 'a non-integer count', 'a fox', { count: 1.5 } ],
+      [ 'a zero count', 'a fox', { count: 0 } ],
+      [ 'a malformed aspect', 'a fox', { aspect: 'wide' } ],
+      [ 'an unknown quality', 'a fox', { quality: 'ultra' } ],
+      [ 'an empty images array', 'a fox', { images: [] } ],
+      [ 'a malformed image source', 'a fox', { images: [ { path: 'x' } ] } ],
+      [ 'provider without model', 'a fox', { provider: 'openai' } ],
+      [ 'model without provider', 'a fox', { model: 'gpt-image-1' } ],
+      [ 'a non-AbortSignal signal', 'a fox', { signal: {} } ]
+    ];
+    for (const [ label, prompt, options ] of rejects) {
+      it(`rejects ${label}`, function() {
+        assert.throws(
+          () => apos.ai.normalizeImageOptions(prompt, options),
+          (e) => e.name === 'invalid'
+        );
+      });
+    }
+  });
+});

--- a/packages/apostrophe/test/ai-image.js
+++ b/packages/apostrophe/test/ai-image.js
@@ -523,12 +523,56 @@ describe('AI image dials', function() {
   });
 
   describe('generateImage under APOS_AI_MOCK', function() {
+    // The caller's req, as the mock option received it
+    let seenReq;
+
     before(async function() {
       await t.destroy(apos);
       process.env.APOS_AI_MOCK = '1';
-      // No providers, no keys: placeholder routing stands in
+      // No providers, no keys: placeholder routing stands in. The
+      // mockImage option scripts by prompt and falls through for the
+      // rest
       apos = await t.create({
-        root: module
+        root: module,
+        modules: {
+          '@apostrophecms/ai': {
+            options: {
+              mockImage(req, request) {
+                seenReq = req;
+                if (request.prompt === 'scripted') {
+                  return {
+                    images: [ {
+                      type: 'png',
+                      data: 'c2NyaXB0ZWQ='
+                    } ],
+                    model: 'scripted-model',
+                    usage: {
+                      inputTokens: 3,
+                      outputTokens: 7
+                    },
+                    size: '512x512'
+                  };
+                }
+                if (request.prompt === 'shorthand') {
+                  return [
+                    {
+                      type: 'png',
+                      data: 'c2hvcnQ='
+                    },
+                    {
+                      type: 'png',
+                      data: 'c2hvcnQy'
+                    }
+                  ];
+                }
+                if (request.prompt === 'broken') {
+                  return 42;
+                }
+                return undefined;
+              }
+            }
+          }
+        }
       });
     });
 
@@ -561,6 +605,56 @@ describe('AI image dials', function() {
       });
       assert.equal(result.provider, 'openai');
       assert.equal(result.model, 'gpt-image-2');
+    });
+
+    it('uses a complete result the mockImage option returns, passing the caller req', async function() {
+      const req = apos.task.getReq();
+      const result = await apos.ai.generateImage(req, 'scripted', {
+        aspect: 'square'
+      });
+      assert.equal(seenReq, req);
+      assert.deepEqual(result, {
+        images: [ {
+          type: 'png',
+          data: 'c2NyaXB0ZWQ='
+        } ],
+        provider: 'mock',
+        model: 'scripted-model',
+        usage: {
+          inputTokens: 3,
+          outputTokens: 7
+        },
+        aspect: '1:1',
+        size: '512x512'
+      });
+    });
+
+    it('fills an images array shorthand out into a result', async function() {
+      const result = await apos.ai.generateImage(apos.task.getReq(), 'shorthand');
+      assert.deepEqual(result.images, [
+        {
+          type: 'png',
+          data: 'c2hvcnQ='
+        },
+        {
+          type: 'png',
+          data: 'c2hvcnQy'
+        }
+      ]);
+      assert.equal(result.model, 'mock');
+      assert(Number.isFinite(result.usage.inputTokens));
+      assert(Number.isFinite(result.usage.outputTokens));
+    });
+
+    it('rejects a mockImage return it does not recognize', async function() {
+      await assert.rejects(
+        apos.ai.generateImage(apos.task.getReq(), 'broken'),
+        (e) => {
+          assert.equal(e.name, 'invalid');
+          assert.match(e.message, /"mockImage" must return an image result/);
+          return true;
+        }
+      );
     });
   });
 

--- a/packages/apostrophe/test/ai-image.js
+++ b/packages/apostrophe/test/ai-image.js
@@ -188,4 +188,495 @@ describe('AI image dials', function() {
       });
     }
   });
+
+  describe('generateImage without configuration', function() {
+    it('fails when no "image" route is configured', async function() {
+      await assert.rejects(
+        apos.ai.generateImage(apos.task.getReq(), 'a fox'),
+        (e) => {
+          assert.equal(e.name, 'invalid');
+          assert.match(e.message, /no "image" route is configured/);
+          return true;
+        }
+      );
+    });
+  });
+
+  describe('generateImage pipeline', function() {
+    // Scripted thunks consumed by the fake adapter's image method, one
+    // per adapter call, receiving the adapter request
+    let imageScript;
+    let imageCalls;
+    let events;
+
+    // A text-only provider, for capability rejections
+    const textAdapter = () => ({
+      name: 'fake',
+      label: 'Fake',
+      capabilities: {
+        text: true,
+        tools: true,
+        structured: true,
+        imageInput: true,
+        image: false,
+        caching: true
+      },
+      effort: {
+        medium: { model: 'fake-medium' }
+      },
+      models: {
+        'fake-medium': {
+          contextWindow: 100000,
+          maxOutputTokens: 8000
+        }
+      },
+      validate() {},
+      normalizeError: (error) => error
+    });
+    // The image-capable provider under test, its image method driven
+    // by the suite's script
+    const imageAdapter = () => ({
+      name: 'fakeimg',
+      label: 'Fake Image',
+      capabilities: {
+        text: false,
+        tools: false,
+        structured: false,
+        imageInput: false,
+        image: true,
+        caching: false
+      },
+      effort: {},
+      models: {
+        'fake-image': { aspects: [ '1:1', '3:2', '2:3' ] }
+      },
+      validate() {},
+      async image(req, request) {
+        imageCalls.push(request);
+        const step = imageScript.shift();
+        if (step === undefined) {
+          throw new Error('image called beyond its script');
+        }
+        return step(request);
+      },
+      normalizeError: (error) => error
+    });
+    const imageResult = (extras = {}) => ({
+      images: [ {
+        type: 'png',
+        data: 'aW1n'
+      } ],
+      model: 'fake-image-9000',
+      usage: {
+        inputTokens: 9,
+        outputTokens: 1000
+      },
+      size: '1024x1024',
+      ...extras
+    });
+
+    before(async function() {
+      await t.destroy(apos);
+      apos = await t.create({
+        root: module,
+        modules: {
+          'fake-adapters': {
+            init(self) {
+              self.apos.ai.addAdapter(textAdapter());
+              self.apos.ai.addAdapter(imageAdapter());
+            }
+          },
+          'event-watch': {
+            handlers(self) {
+              return {
+                '@apostrophecms/ai:beforeGenerateImage': {
+                  record(req, context) {
+                    events.push([ 'before', context ]);
+                  }
+                },
+                '@apostrophecms/ai:afterGenerateImage': {
+                  record(req, context) {
+                    events.push([ 'after', context ]);
+                  }
+                }
+              };
+            }
+          },
+          '@apostrophecms/ai': {
+            options: {
+              provider: 'fake',
+              providers: {
+                fake: { apiKey: 'k1' },
+                fakeimg: { apiKey: 'k2' }
+              },
+              image: {
+                provider: 'fakeimg',
+                model: 'fake-image',
+                aspect: 'landscape',
+                quality: 'medium'
+              },
+              // Keep retried tests fast
+              retryBaseDelay: 1
+            }
+          }
+        }
+      });
+    });
+
+    beforeEach(function() {
+      imageScript = [];
+      imageCalls = [];
+      events = [];
+    });
+
+    it('routes via the image entry, resolving its default dials', async function() {
+      imageScript = [ () => imageResult() ];
+      const result = await apos.ai.generateImage(
+        apos.task.getReq(),
+        'a watercolor fox'
+      );
+      // The entry's 'landscape' resolved against the declared aspects
+      assert.deepEqual(imageCalls, [ {
+        prompt: 'a watercolor fox',
+        count: 1,
+        aspect: '3:2',
+        quality: 'medium',
+        model: 'fake-image'
+      } ]);
+      assert.deepEqual(result, {
+        images: [ {
+          type: 'png',
+          data: 'aW1n'
+        } ],
+        provider: 'fakeimg',
+        model: 'fake-image-9000',
+        usage: {
+          inputTokens: 9,
+          outputTokens: 1000
+        },
+        aspect: '3:2',
+        size: '1024x1024'
+      });
+    });
+
+    it('lets call dials override the entry defaults', async function() {
+      imageScript = [ () => imageResult() ];
+      await apos.ai.generateImage(apos.task.getReq(), 'a fox', {
+        aspect: '9:16',
+        quality: 'high'
+      });
+      assert.equal(imageCalls[0].aspect, '2:3');
+      assert.equal(imageCalls[0].quality, 'high');
+    });
+
+    it('says the call-level facts once, however many images arrive', async function() {
+      const adapterUsage = {
+        inputTokens: 9,
+        outputTokens: 2000
+      };
+      imageScript = [ () => imageResult({
+        images: [
+          {
+            type: 'png',
+            data: 'aW1n'
+          },
+          {
+            type: 'png',
+            data: 'aW1nMg=='
+          }
+        ],
+        usage: adapterUsage
+      }) ];
+      const result = await apos.ai.generateImage(apos.task.getReq(), 'a fox', {
+        count: 2
+      });
+      assert.equal(imageCalls[0].count, 2);
+      assert.equal(result.images.length, 2);
+      assert.deepEqual(result.usage, adapterUsage);
+      // A fresh copy, not the adapter's own object
+      assert.notEqual(result.usage, adapterUsage);
+    });
+
+    it('passes edit sources through to the adapter', async function() {
+      imageScript = [ () => imageResult() ];
+      await apos.ai.generateImage(
+        apos.task.getReq(),
+        'make the fox wear a red scarf',
+        {
+          images: [ {
+            data: 'aGk=',
+            mediaType: 'image/png'
+          } ]
+        }
+      );
+      assert.deepEqual(imageCalls[0].images, [ {
+        data: 'aGk=',
+        mediaType: 'image/png'
+      } ]);
+    });
+
+    it('omits envelope facts the adapter did not report', async function() {
+      imageScript = [ () => ({
+        images: [ {
+          type: 'png',
+          data: 'aW1n'
+        } ]
+      }) ];
+      const result = await apos.ai.generateImage(apos.task.getReq(), 'a fox', {
+        provider: 'fakeimg',
+        model: 'mystery-image'
+      });
+      // No adapter model, usage or size; no dial sent, so no aspect
+      assert.deepEqual(result, {
+        images: [ {
+          type: 'png',
+          data: 'aW1n'
+        } ],
+        provider: 'fakeimg',
+        model: 'mystery-image'
+      });
+    });
+
+    it('bypasses the entry and its dials on an explicit provider and model', async function() {
+      imageScript = [ () => imageResult() ];
+      await apos.ai.generateImage(apos.task.getReq(), 'a fox', {
+        provider: 'fakeimg',
+        model: 'mystery-image',
+        aspect: 'portrait'
+      });
+      const [ request ] = imageCalls;
+      assert.equal(request.model, 'mystery-image');
+      // The unknown model has no declared aspects: the canonical
+      // ratio passes through; the entry's quality does not apply
+      assert.equal(request.aspect, '3:4');
+      assert.equal('quality' in request, false);
+    });
+
+    it('rejects routing to a provider without the image capability', async function() {
+      await assert.rejects(
+        apos.ai.generateImage(apos.task.getReq(), 'a fox', {
+          provider: 'fake',
+          model: 'fake-medium'
+        }),
+        (e) => {
+          assert.equal(e.name, 'invalid');
+          assert.match(e.message, /does not declare the "image" capability/);
+          return true;
+        }
+      );
+      assert.equal(imageCalls.length, 0);
+    });
+
+    it('retries a transient failure and delivers', async function() {
+      imageScript = [
+        () => {
+          throw apos.error('aiRetry', 'blip');
+        },
+        () => imageResult()
+      ];
+      const result = await apos.ai.generateImage(apos.task.getReq(), 'a fox');
+      assert.equal(imageCalls.length, 2);
+      assert.equal(result.images.length, 1);
+    });
+
+    it('retries a malformed result the same way', async function() {
+      imageScript = [
+        () => ({ images: [] }),
+        () => imageResult()
+      ];
+      const result = await apos.ai.generateImage(apos.task.getReq(), 'a fox');
+      assert.equal(imageCalls.length, 2);
+      assert.equal(result.images.length, 1);
+    });
+
+    it('stops at once on a non-retryable code', async function() {
+      imageScript = [ () => {
+        throw apos.error('invalid', 'bad request');
+      } ];
+      await assert.rejects(
+        apos.ai.generateImage(apos.task.getReq(), 'a fox'),
+        (e) => e.name === 'invalid'
+      );
+      assert.equal(imageCalls.length, 1);
+    });
+
+    it('surfaces a refusal without a retry', async function() {
+      imageScript = [ () => {
+        throw apos.error('aiRefusal', 'the model blocked this request');
+      } ];
+      await assert.rejects(
+        apos.ai.generateImage(apos.task.getReq(), 'a fox'),
+        (e) => e.name === 'aiRefusal'
+      );
+      assert.equal(imageCalls.length, 1);
+    });
+
+    it('emits the generate-image events around the call, sharing one context', async function() {
+      imageScript = [ () => imageResult() ];
+      const result = await apos.ai.generateImage(apos.task.getReq(), 'a fox');
+      assert.deepEqual(events.map((event) => event[0]), [ 'before', 'after' ]);
+      assert.equal(events[0][1], events[1][1]);
+      assert.equal(events[0][1].provider, 'fakeimg');
+      assert.equal(events[0][1].request.prompt, 'a fox');
+      assert.equal(events[1][1].result, result);
+    });
+  });
+
+  describe('generateImage under APOS_AI_MOCK', function() {
+    before(async function() {
+      await t.destroy(apos);
+      process.env.APOS_AI_MOCK = '1';
+      // No providers, no keys: placeholder routing stands in
+      apos = await t.create({
+        root: module
+      });
+    });
+
+    after(function() {
+      delete process.env.APOS_AI_MOCK;
+    });
+
+    it('returns placeholder images in the standard shape, no network', async function() {
+      const result = await apos.ai.generateImage(apos.task.getReq(), 'a fox', {
+        count: 2,
+        aspect: 'square'
+      });
+      assert.equal(result.images.length, 2);
+      for (const image of result.images) {
+        assert.equal(image.type, 'png');
+        assert(image.data.length > 0);
+      }
+      assert.equal(result.provider, 'mock');
+      assert.equal(result.model, 'mock');
+      // No declared aspects to resolve against: the canonical ratio
+      assert.equal(result.aspect, '1:1');
+      assert(Number.isFinite(result.usage.inputTokens));
+      assert(Number.isFinite(result.usage.outputTokens));
+    });
+
+    it('honors an explicit provider and model as placeholder routing', async function() {
+      const result = await apos.ai.generateImage(apos.task.getReq(), 'a fox', {
+        provider: 'openai',
+        model: 'gpt-image-2'
+      });
+      assert.equal(result.provider, 'openai');
+      assert.equal(result.model, 'gpt-image-2');
+    });
+  });
+
+  describe('generateImage under APOS_AI_MOCK with providers', function() {
+    // Counts real adapter calls, which mock must never make
+    let called;
+
+    before(async function() {
+      await t.destroy(apos);
+      process.env.APOS_AI_MOCK = '1';
+      called = 0;
+      apos = await t.create({
+        root: module,
+        modules: {
+          'fake-adapters': {
+            init(self) {
+              self.apos.ai.addAdapter({
+                name: 'fakeimg',
+                label: 'Fake Image',
+                capabilities: {
+                  text: false,
+                  tools: false,
+                  structured: false,
+                  imageInput: false,
+                  image: true,
+                  caching: false
+                },
+                effort: {
+                  medium: { model: 'fake-image' }
+                },
+                models: {
+                  'fake-image': { aspects: [ '1:1', '3:2', '2:3' ] }
+                },
+                validate() {},
+                async image() {
+                  called++;
+                  throw new Error('the real adapter must not run under mock');
+                },
+                normalizeError: (error) => error
+              });
+              self.apos.ai.addAdapter({
+                name: 'fake',
+                label: 'Fake',
+                capabilities: {
+                  text: true,
+                  tools: true,
+                  structured: true,
+                  imageInput: true,
+                  image: false,
+                  caching: true
+                },
+                effort: {
+                  medium: { model: 'fake-medium' }
+                },
+                models: {
+                  'fake-medium': {
+                    contextWindow: 100000,
+                    maxOutputTokens: 8000
+                  }
+                },
+                validate() {},
+                normalizeError: (error) => error
+              });
+            }
+          },
+          '@apostrophecms/ai': {
+            options: {
+              provider: 'fakeimg',
+              providers: {
+                fakeimg: { apiKey: 'k1' },
+                fake: { apiKey: 'k2' }
+              }
+              // Deliberately no "image" entry: mock must still answer
+            }
+          }
+        }
+      });
+    });
+
+    after(function() {
+      delete process.env.APOS_AI_MOCK;
+    });
+
+    it('falls back to placeholder routing when no image route is configured', async function() {
+      const result = await apos.ai.generateImage(apos.task.getReq(), 'a fox');
+      assert.equal(result.images[0].type, 'png');
+      assert.equal(result.provider, 'mock');
+      assert.equal(result.model, 'mock');
+      assert.equal(called, 0);
+    });
+
+    it('still resolves explicit routing for real, answering with the mock', async function() {
+      const result = await apos.ai.generateImage(apos.task.getReq(), 'a fox', {
+        provider: 'fakeimg',
+        model: 'fake-image',
+        aspect: 'landscape'
+      });
+      assert.equal(result.provider, 'fakeimg');
+      assert.equal(result.model, 'fake-image');
+      // Resolved against the declared aspects — routing ran for real
+      assert.equal(result.aspect, '3:2');
+      assert.equal(called, 0);
+    });
+
+    it('still enforces the image capability on an explicit override', async function() {
+      await assert.rejects(
+        apos.ai.generateImage(apos.task.getReq(), 'a fox', {
+          provider: 'fake',
+          model: 'fake-medium'
+        }),
+        (e) => {
+          assert.equal(e.name, 'invalid');
+          assert.match(e.message, /does not declare the "image" capability/);
+          return true;
+        }
+      );
+    });
+  });
 });

--- a/packages/apostrophe/test/ai-tools.js
+++ b/packages/apostrophe/test/ai-tools.js
@@ -1166,7 +1166,7 @@ describe('AI tools', function() {
           '@apostrophecms/ai': {
             options: {
               // A scripted model: request a tool once, then answer
-              mock(request) {
+              mock(req, request) {
                 if (request.messages.at(-1).role !== 'tool') {
                   return {
                     content: [ {

--- a/packages/apostrophe/test/ai.js
+++ b/packages/apostrophe/test/ai.js
@@ -258,14 +258,35 @@ describe('AI engine', function() {
         ...valid(),
         image: { provider: 'openai' }
       }, /"image\.model" must be a string/);
+      for (const aspect of [ 16, 'wide', '16x9' ]) {
+        rejects({
+          ...valid(),
+          image: {
+            provider: 'openai',
+            model: 'gpt-image-1-mini',
+            aspect
+          }
+        }, /"image\.aspect" must be "square", "portrait", "landscape" or a "W:H" ratio/);
+      }
       rejects({
         ...valid(),
         image: {
           provider: 'openai',
           model: 'gpt-image-1-mini',
-          aspect: 16
+          quality: 'ultra'
         }
-      }, /"image\.aspect" must be a string/);
+      }, /"image\.quality" must be "low", "medium" or "high"/);
+      // Inline aspects on the entry get the declared-model vetting
+      for (const aspects of [ [], [ '1:1', 'wide' ], '1:1' ]) {
+        rejects({
+          ...valid(),
+          image: {
+            provider: 'openai',
+            model: 'gpt-image-1-mini',
+            aspects
+          }
+        }, /"image\.aspects" must be a non-empty array of "W:H" ratios/);
+      }
     });
 
     it('rejects malformed maxSteps and mock', function() {
@@ -569,6 +590,16 @@ describe('AI engine', function() {
         }, /@apostrophecms\/ai: "image" references unconfigured provider "openai"/);
       });
 
+      it('fails on an image route to a provider without the image capability', async function() {
+        await failsToActivate({
+          providers: { fake: { apiKey: 'k' } },
+          image: {
+            provider: 'fake',
+            model: 'fake-image'
+          }
+        }, /@apostrophecms\/ai: "image" references provider "fake" which does not declare the "image" capability/);
+      });
+
       it('fails on a malformed declared aspect', async function() {
         await failsToActivate({
           providers: {
@@ -624,6 +655,12 @@ describe('AI engine', function() {
       image: false,
       caching: true
     };
+    // The "other" entry overrides image on, so the image route it
+    // hosts passes the activation capability check
+    const imageCapable = {
+      ...capabilities,
+      image: true
+    };
 
     before(async function() {
       await t.destroy(apos);
@@ -643,6 +680,7 @@ describe('AI engine', function() {
                 fake: { apiKey: 'k1' },
                 other: {
                   apiKey: 'k2',
+                  capabilities: { image: true },
                   models: {
                     'other-image': { aspects: [ '1:1', '16:9' ] }
                   }
@@ -705,7 +743,7 @@ describe('AI engine', function() {
         model: 'other-large',
         contextWindow: 400000,
         maxOutputTokens: 32000,
-        capabilities
+        capabilities: imageCapable
       });
     });
 
@@ -716,7 +754,7 @@ describe('AI engine', function() {
         reasoning: 'max',
         contextWindow: 1000000,
         maxOutputTokens: 64000,
-        capabilities
+        capabilities: imageCapable
       });
     });
 
@@ -729,7 +767,7 @@ describe('AI engine', function() {
         model: 'other-medium',
         contextWindow: 200000,
         maxOutputTokens: 16000,
-        capabilities
+        capabilities: imageCapable
       });
     });
 
@@ -752,7 +790,7 @@ describe('AI engine', function() {
         model: 'other-image',
         contextWindow: undefined,
         maxOutputTokens: undefined,
-        capabilities,
+        capabilities: imageCapable,
         aspects: [ '1:1', '16:9' ]
       });
     });
@@ -767,7 +805,7 @@ describe('AI engine', function() {
         model: 'other-image',
         contextWindow: undefined,
         maxOutputTokens: undefined,
-        capabilities,
+        capabilities: imageCapable,
         aspects: [ '1:1', '16:9' ]
       });
     });

--- a/packages/apostrophe/test/ai.js
+++ b/packages/apostrophe/test/ai.js
@@ -569,6 +569,33 @@ describe('AI engine', function() {
         }, /@apostrophecms\/ai: "image" references unconfigured provider "openai"/);
       });
 
+      it('fails on a malformed declared aspect', async function() {
+        await failsToActivate({
+          providers: {
+            fake: {
+              apiKey: 'k',
+              models: { 'fake-medium': { aspects: [ '1:1', 'wide' ] } }
+            }
+          }
+        }, /@apostrophecms\/ai: "providers\.fake" model "fake-medium" declares an invalid aspect "wide"/);
+        await failsToActivate({
+          providers: {
+            fake: {
+              apiKey: 'k',
+              models: { 'fake-medium': { aspects: '1:1' } }
+            }
+          }
+        }, /@apostrophecms\/ai: "providers\.fake" model "fake-medium": "aspects" must be a non-empty array/);
+        await failsToActivate({
+          providers: {
+            fake: {
+              apiKey: 'k',
+              models: { 'fake-medium': { aspects: [] } }
+            }
+          }
+        }, /@apostrophecms\/ai: "providers\.fake" model "fake-medium": "aspects" must be a non-empty array/);
+      });
+
       it('fails when the default effort level resolves to no row', async function() {
         await failsToActivate({
           providers: { fake: { apiKey: 'k' } },

--- a/packages/apostrophe/test/ai.js
+++ b/packages/apostrophe/test/ai.js
@@ -298,6 +298,10 @@ describe('AI engine', function() {
         ...valid(),
         mock: 'fixture reply'
       }, /"mock" must be a function/);
+      rejects({
+        ...valid(),
+        mockImage: 'fixture pixel'
+      }, /"mockImage" must be a function/);
     });
 
     it('rejects malformed retry options', function() {


### PR DESCRIPTION
Implement `apos.ai.generateImage(req, prompt, options)` on the two
image-capable standard providers (OpenAI, Google), covering both modes:
text → image, and image(s) + text → image (editing/variations, when `images`
sources are passed).

**Note:** code refactoring and full doc (comments) rewrite upcoming with the next change. 