### PR TITLE
Fix styles wtih BOM ignored by browsers, leading to UI behavior change

### DIFF
--- a/.changeset/postcss-bom-box-sizing.md
+++ b/.changeset/postcss-bom-box-sizing.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": patch
+---
+
+Fixed incorrect sizing and spacing across the admin UI in webpack builds. A byte order mark preserved by PostCSS 8.5.24 invalidated the stylesheet rule setting `box-sizing` for `.apos-` elements. Sass is now compiled with `charset: false` in webpack builds, so the marker is never emitted. Vite builds were unaffected.

--- a/packages/apostrophe/modules/@apostrophecms/asset/lib/webpack/apos/webpack.scss.js
+++ b/packages/apostrophe/modules/@apostrophecms/asset/lib/webpack/apos/webpack.scss.js
@@ -41,7 +41,10 @@ module.exports = (options, apos) => {
               loader: 'sass-loader',
               options: {
                 sassOptions: {
-                  silenceDeprecations: [ 'import' ]
+                  silenceDeprecations: [ 'import' ],
+                  // Without this Sass emits a BOM, which postcss 8.5.24+ keeps.
+                  // A BOM in the middle of a stylesheet kills the rule after it.
+                  charset: false
                 },
                 sourceMap: false,
                 // "use" rules must come first or sass throws an error

--- a/packages/apostrophe/modules/@apostrophecms/asset/lib/webpack/src/webpack.scss.js
+++ b/packages/apostrophe/modules/@apostrophecms/asset/lib/webpack/src/webpack.scss.js
@@ -45,7 +45,10 @@ module.exports = (options, apos, srcBuildNames) => {
               loader: 'sass-loader',
               options: {
                 sassOptions: {
-                  silenceDeprecations: [ 'import' ]
+                  silenceDeprecations: [ 'import' ],
+                  // Without this Sass emits a BOM, which postcss 8.5.24+ keeps.
+                  // A BOM in the middle of a stylesheet kills the rule after it.
+                  charset: false
                 }
               }
             }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:

*Check one*
- [x] main
- [x] latest
- [x] stable
- [ ] Check if this PR will be resubmitted against another branch

## Summary

Fixed incorrect sizing and spacing across the admin UI in webpack builds. A byte order mark preserved by PostCSS 8.5.24 invalidated the stylesheet rule setting `box-sizing` for `.apos-` elements. Sass is now compiled with `charset: false` in webpack builds, so the marker is never emitted. Vite builds were unaffected.

## What are the specific steps to test this change?

No UI visual change in projects with Webpack builds.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
