### PR TITLE
Add document extraction system

### DIFF
--- a/packages/apostrophe/modules/@apostrophecms/image-widget/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/image-widget/index.js
@@ -160,6 +160,24 @@ module.exports = {
   },
   methods(self) {
     return {
+      // The image itself leads, when the relationship is loaded on the
+      // widget; the schema walk still covers the caption and any fields a
+      // subclass adds
+      extract(req, widget, options) {
+        const attachment = widget._image?.[0]?.attachment;
+        const items = attachment
+          ? [
+            {
+              image: { url: self.apos.attachment.url(attachment, { size: 'full' }) },
+              tags: [ 'image' ]
+            }
+          ]
+          : [];
+        return items.concat(
+          self.apos.schema.extract(req, self.schema, widget, options)
+        );
+      },
+
       // Clear link hrefs that use dangerous URL schemes (e.g.
       // `javascript:`) and may have been stored before the linkHref
       // schema field was changed to `type: 'url'`. Registered per

--- a/packages/apostrophe/modules/@apostrophecms/rich-text-widget/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/rich-text-widget/index.js
@@ -865,6 +865,21 @@ module.exports = {
         });
       },
 
+      // The widget's HTML markup is its content; there is no sub-schema
+      // to walk
+      extract(req, widget, options) {
+        if (self.isEmpty(widget)) {
+          return [];
+        }
+        return [
+          {
+            path: `${options.path}.content`,
+            text: widget.content,
+            tags: [ 'text' ]
+          }
+        ];
+      },
+
       isEmpty(widget) {
         const content = (widget.content || '').trim();
         const text = self.apos.util.htmlToPlaintext(content).trim();

--- a/packages/apostrophe/modules/@apostrophecms/schema/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/schema/index.js
@@ -19,6 +19,7 @@ const { klona } = require('klona');
 const { stripIndents } = require('common-tags');
 const addFieldTypes = require('./lib/addFieldTypes');
 const newInstance = require('./lib/newInstance.js');
+const { finalize } = require('./lib/extract.js');
 
 module.exports = {
   options: {
@@ -503,6 +504,146 @@ module.exports = {
           }
           fieldType.index(object[field.name], field, texts);
         });
+      },
+
+      // Extract the content of `doc` (or any sub-object matching `schema`,
+      // such as a widget) as a flat array of items, by walking the schema.
+      // Whether a field extracts, and with which tags, is the `extractable`
+      // policy resolved once at schema validation time — the walk never
+      // recomputes it, so only validated schemas (any schema registered
+      // with a doc type or widget type) yield items.
+      //
+      // Each item has:
+      //
+      // - `path`: a dot path to the content in `doc`, compatible with
+      //   `apos.util.get` and `apos.util.set`. Content nested in array
+      //   items and widgets is anchored on the nearest `_id`
+      //   (`@xyz.field`), never on array indexes.
+      // - `schemaPath`: the field-name hierarchy, for labels and debugging.
+      // - `type`: the field type, or `widget:name` for widget content.
+      // - `label`: the field label.
+      // - `tags`: the item's resolved tags (see `extractable`).
+      // - `text`: the text content, on text-bearing items.
+      // - `image`: `{ url }` or `{ data, mediaType }`, on image items.
+      // - `metaOnly`: `true` on structural container markers (arrays,
+      //   areas), which carry no direct content.
+      //
+      // Options:
+      //
+      // - `include`: keep only items carrying at least one of these tags
+      //   (omit to keep everything extracted). Structural `metaOnly`
+      //   markers carry no content to select on and are always kept —
+      //   filter them out yourself if unwanted.
+      // - `exclude`: drop items carrying any of these tags, `metaOnly`
+      //   markers included. Wins over `include`.
+      // - `extend`: an object mapping an item `type` to a function. Each
+      //   matching item is replaced by the function's return value, with
+      //   the original item as the sole argument. Consumer-specific
+      //   transforms belong here, per call, never in the field type
+      //   itself, so one consumer's reshaping can never leak into
+      //   another's call.
+      // - `maxLength`: a budget for the total `text` length. Items are
+      //   kept in walk order until the budget would be exceeded; the first
+      //   item over budget and everything after it are dropped.
+      // - `path`, `schemaPath`, `tags`: prefixes for the emitted paths,
+      //   and container tags to union into everything the sub-walk emits.
+      //   Passed by extractors and widget managers reentering the walk for
+      //   a sub-schema; rarely useful otherwise.
+      //
+      // Container field types (arrays, objects, areas) implement `extract`
+      // by calling this method again on their sub-schema, without query
+      // options.
+
+      extract(req, schema, doc, options = {}) {
+        const {
+          include = null,
+          exclude = null,
+          extend = null,
+          maxLength = null,
+          path = '',
+          schemaPath = '',
+          tags: inherited = null
+        } = options;
+        if (include !== null && !isTagArray(include)) {
+          throw self.apos.error('invalid', '"include" must be an array of tag strings');
+        }
+        if (exclude !== null && !isTagArray(exclude)) {
+          throw self.apos.error('invalid', '"exclude" must be an array of tag strings');
+        }
+        if (inherited !== null && !isTagArray(inherited)) {
+          throw self.apos.error('invalid', '"tags" must be an array of tag strings');
+        }
+        if (extend !== null && (
+          typeof extend !== 'object' ||
+          Array.isArray(extend) ||
+          !Object.values(extend).every(fn => typeof fn === 'function')
+        )) {
+          throw self.apos.error(
+            'invalid',
+            '"extend" must be an object mapping field types to functions'
+          );
+        }
+        if (maxLength !== null && (!Number.isInteger(maxLength) || maxLength <= 0)) {
+          throw self.apos.error('invalid', '"maxLength" must be a positive integer');
+        }
+        const items = [];
+        for (const field of schema) {
+          if (!Array.isArray(field._extractable)) {
+            continue;
+          }
+          const fieldTags = inherited?.length
+            ? _.uniq([ ...inherited, ...field._extractable ])
+            : field._extractable;
+          const fieldPath = {
+            value: path ? `${path}.${field.name}` : field.name,
+            schema: schemaPath ? `${schemaPath}.${field.name}` : field.name,
+            tags: fieldTags
+          };
+          const found = self.fieldTypes[field.type]
+            .extract(req, field, doc?.[field.name], fieldPath) ?? [];
+          const defaults = {
+            path: fieldPath.value,
+            schemaPath: fieldPath.schema,
+            type: field.type,
+            label: field.label,
+            tags: fieldTags
+          };
+          for (const item of found) {
+            items.push(finalize(item, defaults));
+          }
+        }
+        if (!include && !exclude && !extend && (maxLength === null)) {
+          return items;
+        }
+        const kept = [];
+        let total = 0;
+        for (const item of items) {
+          if (include && !item.metaOnly && !hasAny(item.tags, include)) {
+            continue;
+          }
+          if (exclude && hasAny(item.tags, exclude)) {
+            continue;
+          }
+          const final = (extend && extend[item.type])
+            ? extend[item.type](item)
+            : item;
+          if ((maxLength !== null) && final.text) {
+            total += final.text.length;
+            if (total > maxLength) {
+              break;
+            }
+          }
+          kept.push(final);
+        }
+        return kept;
+
+        function hasAny(itemTags, query) {
+          return itemTags.some(tag => query.includes(tag));
+        }
+        function isTagArray(value) {
+          return Array.isArray(value) &&
+            value.every(tag => typeof tag === 'string' && tag.length);
+        }
       },
 
       async evaluateCondition(
@@ -1392,8 +1533,18 @@ module.exports = {
         if (type.extend) {
           // Allow a field type to extend another field type and merge
           // in some differences.
-          fieldType = _.cloneDeep(self.fieldTypes[type.extend]);
+          const parent = self.fieldTypes[type.extend];
+          fieldType = _.cloneDeep(parent);
           _.merge(fieldType, type);
+          // A subtype's extractable tags union with its parent's;
+          // lodash merges arrays index-wise, which would drop parent tags
+          if (parent && Array.isArray(parent.extractable) &&
+            Array.isArray(type.extractable)) {
+            fieldType.extractable = _.uniq([
+              ...parent.extractable,
+              ...type.extractable
+            ]);
+          }
         }
         // For bc. csv was a bad name for the string converter, but
         // we need to accept it, and even keep the property around
@@ -1631,6 +1782,7 @@ module.exports = {
         if (options.type === 'doc type' && (field.editPermission || field.viewPermission) && parent) {
           warn(`editPermission or viewPermission must be defined on root fields only, provided on "${parent.name}.${field.name}"`);
         }
+        resolveExtractable();
         if (fieldType.validate) {
           fieldType.validate(field, options, warn, fail);
         }
@@ -1654,6 +1806,40 @@ module.exports = {
             ${s}
 
           `;
+        }
+        // Resolves the field's extraction policy to `false` or an array of
+        // tags, cached as `field._extractable` so the extraction walk is a
+        // single read. The type is the gate: a field instance can opt out of
+        // an extractable type or extend its tags, but can never force in a
+        // type that does not extract.
+        function resolveExtractable() {
+          const typeTags = normalizeExtractable(
+            fieldType.extractable ?? !!fieldType.extract,
+            `The "${field.type}" field type's "extractable" property`
+          );
+          if (typeTags !== false && !fieldType.extract) {
+            fail(`The "${field.type}" field type declares "extractable" but has no extract method.`);
+          }
+          const fieldTags = normalizeExtractable(
+            field.extractable ?? true,
+            'The "extractable" property'
+          );
+          field._extractable = (typeTags === false || fieldTags === false)
+            ? false
+            : _.uniq([ ...typeTags, ...fieldTags ]);
+        }
+        function normalizeExtractable(value, label) {
+          if (value === false) {
+            return false;
+          }
+          if (value === true) {
+            return [];
+          }
+          if (Array.isArray(value) &&
+            value.every(tag => typeof tag === 'string' && tag.length)) {
+            return value;
+          }
+          return fail(`${label} must be true, false or an array of tag strings.`);
         }
       },
 

--- a/packages/apostrophe/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/packages/apostrophe/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -3,6 +3,7 @@ const dayjs = require('dayjs');
 const { klona } = require('klona');
 const { stripIndents } = require('common-tags');
 const joinr = require('./joinr');
+const { finalize } = require('./extract.js');
 
 const dateRegex = /^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/;
 
@@ -72,7 +73,7 @@ module.exports = (self) => {
         for (const group of Object.keys(field.options.groups)) {
           widgets = {
             ...widgets,
-            ...group.widgets
+            ...field.options.groups[group].widgets
           };
         }
       }
@@ -80,6 +81,8 @@ module.exports = (self) => {
       for (const name of Object.keys(widgets)) {
         check(name);
       }
+
+      resolveWidgetExtractable();
 
       function check(name) {
         if (!self.apos.modules[`${name}-widget`]) {
@@ -93,6 +96,82 @@ module.exports = (self) => {
           }
         }
       }
+      // Resolves the extraction policy of every widget type configured in
+      // this area to `false | [tags]`, merging the widget module's
+      // `extractable` option with the per-widget area configuration, so
+      // the extraction walk is a single read per widget. The module
+      // option's form is validated by the widget-type module itself.
+      function resolveWidgetExtractable() {
+        field._extractableWidgets = {};
+        const configured = self.apos.area.getWidgets(field.options || {});
+        for (const [ name, widgetOptions ] of Object.entries(configured)) {
+          const manager = self.apos.area.getWidgetManager(name);
+          if (!manager) {
+            continue;
+          }
+          const moduleTags = normalizeExtractable(manager.options.extractable ?? true);
+          const configTags = normalizeExtractable(widgetOptions?.extractable ?? true);
+          if (configTags === undefined) {
+            fail(`The "${name}" widget's "extractable" property must be true, false or an array of tag strings.`);
+          }
+          field._extractableWidgets[name] =
+            (moduleTags === false || configTags === false)
+              ? false
+              : _.uniq([ ...moduleTags, ...configTags ]);
+        }
+      }
+      function normalizeExtractable(value) {
+        if (value === false) {
+          return false;
+        }
+        if (value === true) {
+          return [];
+        }
+        if (Array.isArray(value) &&
+          value.every(tag => typeof tag === 'string' && tag.length)) {
+          return value;
+        }
+        return undefined;
+      }
+    },
+    extract(req, field, value, path) {
+      const widgets = value?.items;
+      if (!Array.isArray(widgets) || !widgets.length) {
+        return [];
+      }
+      const policies = field._extractableWidgets ?? {};
+      const items = [];
+      for (const widget of widgets) {
+        // An unconfigured or opted-out widget type is skipped whole
+        const policy = policies[widget.type];
+        if (!policy) {
+          continue;
+        }
+        const manager = self.apos.area.getWidgetManager(widget.type);
+        if (!manager) {
+          continue;
+        }
+        const context = {
+          path: `@${widget._id}`,
+          schemaPath: `${path.schema}.${widget.type}`,
+          tags: policy.length ? _.uniq([ ...path.tags, ...policy ]) : path.tags
+        };
+        const found = manager.extract(req, widget, context);
+        const defaults = {
+          path: context.path,
+          schemaPath: context.schemaPath,
+          type: `widget:${widget.type}`,
+          label: manager.label,
+          tags: context.tags
+        };
+        for (const item of found) {
+          items.push(finalize(item, defaults));
+        }
+      }
+      if (items.length) {
+        items.push({ metaOnly: true });
+      }
+      return items;
     },
     index: function (value, field, texts) {
       for (const item of ((value && value.items) || [])) {
@@ -110,6 +189,10 @@ module.exports = (self) => {
 
   self.addFieldType({
     name: 'string',
+    extractable: [ 'text' ],
+    extract(req, field, value) {
+      return value ? [ { text: value } ] : [];
+    },
     convert(req, field, data, destination) {
       destination[field.name] = self.apos.launder.string(data[field.name]);
       destination[field.name] = checkStringLength(
@@ -758,6 +841,8 @@ module.exports = (self) => {
 
   self.addFieldType({
     name: 'password',
+    // A hard "never extract"
+    extractable: false,
     async convert(req, field, data, destination) {
       // This is the only field type that we never update unless
       // there is actually a new value — a blank password is not cool. -Tom
@@ -922,6 +1007,27 @@ module.exports = (self) => {
         self.apos.schema.indexFields(field.schema, item, texts);
       });
     },
+    extract(req, field, value, path) {
+      if (!Array.isArray(value) || !value.length) {
+        return [];
+      }
+      const items = [];
+      for (const item of value) {
+        // Anchor on the item's _id so paths survive reordering
+        const found = self.apos.schema.extract(req, field.schema, item, {
+          path: `@${item._id}`,
+          schemaPath: path.schema,
+          tags: path.tags
+        });
+        for (const sub of found) {
+          items.push(sub);
+        }
+      }
+      if (items.length) {
+        items.push({ metaOnly: true });
+      }
+      return items;
+    },
     validate: function (field, options, warn, fail) {
       for (const subField of field.schema || field.fields.add) {
         self.validateField(subField, options, field);
@@ -1037,6 +1143,16 @@ module.exports = (self) => {
       if (value) {
         self.apos.schema.indexFields(field.schema, value, texts);
       }
+    },
+    extract(req, field, value, path) {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return [];
+      }
+      return self.apos.schema.extract(req, field.schema, value, {
+        path: path.value,
+        schemaPath: path.schema,
+        tags: path.tags
+      });
     },
     def: {}
   });

--- a/packages/apostrophe/modules/@apostrophecms/schema/lib/extract.js
+++ b/packages/apostrophe/modules/@apostrophecms/schema/lib/extract.js
@@ -1,0 +1,34 @@
+// Shared machinery of the content extraction walk. See the
+// `extract` method of the schema module for the contract.
+
+const _ = require('lodash');
+
+// Marks items already finalized by the extract walk, so a reentrant
+// walk never reprocesses what a nested level produced
+const extracted = Symbol('apos.schema.extract');
+
+// Fill an item's missing properties from its origin context and union
+// its tags, exactly once, mutating in place; an already finalized item
+// passes through untouched. `defaults` carries `path`, `schemaPath`,
+// `type`, `label` and `tags`.
+function finalize(item, defaults) {
+  if (item[extracted]) {
+    return item;
+  }
+  item.path ??= defaults.path;
+  item.schemaPath ??= defaults.schemaPath;
+  item.type ??= defaults.type;
+  item.label ??= defaults.label;
+  item.tags = item.tags?.length
+    ? _.uniq([ ...defaults.tags, ...item.tags ])
+    : defaults.tags.slice();
+  // Non-enumerable: the stamp must stay invisible to consumers
+  // serializing or comparing items
+  Object.defineProperty(item, extracted, { value: true });
+  return item;
+}
+
+module.exports = {
+  extracted,
+  finalize
+};

--- a/packages/apostrophe/modules/@apostrophecms/widget-type/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/widget-type/index.js
@@ -202,6 +202,15 @@ module.exports = {
 
     self.label = self.options.label;
 
+    const extractable = self.options.extractable;
+    const validExtractable = extractable === undefined ||
+      typeof extractable === 'boolean' ||
+      (Array.isArray(extractable) &&
+        extractable.every(tag => typeof tag === 'string' && tag.length));
+    if (!validExtractable) {
+      throw new Error(`${self.__meta.name}: "extractable" must be true, false or an array of tag strings`);
+    }
+
     self.composeSchema();
     self.composeWidgetOperations();
 
@@ -629,6 +638,35 @@ module.exports = {
 
       addSearchTexts(widget, texts) {
         self.apos.schema.indexFields(self.schema, widget, texts);
+      },
+
+      // Extract the widget's content for `apos.schema.extract`, which
+      // documents the item shape and drives this walk. By default the
+      // widget's own schema is walked, which covers any widget built from
+      // ordinary fields and areas. Override to contribute content only
+      // this widget knows about, returning your own items ahead of a
+      // recursive walk of the sub-schema:
+      //
+      // ```js
+      // extract(req, widget, options) {
+      //   return [
+      //     { text: widget.special },
+      //     ...self.apos.schema.extract(req, self.schema, widget, options)
+      //   ];
+      // }
+      // ```
+      //
+      // `options` carries the `path`, `schemaPath` and `tags` context of
+      // the walk and must travel to the recursive call unchanged. Missing
+      // item properties are filled in by the caller, so a minimal item
+      // needs only its content (`text` or `image`) and any tags of its
+      // own.
+
+      extract(req, widget, options) {
+        if (self.isEmpty(widget)) {
+          return [];
+        }
+        return self.apos.schema.extract(req, self.schema, widget, options);
       },
 
       // Return true if this widget should be considered

--- a/packages/apostrophe/test/schema-extract.js
+++ b/packages/apostrophe/test/schema-extract.js
@@ -959,3 +959,619 @@ describe('Schema extraction policy', function() {
     });
   });
 });
+
+describe('Schema extraction parity with legacy extraction', function() {
+  this.timeout(t.timeout);
+
+  let apos;
+  let req;
+  let schema;
+
+  // The live output of a legacy translation extract implementation for
+  // the document below, captured against the same schema expressed
+  // through that implementation's `translate` flags: field-level
+  // `translate: false` on `brand`, `offRows.hidden` and `specs.secret`;
+  // type-level `translate` on `legacyOnText`/`legacyOffText`;
+  // module-level `translate: false` on the parity-legacy-off widget;
+  // the double-nested area configuration form
+  // `{ options: { translate: false } }` on the parity-plain widget.
+  // Here every one of those flags is expressed as `extractable`
+  // vocabulary instead, and the translation query below must reproduce
+  // this output through the legacy shape mapping.
+  const legacyFields = [
+    {
+      valuePath: 'title',
+      schemaPath: 'title',
+      type: 'string',
+      text: 'Parity product'
+    },
+    {
+      valuePath: 'slug',
+      schemaPath: 'slug',
+      type: 'slug',
+      text: 'parity product',
+      original: 'parity-product'
+    },
+    {
+      valuePath: 'subtitle',
+      schemaPath: 'subtitle',
+      type: 'string',
+      text: 'A machine for testing'
+    },
+    {
+      valuePath: 'body',
+      schemaPath: 'body',
+      type: 'string',
+      text: 'Long body text for the parity audit.'
+    },
+    {
+      valuePath: 'nickname',
+      schemaPath: 'nickname',
+      type: 'slug',
+      text: 'hello world',
+      original: 'products/hello-world'
+    },
+    {
+      valuePath: 'blurb',
+      schemaPath: 'blurb',
+      type: 'legacyOnText',
+      text: 'Legacy opt-in text'
+    },
+    {
+      valuePath: '@row1.cell',
+      schemaPath: 'rows.cell',
+      type: 'string',
+      text: 'Row one'
+    },
+    {
+      valuePath: '@row1.deep.inner',
+      schemaPath: 'rows.deep.inner',
+      type: 'string',
+      text: 'Deep one'
+    },
+    {
+      valuePath: '@sub1.subCell',
+      schemaPath: 'rows.subRows.subCell',
+      type: 'string',
+      text: 'Sub one'
+    },
+    {
+      valuePath: '@row1.subRows',
+      schemaPath: '@row1.subRows',
+      type: 'array',
+      metaOnly: true
+    },
+    {
+      valuePath: '@row2.cell',
+      schemaPath: 'rows.cell',
+      type: 'string',
+      text: 'Row two'
+    },
+    {
+      valuePath: 'rows',
+      schemaPath: 'rows',
+      type: 'array',
+      metaOnly: true
+    },
+    {
+      valuePath: '@inline1.line',
+      schemaPath: 'inlineRows.line',
+      type: 'string',
+      text: 'Inline one'
+    },
+    {
+      valuePath: '@table1.cellText',
+      schemaPath: 'tableRows.cellText',
+      type: 'string',
+      text: 'Table one'
+    },
+    {
+      valuePath: 'tableRows',
+      schemaPath: 'tableRows',
+      type: 'array',
+      metaOnly: true
+    },
+    {
+      valuePath: 'specs.name',
+      schemaPath: 'specs.name',
+      type: 'string',
+      text: 'Spec name'
+    },
+    {
+      valuePath: '@w1.content',
+      schemaPath: 'main.widget:@apostrophecms/rich-text',
+      type: 'widget:@apostrophecms/rich-text',
+      metaPath: '@w1',
+      text: '<p>Rich text content</p>'
+    },
+    {
+      valuePath: '@w3.caption',
+      schemaPath: 'main.widget:@apostrophecms/image.caption',
+      type: 'string',
+      text: 'A caption'
+    },
+    {
+      valuePath: '@w4.heading',
+      schemaPath: 'main.widget:parity-hero.heading',
+      type: 'string',
+      text: 'Hero heading'
+    },
+    {
+      valuePath: '@w5.content',
+      schemaPath: 'main.widget:parity-hero.nested.widget:@apostrophecms/rich-text',
+      type: 'widget:@apostrophecms/rich-text',
+      metaPath: '@w5',
+      text: '<p>Nested rich text</p>'
+    },
+    {
+      valuePath: '@w4.nested.items',
+      schemaPath: 'main.widget:parity-hero.nested',
+      type: 'area',
+      metaPath: '@w4.nested',
+      metaOnly: true
+    },
+    {
+      valuePath: 'main.items',
+      schemaPath: 'main',
+      type: 'area',
+      metaPath: 'main',
+      metaOnly: true
+    }
+  ];
+
+  before(async function() {
+    apos = await t.create({
+      root: module,
+      modules: {
+        'parity-types': {
+          init(self) {
+            self.apos.schema.addFieldType({
+              name: 'legacyOnText',
+              extend: 'string'
+            });
+            self.apos.schema.addFieldType({
+              name: 'legacyOffText',
+              extend: 'string',
+              extractable: [ 'notranslate' ]
+            });
+          }
+        },
+        'parity-hero-widget': {
+          extend: '@apostrophecms/widget-type',
+          options: {
+            label: 'Parity Hero'
+          },
+          fields: {
+            add: {
+              heading: { type: 'string' },
+              nested: {
+                type: 'area',
+                options: {
+                  widgets: {
+                    '@apostrophecms/rich-text': {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        'parity-legacy-off-widget': {
+          extend: '@apostrophecms/widget-type',
+          options: {
+            label: 'Parity Legacy Off',
+            extractable: [ 'notranslate' ]
+          },
+          fields: {
+            add: {
+              note: { type: 'string' }
+            }
+          }
+        },
+        'parity-plain-widget': {
+          extend: '@apostrophecms/widget-type',
+          options: {
+            label: 'Parity Plain'
+          },
+          fields: {
+            add: {
+              message: { type: 'string' }
+            }
+          }
+        },
+        'parity-product': {
+          extend: '@apostrophecms/piece-type',
+          options: {
+            label: 'Parity Product'
+          },
+          fields: {
+            add: {
+              subtitle: { type: 'string' },
+              body: {
+                type: 'string',
+                textarea: true
+              },
+              nickname: { type: 'slug' },
+              brand: {
+                type: 'string',
+                extractable: [ 'notranslate' ]
+              },
+              blurb: { type: 'legacyOnText' },
+              // A legacy custom type only translated fields carrying
+              // their own `translate: true`; a field without one maps
+              // to the marker tag to keep translation output identical
+              blurbDefault: {
+                type: 'legacyOnText',
+                extractable: [ 'notranslate' ]
+              },
+              internalCode: { type: 'legacyOffText' },
+              stock: { type: 'integer' },
+              tagline: { type: 'string' },
+              rows: {
+                type: 'array',
+                fields: {
+                  add: {
+                    cell: { type: 'string' },
+                    deep: {
+                      type: 'object',
+                      fields: {
+                        add: {
+                          inner: { type: 'string' }
+                        }
+                      }
+                    },
+                    subRows: {
+                      type: 'array',
+                      fields: {
+                        add: {
+                          subCell: { type: 'string' }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              inlineRows: {
+                type: 'array',
+                inline: true,
+                fields: {
+                  add: {
+                    line: { type: 'string' }
+                  }
+                }
+              },
+              tableRows: {
+                type: 'array',
+                inline: true,
+                style: 'table',
+                fields: {
+                  add: {
+                    cellText: { type: 'string' }
+                  }
+                }
+              },
+              offRows: {
+                type: 'array',
+                fields: {
+                  add: {
+                    hidden: {
+                      type: 'string',
+                      extractable: [ 'notranslate' ]
+                    }
+                  }
+                }
+              },
+              specs: {
+                type: 'object',
+                fields: {
+                  add: {
+                    name: { type: 'string' },
+                    secret: {
+                      type: 'string',
+                      extractable: [ 'notranslate' ]
+                    }
+                  }
+                }
+              },
+              main: {
+                type: 'area',
+                options: {
+                  widgets: {
+                    '@apostrophecms/rich-text': {},
+                    '@apostrophecms/image': {},
+                    'parity-hero': {},
+                    'parity-legacy-off': {},
+                    'parity-plain': {
+                      extractable: [ 'notranslate' ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+    req = apos.task.getReq();
+    schema = apos.modules['parity-product'].schema;
+  });
+
+  after(async function() {
+    return t.destroy(apos);
+  });
+
+  // The same document the capture was extracted from; keep in sync
+  // with the capture by hand
+  function parityDoc() {
+    return {
+      title: 'Parity product',
+      slug: 'parity-product',
+      subtitle: 'A machine for testing',
+      body: 'Long body text for the parity audit.',
+      nickname: 'products/hello-world',
+      brand: 'Acme',
+      blurb: 'Legacy opt-in text',
+      blurbDefault: 'Legacy default text',
+      internalCode: 'X-123',
+      stock: 5,
+      tagline: '',
+      rows: [
+        {
+          _id: 'row1',
+          cell: 'Row one',
+          deep: {
+            _id: 'deep1',
+            inner: 'Deep one'
+          },
+          subRows: [
+            {
+              _id: 'sub1',
+              subCell: 'Sub one'
+            }
+          ]
+        },
+        {
+          _id: 'row2',
+          cell: 'Row two',
+          deep: {
+            _id: 'deep2',
+            inner: ''
+          },
+          subRows: []
+        }
+      ],
+      inlineRows: [
+        {
+          _id: 'inline1',
+          line: 'Inline one'
+        }
+      ],
+      tableRows: [
+        {
+          _id: 'table1',
+          cellText: 'Table one'
+        }
+      ],
+      offRows: [
+        {
+          _id: 'off1',
+          hidden: 'Hidden text'
+        }
+      ],
+      specs: {
+        _id: 'specs1',
+        name: 'Spec name',
+        secret: 'Spec secret'
+      },
+      main: {
+        _id: 'area1',
+        metaType: 'area',
+        items: [
+          {
+            _id: 'w1',
+            metaType: 'widget',
+            type: '@apostrophecms/rich-text',
+            content: '<p>Rich text content</p>'
+          },
+          {
+            _id: 'w2',
+            metaType: 'widget',
+            type: '@apostrophecms/rich-text',
+            content: ''
+          },
+          {
+            _id: 'w3',
+            metaType: 'widget',
+            type: '@apostrophecms/image',
+            caption: 'A caption',
+            _image: [
+              {
+                _id: 'image1',
+                attachment: {
+                  _id: 'att1',
+                  name: 'sample',
+                  extension: 'jpg',
+                  group: 'images',
+                  width: 800,
+                  height: 600
+                }
+              }
+            ]
+          },
+          {
+            _id: 'w4',
+            metaType: 'widget',
+            type: 'parity-hero',
+            heading: 'Hero heading',
+            nested: {
+              _id: 'area2',
+              metaType: 'area',
+              items: [
+                {
+                  _id: 'w5',
+                  metaType: 'widget',
+                  type: '@apostrophecms/rich-text',
+                  content: '<p>Nested rich text</p>'
+                }
+              ]
+            }
+          },
+          {
+            _id: 'w6',
+            metaType: 'widget',
+            type: 'parity-legacy-off',
+            note: 'Widget module opt-out'
+          },
+          {
+            _id: 'w7',
+            metaType: 'widget',
+            type: 'parity-plain',
+            message: 'Area config opt-out'
+          }
+        ]
+      }
+    };
+  }
+
+  // The translation consumer's query: translatable text only, minus
+  // the marker tag, with the unslugify transform applied per call
+  function translationQuery() {
+    return apos.schema.extract(req, schema, parityDoc(), {
+      include: [ 'text' ],
+      exclude: [ 'notranslate' ],
+      extend: {
+        slug(item) {
+          return {
+            ...item,
+            original: item.text,
+            text: apos.util.slugify(item.text.split('/').pop(), {
+              separator: ' ',
+              stripAccents: false
+            })
+          };
+        }
+      }
+    });
+  }
+
+  // Resolve an item's dot schemaPath against the schema, returning the
+  // legacy component form (widget components prefixed `widget:`) and
+  // the schema field the path ends on, when it ends on one
+  function resolveLegacy(schemaPath) {
+    const components = [];
+    let fields = schema;
+    let areaField = null;
+    let field = null;
+    for (const part of schemaPath.split('.')) {
+      const found = fields && fields.find(f => f.name === part);
+      if (found) {
+        field = found;
+        components.push(part);
+        fields = found.schema;
+        areaField = (found.type === 'area') ? found : null;
+        continue;
+      }
+      if (areaField) {
+        components.push(`widget:${part}`);
+        fields = apos.area.getWidgetManager(part)?.schema;
+        field = null;
+        areaField = null;
+        continue;
+      }
+      components.push(part);
+      field = null;
+    }
+    return {
+      schemaPath: components.join('.'),
+      field
+    };
+  }
+
+  // Map a core item to the legacy field meta shape
+  function toLegacyShape(item) {
+    const legacy = {
+      valuePath: item.path,
+      schemaPath: resolveLegacy(item.schemaPath).schemaPath,
+      type: item.type
+    };
+    if (item.metaOnly) {
+      if (item.type === 'area') {
+        // Legacy area markers pointed their value path at the items
+        // array and their meta path at the field
+        legacy.valuePath = `${item.path}.items`;
+        legacy.metaPath = item.path;
+      }
+      legacy.metaOnly = true;
+      return legacy;
+    }
+    if (item.type === 'widget:@apostrophecms/rich-text') {
+      // Legacy anchored the rich text meta on the widget itself
+      legacy.metaPath = item.path.replace(/\.content$/, '');
+    }
+    legacy.text = item.text;
+    if (item.original !== undefined) {
+      legacy.original = item.original;
+    }
+    return legacy;
+  }
+
+  // Legacy suppressed the container marker of inline arrays not
+  // styled as tables
+  function isInlineMarker(item) {
+    if (!item.metaOnly || item.type !== 'array') {
+      return false;
+    }
+    const { field } = resolveLegacy(item.schemaPath);
+    return !!(field && field.inline && field.style !== 'table');
+  }
+
+  it('reproduces the legacy translation extraction through the shape mapping', function() {
+    const mapped = translationQuery()
+      .filter(item => !isInlineMarker(item))
+      .map(toLegacyShape);
+    const expected = legacyFields.map(entry => {
+      // Deviation: legacy composed a nested array marker's schemaPath
+      // from its value path components; the walk reports the real
+      // schema location
+      return (entry.metaOnly && entry.valuePath === '@row1.subRows')
+        ? {
+          ...entry,
+          schemaPath: 'rows.subRows'
+        }
+        : entry;
+    });
+    // Deviation: a container whose content is entirely excluded by the
+    // query still emits its marker; legacy emitted nothing for it
+    expected.splice(
+      expected.findIndex(entry => entry.valuePath === 'specs.name'),
+      0,
+      {
+        valuePath: 'offRows',
+        schemaPath: 'offRows',
+        type: 'array',
+        metaOnly: true
+      }
+    );
+    assert.deepEqual(mapped, expected);
+  });
+
+  it('keeps every legacy opt-out visible to non-translation queries', function() {
+    const items = apos.schema.extract(req, schema, parityDoc(), {
+      include: [ 'text' ]
+    });
+    const optedOut = [
+      'brand',
+      'blurbDefault',
+      'internalCode',
+      '@off1.hidden',
+      'specs.secret',
+      '@w6.note',
+      '@w7.message'
+    ];
+    for (const path of optedOut) {
+      const item = items.find(i => i.path === path);
+      assert(item, `expected an item at ${path}`);
+      assert(item.tags.includes('text'), `${path} must stay a text item`);
+      assert(item.tags.includes('notranslate'), `${path} must carry the marker`);
+    }
+  });
+});

--- a/packages/apostrophe/test/schema-extract.js
+++ b/packages/apostrophe/test/schema-extract.js
@@ -1,0 +1,961 @@
+const t = require('../test-lib/test.js');
+const assert = require('assert/strict');
+
+describe('Schema extraction policy', function() {
+  this.timeout(t.timeout);
+
+  let apos;
+
+  before(async function() {
+    apos = await t.create({
+      root: module,
+      modules: {
+        // Field types exercising every extractable form
+        'extract-test-types': {
+          init(self) {
+            self.apos.schema.addFieldType({
+              name: 'plainText',
+              extractable: [ 'text' ],
+              extract() {
+                return [];
+              },
+              def: ''
+            });
+            self.apos.schema.addFieldType({
+              name: 'untaggedText',
+              extract() {
+                return [];
+              },
+              def: ''
+            });
+            self.apos.schema.addFieldType({
+              name: 'testImage',
+              extractable: [ 'image' ],
+              extract(req, field, value) {
+                return value ? [ { image: { url: value } } ] : [];
+              }
+            });
+            self.apos.schema.addFieldType({
+              name: 'noExtract',
+              def: false
+            });
+            self.apos.schema.addFieldType({
+              name: 'apiSecret',
+              extend: 'plainText',
+              extractable: false
+            });
+            self.apos.schema.addFieldType({
+              name: 'taggedChild',
+              extend: 'plainText',
+              extractable: [ 'seo' ]
+            });
+          }
+        },
+        'policy-piece': {
+          extend: '@apostrophecms/piece-type',
+          options: {
+            label: 'Policy Piece'
+          },
+          fields: {
+            add: {
+              plain: { type: 'plainText' },
+              explicitTrue: {
+                type: 'plainText',
+                extractable: true
+              },
+              optOut: {
+                type: 'plainText',
+                extractable: false
+              },
+              keywords: {
+                type: 'plainText',
+                extractable: [ 'seoContext' ]
+              },
+              productCode: {
+                type: 'plainText',
+                extractable: [ 'notranslate' ]
+              },
+              bare: { type: 'untaggedText' },
+              hero: { type: 'testImage' },
+              featured: { type: 'noExtract' },
+              featuredForced: {
+                type: 'noExtract',
+                extractable: true
+              },
+              token: { type: 'apiSecret' },
+              tokenForced: {
+                type: 'apiSecret',
+                extractable: [ 'text' ]
+              },
+              child: { type: 'taggedChild' },
+              childPlus: {
+                type: 'taggedChild',
+                extractable: [ 'extra' ]
+              },
+              secret: { type: 'password' },
+              rows: {
+                type: 'array',
+                fields: {
+                  add: {
+                    cell: { type: 'plainText' },
+                    cellOff: {
+                      type: 'plainText',
+                      extractable: false
+                    }
+                  }
+                }
+              },
+              meta: {
+                type: 'object',
+                fields: {
+                  add: {
+                    inner: {
+                      type: 'plainText',
+                      extractable: [ 'deep' ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        'walk-piece': {
+          extend: '@apostrophecms/piece-type',
+          options: {
+            label: 'Walk Piece'
+          },
+          fields: {
+            add: {
+              headline: { type: 'string' },
+              body: {
+                type: 'string',
+                textarea: true
+              },
+              nickname: { type: 'slug' },
+              productCode: {
+                type: 'string',
+                extractable: [ 'notranslate' ]
+              },
+              internalNote: {
+                type: 'string',
+                extractable: false
+              },
+              count: { type: 'integer' },
+              rows: {
+                type: 'array',
+                fields: {
+                  add: {
+                    cell: { type: 'string' },
+                    deep: {
+                      type: 'object',
+                      fields: {
+                        add: {
+                          inner: { type: 'string' }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              markedRows: {
+                type: 'array',
+                extractable: [ 'notranslate' ],
+                fields: {
+                  add: {
+                    cell: { type: 'string' }
+                  }
+                }
+              },
+              meta: {
+                type: 'object',
+                fields: {
+                  add: {
+                    inner: { type: 'string' }
+                  }
+                }
+              },
+              hero: { type: 'testImage' }
+            }
+          }
+        },
+        'fancy-widget': {
+          extend: '@apostrophecms/widget-type',
+          options: {
+            label: 'Fancy'
+          },
+          fields: {
+            add: {
+              heading: { type: 'string' },
+              nested: {
+                type: 'area',
+                options: {
+                  widgets: {
+                    '@apostrophecms/rich-text': {}
+                  }
+                }
+              }
+            }
+          },
+          methods(self) {
+            return {
+              extract(req, widget, options) {
+                return [
+                  {
+                    text: widget.special,
+                    tags: [ 'special' ]
+                  },
+                  ...self.apos.schema.extract(req, self.schema, widget, options)
+                ];
+              }
+            };
+          }
+        },
+        'muted-widget': {
+          extend: '@apostrophecms/widget-type',
+          options: {
+            label: 'Muted',
+            extractable: false
+          },
+          fields: {
+            add: {
+              note: { type: 'string' }
+            }
+          }
+        },
+        'tagged-widget': {
+          extend: '@apostrophecms/widget-type',
+          options: {
+            label: 'Tagged',
+            extractable: [ 'promo' ]
+          },
+          fields: {
+            add: {
+              blurb: { type: 'string' }
+            }
+          }
+        },
+        'area-piece': {
+          extend: '@apostrophecms/piece-type',
+          options: {
+            label: 'Area Piece'
+          },
+          fields: {
+            add: {
+              body: {
+                type: 'area',
+                options: {
+                  widgets: {
+                    '@apostrophecms/rich-text': {},
+                    '@apostrophecms/image': {},
+                    fancy: {},
+                    muted: {},
+                    tagged: {
+                      extractable: [ 'areaTag' ]
+                    }
+                  }
+                }
+              },
+              mutedByConfig: {
+                type: 'area',
+                options: {
+                  widgets: {
+                    tagged: {
+                      extractable: false
+                    }
+                  }
+                }
+              },
+              markedArea: {
+                type: 'area',
+                extractable: [ 'notranslate' ],
+                options: {
+                  widgets: {
+                    '@apostrophecms/rich-text': {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+  });
+
+  after(async function() {
+    return t.destroy(apos);
+  });
+
+  function field(name) {
+    return apos.modules['policy-piece'].schema.find(f => f.name === name);
+  }
+
+  describe('field type definitions', function() {
+    it('unions a subtype\'s extractable tags with its parent\'s on extend', function() {
+      assert.deepEqual(
+        apos.schema.getFieldType('taggedChild').extractable,
+        [ 'text', 'seo' ]
+      );
+    });
+
+    it('keeps extractable: false on a subtype as a hard opt-out', function() {
+      const apiSecret = apos.schema.getFieldType('apiSecret');
+      assert.equal(apiSecret.extractable, false);
+      // The extractor itself is still inherited; only the policy blocks it
+      assert.equal(typeof apiSecret.extract, 'function');
+    });
+
+    it('leaves an absent type-level extractable absent', function() {
+      assert.equal(apos.schema.getFieldType('untaggedText').extractable, undefined);
+      assert.deepEqual(
+        apos.schema.getFieldType('plainText').extractable,
+        [ 'text' ]
+      );
+    });
+  });
+
+  describe('field instance resolution', function() {
+    it('resolves the policy per field instance', function() {
+      const expected = {
+        plain: [ 'text' ],
+        explicitTrue: [ 'text' ],
+        optOut: false,
+        keywords: [ 'text', 'seoContext' ],
+        productCode: [ 'text', 'notranslate' ],
+        bare: [],
+        hero: [ 'image' ],
+        featured: false,
+        featuredForced: false,
+        token: false,
+        tokenForced: false,
+        child: [ 'text', 'seo' ],
+        childPlus: [ 'text', 'seo', 'extra' ],
+        secret: false
+      };
+      for (const [ name, value ] of Object.entries(expected)) {
+        assert.deepEqual(field(name)._extractable, value, name);
+      }
+    });
+
+    it('resolves fields of nested array and object schemas', function() {
+      const rows = field('rows');
+      assert.deepEqual(
+        rows.schema.find(f => f.name === 'cell')._extractable,
+        [ 'text' ]
+      );
+      assert.equal(
+        rows.schema.find(f => f.name === 'cellOff')._extractable,
+        false
+      );
+      const meta = field('meta');
+      assert.deepEqual(
+        meta.schema.find(f => f.name === 'inner')._extractable,
+        [ 'text', 'deep' ]
+      );
+    });
+  });
+
+  describe('validation failures', function() {
+    // Schema validation throws after every init has run, so the partially
+    // booted instance can be captured and destroyed
+    const failsToBoot = async (typeDef, fieldDef, pattern) => {
+      let captured;
+      try {
+        await assert.rejects(t.create({
+          root: module,
+          exit: 'throw',
+          modules: {
+            'bad-types': {
+              init(self) {
+                captured = self.apos;
+                if (typeDef) {
+                  self.apos.schema.addFieldType(typeDef);
+                }
+              }
+            },
+            'bad-piece': {
+              extend: '@apostrophecms/piece-type',
+              options: {
+                label: 'Bad Piece'
+              },
+              fields: {
+                add: {
+                  bad: fieldDef
+                }
+              }
+            }
+          }
+        }), pattern);
+      } finally {
+        await t.destroy(captured);
+      }
+    };
+
+    it('rejects extractable tags on a type with no extract method', async function() {
+      await failsToBoot(
+        {
+          name: 'noWay',
+          extractable: [ 'text' ]
+        },
+        { type: 'noWay' },
+        /declares "extractable" but has no extract method/
+      );
+    });
+
+    it('rejects extractable: true on a type with no extract method', async function() {
+      await failsToBoot(
+        {
+          name: 'noWay',
+          extractable: true
+        },
+        { type: 'noWay' },
+        /declares "extractable" but has no extract method/
+      );
+    });
+
+    it('rejects a malformed type-level extractable', async function() {
+      await failsToBoot(
+        {
+          name: 'badTags',
+          extractable: 'text',
+          extract() {
+            return [];
+          }
+        },
+        { type: 'badTags' },
+        /field type's "extractable" property must be true, false or an array of tag strings/
+      );
+    });
+
+    it('rejects a malformed field-level extractable', async function() {
+      await failsToBoot(
+        null,
+        {
+          type: 'string',
+          extractable: 'yes'
+        },
+        /The "extractable" property must be true, false or an array of tag strings/
+      );
+      await failsToBoot(
+        null,
+        {
+          type: 'string',
+          extractable: [ 'ok', 3 ]
+        },
+        /The "extractable" property must be true, false or an array of tag strings/
+      );
+    });
+  });
+
+  describe('the extract walk', function() {
+    let req;
+    let schema;
+
+    const doc = () => ({
+      headline: 'Big News',
+      body: 'A long story',
+      nickname: 'big-news',
+      productCode: 'X-100',
+      internalNote: 'do not leak',
+      count: 5,
+      rows: [
+        {
+          _id: 'r1',
+          cell: 'One',
+          deep: { inner: 'Deep one' }
+        },
+        {
+          _id: 'r2',
+          cell: 'Two'
+        }
+      ],
+      markedRows: [
+        {
+          _id: 'm1',
+          cell: 'Marked'
+        }
+      ],
+      meta: { inner: 'About' },
+      hero: '/uploads/hero.png'
+    });
+
+    before(function() {
+      req = apos.task.getReq();
+      schema = apos.modules['walk-piece'].schema;
+    });
+
+    function byPath(items, path) {
+      return items.find(item => item.path === path);
+    }
+
+    it('walks a document into tagged content items', function() {
+      const items = apos.schema.extract(req, schema, doc());
+      assert.deepEqual(byPath(items, 'headline'), {
+        path: 'headline',
+        schemaPath: 'headline',
+        type: 'string',
+        label: 'Headline',
+        tags: [ 'text' ],
+        text: 'Big News'
+      });
+      assert.equal(byPath(items, 'body').text, 'A long story');
+      // Slug inherits the string extractor untransformed
+      assert.deepEqual(byPath(items, 'nickname').tags, [ 'text' ]);
+      assert.equal(byPath(items, 'nickname').text, 'big-news');
+      assert.equal(byPath(items, 'nickname').type, 'slug');
+      assert.deepEqual(byPath(items, 'productCode').tags, [ 'text', 'notranslate' ]);
+      assert.deepEqual(byPath(items, 'hero'), {
+        path: 'hero',
+        schemaPath: 'hero',
+        type: 'testImage',
+        label: 'Hero',
+        tags: [ 'image' ],
+        image: { url: '/uploads/hero.png' }
+      });
+      // Opted out and non-extractable fields never appear
+      assert.equal(byPath(items, 'internalNote'), undefined);
+      assert.equal(byPath(items, 'count'), undefined);
+    });
+
+    it('threads paths through arrays and objects', function() {
+      const items = apos.schema.extract(req, schema, doc());
+      assert.deepEqual(byPath(items, '@r1.cell'), {
+        path: '@r1.cell',
+        schemaPath: 'rows.cell',
+        type: 'string',
+        label: 'Cell',
+        tags: [ 'text' ],
+        text: 'One'
+      });
+      assert.deepEqual(byPath(items, '@r1.deep.inner'), {
+        path: '@r1.deep.inner',
+        schemaPath: 'rows.deep.inner',
+        type: 'string',
+        label: 'Inner',
+        tags: [ 'text' ],
+        text: 'Deep one'
+      });
+      assert.equal(byPath(items, '@r2.cell').text, 'Two');
+      assert.equal(byPath(items, 'meta.inner').text, 'About');
+      assert.equal(byPath(items, 'meta.inner').schemaPath, 'meta.inner');
+      // The emitted paths resolve back to the content
+      for (const item of items.filter(i => !i.metaOnly && i.text)) {
+        assert.equal(apos.util.get(doc(), item.path), item.text);
+      }
+    });
+
+    it('emits a metaOnly container marker for non-empty arrays only', function() {
+      const items = apos.schema.extract(req, schema, doc());
+      assert.deepEqual(byPath(items, 'rows'), {
+        path: 'rows',
+        schemaPath: 'rows',
+        type: 'array',
+        label: 'Rows',
+        tags: [],
+        metaOnly: true
+      });
+      const empty = apos.schema.extract(req, schema, {
+        headline: 'Just this'
+      });
+      assert.equal(byPath(empty, 'rows'), undefined);
+      assert.equal(byPath(empty, 'meta'), undefined);
+    });
+
+    it('unions a container\'s tags into its subtree', function() {
+      const items = apos.schema.extract(req, schema, doc());
+      assert.deepEqual(byPath(items, '@m1.cell').tags, [ 'notranslate', 'text' ]);
+      assert.deepEqual(byPath(items, 'markedRows').tags, [ 'notranslate' ]);
+    });
+
+    it('include keeps any-of, plus metaOnly markers', function() {
+      const items = apos.schema.extract(req, schema, doc(), {
+        include: [ 'text' ]
+      });
+      assert.deepEqual(items.map(item => item.path), [
+        'headline',
+        'body',
+        'nickname',
+        'productCode',
+        '@r1.cell',
+        '@r1.deep.inner',
+        '@r2.cell',
+        'rows',
+        '@m1.cell',
+        'markedRows',
+        'meta.inner'
+      ]);
+      const images = apos.schema.extract(req, schema, doc(), {
+        include: [ 'image' ]
+      });
+      assert.deepEqual(
+        images.filter(item => !item.metaOnly).map(item => item.path),
+        [ 'hero' ]
+      );
+    });
+
+    it('exclude wins over include, markers included', function() {
+      const items = apos.schema.extract(req, schema, doc(), {
+        include: [ 'text' ],
+        exclude: [ 'notranslate' ]
+      });
+      assert.deepEqual(items.map(item => item.path), [
+        'headline',
+        'body',
+        'nickname',
+        '@r1.cell',
+        '@r1.deep.inner',
+        '@r2.cell',
+        'rows',
+        'meta.inner'
+      ]);
+    });
+
+    it('keeps a marker-tagged field visible to every other query', function() {
+      const items = apos.schema.extract(req, schema, doc(), {
+        include: [ 'text' ]
+      });
+      assert.deepEqual(byPath(items, 'productCode').tags, [ 'text', 'notranslate' ]);
+    });
+
+    it('extend transforms matching items with the original in hand', function() {
+      const items = apos.schema.extract(req, schema, doc(), {
+        include: [ 'text' ],
+        extend: {
+          slug: (item) => ({
+            ...item,
+            text: item.text.replace(/-/g, ' '),
+            original: item.text
+          })
+        }
+      });
+      const nickname = byPath(items, 'nickname');
+      assert.equal(nickname.text, 'big news');
+      assert.equal(nickname.original, 'big-news');
+      // Other types are untouched
+      assert.equal(byPath(items, 'headline').text, 'Big News');
+      // The transform is strictly per call
+      const plain = apos.schema.extract(req, schema, doc(), {
+        include: [ 'text' ]
+      });
+      assert.equal(byPath(plain, 'nickname').text, 'big-news');
+    });
+
+    it('maxLength keeps items in walk order until the budget is hit', function() {
+      const items = apos.schema.extract(req, schema, doc(), {
+        include: [ 'text' ],
+        maxLength: 25
+      });
+      // 'Big News' (8) + 'A long story' (12) fit; 'big-news' would overflow
+      assert.deepEqual(items.map(item => item.path), [ 'headline', 'body' ]);
+    });
+
+    it('returns nothing for an unvalidated schema', function() {
+      const items = apos.schema.extract(req, [
+        {
+          name: 'headline',
+          type: 'string',
+          label: 'Headline'
+        }
+      ], { headline: 'Hi' });
+      assert.deepEqual(items, []);
+    });
+
+    it('rejects malformed options', function() {
+      const invalid = (options, pattern) => {
+        assert.throws(() => apos.schema.extract(req, schema, doc(), options), (e) => {
+          assert.equal(e.name, 'invalid');
+          assert.match(e.message, pattern);
+          return true;
+        });
+      };
+      invalid({ include: 'text' }, /"include" must be an array of tag strings/);
+      invalid({ exclude: [ 3 ] }, /"exclude" must be an array of tag strings/);
+      invalid({ tags: 'notranslate' }, /"tags" must be an array of tag strings/);
+      invalid({ extend: { slug: true } }, /"extend" must be an object mapping field types to functions/);
+      invalid({ extend: [ () => {} ] }, /"extend" must be an object mapping field types to functions/);
+      invalid({ maxLength: 0 }, /"maxLength" must be a positive integer/);
+      invalid({ maxLength: 'big' }, /"maxLength" must be a positive integer/);
+    });
+  });
+
+  describe('widget extraction', function() {
+    let req;
+    let schema;
+
+    const areaDoc = () => ({
+      body: {
+        metaType: 'area',
+        items: [
+          {
+            _id: 'w1',
+            type: '@apostrophecms/rich-text',
+            content: '<p>Rich text</p>'
+          },
+          {
+            _id: 'w2',
+            type: 'fancy',
+            special: 'Own data',
+            heading: 'Head',
+            nested: {
+              metaType: 'area',
+              items: [
+                {
+                  _id: 'w3',
+                  type: '@apostrophecms/rich-text',
+                  content: '<p>Deep</p>'
+                }
+              ]
+            }
+          },
+          {
+            _id: 'w4',
+            type: 'muted',
+            note: 'Never seen'
+          },
+          {
+            _id: 'w5',
+            type: 'tagged',
+            blurb: 'Promo text'
+          },
+          {
+            _id: 'w6',
+            type: '@apostrophecms/image',
+            caption: 'A caption',
+            _image: [
+              {
+                attachment: {
+                  _id: 'a1',
+                  name: 'photo',
+                  extension: 'jpg',
+                  group: 'images',
+                  width: 800,
+                  height: 600
+                }
+              }
+            ]
+          }
+        ]
+      },
+      mutedByConfig: {
+        metaType: 'area',
+        items: [
+          {
+            _id: 'w7',
+            type: 'tagged',
+            blurb: 'Hidden'
+          }
+        ]
+      },
+      markedArea: {
+        metaType: 'area',
+        items: [
+          {
+            _id: 'w8',
+            type: '@apostrophecms/rich-text',
+            content: '<p>Brand</p>'
+          }
+        ]
+      }
+    });
+
+    before(function() {
+      req = apos.task.getReq();
+      schema = apos.modules['area-piece'].schema;
+    });
+
+    function byPath(items, path) {
+      return items.find(item => item.path === path);
+    }
+
+    it('resolves widget policies once at schema validation', function() {
+      const body = schema.find(f => f.name === 'body');
+      assert.deepEqual(body._extractableWidgets, {
+        '@apostrophecms/rich-text': [],
+        '@apostrophecms/image': [],
+        fancy: [],
+        muted: false,
+        tagged: [ 'promo', 'areaTag' ]
+      });
+    });
+
+    it('dispatches area content through widget managers', function() {
+      const items = apos.schema.extract(req, schema, areaDoc());
+      assert.deepEqual(byPath(items, '@w1.content'), {
+        path: '@w1.content',
+        schemaPath: 'body.@apostrophecms/rich-text',
+        type: 'widget:@apostrophecms/rich-text',
+        label: apos.modules['@apostrophecms/rich-text-widget'].label,
+        tags: [ 'text' ],
+        text: '<p>Rich text</p>'
+      });
+      assert.deepEqual(byPath(items, 'body'), {
+        path: 'body',
+        schemaPath: 'body',
+        type: 'area',
+        label: 'Body',
+        tags: [],
+        metaOnly: true
+      });
+    });
+
+    it('a custom widget contributes its own items ahead of its sub-schema', function() {
+      const items = apos.schema.extract(req, schema, areaDoc());
+      assert.deepEqual(byPath(items, '@w2'), {
+        path: '@w2',
+        schemaPath: 'body.fancy',
+        type: 'widget:fancy',
+        label: 'Fancy',
+        tags: [ 'special' ],
+        text: 'Own data'
+      });
+      assert.deepEqual(byPath(items, '@w2.heading'), {
+        path: '@w2.heading',
+        schemaPath: 'body.fancy.heading',
+        type: 'string',
+        label: 'Heading',
+        tags: [ 'text' ],
+        text: 'Head'
+      });
+    });
+
+    it('nests widget, area and widget again with correct paths', function() {
+      const items = apos.schema.extract(req, schema, areaDoc());
+      assert.deepEqual(byPath(items, '@w3.content'), {
+        path: '@w3.content',
+        schemaPath: 'body.fancy.nested.@apostrophecms/rich-text',
+        type: 'widget:@apostrophecms/rich-text',
+        label: apos.modules['@apostrophecms/rich-text-widget'].label,
+        tags: [ 'text' ],
+        text: '<p>Deep</p>'
+      });
+      // The nested area emits its own container marker
+      assert.deepEqual(byPath(items, '@w2.nested'), {
+        path: '@w2.nested',
+        schemaPath: 'body.fancy.nested',
+        type: 'area',
+        label: 'Nested',
+        tags: [],
+        metaOnly: true
+      });
+    });
+
+    it('skips a widget opted out at the module level', function() {
+      const items = apos.schema.extract(req, schema, areaDoc());
+      assert.equal(byPath(items, '@w4'), undefined);
+      assert.equal(byPath(items, '@w4.note'), undefined);
+    });
+
+    it('skips a widget opted out in the area configuration', function() {
+      const items = apos.schema.extract(req, schema, areaDoc());
+      assert.equal(byPath(items, '@w7.blurb'), undefined);
+      // Nothing survived, so the area emits no marker either
+      assert.equal(byPath(items, 'mutedByConfig'), undefined);
+    });
+
+    it('unions module and area configuration tags into widget items', function() {
+      const items = apos.schema.extract(req, schema, areaDoc());
+      assert.deepEqual(
+        byPath(items, '@w5.blurb').tags,
+        [ 'promo', 'areaTag', 'text' ]
+      );
+    });
+
+    it('extracts the image widget as an image item plus its schema', function() {
+      const items = apos.schema.extract(req, schema, areaDoc());
+      const image = byPath(items, '@w6');
+      assert.deepEqual(image.tags, [ 'image' ]);
+      assert.equal(image.type, 'widget:@apostrophecms/image');
+      assert.match(image.image.url, /a1-photo/);
+      assert.match(image.image.url, /\.jpg$/);
+      assert.equal(byPath(items, '@w6.caption').text, 'A caption');
+      assert.deepEqual(byPath(items, '@w6.caption').tags, [ 'text' ]);
+    });
+
+    it('a marked area opts its whole subtree out of translation queries', function() {
+      const all = apos.schema.extract(req, schema, areaDoc());
+      assert.deepEqual(
+        byPath(all, '@w8.content').tags,
+        [ 'notranslate', 'text' ]
+      );
+      assert.deepEqual(byPath(all, 'markedArea').tags, [ 'notranslate' ]);
+      const translation = apos.schema.extract(req, schema, areaDoc(), {
+        include: [ 'text' ],
+        exclude: [ 'notranslate' ]
+      });
+      assert.equal(byPath(translation, '@w8.content'), undefined);
+      assert.equal(byPath(translation, 'markedArea'), undefined);
+      // The unmarked area is unaffected, markers included
+      assert(byPath(translation, '@w1.content'));
+      assert(byPath(translation, 'body'));
+      // The image item is not text, but the caption is
+      assert.equal(byPath(translation, '@w6'), undefined);
+      assert(byPath(translation, '@w6.caption'));
+    });
+  });
+
+  describe('widget policy validation failures', function() {
+    it('rejects a malformed extractable in an area widget configuration', async function() {
+      let captured;
+      try {
+        await assert.rejects(t.create({
+          root: module,
+          exit: 'throw',
+          modules: {
+            'a-capture': {
+              init(self) {
+                captured = self.apos;
+              }
+            },
+            'bad-piece': {
+              extend: '@apostrophecms/piece-type',
+              options: {
+                label: 'Bad Piece'
+              },
+              fields: {
+                add: {
+                  bad: {
+                    type: 'area',
+                    options: {
+                      widgets: {
+                        '@apostrophecms/rich-text': {
+                          extractable: 'nope'
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }), /The "@apostrophecms\/rich-text" widget's "extractable" property must be true, false or an array of tag strings/);
+      } finally {
+        await t.destroy(captured);
+      }
+    });
+
+    it('rejects a malformed extractable option on a widget module', async function() {
+      let captured;
+      try {
+        await assert.rejects(t.create({
+          root: module,
+          exit: 'throw',
+          modules: {
+            'a-capture': {
+              init(self) {
+                captured = self.apos;
+              }
+            },
+            'bad-widget': {
+              extend: '@apostrophecms/widget-type',
+              options: {
+                label: 'Bad',
+                extractable: 'nope'
+              }
+            }
+          }
+        }), /bad-widget: "extractable" must be true, false or an array of tag strings/);
+      } finally {
+        await t.destroy(captured);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Adds document extraction `schema.extract()`. Allows value extraction to a flat array (including metadata), supports include/exclude tagging.

