### PR TITLE
Regenerate session when invalid

### DIFF
--- a/.changeset/long-poets-grow.md
+++ b/.changeset/long-poets-grow.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": patch
+---
+
+Fixed a 500 error when logging in on a session that had just been invalidated by a password change or by a disabled account. Such sessions are now regenerated rather than destroyed, so the request keeps a usable session and the invalidated one is removed from the store before the response is sent.

--- a/packages/apostrophe/modules/@apostrophecms/login/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/login/index.js
@@ -1180,8 +1180,12 @@ module.exports = {
             req.user.loginInvalidBefore &&
             (!req.session.loginAt || (req.session.loginAt < req.user.loginInvalidBefore))
           ) {
-            req.session.destroy();
             delete req.user;
+            // Regenerate rather than destroy. `destroy` removes `req.session`
+            // right away and does not wait for the store, so later middleware
+            // and routes, such as a fresh login attempt, are left without a
+            // session, and the old one can still be loaded by the next request.
+            return req.session.regenerate(() => next());
           }
           return next();
         }

--- a/packages/apostrophe/test/login.js
+++ b/packages/apostrophe/test/login.js
@@ -357,6 +357,61 @@ describe('Login', function () {
 
   });
 
+  it('should be able to log in again on a session invalidated by a password change', async function () {
+
+    // Uses its own user so the shared password sequence is not disturbed
+    const req = apos.task.getReq();
+    const instance = apos.user.newInstance();
+    instance.title = 'Ginny Weasel';
+    instance.username = 'GinnyWeasel';
+    instance.password = 'firstPassword';
+    instance.email = 'gweasel@aol.com';
+    instance.role = 'admin';
+    await apos.user.insert(req, instance);
+
+    const jar = apos.http.jar();
+    await apos.http.get('/', { jar });
+    await apos.http.post(
+      '/api/v1/@apostrophecms/login/login',
+      {
+        method: 'POST',
+        body: {
+          username: 'GinnyWeasel',
+          password: 'firstPassword',
+          session: true
+        },
+        jar
+      }
+    );
+
+    let page = await apos.http.get('/', { jar });
+    assert(page.match(/logged in/));
+
+    const user = await apos.user.find(req, {
+      username: 'GinnyWeasel'
+    }).toObject();
+    user.password = 'secondPassword';
+    await apos.user.update(req, user);
+
+    // No request in between, so this login is the first one to carry the
+    // invalidated session
+    await apos.http.post(
+      '/api/v1/@apostrophecms/login/login',
+      {
+        method: 'POST',
+        body: {
+          username: 'GinnyWeasel',
+          password: 'secondPassword',
+          session: true
+        },
+        jar
+      }
+    );
+
+    page = await apos.http.get('/', { jar });
+    assert(page.match(/logged in/));
+  });
+
   it('changing a user\'s password should invalidate bearer tokens for that user', async function () {
 
     // Log in


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:

*Check one*
- [x] main
- [x] latest
- [x] stable
- [ ] Check if this PR will be resubmitted against another branch

## Summary

Fixed a 500 error when logging in on a session that had just been invalidated by a password change or by a disabled account. Such sessions are now regenerated rather than destroyed, so the request keeps a usable session and the invalidated one is removed from the store before the response is sent.

Added a regression test that reproduces the 500 error without the fix.

This is a very old code (5+ years) and not a recent regression. The race comes on request basis (second request at the right time while the session is being deleted). The actual cause is consistently reproducible. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
