### PR TITLE
efficient deep patches for widgets, allows effective in-context editing of complex pages

### DIFF
--- a/.changeset/efficient-deep-patches.md
+++ b/.changeset/efficient-deep-patches.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": patch
+---
+
+The performance of patches to deeply nested properties on the page has been optimized. As a result, each edit to a widget "in context" on the page does not require the same amount of time necessary to save the entire page via the page settings dialog. We consider this a bug fix rather than a feature because the issue was acute enough to prevent effective editing in some cases.

--- a/packages/apostrophe/modules/@apostrophecms/page/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/page/index.js
@@ -1262,7 +1262,7 @@ database.`);
                 force
               });
             }
-            self.enforceParkedProperties(req, page, input);
+            self.enforceParkedProperties(req, page, input, { onlyIfPresent: true });
             if (possiblePatchedFields) {
               await self.applyPatch(req, page, input, { fetchRelationships });
             }
@@ -1308,14 +1308,28 @@ database.`);
         if (!manager) {
           throw self.apos.error('invalid');
         }
-        self.apos.schema.implementPatchOperators(input, page);
         const parentPage = page._ancestors.length &&
           page._ancestors[page._ancestors.length - 1];
-        const schema = self.apos.schema.subsetSchemaForPatch(manager.allowedSchema(req, {
+        const allowedSchema = manager.allowedSchema(req, {
           ...page,
           type: manager.name
-        }, parentPage), input);
-        await self.apos.schema.convert(req, schema, input, page, { fetchRelationships });
+        }, parentPage);
+        // Shortcut for a patch that replaces just one widget, which spares us
+        // converting the rest of the document
+        const patched = await self.apos.schema.patchWidgetIfSuitable(
+          req,
+          allowedSchema,
+          input,
+          page,
+          { fetchRelationships }
+        );
+        if (!patched) {
+          self.apos.schema.implementPatchOperators(input, page);
+          const schema = self.apos.schema.subsetSchemaForPatch(allowedSchema, input);
+          await self.apos.schema.convert(req, schema, input, page, {
+            fetchRelationships
+          });
+        }
         await manager.emit('afterConvert', req, input, page);
       },
       // True delete. Will throw an error if the page
@@ -3043,10 +3057,33 @@ database.`);
         return self.apos.i18n.inferIdLocaleAndMode(req, _id);
       },
       // Copy any parked properties of `page` back into `input` to
-      // prevent any attempt to alter them via the PUT or PATCH APIs
-      enforceParkedProperties(req, page, input) {
+      // prevent any attempt to alter them via the PUT or PATCH APIs.
+      //
+      // With `onlyIfPresent: true`, parked properties `input` says nothing
+      // about are left out of it altogether. Pass this when `input` is a patch
+      // rather than a complete replacement for the page. A property a patch
+      // never mentions is not converted in any case, and adding it makes the
+      // patch look like it touches more of the document than it really does,
+      // which costs the patch code path its shortcuts.
+      enforceParkedProperties(req, page, input, { onlyIfPresent = false } = {}) {
         for (const field of (page.parked || [])) {
+          if (onlyIfPresent && !mentions(field)) {
+            continue;
+          }
           input[field] = page[field];
+        }
+        // Dot notation and the patch operators can reach a parked property
+        // just as a plain property name can
+        function mentions(field) {
+          return [
+            input,
+            input.$push,
+            input.$pullAll,
+            input.$pullAllById,
+            input.$move
+          ].some(object => object && ((typeof object) === 'object') &&
+            Object.keys(object).some(key => key.split('.')[0] === field)
+          );
         }
       },
       async implementParkAllInDefaultLocale() {

--- a/packages/apostrophe/modules/@apostrophecms/piece-type/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/piece-type/index.js
@@ -1098,12 +1098,26 @@ module.exports = {
       // as part of trusted logic that will address missing documents in
       // relationships later.
       async applyPatch(req, piece, input, { fetchRelationships = true } = {}) {
-        self.apos.schema.implementPatchOperators(input, piece);
-        const schema = self.apos.schema.subsetSchemaForPatch(
-          self.allowedSchema(req),
-          input
+        const allowedSchema = self.allowedSchema(req);
+        // Shortcut for a patch that replaces just one widget, which spares us
+        // converting the rest of the document
+        const patched = await self.apos.schema.patchWidgetIfSuitable(
+          req,
+          allowedSchema,
+          input,
+          piece,
+          { fetchRelationships }
         );
-        await self.apos.schema.convert(req, schema, input, piece, { fetchRelationships });
+        if (!patched) {
+          self.apos.schema.implementPatchOperators(input, piece);
+          const schema = self.apos.schema.subsetSchemaForPatch(
+            allowedSchema,
+            input
+          );
+          await self.apos.schema.convert(req, schema, input, piece, {
+            fetchRelationships
+          });
+        }
         await self.emit('afterConvert', req, input, piece);
       },
       // Generate a sample piece of this type. The `i` counter

--- a/packages/apostrophe/modules/@apostrophecms/schema/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/schema/index.js
@@ -20,6 +20,17 @@ const { stripIndents } = require('common-tags');
 const addFieldTypes = require('./lib/addFieldTypes');
 const newInstance = require('./lib/newInstance.js');
 
+// Properties of a patch that are acted upon by the PATCH routes themselves
+// and never reach `convert`. See `patchWidgetIfSuitable`.
+const patchControlProperties = new Set([
+  '_advisory',
+  '_advisoryLock',
+  '_patches',
+  '_position',
+  '_publish',
+  '_targetId'
+]);
+
 module.exports = {
   options: {
     alias: 'schema'
@@ -1711,6 +1722,139 @@ module.exports = {
       // modal.
       getFieldById(_id) {
         return self.fieldsById[_id];
+      },
+
+      // Optimization, called for you by the `applyPatch` methods of pieces
+      // and pages just before `implementPatchOperators`. If `patch` does
+      // nothing more than replace one widget in its entirety, via the `@_id`
+      // syntax, then sanitize just that widget, store it in place in
+      // `destination` and return `true`. The caller must then skip both
+      // `implementPatchOperators` and the `convert` call that normally
+      // follows it.
+      //
+      // The general code path has to copy every top level property touched by
+      // the patch out of the document and re-convert all of it, so that
+      // conditional fields can be evaluated with the whole picture in view.
+      // For a patch aimed at one widget of a large area that can easily mean
+      // thousands of awaits. Widget schemas are independent: a widget field
+      // may not depend on a field of the parent document, and vice versa. So
+      // when the patch is confined to a single widget the rest of the
+      // document does not have to be revisited at all.
+      //
+      // `schema` must be the document's allowed schema, i.e. what the caller
+      // would otherwise pass to `subsetSchemaForPatch`.
+      //
+      // Returns `false` if the patch is not that simple case, or if any part
+      // of it cannot be verified, in which case the caller must carry on with
+      // the general code path. Widgets can be patched in other valid ways
+      // too, those just don't benefit from this shortcut.
+
+      async patchWidgetIfSuitable(
+        req,
+        schema,
+        patch,
+        destination,
+        { fetchRelationships = true } = {}
+      ) {
+        const keys = Object.keys(patch)
+          .filter(key => !patchControlProperties.has(key));
+        if (keys.length !== 1) {
+          return false;
+        }
+        const [ key ] = keys;
+        // Must be an `@_id` reference to an entire widget, with no dot path
+        // narrowing it to a property of that widget
+        if ((key.charAt(0) !== '@') || (key.indexOf('.') !== -1)) {
+          return false;
+        }
+        const value = patch[key];
+        // The browser tells us it means to replace a widget. Take its word
+        // for it only if there really is one there already
+        if (
+          !value ||
+          ((typeof value) !== 'object') ||
+          (value.metaType !== 'widget') ||
+          ((typeof value.type) !== 'string')
+        ) {
+          return false;
+        }
+        const found = self.apos.util.findNestedObjectAndDotPathById(
+          destination,
+          key.substring(1),
+          { ignoreDynamicProperties: true }
+        );
+        if (!found || (found.object.metaType !== 'widget')) {
+          return false;
+        }
+        // The dot path looks like `main.items.3`, or `main.items.3.inner.
+        // items.0` for a widget of an area nested in another widget. Lop off
+        // the index and `items` to arrive at the area, and one more component
+        // to arrive at whatever object the area field belongs to
+        const components = found.dotPath.split('.');
+        const [ topLevelName ] = components;
+        const index = parseInt(components.pop(), 10);
+        components.pop();
+        const name = components.pop();
+        const ownerPath = components.join('.');
+        const owner = ownerPath.length
+          ? self.apos.util.get(destination, ownerPath)
+          : destination;
+        const area = owner && owner[name];
+        // Confirms in one stroke that we lopped off exactly the right
+        // components and that `area` really is the area containing the widget
+        if (!area || (area.items && area.items[index]) !== found.object) {
+          return false;
+        }
+        // However deep the widget lies, the general code path would reach it
+        // only through a top level field, so that field must be one this user
+        // is allowed to edit. `convert` also leaves read-only fields alone,
+        // so a patch aimed inside one is not ours to apply
+        const topLevelField = schema.find(field => field.name === topLevelName);
+        if (!topLevelField || topLevelField.readOnly) {
+          return false;
+        }
+        // At the top level the caller's schema already reflects the fields
+        // this user is allowed to edit. Deeper down that is the manager's job
+        const ownerSchema = (owner === destination)
+          ? schema
+          : ownerSchemaOf(owner);
+        const field = ownerSchema && ownerSchema
+          .find(field => field.name === name);
+        if (!field || (field.type !== 'area') || field.readOnly) {
+          return false;
+        }
+        const options = self.apos.area.getWidgets(field.options || {})[value.type];
+        const manager = self.apos.area.getWidgetManager(value.type);
+        if (!options || !manager) {
+          // Not a widget type this area accepts, or not one this site has at
+          // all. Let the general code path decide what to do about that
+          return false;
+        }
+        let widget;
+        try {
+          // Clone so that a failed attempt leaves nothing behind for the
+          // general code path to trip over
+          widget = await manager.sanitize(req, klona(value), options, {
+            fetchRelationships
+          });
+        } catch (e) {
+          // The general code path reports validation errors with the dot path
+          // context the browser expects, so let it do that work
+          return false;
+        }
+        area.items[index] = widget;
+        return true;
+        function ownerSchemaOf(owner) {
+          const manager = self.apos.util.getManagerOf(owner, { log: false });
+          if (!manager) {
+            return null;
+          }
+          // Widgets filter by permission, arrays and objects have no such
+          // concept and expose their schema directly
+          return manager.allowedSchema
+            ? manager.allowedSchema(req)
+            : manager.schema;
+        }
       },
 
       // Implementation detail, called for you by the PATCH routes.

--- a/packages/apostrophe/test/patch-widget.js
+++ b/packages/apostrophe/test/patch-widget.js
@@ -1,0 +1,513 @@
+const assert = require('assert').strict;
+const t = require('../test-lib/test.js');
+
+// `applyPatch` takes a shortcut when a patch does nothing but replace a single
+// widget via the `@_id` syntax: only that widget is converted, and the rest of
+// the document is left exactly as it was. These tests cover both the shortcut
+// and the many cases that must still fall through to the general code path.
+
+describe('Patch widget shortcut', function() {
+
+  let apos;
+  let productId;
+  // `true` or `false` for each patch applied, or empty if the shortcut was
+  // never consulted at all
+  let shortcut;
+
+  this.timeout(t.timeout);
+
+  after(function() {
+    return t.destroy(apos);
+  });
+
+  before(async function() {
+    apos = await t.create({
+      root: module,
+      modules: {
+        'two-column-widget': {
+          extend: '@apostrophecms/widget-type',
+          fields: {
+            add: {
+              one: {
+                type: 'area',
+                options: {
+                  widgets: {
+                    '@apostrophecms/rich-text': {}
+                  }
+                }
+              },
+              two: {
+                type: 'area',
+                options: {
+                  widgets: {
+                    '@apostrophecms/rich-text': {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        'strict-widget': {
+          extend: '@apostrophecms/widget-type',
+          fields: {
+            add: {
+              value: {
+                type: 'string',
+                required: true
+              }
+            }
+          }
+        },
+        '@apostrophecms/home-page': {
+          fields: {
+            add: {
+              main: {
+                type: 'area',
+                options: {
+                  widgets: {
+                    '@apostrophecms/rich-text': {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        product: {
+          extend: '@apostrophecms/piece-type',
+          options: {
+            alias: 'product'
+          },
+          fields: {
+            add: {
+              main: {
+                type: 'area',
+                options: {
+                  widgets: {
+                    '@apostrophecms/rich-text': {},
+                    'two-column': {},
+                    strict: {}
+                  }
+                }
+              },
+              locked: {
+                type: 'area',
+                readOnly: true,
+                options: {
+                  widgets: {
+                    '@apostrophecms/rich-text': {}
+                  }
+                }
+              },
+              list: {
+                type: 'array',
+                fields: {
+                  add: {
+                    inner: {
+                      type: 'area',
+                      options: {
+                        widgets: {
+                          '@apostrophecms/rich-text': {}
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    const superPatchWidgetIfSuitable = apos.schema.patchWidgetIfSuitable;
+    apos.schema.patchWidgetIfSuitable = async (...args) => {
+      const result = await superPatchWidgetIfSuitable(...args);
+      shortcut.push(result);
+      return result;
+    };
+
+    const req = apos.task.getReq();
+    const product = apos.product.newInstance();
+    await apos.schema.convert(req, apos.product.schema, {
+      title: 'Product',
+      main: {
+        metaType: 'area',
+        items: [
+          richText('first'),
+          {
+            metaType: 'widget',
+            type: 'two-column',
+            one: {
+              metaType: 'area',
+              items: [ richText('nested') ]
+            },
+            two: {
+              metaType: 'area',
+              items: []
+            }
+          },
+          richText('last'),
+          {
+            metaType: 'widget',
+            type: 'strict',
+            value: 'required'
+          }
+        ]
+      },
+      list: [
+        {
+          inner: {
+            metaType: 'area',
+            items: [ richText('in an array') ]
+          }
+        }
+      ]
+    }, product);
+    // `convert` skips read only fields, so this one is populated by hand
+    product.locked = {
+      metaType: 'area',
+      _id: apos.util.generateId(),
+      items: [
+        {
+          ...richText('untouchable'),
+          _id: apos.util.generateId()
+        }
+      ]
+    };
+    await apos.product.insert(req, product);
+    productId = product._id;
+
+    const home = await apos.page.findOneForEditing(req, { level: 0 });
+    home.main = {
+      metaType: 'area',
+      _id: apos.util.generateId(),
+      items: [
+        {
+          ...richText('home first'),
+          _id: apos.util.generateId()
+        },
+        {
+          ...richText('home last'),
+          _id: apos.util.generateId()
+        }
+      ]
+    };
+    await apos.page.update(req, home);
+  });
+
+  beforeEach(function() {
+    shortcut = [];
+  });
+
+  function richText(content) {
+    return {
+      metaType: 'widget',
+      type: '@apostrophecms/rich-text',
+      content: `<p>${content}</p>`
+    };
+  }
+
+  // A fresh copy of the piece straight from the database, so that object
+  // identity means something in the assertions below
+  async function get() {
+    const req = apos.task.getReq();
+    return apos.product.findOneForEditing(req, { _id: productId });
+  }
+
+  async function patch(product, input) {
+    return apos.product.applyPatch(apos.task.getReq(), product, input);
+  }
+
+  it('takes the shortcut for a patch replacing one top level widget', async function() {
+    const product = await get();
+    const widget = product.main.items[0];
+    const sibling = product.main.items[2];
+    await patch(product, {
+      [`@${widget._id}`]: {
+        ...widget,
+        content: '<p>patched</p>'
+      }
+    });
+    assert.deepEqual(shortcut, [ true ]);
+    assert.equal(product.main.items[0]._id, widget._id);
+    assert.equal(product.main.items[0].content, '<p>patched</p>');
+    // The rest of the document is not merely equal, it is untouched. That is
+    // the whole point of the shortcut
+    assert.equal(product.main.items[2], sibling);
+    assert.equal(product.locked, product.locked);
+  });
+
+  it('takes the shortcut for a widget of an area nested in another widget', async function() {
+    const product = await get();
+    const parent = product.main.items[1];
+    const widget = parent.one.items[0];
+    const sibling = product.main.items[0];
+    await patch(product, {
+      [`@${widget._id}`]: {
+        ...widget,
+        content: '<p>patched nested</p>'
+      }
+    });
+    assert.deepEqual(shortcut, [ true ]);
+    assert.equal(product.main.items[1].one.items[0]._id, widget._id);
+    assert.equal(product.main.items[1].one.items[0].content, '<p>patched nested</p>');
+    assert.equal(product.main.items[0], sibling);
+  });
+
+  it('takes the shortcut for a widget of an area nested in an array item', async function() {
+    const product = await get();
+    const widget = product.list[0].inner.items[0];
+    const sibling = product.main.items[0];
+    await patch(product, {
+      [`@${widget._id}`]: {
+        ...widget,
+        content: '<p>patched in an array</p>'
+      }
+    });
+    assert.deepEqual(shortcut, [ true ]);
+    assert.equal(product.list[0].inner.items[0].content, '<p>patched in an array</p>');
+    assert.equal(product.main.items[0], sibling);
+  });
+
+  it('takes the shortcut when only an advisory lock accompanies the widget', async function() {
+    const product = await get();
+    const widget = product.main.items[0];
+    await patch(product, {
+      _advisoryLock: {
+        tabId: 'test',
+        lock: true
+      },
+      [`@${widget._id}`]: {
+        ...widget,
+        content: '<p>patched with a lock</p>'
+      }
+    });
+    assert.deepEqual(shortcut, [ true ]);
+    assert.equal(product.main.items[0].content, '<p>patched with a lock</p>');
+  });
+
+  it('sanitizes the widget it takes the shortcut for', async function() {
+    const product = await get();
+    const widget = product.main.items[0];
+    await patch(product, {
+      [`@${widget._id}`]: {
+        ...widget,
+        content: '<p>clean</p><script>alert(1)</script>',
+        nonsense: 'not in the schema'
+      }
+    });
+    assert.deepEqual(shortcut, [ true ]);
+    assert.equal(product.main.items[0].content, '<p>clean</p>');
+    assert.equal(product.main.items[0].nonsense, undefined);
+  });
+
+  it('falls through for a patch of one property of a widget', async function() {
+    const product = await get();
+    const widget = product.main.items[0];
+    const sibling = product.main.items[2];
+    await patch(product, {
+      [`@${widget._id}.content`]: '<p>by dot path</p>'
+    });
+    assert.deepEqual(shortcut, [ false ]);
+    assert.equal(product.main.items[0].content, '<p>by dot path</p>');
+    // The general code path converts the whole area, so nothing survives
+    // by identity
+    assert.notEqual(product.main.items[2], sibling);
+  });
+
+  it('falls through for a patch by dot path', async function() {
+    const product = await get();
+    const widget = product.main.items[0];
+    await patch(product, {
+      'main.items.0': {
+        ...widget,
+        content: '<p>positional</p>'
+      }
+    });
+    assert.deepEqual(shortcut, [ false ]);
+    assert.equal(product.main.items[0].content, '<p>positional</p>');
+  });
+
+  it('falls through for a patch that also touches another field', async function() {
+    const product = await get();
+    const widget = product.main.items[0];
+    await patch(product, {
+      title: 'Renamed',
+      [`@${widget._id}`]: {
+        ...widget,
+        content: '<p>and a title</p>'
+      }
+    });
+    assert.deepEqual(shortcut, [ false ]);
+    assert.equal(product.title, 'Renamed');
+    assert.equal(product.main.items[0].content, '<p>and a title</p>');
+  });
+
+  it('falls through for a $push', async function() {
+    const product = await get();
+    await patch(product, {
+      $push: {
+        'main.items': richText('pushed')
+      }
+    });
+    assert.deepEqual(shortcut, [ false ]);
+    assert.equal(product.main.items.length, 5);
+    assert.equal(product.main.items[4].content, '<p>pushed</p>');
+  });
+
+  it('falls through when the value is not marked as a widget', async function() {
+    const product = await get();
+    const widget = product.main.items[0];
+    await patch(product, {
+      [`@${widget._id}`]: {
+        ...widget,
+        metaType: 'area',
+        content: '<p>not a widget</p>'
+      }
+    });
+    assert.deepEqual(shortcut, [ false ]);
+  });
+
+  it('falls through when no widget in the document has that _id', async function() {
+    const product = await get();
+    const sibling = product.main.items[0];
+    // The general code path rejects an unresolvable @ reference, as it always
+    // has. Getting that error is the point: the shortcut must not swallow it
+    await assert.rejects(patch(product, {
+      '@nosuchwidgetidatall': {
+        ...richText('nowhere'),
+        _id: 'nosuchwidgetidatall'
+      }
+    }), {
+      name: 'invalid'
+    });
+    assert.deepEqual(shortcut, [ false ]);
+    assert.equal(product.main.items[0], sibling);
+  });
+
+  it('falls through when the _id belongs to something other than a widget', async function() {
+    const product = await get();
+    await patch(product, {
+      [`@${product.main._id}`]: {
+        ...richText('an area is not a widget'),
+        _id: product.main._id
+      }
+    });
+    assert.deepEqual(shortcut, [ false ]);
+  });
+
+  it('falls through for a widget type the area does not accept', async function() {
+    const product = await get();
+    const widget = product.main.items[1].one.items[0];
+    await patch(product, {
+      // The `one` area of a two-column widget accepts rich text only
+      [`@${widget._id}`]: {
+        _id: widget._id,
+        metaType: 'widget',
+        type: 'two-column'
+      }
+    });
+    assert.deepEqual(shortcut, [ false ]);
+    // And the general code path discards it, as it always has
+    assert.equal(product.main.items[1].one.items.length, 0);
+  });
+
+  it('falls through for a read only area, which is then left alone', async function() {
+    const product = await get();
+    const widget = product.locked.items[0];
+    await patch(product, {
+      [`@${widget._id}`]: {
+        ...widget,
+        content: '<p>should not stick</p>'
+      }
+    });
+    assert.deepEqual(shortcut, [ false ]);
+    assert.equal(product.locked.items[0].content, '<p>untouchable</p>');
+  });
+
+  // A fresh copy of the home page straight from the database
+  async function getHome() {
+    return apos.page.findOneForEditing(apos.task.getReq(), { level: 0 });
+  }
+
+  // The real route method, so that everything it does to the patch on the way
+  // in, notably enforcing parked properties, is part of the test
+  async function patchPage(page, body) {
+    return apos.page.patch(apos.task.getReq({ body }), page._id);
+  }
+
+  it('takes the shortcut for a page too', async function() {
+    const home = await getHome();
+    const widget = home.main.items[0];
+    const result = await patchPage(home, {
+      [`@${widget._id}`]: {
+        ...widget,
+        content: '<p>patched home</p>'
+      }
+    });
+    assert.deepEqual(shortcut, [ true ]);
+    assert.equal(result.main.items[0].content, '<p>patched home</p>');
+    assert.equal(result.main.items[1].content, '<p>home last</p>');
+  });
+
+  // The home page is parked, and parked properties are enforced on the way in.
+  // If that enforcement were to add properties the patch never mentioned, the
+  // shortcut above would never be taken for any page of a real site
+  it('takes the shortcut for a parked page without disturbing its parked properties', async function() {
+    const home = await getHome();
+    const widget = home.main.items[0];
+    assert.deepEqual(home.parked, [ 'slug', 'parkedId' ]);
+    const result = await patchPage(home, {
+      [`@${widget._id}`]: {
+        ...widget,
+        content: '<p>still parked</p>'
+      }
+    });
+    assert.deepEqual(shortcut, [ true ]);
+    assert.equal(result.main.items[0].content, '<p>still parked</p>');
+    assert.equal(result.slug, '/');
+    assert.equal(result.parkedId, 'home');
+  });
+
+  it('falls through for a page patch that also touches another field', async function() {
+    const home = await getHome();
+    const widget = home.main.items[0];
+    const result = await patchPage(home, {
+      title: 'Renamed Home',
+      [`@${widget._id}`]: {
+        ...widget,
+        content: '<p>and a title</p>'
+      }
+    });
+    assert.deepEqual(shortcut, [ false ]);
+    assert.equal(result.title, 'Renamed Home');
+    assert.equal(result.main.items[0].content, '<p>and a title</p>');
+  });
+
+  it('falls through for a page patch that tries to change a parked property, which is still refused', async function() {
+    const home = await getHome();
+    const widget = home.main.items[0];
+    const result = await patchPage(home, {
+      slug: '/not-the-home-page',
+      [`@${widget._id}`]: {
+        ...widget,
+        content: '<p>and a slug</p>'
+      }
+    });
+    assert.deepEqual(shortcut, [ false ]);
+    assert.equal(result.main.items[0].content, '<p>and a slug</p>');
+    assert.equal(result.slug, '/');
+  });
+
+  it('falls through when the widget does not validate, reporting the error', async function() {
+    const product = await get();
+    const widget = product.main.items[3];
+    await assert.rejects(patch(product, {
+      [`@${widget._id}`]: {
+        ...widget,
+        value: ''
+      }
+    }));
+    assert.deepEqual(shortcut, [ false ]);
+  });
+});


### PR DESCRIPTION
This optimization is appropriate for widgets because they have always had a firewall between their properties and parent properties (you cannot, in the general case, expect access to parent document properties or vice versa with widgets, even with conditional fields). This should address a major issue for GO.