### PR TITLE
AI non-blocking generate (job)

### DIFF
--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -30,7 +30,15 @@ module.exports = {
     retryBaseDelay: 1000,
     // Elapsed-time budget in milliseconds for one call including its
     // retry waits; a delay that would land past it stops the call
-    retryMaxElapsed: 60000
+    retryMaxElapsed: 60000,
+    // Seconds an AI job record is kept before the job layer deletes it;
+    // 0 keeps records forever. Overridable per call (generateJob's
+    // expireAfter). Also the upper bound on a background run's
+    // cancellation watcher: a deleted record cancels its own run
+    jobExpireAfter: 86400,
+    // Milliseconds between checks of the job's cancellation flag while
+    // a background run is in flight
+    jobPollInterval: 2000
   },
   init(self) {
     self.adapters = {};
@@ -77,6 +85,11 @@ module.exports = {
     function isObject(value) {
       return Boolean(value) && typeof value === 'object' &&
         !Array.isArray(value);
+    }
+    // An abort-shaped throw: the AbortError the http stack raises when
+    // an AbortSignal fires, or Node's ABORT_ERR code
+    function isAbort(error) {
+      return error?.name === 'AbortError' || error?.code === 'ABORT_ERR';
     }
     // A 1×1 transparent PNG, the placeholder pixel mock image calls
     // return
@@ -306,7 +319,7 @@ module.exports = {
       // arguments, exactly as passed to it, into one canonical options
       // object `{ system, messages, tools, maxSteps, schema,
       // validateObject, effort, provider, model, reasoning, maxTokens,
-      // cache, signal }` — the positional prompt string appended to
+      // cache, signal, onMessage }` — the positional prompt string appended to
       // `messages` as the final user turn, message content collapsed to
       // content-part form, `tools` names resolved to their activated
       // definitions, `maxSteps` defaulted from the module option, a
@@ -338,7 +351,8 @@ module.exports = {
         }
         const known = [
           'system', 'messages', 'tools', 'maxSteps', 'schema', 'effort',
-          'provider', 'model', 'reasoning', 'maxTokens', 'cache', 'signal'
+          'provider', 'model', 'reasoning', 'maxTokens', 'cache', 'signal',
+          'onMessage'
         ];
         for (const name of Object.keys(options)) {
           if (!known.includes(name)) {
@@ -347,7 +361,7 @@ module.exports = {
         }
         const {
           system, effort, provider, model, reasoning,
-          maxTokens, cache = 'short', signal
+          maxTokens, cache = 'short', signal, onMessage
         } = options;
         for (const [ name, value ] of Object.entries({
           system,
@@ -369,6 +383,9 @@ module.exports = {
         }
         if (signal !== undefined && !(signal instanceof AbortSignal)) {
           invalid('"signal" must be an AbortSignal');
+        }
+        if (onMessage !== undefined && typeof onMessage !== 'function') {
+          invalid('"onMessage" must be a function');
         }
         const maxSteps = options.maxSteps === undefined
           ? self.options.maxSteps
@@ -404,7 +421,8 @@ module.exports = {
           reasoning,
           maxTokens,
           cache,
-          signal
+          signal,
+          onMessage
         };
 
         // The tools option → the activated definitions it names; every
@@ -1321,8 +1339,14 @@ module.exports = {
       //   the routed model's declared ceiling when it is known;
       // `cache` (false | 'short' | 'long', default 'short'): the
       //   prompt-cache policy the adapter translates for its provider;
-      // `signal` (AbortSignal): aborts the in-flight provider call;
-      //   also injected into every handler's `args._context`.
+      // `signal` (AbortSignal): cancels the call — see the cancellation
+      //   paragraph below; also injected into every handler's
+      //   `args._context`;
+      // `onMessage` (async function): called with each intermediate
+      //   assistant message — a turn whose tool requests the loop goes
+      //   on to execute — as { role, content }, awaited before the
+      //   tools run. The final answer is not reported here, it is the
+      //   return value; a throw stops the call.
       //
       // Returns { text, messages, finishReason, usage, model,
       // provider }, plus `steps` when the call carried tools,
@@ -1336,11 +1360,20 @@ module.exports = {
       // executed in model order, { toolCall, result } per success and
       // { toolCall, error } per recoverable failure the model was told
       // about; `toolCalls` are unexecuted requests the caller must run
-      // itself; `finishReason` is 'stop', 'length' or — whenever
-      // `toolCalls` is present — 'maxSteps', the step budget's
-      // counterpart of 'length'; `usage` aggregates { inputTokens,
-      // outputTokens } across every model turn; `model` / `provider`
-      // name what actually answered.
+      // itself; `finishReason` is 'stop', 'length', 'cancel' or —
+      // whenever the step budget cut the loop — 'maxSteps', the step
+      // budget's counterpart of 'length'; `usage` aggregates
+      // { inputTokens, outputTokens } across every model turn; `model` /
+      // `provider` name what actually answered.
+      //
+      // Cancellation: when the call's `signal` fires the loop winds
+      // down instead of failing. The in-flight step is waited out — a
+      // running handler is never abandoned, its completed work stays
+      // recorded — while the aborted provider call is not retried, and
+      // the call returns normally with finishReason 'cancel': partial
+      // text, steps and usage preserved, unexecuted requests on
+      // `toolCalls`. Only abort-shaped throws convert; a genuine
+      // failure racing a cancel still throws.
       //
       // Throws normalized apos errors: "invalid" for bad calls,
       // "aiRetry" when transient provider failures outlast the retry
@@ -1410,70 +1443,255 @@ module.exports = {
           inputTokens: 0,
           outputTokens: 0
         };
-        let turn;
+        let turn = null;
         let pending = null;
-        for (let turns = 1; ; turns++) {
-          turn = await self.callAdapter(req, record, context.request, async () => {
-            const answer = self.validateTurn(
-              await record.adapter.chat(req, context.request)
-            );
-            // The adapter placed the final answer on `answer.object`;
-            // backstop-validate it here so a malformed one travels the
-            // same retry path as the turn. Only a 'stop' turn is the
-            // answer: tool turns run the loop with their own validation,
-            // a refusal surfaces as aiRefusal below, and a 'length'
-            // turn returns as-is — no object, the finish reason tells
-            // the caller why
-            if (canonical.schema && answer.finishReason === 'stop') {
-              self.validateStructured(answer, canonical.validateObject);
+        let cancelled = false;
+        try {
+          for (let turns = 1; ; turns++) {
+            turn = await self.callAdapter(req, record, context.request, async () => {
+              const answer = self.validateTurn(
+                await record.adapter.chat(req, context.request)
+              );
+              // The adapter placed the final answer on `answer.object`;
+              // backstop-validate it here so a malformed one travels the
+              // same retry path as the turn. Only a 'stop' turn is the
+              // answer: tool turns run the loop with their own validation,
+              // a refusal surfaces as aiRefusal below, and a 'length'
+              // turn returns as-is — no object, the finish reason tells
+              // the caller why
+              if (canonical.schema && answer.finishReason === 'stop') {
+                self.validateStructured(answer, canonical.validateObject);
+              }
+              return answer;
+            });
+            usage.inputTokens += turn.usage.inputTokens;
+            usage.outputTokens += turn.usage.outputTokens;
+            if (turn.finishReason === 'refusal') {
+              throw self.apos.error('aiRefusal', 'the model refused this request');
             }
-            return answer;
-          });
-          usage.inputTokens += turn.usage.inputTokens;
-          usage.outputTokens += turn.usage.outputTokens;
-          if (turn.finishReason === 'refusal') {
-            throw self.apos.error('aiRefusal', 'the model refused this request');
-          }
-          if (turn.finishReason === 'toolCalls' && !tools.size) {
-            throw self.apos.error(
-              'invalid',
-              'the model returned tool calls but the call sent no tools'
+            if (turn.finishReason === 'toolCalls' && !tools.size) {
+              throw self.apos.error(
+                'invalid',
+                'the model returned tool calls but the call sent no tools'
+              );
+            }
+            context.request.messages.push({
+              role: 'assistant',
+              content: turn.content
+            });
+            if (turn.finishReason !== 'toolCalls') {
+              break;
+            }
+            const calls = turn.content.filter((part) => part.type === 'toolCall');
+            if (turns === canonical.maxSteps) {
+              pending = calls;
+              break;
+            }
+            // A cancellation observed between steps ends the run before
+            // more work starts; the turn's requests stay unexecuted on
+            // `toolCalls`
+            if (canonical.signal?.aborted) {
+              pending = calls;
+              cancelled = true;
+              break;
+            }
+            if (canonical.onMessage) {
+              await canonical.onMessage({
+                role: 'assistant',
+                content: turn.content
+              });
+            }
+            const outcomes = await self.executeToolCalls(
+              req, tools, calls, handlerContext
             );
+            steps.push(...outcomes);
+            context.request.messages.push({
+              role: 'tool',
+              content: outcomes.map((outcome) => ({
+                type: 'toolResult',
+                toolCallId: outcome.toolCall.id,
+                ...(outcome.error !== undefined
+                  ? { error: outcome.error }
+                  : { output: outcome.result })
+              }))
+            });
+            // The batch was waited out and recorded; wind down before
+            // asking the model again
+            if (canonical.signal?.aborted) {
+              cancelled = true;
+              break;
+            }
           }
-          context.request.messages.push({
-            role: 'assistant',
-            content: turn.content
-          });
-          if (turn.finishReason !== 'toolCalls') {
-            break;
+        } catch (e) {
+          // Only an abort-shaped throw converts to a cancelled run, and
+          // only while this call's signal has fired — a genuine failure
+          // racing a cancel still throws
+          if (!isAbort(e) || !canonical.signal?.aborted) {
+            throw e;
           }
-          const calls = turn.content.filter((part) => part.type === 'toolCall');
-          if (turns === canonical.maxSteps) {
-            pending = calls;
-            break;
-          }
-          const outcomes = await self.executeToolCalls(req, tools, calls, handlerContext);
-          steps.push(...outcomes);
-          context.request.messages.push({
-            role: 'tool',
-            content: outcomes.map((outcome) => ({
-              type: 'toolResult',
-              toolCallId: outcome.toolCall.id,
-              ...(outcome.error !== undefined
-                ? { error: outcome.error }
-                : { output: outcome.result })
-            }))
-          });
+          cancelled = true;
         }
         context.result = self.assembleResult(context, turn, {
           steps,
           usage,
           pending,
-          object: turn.object,
-          hadTools: tools.size > 0
+          object: turn?.object,
+          hadTools: tools.size > 0,
+          ...(cancelled && { finishReason: 'cancel' })
         });
         await self.emit('afterGenerate', req, context);
         return context.result;
+      },
+      // The non-blocking form of `generate`: the same flow wrapped in a
+      // job on `@apostrophecms/job`. The `await` covers job creation
+      // only — the method returns { jobId, cancel } as soon as the job
+      // record exists, the run continues in the background, and the
+      // exact object `generate` would have returned is stored on the
+      // record as `results` (a failure stores its error instead),
+      // readable via the job module's status route.
+      //
+      // Accepts everything `generate` accepts, passed through
+      // untouched — `onMessage` is called as `(message, { jobId })`
+      // here — plus:
+      // `onEnd` (async function): called once with `(error, result)`
+      //   when the run ends — the error it failed with, or the unified
+      //   result (a cancelled run is a result, finishReason 'cancel').
+      //   Its own throw is logged, never recorded on the job;
+      // `expireAfter` (seconds): how long the job record is kept,
+      //   defaulting to the `jobExpireAfter` option; 0 keeps it
+      //   forever.
+      //
+      // `cancel()` requests cancellation, in process; the job module's
+      // cancel route does the same cross-process, by jobId. Either way
+      // the flag travels through the job record, the abort signal
+      // reaches the in-flight provider call and every handler, the run
+      // winds down per generate's cancellation semantics with the
+      // partial result stored, and the job ends 'cancelled'.
+      //
+      // Invalid options throw here, synchronously — a job record is
+      // created only for a run that can start. Tool handlers may not
+      // start jobs: a subagent's work is blocking by design.
+      async generateJob(req, stringOrOptions, options) {
+        if ((req.aposAiDepth || 0) > 0) {
+          throw self.apos.error('invalid', 'generateJob cannot be called from a tool handler: a subagent is blocking only');
+        }
+        const isPrompt = typeof stringOrOptions === 'string';
+        let source;
+        if (isPrompt && (options === undefined || isObject(options))) {
+          source = options || {};
+        } else if (!isPrompt && isObject(stringOrOptions) &&
+          options === undefined) {
+          source = stringOrOptions;
+        } else {
+          // Malformed argument shapes: the normalizer throws its own
+          // message for every one of them
+          self.normalizeGenerateOptions(stringOrOptions, options);
+        }
+        const {
+          onEnd, expireAfter, ...generateOptions
+        } = source;
+        if (onEnd !== undefined && typeof onEnd !== 'function') {
+          throw self.apos.error('invalid', '"onEnd" must be a function');
+        }
+        if (expireAfter !== undefined &&
+          (!Number.isInteger(expireAfter) || expireAfter < 0)) {
+          throw self.apos.error('invalid', '"expireAfter" must be a non-negative integer');
+        }
+        // Fail bad generate options now, before any record exists
+        self.normalizeGenerateOptions(
+          isPrompt ? stringOrOptions : generateOptions,
+          isPrompt ? generateOptions : undefined
+        );
+        const jobModule = self.apos.modules['@apostrophecms/job'];
+        const controller = new AbortController();
+        const signal = generateOptions.signal
+          ? AbortSignal.any([ controller.signal, generateOptions.signal ])
+          : controller.signal;
+        const ttl = expireAfter !== undefined
+          ? expireAfter
+          : self.options.jobExpireAfter;
+        let jobId = null;
+        const backgroundOptions = {
+          ...generateOptions,
+          signal,
+          ...(generateOptions.onMessage && {
+            onMessage: (message) => generateOptions.onMessage(message, { jobId })
+          })
+        };
+        const returned = await jobModule.run(req, doTheWork, {
+          notifications: false,
+          ...(req.user?._id && { userId: req.user._id }),
+          ...(ttl > 0 && { expireAfter: ttl })
+        });
+        jobId = returned?.jobId;
+        if (!jobId) {
+          throw self.apos.error('error', 'the job record could not be created');
+        }
+        return {
+          jobId,
+          cancel: async () => {
+            // The record first, so the status can only end 'cancelled',
+            // then the local signal — no waiting for the poll
+            await jobModule.requestCancel(jobId);
+            controller.abort();
+          }
+        };
+
+        async function doTheWork(workReq, reporting) {
+          let running = true;
+          watchCancellation();
+          try {
+            const result = isPrompt
+              ? await self.generate(workReq, stringOrOptions, backgroundOptions)
+              : await self.generate(workReq, backgroundOptions);
+            reporting.setResults(result);
+            await report(null, result);
+          } catch (error) {
+            await report(error, undefined);
+            throw error;
+          } finally {
+            running = false;
+          }
+
+          // A cross-process cancel only reaches this process through
+          // the job record: watch the flag while the run is live and
+          // fire the local signal when it appears. The loop cannot
+          // outlive the record: isCanceling also reports true once the
+          // record is gone or ended, so even a run stuck forever has
+          // its watcher stop — and its signal fired — no later than the
+          // record's expiry
+          async function watchCancellation() {
+            try {
+              for (;;) {
+                await self.pause(self.options.jobPollInterval);
+                if (!running || signal.aborted) {
+                  break;
+                }
+                if (await reporting.isCanceling()) {
+                  controller.abort();
+                  break;
+                }
+              }
+            } catch (e) {
+              self.apos.util.error(e);
+            }
+          }
+
+          async function report(error, result) {
+            if (!onEnd) {
+              return;
+            }
+            try {
+              await onEnd(error, result);
+            } catch (e) {
+              self.logError(workReq, 'hook', e.message, {
+                jobId,
+                hook: 'onEnd',
+                stack: e.stack
+              });
+            }
+          }
+        }
       },
       // The image method: text → image against the routed image
       // provider, or image(s) + text → image (editing) when `images`
@@ -1748,6 +1966,11 @@ module.exports = {
           try {
             return await call();
           } catch (e) {
+            // A fired abort signal is the caller's own doing, not a
+            // provider failure: no failure record, no retry
+            if (isAbort(e)) {
+              throw e;
+            }
             const error = (e?.aposError ? e : record.adapter.normalizeError(e)) || e;
             const elapsed = Date.now() - started;
             const data = {
@@ -1922,9 +2145,12 @@ module.exports = {
       // populated tells the caller what happened. The transcript is
       // resumable as the next call's `messages`.
       assembleResult(context, turn, {
-        steps, usage, pending, object, hadTools
+        steps, usage, pending, object, hadTools, finishReason
       }) {
-        const text = turn.content
+        // `turn` is null when a cancellation aborted the first provider
+        // call of a step: there is no final assistant turn, only the
+        // work recorded so far
+        const text = (turn ? turn.content : [])
           .filter(part => part.type === 'text')
           .map(part => part.text)
           .join('');
@@ -1935,10 +2161,12 @@ module.exports = {
           ...(hadTools && { steps }),
           ...(pending && { toolCalls: pending }),
           // The step budget cutting the loop is its own finish reason,
-          // like the token budget's 'length'
-          finishReason: pending ? 'maxSteps' : turn.finishReason,
+          // like the token budget's 'length'; an explicit override wins
+          // (a cancelled run)
+          finishReason: finishReason ||
+            (pending ? 'maxSteps' : turn.finishReason),
           usage,
-          model: turn.model || context.request.model,
+          model: turn?.model || context.request.model,
           provider: context.provider
         };
       },
@@ -2002,7 +2230,8 @@ module.exports = {
 
         const {
           providers, provider, effort, image, maxSteps, mock, mockImage,
-          retryAttempts, retryBaseDelay, retryMaxElapsed
+          retryAttempts, retryBaseDelay, retryMaxElapsed,
+          jobExpireAfter, jobPollInterval
         } = options;
 
         if (!isObject(providers)) {
@@ -2107,11 +2336,16 @@ module.exports = {
         for (const [ name, value ] of Object.entries({
           retryAttempts,
           retryBaseDelay,
-          retryMaxElapsed
+          retryMaxElapsed,
+          jobPollInterval
         })) {
           if (!Number.isInteger(value) || value < 1) {
             fail(`"${name}" must be a positive integer`);
           }
+        }
+
+        if (!Number.isInteger(jobExpireAfter) || jobExpireAfter < 0) {
+          fail('"jobExpireAfter" must be a non-negative integer');
         }
       }
     };

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -31,7 +31,7 @@ module.exports = {
     // Elapsed-time budget in milliseconds for one call including its
     // retry waits; a delay that would land past it stops the call
     retryMaxElapsed: 60000,
-    // Seconds an AI job record is kept before the job layer deletes it;
+    // Seconds an AI job record is kept before the database expires it;
     // 0 keeps records forever. Overridable per call (generateJob's
     // expireAfter). Also the upper bound on a background run's
     // cancellation watcher: a deleted record cancels its own run

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -1559,7 +1559,18 @@ module.exports = {
       //   Its own throw is logged, never recorded on the job;
       // `expireAfter` (seconds): how long the job record is kept,
       //   defaulting to the `jobExpireAfter` option; 0 keeps it
-      //   forever.
+      //   forever;
+      // `notify` (boolean, default true): publish the run's progress
+      //   to the caller's browser (see publishJobEvent) — 'started'
+      //   once the record exists, 'message' per intermediate assistant
+      //   turn with the turn as `message`, and 'ended' with the
+      //   record's terminal `status` plus the result's `finishReason`
+      //   or the failure's `error` ({ name, message }). Correlate by
+      //   `jobId` and read the stored result from the job's status
+      //   route — the record may flip to its terminal status moments
+      //   after the event. `false` opts out; the hooks then own the
+      //   whole transport, while cancellation stays on the job layer
+      //   either way.
       //
       // `cancel()` requests cancellation, in process; the job module's
       // cancel route does the same cross-process, by jobId. Either way
@@ -1588,10 +1599,13 @@ module.exports = {
           self.normalizeGenerateOptions(stringOrOptions, options);
         }
         const {
-          onEnd, expireAfter, ...generateOptions
+          onEnd, expireAfter, notify = true, ...generateOptions
         } = source;
         if (onEnd !== undefined && typeof onEnd !== 'function') {
           throw self.apos.error('invalid', '"onEnd" must be a function');
+        }
+        if (typeof notify !== 'boolean') {
+          throw self.apos.error('invalid', '"notify" must be a boolean');
         }
         if (expireAfter !== undefined &&
           (!Number.isInteger(expireAfter) || expireAfter < 0)) {
@@ -1614,8 +1628,15 @@ module.exports = {
         const backgroundOptions = {
           ...generateOptions,
           signal,
-          ...(generateOptions.onMessage && {
-            onMessage: (message) => generateOptions.onMessage(message, { jobId })
+          ...((notify || generateOptions.onMessage) && {
+            onMessage: async (message) => {
+              if (notify) {
+                await self.publishJobEvent(req, jobId, 'message', { message });
+              }
+              if (generateOptions.onMessage) {
+                await generateOptions.onMessage(message, { jobId });
+              }
+            }
           })
         };
         const returned = await jobModule.run(req, doTheWork, {
@@ -1637,9 +1658,15 @@ module.exports = {
           }
         };
 
-        async function doTheWork(workReq, reporting) {
+        async function doTheWork(workReq, reporting, info) {
+          // Known here before the creating call has even returned, so
+          // the started event can only precede every message event
+          jobId = info.jobId;
           let running = true;
           watchCancellation();
+          if (notify) {
+            await self.publishJobEvent(workReq, jobId, 'started');
+          }
           try {
             const result = isPrompt
               ? await self.generate(workReq, stringOrOptions, backgroundOptions)
@@ -1678,6 +1705,22 @@ module.exports = {
           }
 
           async function report(error, result) {
+            if (notify) {
+              await self.publishJobEvent(workReq, jobId, 'ended', error
+                ? {
+                  status: 'failed',
+                  error: {
+                    name: error.name,
+                    message: error.message
+                  }
+                }
+                : {
+                  status: result.finishReason === 'cancel'
+                    ? 'cancelled'
+                    : 'completed',
+                  finishReason: result.finishReason
+                });
+            }
             if (!onEnd) {
               return;
             }
@@ -1691,6 +1734,45 @@ module.exports = {
               });
             }
           }
+        }
+      },
+      // The built-in progress publisher for generateJob: deliver one
+      // stage of a background run — 'started', 'message' or 'ended',
+      // with `data` as the stage's payload — to the job owner's
+      // browser over the notification channel. Each stage is an
+      // invisible, auto-dismissing notification whose real cargo is
+      // the one-shot browser-bus event "ai-generate-job", emitted in
+      // exactly one tab, carrying { jobId, stage, ...data }:
+      // apos.bus.$on('ai-generate-job', (data) => ...) and filter by
+      // jobId. Notifications reach logged-in users only, so a req
+      // without a user _id is a silent no-op — there is nobody to
+      // deliver to. A delivery failure is logged and never fails the
+      // run it reports on.
+      async publishJobEvent(req, jobId, stage, data = {}) {
+        if (!req.user?._id) {
+          return;
+        }
+        try {
+          await self.apos.notification.trigger(req, ' ', {
+            classes: [ 'apos-notification--hidden' ],
+            // Seconds; the shortest the dismiss knob offers, so the
+            // carrier leaves the DOM and the database promptly
+            dismiss: 1,
+            event: {
+              name: 'ai-generate-job',
+              data: {
+                jobId,
+                stage,
+                ...data
+              }
+            }
+          });
+        } catch (e) {
+          self.logError(req, 'notify', e.message, {
+            jobId,
+            stage,
+            stack: e.stack
+          });
         }
       },
       // The image method: text → image against the routed image

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -1739,10 +1739,10 @@ module.exports = {
       // The built-in progress publisher for generateJob: deliver one
       // stage of a background run — 'started', 'message' or 'ended',
       // with `data` as the stage's payload — to the job owner's
-      // browser over the notification channel. Each stage is an
-      // invisible, auto-dismissing notification whose real cargo is
-      // the one-shot browser-bus event "ai-generate-job", emitted in
-      // exactly one tab, carrying { jobId, stage, ...data }:
+      // browser over the notification channel. Each stage is a bus
+      // notification — never rendered — whose one-shot browser-bus
+      // event "ai-generate-job" is emitted in exactly one tab,
+      // carrying { jobId, stage, ...data }:
       // apos.bus.$on('ai-generate-job', (data) => ...) and filter by
       // jobId. Notifications reach logged-in users only, so a req
       // without a user _id is a silent no-op — there is nobody to
@@ -1753,11 +1753,8 @@ module.exports = {
           return;
         }
         try {
-          await self.apos.notification.trigger(req, ' ', {
-            classes: [ 'apos-notification--hidden' ],
-            // Seconds; the shortest the dismiss knob offers, so the
-            // carrier leaves the DOM and the database promptly
-            dismiss: 1,
+          await self.apos.notification.trigger(req, {
+            bus: true,
             event: {
               name: 'ai-generate-job',
               data: {

--- a/packages/apostrophe/modules/@apostrophecms/job/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/job/index.js
@@ -440,7 +440,7 @@ module.exports = {
       // comfortably above the longest expected run — this also cleans up
       // orphaned records whose process died before calling `end`. Jobs
       // without `expireAfter` are kept forever, as before.
-      async start(options) {
+      async start(options = {}) {
         const now = new Date();
         const job = {
           _id: self.apos.util.generateId(),

--- a/packages/apostrophe/modules/@apostrophecms/job/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/job/index.js
@@ -44,6 +44,30 @@ module.exports = {
           `);
 
           return {};
+        },
+        // Request cancellation of a running job. The running process
+        // observes the flag via `reporting.isCanceling` and decides how
+        // to wind down; the request is a no-op for jobs that never
+        // check it and for jobs that already ended.
+        async ':_id/cancel'(req) {
+          if (!self.apos.permission.can(req, 'view-draft')) {
+            throw self.apos.error('notfound');
+          }
+
+          const jobId = self.apos.launder.id(req.params._id);
+          const job = await self.db.findOne({ _id: jobId });
+
+          if (!job) {
+            throw self.apos.error('notfound');
+          }
+
+          if (job.userId && job.userId !== (req.user && req.user._id)) {
+            throw self.apos.error('notfound');
+          }
+
+          await self.requestCancel(jobId);
+
+          return {};
         }
       }
     };
@@ -59,6 +83,10 @@ module.exports = {
         const job = await self.db.findOne({ _id: jobId });
 
         if (!job) {
+          throw self.apos.error('notfound');
+        }
+
+        if (job.userId && job.userId !== (req.user && req.user._id)) {
           throw self.apos.error('notfound');
         }
 
@@ -98,10 +126,13 @@ module.exports = {
       // operation on a single type of piece.
       //
       // Notification messages should be included on a `req.body.messages`
-      // object. See `triggerNotification for details`.
+      // object. See `triggerNotification for details`. Pass
+      // `notifications: false` in `options` to skip that wiring entirely,
+      // e.g. when the caller provides its own progress transport.
       async runBatch(req, ids, change, options = {}) {
         let job;
         let notification;
+        const notifications = options.notifications !== false;
         const total = ids.length;
 
         const results = {};
@@ -117,7 +148,7 @@ module.exports = {
           run();
 
           // Trigger the "in progress" notification.
-          notification = await self.triggerNotification(req, 'progress', {
+          notification = notifications && await self.triggerNotification(req, 'progress', {
             // It's only relevant to pass a job ID to the notification if
             // the notification will show progress. Without a total number we
             // can't show progress.
@@ -136,7 +167,7 @@ module.exports = {
             return res.status(500).send('error');
           }
           try {
-            return await self.end(job, false);
+            return await self.end(job, false, undefined, err);
           } catch (err) {
             // Not a lot we can do about this since we already
             // stopped talking to the user
@@ -161,15 +192,19 @@ module.exports = {
             await self.end(job, good, results);
             // Wait for increments to be updated in DB
             await Promise.allSettled(promises);
-            // Trigger the completed notification.
-            await self.triggerNotification(req, 'completed', {
-              contextId: job._id,
-              dismiss: true
-            });
-            // Dismiss the progress notification. It will delay 4 seconds
-            // because "completed" notification will dismiss in 5 and we want
-            // to maintain the feeling of process order for users.
-            await self.apos.notification.dismiss(req, notification.noteId, 4000);
+            if (notifications) {
+              // Trigger the completed notification.
+              await self.triggerNotification(req, 'completed', {
+                contextId: job._id,
+                dismiss: true
+              });
+              // Dismiss the progress notification. It will delay 4 seconds
+              // because "completed" notification will dismiss in 5 and we want
+              // to maintain the feeling of process order for users.
+              if (notification && notification.noteId) {
+                await self.apos.notification.dismiss(req, notification.noteId, 4000);
+              }
+            }
           }
         }
       },
@@ -189,29 +224,43 @@ module.exports = {
       // `reporting.setResults(object)` may also be called to pass a
       // results object, which will be available on the finished job document.
       //
+      // `reporting.isCanceling()` resolves to `true` once cancellation of
+      // the job has been requested (see the cancel route and
+      // `requestCancel`). `doTheWork` may check it at convenient points
+      // and wind down early; the job then ends with a `cancelled` status.
+      // Jobs that never check it simply run to completion.
+      //
+      // If `doTheWork` throws, the job ends with a `failed` status and the
+      // error is recorded on the job document (see `end`).
+      //
       // This method will return an object with a `jobId` identifier as soon as
       // the job is ready to start, and the actual job will continue in the
       // background afterwards. You can pass `jobId` to the `progress` API route
       // of this module as `_id` on the request body to get job status info.
       //
       // Notification messages should be included on a `req.body.messages`
-      // object. See `triggerNotification for details`.
+      // object. See `triggerNotification for details`. Pass
+      // `notifications: false` in `options` to skip that wiring entirely,
+      // e.g. when the caller provides its own progress transport
+      // (`req.body` is client-controlled, so callers cannot rely on the
+      // absence of `messages`).
       async run(req, doTheWork, options = {}) {
         const res = req.res;
+        const notifications = options.notifications !== false;
         let job;
         let total;
 
         try {
           job = await self.start(options);
 
-          const notification = await self.triggerNotification(req, 'progress', {
+          const notification = notifications && await self.triggerNotification(req, 'progress', {
             jobId: job._id,
             ids: options.ids,
             action: options.action,
             docTypes: options.docTypes
           });
 
-          run({ notificationId: notification.noteId });
+          run({ notificationId: notification && notification.noteId });
 
           return {
             jobId: job._id
@@ -228,6 +277,7 @@ module.exports = {
 
         async function run(info) {
           let results;
+          let error;
           let good = false;
           const promises = [];
           try {
@@ -252,23 +302,36 @@ module.exports = {
               },
               setResults (_results) {
                 results = _results;
+              },
+              async isCanceling () {
+                const found = await self.db.findOne({ _id: job._id }, {
+                  projection: { cancelRequested: 1 }
+                });
+                return Boolean(found && found.cancelRequested);
               }
             }, info);
             good = true;
+          } catch (err) {
+            error = err;
+            self.apos.util.error(err);
           } finally {
-            await self.end(job, good, results);
+            await self.end(job, good, results, error);
             // Wait for increments to be updated in DB
             await Promise.allSettled(promises);
-            // Trigger the completed notification.
-            await self.triggerNotification(req, 'completed', {
-              contextId: job._id,
-              count: total,
-              dismiss: true
-            }, results);
-            // Dismiss the progress notification. It will delay 4 seconds
-            // because "completed" notification will dismiss in 5 and we want
-            // to maintain the feeling of process order for users.
-            await self.apos.notification.dismiss(req, info.notificationId, 4000);
+            if (notifications) {
+              // Trigger the completed notification.
+              await self.triggerNotification(req, 'completed', {
+                contextId: job._id,
+                count: total,
+                dismiss: true
+              }, results);
+              // Dismiss the progress notification. It will delay 4 seconds
+              // because "completed" notification will dismiss in 5 and we want
+              // to maintain the feeling of process order for users.
+              if (info.notificationId) {
+                await self.apos.notification.dismiss(req, info.notificationId, 4000);
+              }
+            }
           }
         }
       },
@@ -351,7 +414,21 @@ module.exports = {
       // to indicate the success or failure of one "row" or other item
       // processed, and you *may* call `setTotal(job, n)` to indicate
       // how many rows to expect for better progress display.
+      //
+      // `options` may include:
+      //
+      // `userId`: the `_id` of the user who owns the job. When present,
+      // the status and cancel routes are restricted to that user; jobs
+      // without a `userId` remain readable by anyone who can `view-draft`.
+      //
+      // `expireAfter`: a number of seconds after which the job document
+      // is deleted from the database (see `cleanupExpired`). The
+      // countdown starts now, not at completion, so pick a value
+      // comfortably above the longest expected run — this also cleans up
+      // orphaned records whose process died before calling `end`. Jobs
+      // without `expireAfter` are kept forever, as before.
       async start(options) {
+        const now = new Date();
         const job = {
           _id: self.apos.util.generateId(),
           good: 0,
@@ -359,13 +436,22 @@ module.exports = {
           processed: 0,
           status: 'running',
           ended: false,
-          when: new Date()
+          cancelRequested: false,
+          when: now,
+          // same instant as the legacy `when`, which is kept for
+          // backwards compatibility; startedAt/endedAt are the pair to use
+          startedAt: now,
+          ...(options.userId && { userId: options.userId }),
+          ...(options.expireAfter && {
+            expireAt: new Date(now.getTime() + options.expireAfter * 1000)
+          })
         };
         const context = {
           _id: job._id,
           options
         };
 
+        self.cleanupExpired();
         await self.db.insertOne(job);
         return context;
       },
@@ -433,20 +519,86 @@ module.exports = {
       // If the results parameter is not omitted entirely,
       // it is added to the job object in the database
       // as the `results` property.
-      async end(job, success, results) {
+      //
+      // A successful end after cancellation was requested is recorded
+      // with the `cancelled` status instead of `completed` — a
+      // cooperatively cancelled job winds down and ends normally, with
+      // any partial results preserved. A failure is always `failed`.
+      //
+      // If `error` is present it is recorded on the job document:
+      // an `Error` instance is reduced to `{ name, message, data? }`
+      // (already-serializable payloads are stored as given).
+      async end(job, success, results, error) {
         // context object gets an update to avoid a
         // race condition with checkStopped
         job.ended = true;
+        // Read-then-update leaves a small window: a cancel request landing
+        // between the two ends up `completed` with `cancelRequested: true`,
+        // which is acceptable — cancellation is a request that arrived too
+        // late. Closing the window would take an aggregation-pipeline
+        // update, which not every supported database backend understands;
+        // revisit if a stricter guarantee is ever needed.
+        const current = await self.db.findOne({ _id: job._id }, {
+          projection: { cancelRequested: 1 }
+        });
+        const status = success
+          ? (current && current.cancelRequested ? 'cancelled' : 'completed')
+          : 'failed';
         return self.db.updateOne({ _id: job._id }, {
           $set: {
             ended: true,
-            status: success ? 'completed' : 'failed',
-            results
+            endedAt: new Date(),
+            status,
+            results,
+            ...(error !== undefined && { error: serializeError(error) })
           }
         });
+
+        function serializeError(error) {
+          if (error instanceof Error) {
+            return {
+              name: error.name,
+              message: error.message,
+              ...(error.data !== undefined && { data: error.data })
+            };
+          }
+          return error;
+        }
+      },
+      // Request cancellation of a running job. Sets the `cancelRequested`
+      // flag the running process observes via `reporting.isCanceling`,
+      // whichever process that is — the flag travels through the
+      // database, so it works across processes. Like SIGTERM, this is a
+      // request rather than preemption: the job decides when and whether
+      // to wind down, and its status flips to `cancelled` only once it
+      // actually ends. Unlike SIGTERM there is no default handler — a
+      // job that never checks the flag simply runs to completion.
+      // Has no effect on jobs that already ended.
+      async requestCancel(jobId) {
+        return self.db.updateOne({
+          _id: jobId,
+          ended: false
+        }, {
+          $set: { cancelRequested: true }
+        });
+      },
+      // Delete job documents whose opt-in `expireAt` has passed. Invoked
+      // on every `start`, so cleanup rides on activity — no timers, no
+      // reliance on database-level expiry mechanisms, works the same on
+      // every backend. Safe to fire and forget: errors are logged, never
+      // thrown.
+      async cleanupExpired() {
+        try {
+          await self.db.deleteMany({ expireAt: { $lte: new Date() } });
+        } catch (err) {
+          self.apos.util.error(err);
+        }
       },
       async ensureCollection() {
         self.db = await self.apos.db.collection(self.options.collectionName);
+        // Supports the expired-job sweep in `cleanupExpired`; `sparse`
+        // keeps the many jobs without `expireAt` out of the index
+        await self.db.createIndex({ expireAt: 1 }, { sparse: true });
       },
       getBrowserData(req) {
         return {

--- a/packages/apostrophe/modules/@apostrophecms/job/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/job/index.js
@@ -429,7 +429,7 @@ module.exports = {
       // without a `userId` remain readable by anyone who can `view-draft`.
       //
       // `expireAfter`: a number of seconds after which the job document
-      // is deleted from the database (see `cleanupExpired`). The
+      // is deleted from the database (a TTL index on `expireAt`). The
       // countdown starts now, not at completion, so pick a value
       // comfortably above the longest expected run — this also cleans up
       // orphaned records whose process died before calling `end`. Jobs
@@ -458,7 +458,6 @@ module.exports = {
           options
         };
 
-        self.cleanupExpired();
         await self.db.insertOne(job);
         return context;
       },
@@ -589,23 +588,16 @@ module.exports = {
           $set: { cancelRequested: true }
         });
       },
-      // Delete job documents whose opt-in `expireAt` has passed. Invoked
-      // on every `start`, so cleanup rides on activity — no timers, no
-      // reliance on database-level expiry mechanisms, works the same on
-      // every backend. Safe to fire and forget: errors are logged, never
-      // thrown.
-      async cleanupExpired() {
-        try {
-          await self.db.deleteMany({ expireAt: { $lte: new Date() } });
-        } catch (err) {
-          self.apos.util.error(err);
-        }
-      },
       async ensureCollection() {
         self.db = await self.apos.db.collection(self.options.collectionName);
-        // Supports the expired-job sweep in `cleanupExpired`; `sparse`
-        // keeps the many jobs without `expireAt` out of the index
-        await self.db.createIndex({ expireAt: 1 }, { sparse: true });
+        // Per-document TTL: `expireAfterSeconds: 0` expires each document
+        // at the exact time stored in its `expireAt` field; documents
+        // without the field never expire, and `sparse` keeps them out of
+        // the index entirely.
+        await self.db.createIndex({ expireAt: 1 }, {
+          expireAfterSeconds: 0,
+          sparse: true
+        });
       },
       getBrowserData(req) {
         return {

--- a/packages/apostrophe/modules/@apostrophecms/job/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/job/index.js
@@ -214,7 +214,7 @@ module.exports = {
       // This is not the way to implement a batch operation on pieces; see the
       // `batchSimple` method of that module.
       //
-      // The `doTheWork` function receives `(req, reporting)` and may
+      // The `doTheWork` function receives `(req, reporting, info)` and may
       // optionally invoke `reporting.success()` and `reporting.failure()` to
       // update the progress and error counters, and `reporting.setTotal()` to
       // indicate the total number of counts expected so a progress meter can be
@@ -223,6 +223,9 @@ module.exports = {
       //
       // `reporting.setResults(object)` may also be called to pass a
       // results object, which will be available on the finished job document.
+      //
+      // `info` carries the job's `jobId` — the same id returned to the
+      // caller — so the work can label its own progress transport.
       //
       // `reporting.isCanceling()` resolves to `true` once cancellation of
       // the job has been requested (see the cancel route and
@@ -264,7 +267,10 @@ module.exports = {
             docTypes: options.docTypes
           });
 
-          run({ notificationId: notification && notification.noteId });
+          run({
+            notificationId: notification && notification.noteId,
+            jobId: job._id
+          });
 
           return {
             jobId: job._id

--- a/packages/apostrophe/modules/@apostrophecms/job/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/job/index.js
@@ -226,9 +226,13 @@ module.exports = {
       //
       // `reporting.isCanceling()` resolves to `true` once cancellation of
       // the job has been requested (see the cancel route and
-      // `requestCancel`). `doTheWork` may check it at convenient points
-      // and wind down early; the job then ends with a `cancelled` status.
-      // Jobs that never check it simply run to completion.
+      // `requestCancel`) — or when the job document is gone or already
+      // marked ended: a record nobody can observe or cancel anymore is a
+      // standing instruction to stop, so an expired (`expireAfter`) or
+      // externally deleted record winds down its own orphaned run.
+      // `doTheWork` may check it at convenient points and wind down
+      // early; the job then ends with a `cancelled` status. Jobs that
+      // never check it simply run to completion.
       //
       // If `doTheWork` throws, the job ends with a `failed` status and the
       // error is recorded on the job document (see `end`).
@@ -305,9 +309,12 @@ module.exports = {
               },
               async isCanceling () {
                 const found = await self.db.findOne({ _id: job._id }, {
-                  projection: { cancelRequested: 1 }
+                  projection: {
+                    cancelRequested: 1,
+                    ended: 1
+                  }
                 });
-                return Boolean(found && found.cancelRequested);
+                return !found || Boolean(found.cancelRequested || found.ended);
               }
             }, info);
             good = true;

--- a/packages/apostrophe/modules/@apostrophecms/notification/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/notification/index.js
@@ -270,6 +270,16 @@ module.exports = {
       // `_id` and, for the 'completed' stage, the job `action`,
       // e.g., 'archive'.
       //
+      // `options.event`, an object with `name` and optional `data`
+      // properties, is emitted on the browser bus (`apos.bus`) in exactly
+      // one tab when the notification arrives.
+      //
+      // If `options.bus` is set to `true`, the notification is a pure
+      // message-bus carrier: it is never rendered — the browser emits its
+      // `event` and dismisses it. `event` is then required, the `message`
+      // argument becomes optional, and the options object may be passed in
+      // its place: `apos.notify(req, { bus: true, event })`.
+      //
       // Throws an error if there is no `req.user`.
       //
       // `interpolate` may contain an object with properties to be
@@ -291,7 +301,15 @@ module.exports = {
         if (!req.user) {
           throw self.apos.error('forbidden');
         }
-        if (!message) {
+        if (message && (typeof message === 'object') && !Array.isArray(message)) {
+          // The options object may be passed in place of the message
+          options = message;
+          message = null;
+        }
+        if (options.bus && !options.event?.name) {
+          throw self.apos.error('invalid', 'a bus notification requires an event');
+        }
+        if (!message && !options.bus) {
           throw self.apos.error('required');
         }
 
@@ -301,7 +319,7 @@ module.exports = {
           _id: self.apos.util.generateId(),
           createdAt: new Date(),
           userId: req.user._id,
-          message,
+          message: message || null,
           icon: options.icon,
           interpolate: interpolate || options.interpolate || {},
           // Defaults to true, otherwise launder as boolean

--- a/packages/apostrophe/modules/@apostrophecms/ui/ui/apos/stores/notification.js
+++ b/packages/apostrophe/modules/@apostrophecms/ui/ui/apos/stores/notification.js
@@ -97,9 +97,13 @@ export const useNotificationStore = defineStore('notification', () => {
           })
         });
 
+        const incoming = res.notifications || [];
+        // Bus notifications are pure event carriers: emit their events
+        // and keep them out of the visible list
+        await emitBusEvents(incoming.filter((notif) => notif.bus));
         backendNotifs.value = [
           ...backendNotifs.value,
-          ...(res.notifications || [])
+          ...incoming.filter((notif) => !notif.bus)
         ];
         dismissed.value = [ ...dismissed.value, ...(res.dismissed || []) ];
         if (res.dismissed.length) {
@@ -119,6 +123,19 @@ export const useNotificationStore = defineStore('notification', () => {
       // eslint-disable-next-line no-console
       console.error(err);
       setTimeout(poll, 5000);
+    }
+
+    // Emit each bus notification's event, oldest first — clearEvent
+    // makes exactly one tab the emitter — then dismiss the carrier.
+    // An already-cleared event is dismissed without emitting
+    async function emitBusEvents(notifs) {
+      notifs.sort((a, b) => a.updatedAt > b.updatedAt ? 1 : -1);
+      for (const notif of notifs) {
+        if (notif.event?.name && await clearEvent(notif._id)) {
+          apos.bus.$emit(notif.event.name, notif.event.data);
+        }
+        await dismiss(notif._id);
+      }
     }
   }
 

--- a/packages/apostrophe/test/add-missing-schema-fields-project/test.js
+++ b/packages/apostrophe/test/add-missing-schema-fields-project/test.js
@@ -25,8 +25,9 @@ describe('Apostrophe - add-missing-schema-fields task', function() {
     : {};
 
   before(async function() {
+    // This only links `apostrophe` (a `file:` dependency) into node_modules.
     await util.promisify(exec)(
-      'npm install',
+      'npm install --no-audit --no-fund --prefer-offline',
       { cwd: projectCwd }
     );
   });

--- a/packages/apostrophe/test/ai-generate.js
+++ b/packages/apostrophe/test/ai-generate.js
@@ -271,6 +271,10 @@ describe('AI generate', function() {
         () => apos.ai.normalizeGenerateOptions('p', { signal: {} }),
         /"signal" must be an AbortSignal/
       );
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions('p', { onMessage: 'notify me' }),
+        /"onMessage" must be a function/
+      );
     });
 
     it('defaults cache to short and honors an explicit false', function() {

--- a/packages/apostrophe/test/ai-job.js
+++ b/packages/apostrophe/test/ai-job.js
@@ -11,6 +11,10 @@ describe('AI generateJob', function() {
   let chatScript;
   let chatCalls;
   let logRecords;
+  // Every notification the publisher triggered, in call order; the
+  // spy delegates to the real method so the docs land for real
+  let triggered;
+  let realTrigger;
   // Per-test coordination with the fixture tool handlers
   let gateNotify = null;
   let gateWait = null;
@@ -147,6 +151,7 @@ describe('AI generateJob', function() {
       }
     });
     jobModule = apos.modules['@apostrophecms/job'];
+    realTrigger = apos.notification.trigger;
   });
 
   after(function() {
@@ -174,7 +179,17 @@ describe('AI generateJob', function() {
     });
     // The job module logs background failures; keep the output clean
     apos.util.error = () => {};
+    triggered = [];
+    apos.notification.trigger = (req, message, options) => {
+      // Snapshot: trigger normalizes the options object in place
+      triggered.push({
+        message,
+        options: { ...options }
+      });
+      return realTrigger.call(apos.notification, req, message, options);
+    };
     await jobModule.db.deleteMany({});
+    await apos.notification.db.deleteMany({});
   });
 
   it('returns a handle immediately and stores the exact blocking result', async function() {
@@ -435,6 +450,167 @@ describe('AI generateJob', function() {
     ]);
   });
 
+  it('publishes started, per-turn and ended events over hidden notifications', async function() {
+    const req = apos.task.getReq({ user: { _id: 'owner1' } });
+    const seen = [];
+    chatScript = [
+      toolTurn(toolCall('c1', 'echo')),
+      textTurn('all done')
+    ];
+
+    const { jobId } = await apos.ai.generateJob(req, 'go', {
+      tools: [ 'echo' ],
+      onMessage(message) {
+        seen.push(message);
+      }
+    });
+    await waitForJob(jobId);
+
+    const events = triggered.map(({ options }) => options.event);
+    assert.deepEqual(
+      events.map((event) => [ event.name, event.data.stage, event.data.jobId ]),
+      [
+        [ 'ai-generate-job', 'started', jobId ],
+        [ 'ai-generate-job', 'message', jobId ],
+        [ 'ai-generate-job', 'ended', jobId ]
+      ]
+    );
+    assert.deepEqual(events[1].data.message, {
+      role: 'assistant',
+      content: [ toolCall('c1', 'echo') ]
+    });
+    assert.deepEqual(events[2].data, {
+      jobId,
+      stage: 'ended',
+      status: 'completed',
+      finishReason: 'stop'
+    });
+    // The caller's own hook ran alongside the publisher
+    assert.equal(seen.length, 1);
+    // Every stage travels as an invisible notification dismissing at
+    // the fastest rate the knob offers
+    for (const { message, options } of triggered) {
+      assert.equal(message, ' ');
+      assert.deepEqual(options.classes, [ 'apos-notification--hidden' ]);
+      assert.equal(options.dismiss, 1);
+    }
+    // Delivered for real, to the job owner
+    assert.equal(
+      await apos.notification.db.countDocuments({ userId: 'owner1' }),
+      3
+    );
+  });
+
+  it('a failed run publishes an ended event carrying the error', async function() {
+    const req = apos.task.getReq({ user: { _id: 'owner1' } });
+    chatScript = [
+      () => {
+        throw apos.error('forbidden', 'nope');
+      }
+    ];
+
+    const { jobId } = await apos.ai.generateJob(req, 'go');
+    await waitForJob(jobId);
+
+    assert.deepEqual(
+      triggered.map(({ options }) => options.event.data.stage),
+      [ 'started', 'ended' ]
+    );
+    assert.deepEqual(triggered.at(-1).options.event.data, {
+      jobId,
+      stage: 'ended',
+      status: 'failed',
+      error: {
+        name: 'forbidden',
+        message: 'nope'
+      }
+    });
+  });
+
+  it('a cancelled run publishes an ended event with the cancelled status', async function() {
+    const req = apos.task.getReq({ user: { _id: 'owner1' } });
+    chatScript = [
+      (request) => new Promise((resolve, reject) => {
+        request.signal.addEventListener('abort', () => {
+          const error = new Error('This operation was aborted');
+          error.name = 'AbortError';
+          reject(error);
+        });
+      })
+    ];
+
+    const { jobId, cancel } = await apos.ai.generateJob(req, 'slow one');
+    await waitFor(() => chatCalls.length === 1);
+    await cancel();
+    const job = await waitForJob(jobId);
+
+    assert.equal(job.status, 'cancelled');
+    assert.deepEqual(triggered.at(-1).options.event.data, {
+      jobId,
+      stage: 'ended',
+      status: 'cancelled',
+      finishReason: 'cancel'
+    });
+  });
+
+  it('notify: false delivers nothing while cancel still works', async function() {
+    const req = apos.task.getReq({ user: { _id: 'owner1' } });
+    chatScript = [
+      (request) => new Promise((resolve, reject) => {
+        request.signal.addEventListener('abort', () => {
+          const error = new Error('This operation was aborted');
+          error.name = 'AbortError';
+          reject(error);
+        });
+      })
+    ];
+
+    const { jobId, cancel } = await apos.ai.generateJob(req, 'slow one', {
+      notify: false
+    });
+    await waitFor(() => chatCalls.length === 1);
+    await cancel();
+    const job = await waitForJob(jobId);
+
+    assert.equal(job.status, 'cancelled');
+    assert.equal(job.results.finishReason, 'cancel');
+    assert.deepEqual(triggered, []);
+  });
+
+  it('a run without a user publishes nothing and still completes', async function() {
+    // The task req has a user without an _id: nobody to deliver to
+    const req = apos.task.getReq();
+    chatScript = [ textTurn('fine') ];
+
+    const { jobId } = await apos.ai.generateJob(req, 'go');
+    const job = await waitForJob(jobId);
+
+    assert.equal(job.status, 'completed');
+    assert.deepEqual(triggered, []);
+    assert.deepEqual(logRecords, []);
+  });
+
+  it('a delivery failure is logged and never fails the run', async function() {
+    const req = apos.task.getReq({ user: { _id: 'owner1' } });
+    chatScript = [ textTurn('fine') ];
+    apos.notification.trigger = async () => {
+      throw new Error('channel down');
+    };
+
+    const { jobId } = await apos.ai.generateJob(req, 'go');
+    const job = await waitForJob(jobId);
+
+    assert.equal(job.status, 'completed');
+    assert.equal(job.results.text, 'fine');
+    assert.deepEqual(
+      logRecords.map((record) => [ record.type, record.message, record.data.stage ]),
+      [
+        [ 'notify', 'channel down', 'started' ],
+        [ 'notify', 'channel down', 'ended' ]
+      ]
+    );
+  });
+
   it('a tool handler cannot start a job', async function() {
     const req = apos.task.getReq();
 
@@ -467,6 +643,10 @@ describe('AI generateJob', function() {
     await invalid(
       apos.ai.generateJob(req, 'x', { expireAfter: -1 }),
       /"expireAfter" must be a non-negative integer/
+    );
+    await invalid(
+      apos.ai.generateJob(req, 'x', { notify: 1 }),
+      /"notify" must be a boolean/
     );
     await invalid(
       apos.ai.generateJob(req),

--- a/packages/apostrophe/test/ai-job.js
+++ b/packages/apostrophe/test/ai-job.js
@@ -364,8 +364,8 @@ describe('AI generateJob', function() {
       }
     });
     await startedPromise;
-    // What the expiry sweep — or any external cleanup — does; the
-    // record is the only handle on the run, so its removal must stop it
+    // What record expiry — or any external cleanup — does; the record
+    // is the only handle on the run, so its removal must stop it
     await jobModule.db.deleteMany({});
     await endedPromise;
 

--- a/packages/apostrophe/test/ai-job.js
+++ b/packages/apostrophe/test/ai-job.js
@@ -1,0 +1,521 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert/strict');
+
+describe('AI generateJob', function() {
+  this.timeout(t.timeout);
+
+  let apos;
+  let jobModule;
+  // Each test scripts the fake adapter's chat: an array of thunks,
+  // one consumed per call, each receiving the live request
+  let chatScript;
+  let chatCalls;
+  let logRecords;
+  // Per-test coordination with the fixture tool handlers
+  let gateNotify = null;
+  let gateWait = null;
+  let abortNotify = null;
+
+  const toolCall = (id, name, input = {}) => ({
+    type: 'toolCall',
+    id,
+    name,
+    input
+  });
+  const toolTurn = (...calls) => () => ({
+    content: calls,
+    finishReason: 'toolCalls',
+    usage: {
+      inputTokens: 10,
+      outputTokens: 5
+    },
+    model: 'fake-medium'
+  });
+  const textTurn = (text = 'done') => () => ({
+    content: [ {
+      type: 'text',
+      text
+    } ],
+    finishReason: 'stop',
+    usage: {
+      inputTokens: 20,
+      outputTokens: 3
+    },
+    model: 'fake-medium'
+  });
+
+  before(async function() {
+    apos = await t.create({
+      root: module,
+      modules: {
+        'fake-adapters': {
+          init(self) {
+            self.apos.ai.addAdapter({
+              name: 'fake',
+              label: 'Fake',
+              capabilities: {
+                text: true,
+                tools: true,
+                structured: true
+              },
+              effort: {
+                medium: { model: 'fake-medium' }
+              },
+              models: {
+                'fake-medium': {
+                  contextWindow: 200000,
+                  maxOutputTokens: 16000
+                }
+              },
+              validate() {},
+              async chat(req, request) {
+                // Snapshot: the loop keeps growing request.messages
+                chatCalls.push({
+                  ...request,
+                  messages: [ ...request.messages ]
+                });
+                const step = chatScript.shift();
+                if (step === undefined) {
+                  throw new Error('chat called beyond its script');
+                }
+                return step(request);
+              },
+              normalizeError(err) {
+                return err;
+              }
+            });
+          }
+        },
+        'job-tools': {
+          init(self) {
+            const okInput = {
+              type: 'object',
+              properties: {}
+            };
+            const okSchema = { ok: { type: 'boolean' } };
+            self.apos.ai.addTool({
+              name: 'echo',
+              description: 'The echo tool.',
+              input: okInput,
+              schema: okSchema,
+              handler: async () => ({ ok: true })
+            });
+            // Ignores the abort signal: runs until the test releases it
+            self.apos.ai.addTool({
+              name: 'gate',
+              description: 'The gate tool.',
+              input: okInput,
+              schema: okSchema,
+              handler: async () => {
+                if (gateNotify) {
+                  gateNotify();
+                }
+                if (gateWait) {
+                  await gateWait;
+                }
+                return { ok: true };
+              }
+            });
+            // Honors the abort signal: winds down when it fires
+            self.apos.ai.addTool({
+              name: 'until_abort',
+              description: 'The until_abort tool.',
+              input: okInput,
+              schema: { sawAbort: { type: 'boolean' } },
+              handler: async (req, args) => {
+                if (abortNotify) {
+                  abortNotify();
+                }
+                while (!args._context.signal?.aborted) {
+                  await delay(5);
+                }
+                return { sawAbort: true };
+              }
+            });
+          }
+        },
+        '@apostrophecms/ai': {
+          options: {
+            provider: 'fake',
+            providers: {
+              fake: { apiKey: 'k1' }
+            },
+            retryBaseDelay: 1,
+            jobPollInterval: 25
+          }
+        }
+      }
+    });
+    jobModule = apos.modules['@apostrophecms/job'];
+  });
+
+  after(function() {
+    return t.destroy(apos);
+  });
+
+  beforeEach(async function() {
+    chatScript = [];
+    chatCalls = [];
+    logRecords = [];
+    gateNotify = null;
+    gateWait = null;
+    abortNotify = null;
+    apos.ai.logWarn = (req, type, message, data) => logRecords.push({
+      severity: 'warn',
+      type,
+      message,
+      data
+    });
+    apos.ai.logError = (req, type, message, data) => logRecords.push({
+      severity: 'error',
+      type,
+      message,
+      data
+    });
+    // The job module logs background failures; keep the output clean
+    apos.util.error = () => {};
+    await jobModule.db.deleteMany({});
+  });
+
+  it('returns a handle immediately and stores the exact blocking result', async function() {
+    const req = apos.task.getReq({ user: { _id: 'owner1' } });
+    const script = () => [
+      toolTurn(toolCall('c1', 'echo')),
+      textTurn('all done')
+    ];
+
+    chatScript = script();
+    const blocking = await apos.ai.generate(req, 'find it', {
+      tools: [ 'echo' ]
+    });
+
+    chatScript = script();
+    const { jobId, cancel } = await apos.ai.generateJob(req, 'find it', {
+      tools: [ 'echo' ]
+    });
+
+    assert.equal(typeof jobId, 'string');
+    assert.equal(typeof cancel, 'function');
+    const job = await waitForJob(jobId);
+
+    assert.equal(job.status, 'completed');
+    assert.deepEqual(job.results, blocking);
+    assert.equal(job.userId, 'owner1');
+    assert.equal(job.expireAt instanceof Date, true);
+  });
+
+  it('fires onMessage with the jobId and onEnd with the result', async function() {
+    const req = apos.task.getReq();
+    const seen = [];
+    let ended = null;
+    chatScript = [
+      toolTurn(toolCall('c1', 'echo')),
+      textTurn('finished')
+    ];
+
+    const { jobId } = await apos.ai.generateJob(req, 'go', {
+      tools: [ 'echo' ],
+      onMessage(message, meta) {
+        seen.push({
+          message,
+          meta
+        });
+      },
+      onEnd(err, result) {
+        ended = {
+          err,
+          result
+        };
+      }
+    });
+    const job = await waitForJob(jobId);
+
+    assert.deepEqual(seen, [ {
+      message: {
+        role: 'assistant',
+        content: [ toolCall('c1', 'echo') ]
+      },
+      meta: { jobId }
+    } ]);
+    assert.equal(ended.err, null);
+    assert.equal(ended.result.finishReason, 'stop');
+    assert.equal(ended.result.text, 'finished');
+    assert.deepEqual(job.results, ended.result);
+  });
+
+  it('a failed run stores the error payload and reports it to onEnd', async function() {
+    const req = apos.task.getReq();
+    let ended = null;
+    chatScript = [
+      () => {
+        throw apos.error('forbidden', 'nope', { docId: 'd1' });
+      }
+    ];
+
+    const { jobId } = await apos.ai.generateJob(req, 'go', {
+      onEnd(err, result) {
+        ended = {
+          err,
+          result
+        };
+      }
+    });
+    const job = await waitForJob(jobId);
+
+    assert.equal(job.status, 'failed');
+    assert.deepEqual(job.error, {
+      name: 'forbidden',
+      message: 'nope',
+      data: { docId: 'd1' }
+    });
+    assert.equal(ended.err.name, 'forbidden');
+    assert.equal(ended.result, undefined);
+  });
+
+  it('cancel(): the in-flight handler is waited out and its work recorded', async function() {
+    const req = apos.task.getReq();
+    let started;
+    let release;
+    const startedPromise = new Promise((resolve) => {
+      started = resolve;
+    });
+    gateNotify = started;
+    gateWait = new Promise((resolve) => {
+      release = resolve;
+    });
+    chatScript = [
+      toolTurn(toolCall('c1', 'gate'))
+    ];
+
+    const { jobId, cancel } = await apos.ai.generateJob(req, 'go', {
+      tools: [ 'gate' ]
+    });
+    await startedPromise;
+    await cancel();
+    release();
+    const job = await waitForJob(jobId);
+
+    assert.equal(job.status, 'cancelled');
+    assert.equal(job.cancelRequested, true);
+    assert.equal(job.results.finishReason, 'cancel');
+    // The handler ignored the signal; the loop waited it out and its
+    // completed work is recorded
+    assert.deepEqual(job.results.steps, [ {
+      toolCall: toolCall('c1', 'gate'),
+      result: { ok: true }
+    } ]);
+    // No further model turn after the cancelled batch
+    assert.equal(chatCalls.length, 1);
+  });
+
+  it('a cancel landing on the job record alone stops the run', async function() {
+    const req = apos.task.getReq();
+    let started;
+    const startedPromise = new Promise((resolve) => {
+      started = resolve;
+    });
+    abortNotify = started;
+    chatScript = [
+      toolTurn(toolCall('c1', 'until_abort'))
+    ];
+
+    const { jobId } = await apos.ai.generateJob(req, 'go', {
+      tools: [ 'until_abort' ]
+    });
+    await startedPromise;
+    // Another process would do exactly this — no local abort involved;
+    // the run's poll of the record must pick it up
+    await jobModule.requestCancel(jobId);
+    const job = await waitForJob(jobId);
+
+    assert.equal(job.status, 'cancelled');
+    assert.equal(job.results.finishReason, 'cancel');
+    // The handler honored the signal the poll fired
+    assert.deepEqual(job.results.steps, [ {
+      toolCall: toolCall('c1', 'until_abort'),
+      result: { sawAbort: true }
+    } ]);
+  });
+
+  it('a deleted job record winds down its own run', async function() {
+    const req = apos.task.getReq();
+    let started;
+    const startedPromise = new Promise((resolve) => {
+      started = resolve;
+    });
+    abortNotify = started;
+    let ended = null;
+    let endedNotify;
+    const endedPromise = new Promise((resolve) => {
+      endedNotify = resolve;
+    });
+    chatScript = [
+      toolTurn(toolCall('c1', 'until_abort'))
+    ];
+
+    await apos.ai.generateJob(req, 'go', {
+      tools: [ 'until_abort' ],
+      onEnd(err, result) {
+        ended = {
+          err,
+          result
+        };
+        endedNotify();
+      }
+    });
+    await startedPromise;
+    // What the expiry sweep — or any external cleanup — does; the
+    // record is the only handle on the run, so its removal must stop it
+    await jobModule.db.deleteMany({});
+    await endedPromise;
+
+    assert.equal(ended.err, null);
+    assert.equal(ended.result.finishReason, 'cancel');
+    assert.deepEqual(ended.result.steps, [ {
+      toolCall: toolCall('c1', 'until_abort'),
+      result: { sawAbort: true }
+    } ]);
+  });
+
+  it('cancel mid provider call: aborts without retries, partial result preserved', async function() {
+    const req = apos.task.getReq();
+    chatScript = [
+      (request) => new Promise((resolve, reject) => {
+        request.signal.addEventListener('abort', () => {
+          const error = new Error('This operation was aborted');
+          error.name = 'AbortError';
+          reject(error);
+        });
+      })
+    ];
+
+    const { jobId, cancel } = await apos.ai.generateJob(req, 'slow one');
+    await waitFor(() => chatCalls.length === 1);
+    await cancel();
+    const job = await waitForJob(jobId);
+
+    assert.equal(job.status, 'cancelled');
+    assert.deepEqual(job.results, {
+      text: '',
+      messages: [ {
+        role: 'user',
+        content: [ {
+          type: 'text',
+          text: 'slow one'
+        } ]
+      } ],
+      finishReason: 'cancel',
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0
+      },
+      model: 'fake-medium',
+      provider: 'fake'
+    });
+    // An abort is the caller's own doing: no failure record, no retry
+    assert.deepEqual(logRecords, []);
+  });
+
+  it('onEnd throwing is logged, never recorded on the job', async function() {
+    const req = apos.task.getReq();
+    chatScript = [ textTurn('fine') ];
+
+    const { jobId } = await apos.ai.generateJob(req, 'go', {
+      onEnd() {
+        throw new Error('hook bug');
+      }
+    });
+    const job = await waitForJob(jobId);
+
+    assert.equal(job.status, 'completed');
+    assert.equal(job.results.text, 'fine');
+    assert.equal(job.error, undefined);
+    assert.deepEqual(logRecords.map((record) => [ record.type, record.message ]), [
+      [ 'hook', 'hook bug' ]
+    ]);
+  });
+
+  it('a tool handler cannot start a job', async function() {
+    const req = apos.task.getReq();
+
+    await assert.rejects(
+      apos.ai.generateJob(req.clone({ aposAiDepth: 1 }), 'x'),
+      (e) => {
+        assert.equal(e.name, 'invalid');
+        assert.match(e.message, /blocking only/);
+        return true;
+      }
+    );
+  });
+
+  it('validates synchronously: no record is created for a bad call', async function() {
+    const req = apos.task.getReq();
+    const invalid = (promise, pattern) => assert.rejects(promise, (e) => {
+      assert.equal(e.name, 'invalid');
+      assert.match(e.message, pattern);
+      return true;
+    });
+
+    await invalid(
+      apos.ai.generateJob(req, 'x', { bogus: 1 }),
+      /unknown option "bogus"/
+    );
+    await invalid(
+      apos.ai.generateJob(req, 'x', { onEnd: 'call me' }),
+      /"onEnd" must be a function/
+    );
+    await invalid(
+      apos.ai.generateJob(req, 'x', { expireAfter: -1 }),
+      /"expireAfter" must be a non-negative integer/
+    );
+    await invalid(
+      apos.ai.generateJob(req),
+      /a prompt string or an options object is required/
+    );
+
+    assert.equal(await jobModule.db.countDocuments({}), 0);
+  });
+
+  it('expireAfter: 0 keeps the record forever', async function() {
+    const req = apos.task.getReq();
+    chatScript = [ textTurn('fast') ];
+
+    const { jobId } = await apos.ai.generateJob(req, 'quick', {
+      expireAfter: 0
+    });
+    const job = await waitForJob(jobId);
+
+    assert.equal(job.status, 'completed');
+    assert.equal(job.expireAt, undefined);
+  });
+
+  async function waitForJob(jobId, deadline = Date.now() + 10000) {
+    const job = await jobModule.db.findOne({ _id: jobId });
+
+    if (!job || !job.ended) {
+      if (Date.now() > deadline) {
+        throw new Error(`Timed out waiting for job ${jobId} to end`);
+      }
+      await delay(25);
+
+      return waitForJob(jobId, deadline);
+    }
+
+    return job;
+  }
+
+  async function waitFor(condition, deadline = Date.now() + 10000) {
+    while (!condition()) {
+      if (Date.now() > deadline) {
+        throw new Error('Timed out waiting for the condition');
+      }
+      await delay(10);
+    }
+  }
+
+  function delay(ms) {
+    return new Promise((resolve) => {
+      setTimeout(() => resolve(true), ms);
+    });
+  }
+});

--- a/packages/apostrophe/test/ai-job.js
+++ b/packages/apostrophe/test/ai-job.js
@@ -180,13 +180,12 @@ describe('AI generateJob', function() {
     // The job module logs background failures; keep the output clean
     apos.util.error = () => {};
     triggered = [];
-    apos.notification.trigger = (req, message, options) => {
+    apos.notification.trigger = (req, options) => {
       // Snapshot: trigger normalizes the options object in place
       triggered.push({
-        message,
         options: { ...options }
       });
-      return realTrigger.call(apos.notification, req, message, options);
+      return realTrigger.call(apos.notification, req, options);
     };
     await jobModule.db.deleteMany({});
     await apos.notification.db.deleteMany({});
@@ -450,7 +449,7 @@ describe('AI generateJob', function() {
     ]);
   });
 
-  it('publishes started, per-turn and ended events over hidden notifications', async function() {
+  it('publishes started, per-turn and ended events over bus notifications', async function() {
     const req = apos.task.getReq({ user: { _id: 'owner1' } });
     const seen = [];
     chatScript = [
@@ -487,16 +486,18 @@ describe('AI generateJob', function() {
     });
     // The caller's own hook ran alongside the publisher
     assert.equal(seen.length, 1);
-    // Every stage travels as an invisible notification dismissing at
-    // the fastest rate the knob offers
-    for (const { message, options } of triggered) {
-      assert.equal(message, ' ');
-      assert.deepEqual(options.classes, [ 'apos-notification--hidden' ]);
-      assert.equal(options.dismiss, 1);
+    // Every stage travels as a pure bus carrier, nothing to render
+    for (const { options } of triggered) {
+      assert.equal(options.bus, true);
+      assert.equal(options.classes, undefined);
+      assert.equal(options.dismiss, undefined);
     }
     // Delivered for real, to the job owner
     assert.equal(
-      await apos.notification.db.countDocuments({ userId: 'owner1' }),
+      await apos.notification.db.countDocuments({
+        userId: 'owner1',
+        bus: true
+      }),
       3
     );
   });

--- a/packages/apostrophe/test/ai-job.js
+++ b/packages/apostrophe/test/ai-job.js
@@ -669,6 +669,102 @@ describe('AI generateJob', function() {
     assert.equal(job.expireAt, undefined);
   });
 
+  describe('cross-process cancellation', function() {
+    // A second apos instance on the same database — two processes of
+    // one production cluster. The run lives in the first instance;
+    // the cancel arrives through this one, and only the shared job
+    // record connects them.
+    let apos2;
+    let jobModule2;
+
+    before(async function() {
+      apos2 = await t.create({
+        root: module,
+        shortName: apos.options.shortName
+      });
+      jobModule2 = apos2.modules['@apostrophecms/job'];
+    });
+
+    after(async function() {
+      // Close the second instance without dropping the shared
+      // database the first one is still using
+      if (apos2) {
+        await apos2.destroy();
+      }
+    });
+
+    it('a cancel landing on the other process stops the loop', async function() {
+      const req = apos.task.getReq();
+      let started;
+      const startedPromise = new Promise((resolve) => {
+        started = resolve;
+      });
+      abortNotify = started;
+      chatScript = [
+        toolTurn(toolCall('c1', 'until_abort'))
+      ];
+
+      const { jobId } = await apos.ai.generateJob(req, 'go', {
+        tools: [ 'until_abort' ]
+      });
+      await startedPromise;
+      await jobModule2.requestCancel(jobId);
+      const job = await waitForJob(jobId);
+
+      assert.equal(job.status, 'cancelled');
+      assert.equal(job.results.finishReason, 'cancel');
+      // The handler honored the signal the poll fired; its work is
+      // preserved on the stored partial result
+      assert.deepEqual(job.results.steps, [ {
+        toolCall: toolCall('c1', 'until_abort'),
+        result: { sawAbort: true }
+      } ]);
+      // No further model turn after the cancelled batch
+      assert.equal(chatCalls.length, 1);
+    });
+
+    it('the status flips only after the in-flight step finishes', async function() {
+      const req = apos.task.getReq();
+      let started;
+      let release;
+      const startedPromise = new Promise((resolve) => {
+        started = resolve;
+      });
+      gateNotify = started;
+      gateWait = new Promise((resolve) => {
+        release = resolve;
+      });
+      chatScript = [
+        toolTurn(toolCall('c1', 'gate'))
+      ];
+
+      const { jobId } = await apos.ai.generateJob(req, 'go', {
+        tools: [ 'gate' ]
+      });
+      await startedPromise;
+      await jobModule2.requestCancel(jobId);
+      // Ample watcher polls: the request is observed, yet the run
+      // keeps waiting out the in-flight handler rather than preempt it
+      await delay(200);
+      const current = await jobModule2.db.findOne({ _id: jobId });
+      assert.equal(current.cancelRequested, true);
+      assert.equal(current.ended, false);
+      assert.equal(current.status, 'running');
+
+      release();
+      const job = await waitForJob(jobId);
+
+      assert.equal(job.status, 'cancelled');
+      assert.equal(job.results.finishReason, 'cancel');
+      // The handler ignored the signal; the loop waited it out and
+      // its completed work is recorded
+      assert.deepEqual(job.results.steps, [ {
+        toolCall: toolCall('c1', 'gate'),
+        result: { ok: true }
+      } ]);
+    });
+  });
+
   async function waitForJob(jobId, deadline = Date.now() + 10000) {
     const job = await jobModule.db.findOne({ _id: jobId });
 

--- a/packages/apostrophe/test/ai-tools.js
+++ b/packages/apostrophe/test/ai-tools.js
@@ -788,6 +788,31 @@ describe('AI tools', function() {
       ]);
     });
 
+    it('onMessage reports each intermediate assistant turn, never the final answer', async function() {
+      const req = apos.task.getReq();
+      const messages = [];
+      chatScript = [
+        toolTurn(toolCall('c1', 'echo', { value: 'one' })),
+        toolTurn(toolCall('c2', 'echo', { value: 'two' })),
+        textTurn('all done')
+      ];
+      const result = await apos.ai.generate(req, 'find it', {
+        tools: [ 'echo' ],
+        onMessage(message) {
+          messages.push(message);
+        }
+      });
+
+      assert.equal(result.text, 'all done');
+      assert.deepEqual(messages, [ {
+        role: 'assistant',
+        content: [ toolCall('c1', 'echo', { value: 'one' }) ]
+      }, {
+        role: 'assistant',
+        content: [ toolCall('c2', 'echo', { value: 'two' }) ]
+      } ]);
+    });
+
     it('combines tools and schema: the loop runs free, the final answer validates', async function() {
       const req = apos.task.getReq();
       const object = { found: 'pricing' };

--- a/packages/apostrophe/test/ai.js
+++ b/packages/apostrophe/test/ai.js
@@ -72,6 +72,8 @@ describe('AI engine', function() {
     assert.equal(apos.ai.options.retryAttempts, 5);
     assert.equal(apos.ai.options.retryBaseDelay, 1000);
     assert.equal(apos.ai.options.retryMaxElapsed, 60000);
+    assert.equal(apos.ai.options.jobExpireAfter, 86400);
+    assert.equal(apos.ai.options.jobPollInterval, 2000);
     // Unconfigured: a call falls through to an empty routing table
     assert.throws(() => apos.ai.modelInfo(), (e) => {
       assert.equal(e.name, 'invalid');
@@ -87,7 +89,9 @@ describe('AI engine', function() {
       maxSteps: 5,
       retryAttempts: 5,
       retryBaseDelay: 1000,
-      retryMaxElapsed: 60000
+      retryMaxElapsed: 60000,
+      jobExpireAfter: 86400,
+      jobPollInterval: 2000
     });
 
     it('accepts the minimal single-provider configuration', function() {
@@ -321,6 +325,21 @@ describe('AI engine', function() {
         ...valid(),
         retryMaxElapsed: 1.5
       }, /"retryMaxElapsed" must be a positive integer/);
+    });
+
+    it('rejects malformed job options', function() {
+      rejects({
+        ...valid(),
+        jobPollInterval: 0
+      }, /"jobPollInterval" must be a positive integer/);
+      rejects({
+        ...valid(),
+        jobExpireAfter: -1
+      }, /"jobExpireAfter" must be a non-negative integer/);
+      rejects({
+        ...valid(),
+        jobExpireAfter: 'never'
+      }, /"jobExpireAfter" must be a non-negative integer/);
     });
   });
 

--- a/packages/apostrophe/test/job.js
+++ b/packages/apostrophe/test/job.js
@@ -135,14 +135,11 @@ describe('Job module', function() {
       { route: `${jobModule.action}/${jobId}` },
       { jar }
     );
+    const notifications = await waitForNotifications({
+      'context._id': jobId,
+      message: /^Tested/
+    });
     const job = await jobModule.db.findOne({ _id: jobId });
-
-    const notifications = await apos.notification.db
-      .find({
-        'context._id': job._id,
-        message: /^Tested/
-      })
-      .toArray();
 
     const actual = {
       job,
@@ -211,14 +208,11 @@ describe('Job module', function() {
       { route: `${jobModule.action}/${jobId}` },
       { jar }
     );
+    const notifications = await waitForNotifications({
+      'context._id': jobId,
+      message: /^Testing.*failed\.$/
+    });
     const job = await jobModule.db.findOne({ _id: jobId });
-
-    const notifications = await apos.notification.db
-      .find({
-        'context._id': job._id,
-        message: /^Testing.*failed\.$/
-      })
-      .toArray();
 
     const actual = {
       job,
@@ -675,6 +669,23 @@ describe('Job module', function() {
         total
       };
     }
+  }
+
+  // The completion notification is written after the run's counters reach the
+  // total, so a poll that only waits for the counters can read ahead of it.
+  async function waitForNotifications(query, deadline = Date.now() + 10000) {
+    const notifications = await apos.notification.db.find(query).toArray();
+
+    if (!notifications.length) {
+      if (Date.now() > deadline) {
+        throw new Error(`Timed out waiting for notifications ${JSON.stringify(query)}`);
+      }
+      await delay(50);
+
+      return waitForNotifications(query, deadline);
+    }
+
+    return notifications;
   }
 
   async function waitForEnded(jobId, deadline = Date.now() + 10000) {

--- a/packages/apostrophe/test/job.js
+++ b/packages/apostrophe/test/job.js
@@ -343,12 +343,14 @@ describe('Job module', function() {
 
     {
       const route = `${jobModule.action}/${jobThree.jobId}`;
-      const { total } = await apos.http.get(route, { jar });
 
+      // The total is read from the finished record: reading it right
+      // after run() returns races the background setTotal write
       const {
         completed,
         good,
-        bad
+        bad,
+        total
       } = await pollJob({
         route
       }, {
@@ -659,7 +661,9 @@ describe('Job module', function() {
       bad
     } = await apos.http.get(job.route, { jar });
 
-    if (processed < total) {
+    // No total yet means the run's setTotal write has not landed:
+    // keep polling, or an early poll would read as already done
+    if (total === undefined || processed < total) {
       await delay(100);
 
       return await pollJob(job, { jar });
@@ -667,7 +671,8 @@ describe('Job module', function() {
       return {
         completed: processed,
         good,
-        bad
+        bad,
+        total
       };
     }
   }

--- a/packages/apostrophe/test/job.js
+++ b/packages/apostrophe/test/job.js
@@ -1,6 +1,8 @@
 const { strict: assert } = require('node:assert');
 const t = require('../test-lib/test.js');
 
+const testDbProtocol = process.env.APOS_TEST_DB_PROTOCOL || 'mongodb';
+
 describe('Job module', function() {
   const logged = [];
   let apos;
@@ -410,48 +412,15 @@ describe('Job module', function() {
       assert.deepEqual(actual, expected);
     });
 
-    it('has a sparse index on expireAt for the expired-job sweep', async function() {
+    it('has a sparse TTL index on expireAt', async function() {
       const indexes = await jobModule.db.indexes();
       const index = indexes.find(index => index.key.expireAt === 1);
 
       assert.equal(index && index.sparse, true);
-    });
-
-    it('cleanupExpired: deletes only jobs whose expireAt has passed', async function() {
-      const expired = await jobModule.start({ expireAfter: 0.001 });
-      const kept = await jobModule.start({ expireAfter: 3600 });
-      const legacy = await jobModule.start({});
-      await delay(10);
-
-      await jobModule.cleanupExpired();
-
-      const actual = {
-        expired: await jobModule.db.findOne({ _id: expired._id }),
-        kept: (await jobModule.db.findOne({ _id: kept._id }))._id,
-        legacy: (await jobModule.db.findOne({ _id: legacy._id }))._id
-      };
-      const expected = {
-        expired: null,
-        kept: kept._id,
-        legacy: legacy._id
-      };
-
-      assert.deepEqual(actual, expected);
-    });
-
-    it('start: sweeps expired jobs', async function() {
-      const expired = await jobModule.start({ expireAfter: 0.001 });
-      await delay(10);
-
-      await jobModule.start({});
-
-      // The sweep is fire-and-forget; poll until it lands
-      const deadline = Date.now() + 10000;
-      while (await jobModule.db.findOne({ _id: expired._id })) {
-        if (Date.now() > deadline) {
-          throw new Error('Timed out waiting for the expired job to be swept');
-        }
-        await delay(25);
+      // Database-level expiry: only MongoDB honors (and reports) the
+      // TTL option; other adapters accept and ignore it
+      if (testDbProtocol === 'mongodb') {
+        assert.equal(index.expireAfterSeconds, 0);
       }
     });
 

--- a/packages/apostrophe/test/job.js
+++ b/packages/apostrophe/test/job.js
@@ -571,6 +571,28 @@ describe('Job module', function() {
       assert.deepEqual(actual, expected);
     });
 
+    it('run: isCanceling reports true once the job record is gone', async function() {
+      const req = apos.task.getReq();
+      const observed = [];
+
+      const { jobId } = await jobModule.run(req, async function(_req, reporting) {
+        observed.push(await reporting.isCanceling());
+        await jobModule.db.deleteMany({ _id: jobId });
+        observed.push(await reporting.isCanceling());
+      });
+
+      // The record is deleted mid-run, so poll the observations instead
+      const deadline = Date.now() + 10000;
+      while (observed.length < 2) {
+        if (Date.now() > deadline) {
+          throw new Error('Timed out waiting for the run to observe both states');
+        }
+        await delay(25);
+      }
+
+      assert.deepEqual(observed, [ false, true ]);
+    });
+
     it('run: records a failed status and the error payload when doTheWork throws', async function() {
       const req = apos.task.getReq();
       const originalError = apos.util.error;

--- a/packages/apostrophe/test/job.js
+++ b/packages/apostrophe/test/job.js
@@ -4,7 +4,9 @@ const t = require('../test-lib/test.js');
 describe('Job module', function() {
   const logged = [];
   let apos;
+  let admin;
   let jar;
+  let editorJar;
   let jobModule;
 
   this.timeout(t.timeout);
@@ -22,8 +24,10 @@ describe('Job module', function() {
 
     jobModule = apos.modules['@apostrophecms/job'];
 
-    await t.createAdmin(apos);
+    admin = await t.createAdmin(apos);
     jar = await t.getUserJar(apos);
+    await t.createUser(apos, 'editor');
+    editorJar = await t.loginAs(apos, 'editor');
   });
 
   after(function() {
@@ -150,10 +154,13 @@ describe('Job module', function() {
       job: {
         _id: job._id,
         bad: 50,
+        cancelRequested: false,
         ended: true,
+        endedAt: job.endedAt,
         good: 450,
         processed: 500,
         results: job.results,
+        startedAt: job.startedAt,
         status: 'completed',
         total: 500,
         when: job.when
@@ -223,10 +230,13 @@ describe('Job module', function() {
       job: {
         _id: job._id,
         bad: 50,
+        cancelRequested: false,
         ended: true,
+        endedAt: job.endedAt,
         good: 0,
         processed: 50,
         results: job.results,
+        startedAt: job.startedAt,
         status: 'completed',
         total: 50,
         when: job.when
@@ -360,6 +370,263 @@ describe('Job module', function() {
     };
   });
 
+  describe('ownership, cancellation, error payload and TTL', function() {
+    it('start: stamps startedAt and cancelRequested, records opt-in userId and expireAt', async function() {
+      const job = await jobModule.start({
+        userId: admin._id,
+        expireAfter: 3600
+      });
+      const found = await jobModule.db.findOne({ _id: job._id });
+
+      const actual = {
+        cancelRequested: found.cancelRequested,
+        startedAt: found.startedAt,
+        userId: found.userId,
+        expireAt: found.expireAt
+      };
+      const expected = {
+        cancelRequested: false,
+        startedAt: found.when,
+        userId: admin._id,
+        expireAt: new Date(found.when.getTime() + 3600 * 1000)
+      };
+
+      assert.deepEqual(actual, expected);
+    });
+
+    it('start: jobs carry no userId or expireAt unless requested', async function() {
+      const job = await jobModule.start({});
+      const found = await jobModule.db.findOne({ _id: job._id });
+
+      const actual = {
+        userId: found.userId,
+        expireAt: found.expireAt
+      };
+      const expected = {
+        userId: undefined,
+        expireAt: undefined
+      };
+
+      assert.deepEqual(actual, expected);
+    });
+
+    it('has a sparse index on expireAt for the expired-job sweep', async function() {
+      const indexes = await jobModule.db.indexes();
+      const index = indexes.find(index => index.key.expireAt === 1);
+
+      assert.equal(index && index.sparse, true);
+    });
+
+    it('cleanupExpired: deletes only jobs whose expireAt has passed', async function() {
+      const expired = await jobModule.start({ expireAfter: 0.001 });
+      const kept = await jobModule.start({ expireAfter: 3600 });
+      const legacy = await jobModule.start({});
+      await delay(10);
+
+      await jobModule.cleanupExpired();
+
+      const actual = {
+        expired: await jobModule.db.findOne({ _id: expired._id }),
+        kept: (await jobModule.db.findOne({ _id: kept._id }))._id,
+        legacy: (await jobModule.db.findOne({ _id: legacy._id }))._id
+      };
+      const expected = {
+        expired: null,
+        kept: kept._id,
+        legacy: legacy._id
+      };
+
+      assert.deepEqual(actual, expected);
+    });
+
+    it('start: sweeps expired jobs', async function() {
+      const expired = await jobModule.start({ expireAfter: 0.001 });
+      await delay(10);
+
+      await jobModule.start({});
+
+      // The sweep is fire-and-forget; poll until it lands
+      const deadline = Date.now() + 10000;
+      while (await jobModule.db.findOne({ _id: expired._id })) {
+        if (Date.now() > deadline) {
+          throw new Error('Timed out waiting for the expired job to be swept');
+        }
+        await delay(25);
+      }
+    });
+
+    it('getOne: a job with userId is visible to its owner only', async function() {
+      const job = await jobModule.start({ userId: admin._id });
+      const route = `${jobModule.action}/${job._id}`;
+
+      const fetched = await apos.http.get(route, { jar });
+      assert.equal(fetched._id, job._id);
+
+      await assert.rejects(
+        apos.http.get(route, { jar: editorJar }),
+        { status: 404 }
+      );
+    });
+
+    it('getOne: a job without userId keeps the legacy access rule', async function() {
+      const job = await jobModule.start({});
+
+      const fetched = await apos.http.get(`${jobModule.action}/${job._id}`, {
+        jar: editorJar
+      });
+
+      assert.equal(fetched._id, job._id);
+    });
+
+    it('cancel route: the owner can request cancellation, others cannot', async function() {
+      const job = await jobModule.start({ userId: admin._id });
+      const route = `${jobModule.action}/${job._id}/cancel`;
+
+      await assert.rejects(
+        apos.http.post(route, {
+          jar: editorJar,
+          body: {}
+        }),
+        { status: 404 }
+      );
+
+      await apos.http.post(route, {
+        jar,
+        body: {}
+      });
+      const found = await jobModule.db.findOne({ _id: job._id });
+
+      assert.equal(found.cancelRequested, true);
+    });
+
+    it('requestCancel: has no effect on an ended job', async function() {
+      const job = await jobModule.start({});
+      await jobModule.end(job, true);
+
+      await jobModule.requestCancel(job._id);
+      const found = await jobModule.db.findOne({ _id: job._id });
+
+      const actual = {
+        cancelRequested: found.cancelRequested,
+        status: found.status
+      };
+      const expected = {
+        cancelRequested: false,
+        status: 'completed'
+      };
+
+      assert.deepEqual(actual, expected);
+    });
+
+    it('end: stamps endedAt and a cancelled status when cancellation was requested', async function() {
+      const job = await jobModule.start({});
+      await jobModule.requestCancel(job._id);
+
+      await jobModule.end(job, true, { partial: true });
+      const found = await jobModule.db.findOne({ _id: job._id });
+
+      const actual = {
+        status: found.status,
+        ended: found.ended,
+        results: found.results,
+        endedAt: found.endedAt instanceof Date
+      };
+      const expected = {
+        status: 'cancelled',
+        ended: true,
+        results: { partial: true },
+        endedAt: true
+      };
+
+      assert.deepEqual(actual, expected);
+    });
+
+    it('run: a cooperatively cancelled job ends cancelled with partial results', async function() {
+      const req = apos.task.getReq();
+
+      const { jobId } = await jobModule.run(req, async function(_req, reporting) {
+        reporting.setTotal(20);
+        for (let i = 0; i < 20; i++) {
+          if (await reporting.isCanceling()) {
+            reporting.setResults({ stoppedAt: i });
+            return;
+          }
+          reporting.success();
+          await delay(25);
+        }
+        reporting.setResults({ stoppedAt: null });
+      });
+      await jobModule.requestCancel(jobId);
+      const job = await waitForEnded(jobId);
+
+      const actual = {
+        status: job.status,
+        stoppedEarly: job.results.stoppedAt !== null && job.results.stoppedAt < 20
+      };
+      const expected = {
+        status: 'cancelled',
+        stoppedEarly: true
+      };
+
+      assert.deepEqual(actual, expected);
+    });
+
+    it('run: records a failed status and the error payload when doTheWork throws', async function() {
+      const req = apos.task.getReq();
+      const originalError = apos.util.error;
+      apos.util.error = () => {};
+
+      try {
+        const { jobId } = await jobModule.run(req, async function() {
+          throw apos.error('invalid', 'boom', { reason: 'testing' });
+        });
+        const job = await waitForEnded(jobId);
+
+        const actual = {
+          status: job.status,
+          error: job.error
+        };
+        const expected = {
+          status: 'failed',
+          error: {
+            name: 'invalid',
+            message: 'boom',
+            data: { reason: 'testing' }
+          }
+        };
+
+        assert.deepEqual(actual, expected);
+      } finally {
+        apos.util.error = originalError;
+      }
+    });
+
+    it('run: notifications: false skips the legacy messages wiring', async function() {
+      const req = apos.task.getReq({
+        body: {
+          messages: {
+            progress: 'Opted out progress...',
+            completed: 'Opted out done.'
+          }
+        }
+      });
+
+      const { jobId } = await jobModule.run(req, async function(_req, reporting) {
+        reporting.setTotal(1);
+        reporting.success();
+      }, {
+        notifications: false
+      });
+      await waitForEnded(jobId);
+
+      const notifications = await apos.notification.db
+        .find({ message: /^Opted out/ })
+        .toArray();
+
+      assert.equal(notifications.length, 0);
+    });
+  });
+
   function padInteger (i, places) {
     let s = i + '';
     while (s.length < places) {
@@ -412,6 +679,21 @@ describe('Job module', function() {
         bad
       };
     }
+  }
+
+  async function waitForEnded(jobId, deadline = Date.now() + 10000) {
+    const job = await jobModule.db.findOne({ _id: jobId });
+
+    if (!job || !job.ended) {
+      if (Date.now() > deadline) {
+        throw new Error(`Timed out waiting for job ${jobId} to end`);
+      }
+      await delay(50);
+
+      return waitForEnded(jobId, deadline);
+    }
+
+    return job;
   }
 
   function delay(ms) {

--- a/packages/apostrophe/test/notification.js
+++ b/packages/apostrophe/test/notification.js
@@ -1,0 +1,128 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert/strict');
+
+describe('Notifications', function() {
+  this.timeout(t.timeout);
+
+  let apos;
+
+  before(async function() {
+    apos = await t.create({
+      root: module
+    });
+  });
+
+  after(function() {
+    return t.destroy(apos);
+  });
+
+  beforeEach(function() {
+    return apos.notification.db.deleteMany({});
+  });
+
+  it('triggers and stores a regular notification', async function() {
+    const req = apos.task.getReq({ user: { _id: 'user1' } });
+
+    const { noteId } = await apos.notify(req, 'hello', { type: 'success' });
+    const doc = await apos.notification.db.findOne({ _id: noteId });
+
+    assert.equal(doc.message, 'hello');
+    assert.equal(doc.type, 'success');
+    assert.equal(doc.userId, 'user1');
+  });
+
+  it('requires a message without the bus flag', async function() {
+    const req = apos.task.getReq({ user: { _id: 'user1' } });
+
+    await assert.rejects(apos.notify(req), { name: 'required' });
+    await assert.rejects(
+      apos.notify(req, null, { type: 'info' }),
+      { name: 'required' }
+    );
+    // The options-in-place form does not relax the requirement by itself
+    await assert.rejects(
+      apos.notify(req, {
+        type: 'info',
+        event: { name: 'my-event' }
+      }),
+      { name: 'required' }
+    );
+  });
+
+  it('stores a bus notification without a message', async function() {
+    const req = apos.task.getReq({ user: { _id: 'user1' } });
+
+    const { noteId } = await apos.notify(req, {
+      bus: true,
+      event: {
+        name: 'my-event',
+        data: { a: 1 }
+      }
+    });
+    const doc = await apos.notification.db.findOne({ _id: noteId });
+
+    assert.equal(doc.bus, true);
+    assert.equal(doc.message, null);
+    assert.deepEqual(doc.event, {
+      name: 'my-event',
+      data: { a: 1 }
+    });
+    assert.equal(doc.userId, 'user1');
+  });
+
+  it('accepts a bus notification with an explicit null message', async function() {
+    const req = apos.task.getReq({ user: { _id: 'user1' } });
+
+    const { noteId } = await apos.notify(req, null, {
+      bus: true,
+      event: { name: 'my-event' }
+    });
+    const doc = await apos.notification.db.findOne({ _id: noteId });
+
+    assert.equal(doc.bus, true);
+    assert.equal(doc.message, null);
+  });
+
+  it('a bus notification requires an event with a name', async function() {
+    const req = apos.task.getReq({ user: { _id: 'user1' } });
+
+    await assert.rejects(
+      apos.notify(req, { bus: true }),
+      { name: 'invalid' }
+    );
+    await assert.rejects(
+      apos.notify(req, {
+        bus: true,
+        event: {}
+      }),
+      { name: 'invalid' }
+    );
+  });
+
+  it('a bus notification travels to its owner like any other', async function() {
+    const req = apos.task.getReq({ user: { _id: 'user1' } });
+
+    await apos.notify(req, {
+      bus: true,
+      event: { name: 'my-event' }
+    });
+    const { notifications } = await apos.notification.find(req, {});
+
+    assert.equal(notifications.length, 1);
+    assert.equal(notifications[0].bus, true);
+
+    const other = apos.task.getReq({ user: { _id: 'user2' } });
+    const found = await apos.notification.find(other, {});
+    assert.equal(found.notifications.length, 0);
+  });
+
+  it('still requires a user', async function() {
+    await assert.rejects(
+      apos.notify({}, {
+        bus: true,
+        event: { name: 'my-event' }
+      }),
+      { name: 'forbidden' }
+    );
+  });
+});


### PR DESCRIPTION
`apos.ai.generateJob` brings **non-blocking generation**: it accepts everything `generate` accepts, returns `{ jobId, cancel }` immediately, and stores the exact blocking result on an **expiring job record**, with **`onMessage`/`onEnd` hooks** for callers. It rides **additive `@apostrophecms/job` extensions** (job owner with scoped routes, cancel flag and route, `cancelled` status, `error` payload, `startedAt`/`endedAt`, opt-in per-document TTL), supports **in-process and cross-process cancellation** that waits out the in-flight step and preserves partial results (`finishReason: 'cancel'`), publishes **progress notifications** (started / per-turn / ended, correlated by `jobId`, opt-out via `notify: false`), and introduces a first-class **notification `bus: true` flag** — a never-rendered message-bus carrier emitted in exactly one tab — retiring the hidden-notification hack.

> Note: The job tests change do not imply a BC break - it fixes old race that was exposed by the additional DB roundtrip that we made to support job canceling. It's internal behavior change bringing enough latency to expose the race more often. 
