### PR TITLE
Self-debouncing widget renders. The widget component now handles this on its own

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/.changeset/self-debouncing-renders.md
+++ b/.changeset/self-debouncing-renders.md
@@ -1,5 +1,5 @@
 ---
-"@apostrophecms/apostrophe": patch
+"apostrophe": patch
 ---
 
 Widget preview rendering are now properly debounced in cases where the server does not return the first preview before

--- a/.changeset/self-debouncing-renders.md
+++ b/.changeset/self-debouncing-renders.md
@@ -1,0 +1,8 @@
+---
+"@apostrophecms/apostrophe": patch
+---
+
+Widget preview rendering are now properly debounced in cases where the server does not return the first preview before
+the timeout to generate a second preview arrives. Apostrophe will always wait for a previous render before attempting
+a new one based on the latest data available. This greatly mitigates the performance impact on the server if
+a widget is particularly slow and expensive to preview.

--- a/packages/apostrophe/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
+++ b/packages/apostrophe/modules/@apostrophecms/area/ui/apos/apps/AposAreas.js
@@ -22,7 +22,6 @@ export default function() {
   apos.bus.$on('widget-rendered', options => {
     widgetsRendering--;
     createAreaAppsAndRunPlayersIfDone(options);
-
   });
 
   apos.bus.$on('refreshed', function() {

--- a/packages/apostrophe/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
+++ b/packages/apostrophe/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
@@ -1,3 +1,4 @@
+import { klona } from 'klona';
 import props from '../composables/AposWidgetProps.js';
 import {
   _renderContent, _emitWidgetRendered, _getClasses
@@ -7,7 +8,10 @@ export default {
   props,
   data() {
     return {
-      rendered: '...'
+      rendered: '...',
+      renderId: 0,
+      lastShownRenderId: -1,
+      active: false
     };
   },
   watch: {
@@ -31,16 +35,45 @@ export default {
     getClasses() {
       return _getClasses(this.modelValue, this.moduleOptions);
     },
+    // This method id fire-and-forget. It uses async internally to
+    // debounce simultaneous async requests
     async renderContent() {
-      const result = await _renderContent(this.$props);
-      if (Object.hasOwn(result, 'data')) {
-        this.rendered = result.data;
+      this.renderId++;
+      // Because it can change in a later invocation during
+      // the network request
+      const renderId = this.renderId;
+      if (this.active) {
+        // Wait for the current render request to finish
+        await this.active;
+        console.log('after the wait');
+        if (renderId < this.renderId) {
+          // Skip this render request, a newer one has shown up
+          // in the meantime
+          return;
+        }
       }
-      if (!result.error) {
-        this.$nextTick(() => {
-          _emitWidgetRendered(this.modelValue.aposLivePreview, { el: this.$el });
-        });
-      }
+      // We didn't get skipped and it's our turn now
+      this.active = (async () => {
+        console.log('starting');
+        const result = await _renderContent(this.$props);
+        this.active = false;
+        if (renderId < this.lastShownRenderId) {
+          // The network can return renders out of order,
+          // never display something more stale than the
+          // last thing displayed
+          return;
+        }
+        this.lastShownRenderId = renderId;
+        if (Object.hasOwn(result, 'data')) {
+          this.rendered = result.data;
+        }
+        if (!result.error) {
+          this.$nextTick(() => {
+            _emitWidgetRendered(this.modelValue.aposLivePreview, { el: this.$el });
+          });
+        }
+        console.log('finished');
+      })();
     }
   }
 };

--- a/packages/apostrophe/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
+++ b/packages/apostrophe/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
@@ -1,4 +1,3 @@
-import { klona } from 'klona';
 import props from '../composables/AposWidgetProps.js';
 import {
   _renderContent, _emitWidgetRendered, _getClasses
@@ -45,7 +44,6 @@ export default {
       if (this.active) {
         // Wait for the current render request to finish
         await this.active;
-        console.log('after the wait');
         if (renderId < this.renderId) {
           // Skip this render request, a newer one has shown up
           // in the meantime
@@ -54,7 +52,6 @@ export default {
       }
       // We didn't get skipped and it's our turn now
       this.active = (async () => {
-        console.log('starting');
         const result = await _renderContent(this.$props);
         this.active = false;
         if (renderId < this.lastShownRenderId) {
@@ -72,7 +69,6 @@ export default {
             _emitWidgetRendered(this.modelValue.aposLivePreview, { el: this.$el });
           });
         }
-        console.log('finished');
       })();
     }
   }

--- a/packages/apostrophe/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
+++ b/packages/apostrophe/modules/@apostrophecms/widget-type/ui/apos/mixins/AposWidgetMixin.js
@@ -35,7 +35,7 @@ export default {
     getClasses() {
       return _getClasses(this.modelValue, this.moduleOptions);
     },
-    // This method id fire-and-forget. It uses async internally to
+    // This method is fire-and-forget. It uses async internally to
     // debounce simultaneous async requests
     async renderContent() {
       this.renderId++;


### PR DESCRIPTION
Additional work could be done to get rid of the nonfunctional async plumbing elsewhere that never really worked, but it makes sense to get this to Go7 as a beta.

It doesn't solve the underlying problem of a widget being very slow to render (I haven't reproduced their results locally yet) but it should greatly mitigate the pain and this is what we always intended so it's considered a bug fix.