### PR TITLE
AI Adapters: Features and problems discovered while prototyping

### DIFF
--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-anthropic/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-anthropic/index.js
@@ -16,6 +16,11 @@
 const FINAL_ANSWER = '_final_answer';
 const FINAL_ANSWER_DESCRIPTION = 'Provide your final answer by calling this tool with the required fields. This is the only way to return your response.';
 
+// The levels Anthropic's own effort parameter accepts, which is what a
+// reasoning level names on a model whose thinking is adaptive. Not every
+// model accepts every level, so the provider has the final word
+const EFFORT_LEVELS = Object.freeze([ 'low', 'medium', 'high', 'xhigh', 'max' ]);
+
 module.exports = {
   options: {
     // The anthropic-version request header
@@ -24,12 +29,18 @@ module.exports = {
     // transient failure the engine retries
     timeout: 600000,
     // reasoning level - extended-thinking budget_tokens (Anthropic's
-    // floor for a budget is 1024).
+    // floor for a budget is 1024). Read for the models that take a
+    // budget; the adaptive ones below reject one outright
     thinkingBudgets: {
       low: 1024,
       medium: 4096,
       high: 16384
-    }
+    },
+    // Models whose thinking is adaptive: the model decides when and how
+    // deeply to think, and a reasoning level names an effort level
+    // instead of a token budget. Extend the list when configuring a
+    // newer model of the same kind
+    adaptiveModels: [ 'claude-opus-5', 'claude-sonnet-5' ]
   },
   init(self) {
     self.apos.ai.addAdapter(self.adapter());
@@ -58,23 +69,34 @@ module.exports = {
           },
           effort: {
             low: { model: 'claude-haiku-4-5' },
-            medium: { model: 'claude-sonnet-4-6' },
+            // The adaptive models think whether or not a request says
+            // so, so both rungs name the level they think at rather
+            // than leaving it to the provider's default
+            medium: {
+              model: 'claude-sonnet-5',
+              reasoning: 'medium'
+            },
             high: {
-              model: 'claude-opus-4-8',
+              model: 'claude-opus-5',
               reasoning: 'high'
             }
           },
+          // maxOutputTokens is the default cap a call inherits, not the
+          // model's ceiling: this adapter posts and waits for a whole
+          // answer, so the default stays where one response comfortably
+          // completes inside the timeout. The published ceilings are
+          // 128k for the Claude 5 models and 64k for Haiku 4.5
           models: {
             'claude-haiku-4-5': {
               contextWindow: 200000,
               maxOutputTokens: 32000
             },
-            'claude-sonnet-4-6': {
-              contextWindow: 200000,
+            'claude-sonnet-5': {
+              contextWindow: 1000000,
               maxOutputTokens: 64000
             },
-            'claude-opus-4-8': {
-              contextWindow: 200000,
+            'claude-opus-5': {
+              contextWindow: 1000000,
               maxOutputTokens: 64000
             }
           },
@@ -101,7 +123,8 @@ module.exports = {
       // Translate a normalized adapter request (see the engine's
       // buildRequest) to an Anthropic Messages API body: content parts
       // become Anthropic blocks, tool definitions become `tools`,
-      // `reasoning` becomes a thinking budget, and the cache policy is
+      // `reasoning` becomes whichever thinking the model speaks — a
+      // token budget, or a mode plus an effort level — and the cache is
       // placed as `cache_control` markers — one on the system tail (the
       // static prefix) and a rolling one on the last message, so the
       // next call in a conversation reads what this one wrote. Tool
@@ -126,6 +149,10 @@ module.exports = {
         if (!Number.isInteger(maxTokens)) {
           invalid(`"maxTokens" is required: model "${model}" declares no maxOutputTokens to default to`);
         }
+        const adaptive = self.options.adaptiveModels.includes(model);
+        // A turn that reserves part of max_tokens for thinking, which is
+        // the shape of thinking a forced tool cannot share the turn with
+        const budgeted = reasoning !== undefined && !adaptive;
         const wireTools = [
           ...(tools || []).map(toTool),
           ...(schema
@@ -142,11 +169,12 @@ module.exports = {
           ...(system !== undefined && { system }),
           ...(wireTools.length && { tools: wireTools }),
           // Force the structured answer only when nothing else needs the
-          // turn: a real tool the model must be free to call first, or
-          // extended thinking, which Anthropic forbids alongside a forced
-          // tool. Otherwise the tool's description drives it and the
-          // engine's backstop retries a miss.
-          ...(schema && !(tools && tools.length) && reasoning === undefined && {
+          // turn: a real tool the model must be free to call first, or a
+          // budgeted thinking turn, which Anthropic forbids alongside a
+          // forced tool — adaptive thinking carries no such restriction.
+          // Otherwise the tool's description drives it and the engine's
+          // backstop retries a miss.
+          ...(schema && !(tools && tools.length) && !budgeted && {
             tool_choice: {
               type: 'tool',
               name: FINAL_ANSWER
@@ -158,7 +186,9 @@ module.exports = {
           }))
         };
         if (reasoning !== undefined) {
-          body.thinking = toThinking(reasoning);
+          Object.assign(body, adaptive
+            ? toAdaptive(reasoning)
+            : { thinking: toThinking(reasoning) });
         }
         if (cache) {
           const marker = {
@@ -237,6 +267,18 @@ module.exports = {
           }
           // Another dialect's part; not ours to translate
           return null;
+        }
+        // An adaptive model is told to think and how hard to work,
+        // never how many tokens to spend: a budget is refused outright
+        // by the models that take this path
+        function toAdaptive(reasoning) {
+          if (!EFFORT_LEVELS.includes(reasoning)) {
+            invalid(`reasoning "${reasoning}" is not an effort level; model "${model}" takes one of ${EFFORT_LEVELS.join(', ')}`);
+          }
+          return {
+            thinking: { type: 'adaptive' },
+            output_config: { effort: reasoning }
+          };
         }
         // Anthropic wants an absolute token budget, mapped by the
         // thinkingBudgets option; the budget must leave max_tokens

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-anthropic/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-anthropic/index.js
@@ -85,19 +85,28 @@ module.exports = {
           // model's ceiling: this adapter posts and waits for a whole
           // answer, so the default stays where one response comfortably
           // completes inside the timeout. The published ceilings are
-          // 128k for the Claude 5 models and 64k for Haiku 4.5
+          // 128k for the Claude 5 models and 64k for Haiku 4.5.
+          // `reasoning` declares what a call may pass, in this dialect's
+          // own vocabulary: effort levels on the adaptive models, the
+          // configured budget names on the budgeted ones.
           models: {
             'claude-haiku-4-5': {
+              label: 'Haiku 4.5',
               contextWindow: 200000,
-              maxOutputTokens: 32000
+              maxOutputTokens: 32000,
+              reasoning: reasoningValues('claude-haiku-4-5')
             },
             'claude-sonnet-5': {
+              label: 'Sonnet 5',
               contextWindow: 1000000,
-              maxOutputTokens: 64000
+              maxOutputTokens: 64000,
+              reasoning: reasoningValues('claude-sonnet-5')
             },
             'claude-opus-5': {
+              label: 'Opus 5',
               contextWindow: 1000000,
-              maxOutputTokens: 64000
+              maxOutputTokens: 64000,
+              reasoning: reasoningValues('claude-opus-5')
             }
           },
           validate() {
@@ -119,6 +128,11 @@ module.exports = {
             return self.normalizeError(error);
           }
         };
+        function reasoningValues(model) {
+          return self.options.adaptiveModels.includes(model)
+            ? [ ...EFFORT_LEVELS ]
+            : Object.keys(self.options.thinkingBudgets);
+        }
       },
       // Translate a normalized adapter request (see the engine's
       // buildRequest) to an Anthropic Messages API body: content parts

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-google/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-google/index.js
@@ -41,6 +41,10 @@ const FINISH_REASONS = {
 const ASPECTS = [
   '1:1', '3:2', '2:3', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9'
 ];
+// The `thinkingLevel` values every current text model accepts
+const THINKING_LEVELS = Object.freeze([
+  'minimal', 'low', 'medium', 'high'
+]);
 // The normalized quality tiers → the dialect's output resolution
 // (the uppercase K is required)
 const IMAGE_SIZES = {
@@ -93,22 +97,31 @@ module.exports = {
               reasoning: 'high'
             }
           },
+          // `reasoning` is the dialect's `thinkingLevel` vocabulary,
+          // shared by both current text models
           models: {
             'gemini-3.1-flash-lite': {
+              label: 'Gemini 3.1 Flash-Lite',
               contextWindow: 1048576,
-              maxOutputTokens: 65536
+              maxOutputTokens: 65536,
+              reasoning: THINKING_LEVELS
             },
             'gemini-3.5-flash': {
+              label: 'Gemini 3.5 Flash',
               contextWindow: 1048576,
-              maxOutputTokens: 65536
+              maxOutputTokens: 65536,
+              reasoning: THINKING_LEVELS
             },
             'gemini-3.1-flash-image': {
+              label: 'Gemini 3.1 Flash Image',
               aspects: ASPECTS
             },
             'gemini-3-pro-image': {
+              label: 'Gemini 3 Pro Image',
               aspects: ASPECTS
             },
             'gemini-3.1-flash-lite-image': {
+              label: 'Gemini 3.1 Flash-Lite Image',
               aspects: ASPECTS
             }
           },

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai-compatible/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai-compatible/index.js
@@ -22,6 +22,14 @@
 
 const image = require('../ai-adapter-openai/lib/image');
 
+// The `reasoning_effort` values the native service accepts on every
+// current text model. The native tools-request degrade drops reasoning
+// as behavior; the vocabulary itself is unchanged by it. Aliased
+// entries describe other services and declare their own.
+const REASONING_EFFORTS = Object.freeze([
+  'none', 'low', 'medium', 'high', 'xhigh', 'max'
+]);
+
 module.exports = {
   options: {
     // Per-request timeout in milliseconds; a timed-out call is a
@@ -66,16 +74,22 @@ module.exports = {
           },
           models: {
             'gpt-5.6-luna': {
+              label: 'GPT-5.6 Luna',
               contextWindow: 1050000,
-              maxOutputTokens: 128000
+              maxOutputTokens: 128000,
+              reasoning: REASONING_EFFORTS
             },
             'gpt-5.6-terra': {
+              label: 'GPT-5.6 Terra',
               contextWindow: 1050000,
-              maxOutputTokens: 128000
+              maxOutputTokens: 128000,
+              reasoning: REASONING_EFFORTS
             },
             'gpt-5.6-sol': {
+              label: 'GPT-5.6 Sol',
               contextWindow: 1050000,
-              maxOutputTokens: 128000
+              maxOutputTokens: 128000,
+              reasoning: REASONING_EFFORTS
             },
             ...image.models
           },

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai/index.js
@@ -19,6 +19,12 @@
 
 const image = require('./lib/image');
 
+// The `reasoning.effort` values every current text model accepts —
+// the whole GPT-5.6 tier shares one vocabulary
+const REASONING_EFFORTS = Object.freeze([
+  'none', 'low', 'medium', 'high', 'xhigh', 'max'
+]);
+
 module.exports = {
   options: {
     // Per-request timeout in milliseconds; a timed-out call is a
@@ -60,16 +66,22 @@ module.exports = {
           },
           models: {
             'gpt-5.6-luna': {
+              label: 'GPT-5.6 Luna',
               contextWindow: 1050000,
-              maxOutputTokens: 128000
+              maxOutputTokens: 128000,
+              reasoning: REASONING_EFFORTS
             },
             'gpt-5.6-terra': {
+              label: 'GPT-5.6 Terra',
               contextWindow: 1050000,
-              maxOutputTokens: 128000
+              maxOutputTokens: 128000,
+              reasoning: REASONING_EFFORTS
             },
             'gpt-5.6-sol': {
+              label: 'GPT-5.6 Sol',
               contextWindow: 1050000,
-              maxOutputTokens: 128000
+              maxOutputTokens: 128000,
+              reasoning: REASONING_EFFORTS
             },
             ...image.models
           },

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai/lib/image.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-openai/lib/image.js
@@ -50,9 +50,11 @@ module.exports = async function image(deps, request) {
 // fixed to its three.
 module.exports.models = {
   'gpt-image-2': {
+    label: 'GPT Image 2',
     aspects: Object.keys(SIZES)
   },
   'gpt-image-1': {
+    label: 'GPT Image 1',
     aspects: [ '1:1', '3:2', '2:3' ]
   }
 };

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -79,6 +79,13 @@ module.exports = {
     self.effortDefault = self.options.effort?.default || 'medium';
     self.mockMode = process.env.APOS_AI_MOCK === '1';
     self.ajv = new Ajv({ allErrors: true });
+    // Tool input schemas only: declared "default" values are written
+    // into the arguments a handler receives. Results and structured
+    // output stay on the plain instance — those are never mutated
+    self.ajvArgs = new Ajv({
+      allErrors: true,
+      useDefaults: true
+    });
     self.apos.http.addError('aiRetry', 503);
     self.apos.http.addError('aiRefusal', 422);
     self.apos.http.addError('aiToolError', 422);
@@ -142,15 +149,19 @@ module.exports = {
        * @property {object} input The JSON Schema (draft 2020-12) the model's
        *   arguments must satisfy. Sent to the provider; must declare an object
        *   root.
-       * @property {object} schema The handler result's shape as Apostrophe
-       *   schema fields, like a module's `add` configuration. Internal — never
-       *   sent to the model — and every result is validated against it via
-       *   apos.schema.convert.
+       * @property {object} [schema] The handler result's shape as a JSON
+       *   Schema (draft 2020-12) with an object root — the same format as
+       *   `input`, but internal: never sent to the model. When present, every
+       *   result is validated against it and a mismatch is a handler bug that
+       *   fails the call; when absent, the result only has to be an object.
+       *   Either way the handler's object is serialized for the model as-is,
+       *   never coerced or normalized.
        * @property {((req: object, args: object) => Promise<object>)|string}
        *   handler The implementation: an async (req, args) function, or a
        *   'moduleName:methodName' reference resolved at activation. Runs with
        *   the caller's req and the validated model arguments, plus the
-       *   core-injected args._context, and returns an object matching `schema`.
+       *   core-injected args._context, and returns an object matching `schema`
+       *   when one is declared.
        * @property {string} [label] A human-facing name — what a chat log or an
        *   activity trail shows for the tool; may be an i18n key. Defaults from
        *   the name ('find_pages' → 'Find Pages'). Never sent to the model.

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -312,6 +312,53 @@ module.exports = {
       },
 
       /**
+       * Synchronous introspection of the whole routing configuration, shaped
+       * for building pickers: the resolved effort table with its default
+       * level, and every configured provider with its adapter's label,
+       * capabilities and merged per-model metadata. A model's optional
+       * `reasoning` array lists the values a call may pass as `reasoning`
+       * for it, in the provider's own vocabulary — declared by the adapter,
+       * extendable per model on the provider entry, and never enforced: the
+       * adapter keeps its own rejections, and a model without a declaration
+       * still answers. Everything returned is a copy, safe to serialize or
+       * amend, and nothing here reaches the browser unless the caller sends
+       * it there. Under mock mode with no providers the catalog is empty —
+       * `self.active` answers "is AI usable", this method answers "what is
+       * configured".
+       *
+       * @returns {AiModelCatalog}
+       */
+      modelCatalog() {
+        const providers = {};
+        for (const [ name, record ] of Object.entries(self.providers)) {
+          const models = {};
+          for (const [ id, meta ] of Object.entries(record.models)) {
+            models[id] = {
+              ...meta,
+              ...(meta.reasoning && { reasoning: [ ...meta.reasoning ] }),
+              ...(meta.aspects && { aspects: [ ...meta.aspects ] })
+            };
+          }
+          providers[name] = {
+            label: record.adapter.label,
+            capabilities: { ...record.capabilities },
+            models
+          };
+        }
+        const levels = {};
+        for (const [ level, row ] of Object.entries(self.effortTable)) {
+          levels[level] = { ...row };
+        }
+        return {
+          effort: {
+            default: self.effortDefault,
+            levels
+          },
+          providers
+        };
+      },
+
+      /**
        * The AI permission seam: whether this AI action is permitted for `req`.
        * Same signature and semantics as
        * `apos.permission.can(req, action, docOrType, mode)`, and today a pure

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -89,6 +89,7 @@ module.exports = {
     self.apos.http.addError('aiRetry', 503);
     self.apos.http.addError('aiRefusal', 422);
     self.apos.http.addError('aiToolError', 422);
+    self.apos.http.addError('aiInput', 422);
   },
   handlers(self) {
     return {
@@ -442,6 +443,19 @@ module.exports = {
        * unexecuted requests on `toolCalls`. Only abort-shaped throws convert; a
        * genuine failure racing a cancel still throws.
        *
+       * Suspension: a tool handler that cannot answer without outside input
+       * throws "aiInput", the ask riding the throw's `data`. The loop stops
+       * the batch at that call — queries all complete together, so several
+       * may suspend at once; no action past the earliest suspended call in
+       * model order ever starts — and the run returns normally with
+       * finishReason 'input': executed outcomes on `steps` and appended to
+       * the transcript as a partial tool message, the suspended calls and
+       * unstarted actions unexecuted on `toolCalls`, and the asks on
+       * `suspended`, in model order. In a nested run the throw converts to
+       * "aiToolError" instead — a delegated run cannot wait for input. A
+       * cancellation observed at the suspension wins: the run ends 'cancel'
+       * and no ask is surfaced.
+       *
        * Under APOS_AI_MOCK the built-in mock answers every call in place of any
        * adapter — same pipeline, no network; with no providers configured at
        * all, placeholder routing stands in. A scripted mock turn may request
@@ -515,6 +529,7 @@ module.exports = {
         };
         let turn = null;
         let pending = null;
+        let suspended = null;
         let cancelled = false;
         try {
           for (let turns = 1; ; turns++) {
@@ -578,17 +593,45 @@ module.exports = {
             const outcomes = await self.executeToolCalls(
               req, tools, calls, handlerContext, onToolCall
             );
-            steps.push(...outcomes);
-            context.request.messages.push({
-              role: 'tool',
-              content: outcomes.map((outcome) => ({
-                type: 'toolResult',
-                toolCallId: outcome.toolCall.id,
-                ...(outcome.error !== undefined
-                  ? { error: outcome.error }
-                  : { output: outcome.result })
-              }))
-            });
+            const executed = outcomes.filter(
+              (outcome) => outcome && outcome.suspended === undefined
+            );
+            steps.push(...executed);
+            if (executed.length) {
+              context.request.messages.push({
+                role: 'tool',
+                content: executed.map((outcome) => ({
+                  type: 'toolResult',
+                  toolCallId: outcome.toolCall.id,
+                  ...(outcome.error !== undefined
+                    ? { error: outcome.error }
+                    : { output: outcome.result })
+                }))
+              });
+            }
+            if (executed.length < calls.length) {
+              // A handler suspended and the batch stopped at that call.
+              // The executed outcomes just became a partial tool
+              // message, so the transcript is the run's complete state;
+              // the suspended calls and the unstarted actions come back
+              // unexecuted. A cancellation observed here wins: the run
+              // ends 'cancel' and no ask is surfaced
+              pending = calls.filter((call, index) => !outcomes[index] ||
+                outcomes[index].suspended !== undefined);
+              if (canonical.signal?.aborted) {
+                cancelled = true;
+              } else {
+                suspended = outcomes
+                  .filter((outcome) => outcome &&
+                    outcome.suspended !== undefined)
+                  .map((outcome) => ({
+                    callId: outcome.toolCall.id,
+                    name: outcome.toolCall.name,
+                    payload: outcome.suspended
+                  }));
+              }
+              break;
+            }
             // The batch was waited out and recorded; wind down before
             // asking the model again
             if (canonical.signal?.aborted) {
@@ -609,8 +652,10 @@ module.exports = {
           steps,
           usage,
           pending,
+          suspended,
           object: turn?.object,
           hadTools: tools.size > 0,
+          ...(suspended && { finishReason: 'input' }),
           ...(cancelled && { finishReason: 'cancel' })
         });
         await self.emit('afterGenerate', req, context);

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -148,7 +148,9 @@ module.exports = {
        *   tool by; treat it as part of the prompt.
        * @property {object} input The JSON Schema (draft 2020-12) the model's
        *   arguments must satisfy. Sent to the provider; must declare an object
-       *   root.
+       *   root. Declared "default" values are written into the arguments the
+       *   handler receives when the model omits them; the conversation
+       *   transcript keeps the call as the model made it.
        * @property {object} [schema] The handler result's shape as a JSON
        *   Schema (draft 2020-12) with an object root — the same format as
        *   `input`, but internal: never sent to the model. When present, every
@@ -162,6 +164,11 @@ module.exports = {
        *   the caller's req and the validated model arguments, plus the
        *   core-injected args._context, and returns an object matching `schema`
        *   when one is declared.
+       * @property {number} [maxResultChars] The result-size budget: the
+       *   JSON-serialized result may not exceed this many characters. An
+       *   oversized result is withheld and a recoverable tool error naming
+       *   the actual size, the budget and the largest properties is fed back
+       *   to the model instead. Absent means unlimited.
        * @property {string} [label] A human-facing name — what a chat log or an
        *   activity trail shows for the tool; may be an i18n key. Defaults from
        *   the name ('find_pages' → 'Find Pages'). Never sent to the model.

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -174,14 +174,15 @@ module.exports = {
        *   the name ('find_pages' → 'Find Pages'). Never sent to the model.
        * @property {string[]} [tags] Strings to query the registry by, see
        *   getTools.
-       * @property {'read'|'write'|'agent'} [access] Not a permission but a
-       *   scheduling class; 'write' by default. Reads run in parallel within
-       *   one batch of tool calls; writes and agents follow serially in model
-       *   order. 'agent' declares that the handler makes its own generate call
-       *   (a subagent, with its own budgets). One level of nesting is allowed:
-       *   a nested call silently drops agent tools from its set — a subagent
-       *   cannot spawn subagents — and generation below the subagent level
-       *   fails.
+       * @property {'query'|'action'|'agent'} [kind] The tool's consequence
+       *   class; 'action' by default. A query is effect-free: queries run in
+       *   parallel within one batch of tool calls. An action has effects:
+       *   actions and agents follow serially in model order, and are never
+       *   re-run or reordered. 'agent' declares that the handler makes its own
+       *   generate call (a subagent, with its own budgets). One level of
+       *   nesting is allowed: a nested call silently drops agent tools from
+       *   its set — a subagent cannot spawn subagents — and generation below
+       *   the subagent level fails.
        */
 
       /**
@@ -389,8 +390,8 @@ module.exports = {
        *   for a single text part.
        * @property {string[]} [tools] Registered tool names the model may
        *   call — see addTool. The loop validates the model's arguments,
-       *   executes the handlers by their `access` scheduling (reads in parallel
-       *   first, writes serial in model order), feeds results back, and asks
+       *   executes the handlers by their `kind` scheduling (queries in parallel
+       *   first, actions serial in model order), feeds results back, and asks
        *   the model again until it answers or `maxSteps` is spent.
        * @property {number} [maxSteps] The cap on model turns for this call, a
        *   positive integer defaulting to the module's `maxSteps` option. When
@@ -478,7 +479,7 @@ module.exports = {
           throw self.apos.error('invalid', 'AI generation is limited to one level of nesting: the tools of a subagent cannot generate');
         }
         if (depth === self.allowedDepth) {
-          canonical.tools = canonical.tools.filter((tool) => tool.access !== 'agent');
+          canonical.tools = canonical.tools.filter((tool) => tool.kind !== 'agent');
         }
         let provider;
         let request;

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -399,6 +399,22 @@ module.exports = {
        *   the last allowed turn still requests tools, the call finishes as
        *   'maxSteps' and the requests come back unexecuted on `toolCalls` — so
        *   `maxSteps: 1` is manual mode: one turn, inspect, run them yourself.
+       * @property {'refuse'|'execute'} [pending] What to do with a transcript
+       *   ending in unanswered tool calls. 'refuse', the default, throws a
+       *   clear "invalid" — no provider accepts the shape. 'execute' turns
+       *   continuation on: the trailing calls run before any model turn — a
+       *   suspended call reading its answer on `args._context.input` — their
+       *   results complete the trailing tool message in model order, and only
+       *   then is the model asked; the engine never knows how long the
+       *   transcript was stored between calls. A prompt string cannot be
+       *   combined with unanswered trailing calls.
+       * @property {Object<string, object>} [toolInput] Per-call answers for
+       *   the trailing calls, keyed by tool call id — legal only with
+       *   pending: 'execute', and every key must name an unanswered trailing
+       *   call. The matching call's handler finds its entry on
+       *   `args._context.input`; calls with no entry run as usual, and a
+       *   handler still lacking what it needs may throw "aiInput" again —
+       *   the engine puts no bound on re-suspension.
        * @property {object} [schema] Request structured output: a JSON Schema
        *   with an object root, which the provider's native structured mode is
        *   constrained to, the validated result coming back on `object`.
@@ -455,6 +471,13 @@ module.exports = {
        * "aiToolError" instead — a delegated run cannot wait for input. A
        * cancellation observed at the suspension wins: the run ends 'cancel'
        * and no ask is surfaced.
+       *
+       * A suspended transcript continues by handing it back with
+       * pending: 'execute' and the answers on `toolInput`: the trailing
+       * calls run first and the completed tool message goes to the model as
+       * an ordinary tool round. Continuation, not resumption — a request
+       * built from a continued transcript is byte-shaped like a mid-loop
+       * step, and no adapter knows the difference.
        *
        * Under APOS_AI_MOCK the built-in mock answers every call in place of any
        * adapter — same pipeline, no network; with no providers configured at
@@ -532,6 +555,33 @@ module.exports = {
         let suspended = null;
         let cancelled = false;
         try {
+          await continuePending();
+          if (!suspended && !cancelled) {
+            await runLoop();
+          }
+        } catch (e) {
+          // Only an abort-shaped throw converts to a cancelled run, and
+          // only while this call's signal has fired — a genuine failure
+          // racing a cancel still throws
+          if (!isAbort(e) || !canonical.signal?.aborted) {
+            throw e;
+          }
+          cancelled = true;
+        }
+        context.result = self.assembleResult(context, turn, {
+          steps,
+          usage,
+          pending,
+          suspended,
+          object: turn?.object,
+          hadTools: tools.size > 0 || Boolean(canonical.pendingCalls),
+          ...(suspended && { finishReason: 'input' }),
+          ...(cancelled && { finishReason: 'cancel' })
+        });
+        await self.emit('afterGenerate', req, context);
+        return context.result;
+
+        async function runLoop() {
           for (let turns = 1; ; turns++) {
             turn = await self.callAdapter(req, record, context.request, async () => {
               const answer = self.validateTurn(
@@ -593,43 +643,16 @@ module.exports = {
             const outcomes = await self.executeToolCalls(
               req, tools, calls, handlerContext, onToolCall
             );
-            const executed = outcomes.filter(
-              (outcome) => outcome && outcome.suspended === undefined
-            );
+            const executed = executedOutcomes(outcomes);
             steps.push(...executed);
             if (executed.length) {
               context.request.messages.push({
                 role: 'tool',
-                content: executed.map((outcome) => ({
-                  type: 'toolResult',
-                  toolCallId: outcome.toolCall.id,
-                  ...(outcome.error !== undefined
-                    ? { error: outcome.error }
-                    : { output: outcome.result })
-                }))
+                content: toolResultParts(executed)
               });
             }
             if (executed.length < calls.length) {
-              // A handler suspended and the batch stopped at that call.
-              // The executed outcomes just became a partial tool
-              // message, so the transcript is the run's complete state;
-              // the suspended calls and the unstarted actions come back
-              // unexecuted. A cancellation observed here wins: the run
-              // ends 'cancel' and no ask is surfaced
-              pending = calls.filter((call, index) => !outcomes[index] ||
-                outcomes[index].suspended !== undefined);
-              if (canonical.signal?.aborted) {
-                cancelled = true;
-              } else {
-                suspended = outcomes
-                  .filter((outcome) => outcome &&
-                    outcome.suspended !== undefined)
-                  .map((outcome) => ({
-                    callId: outcome.toolCall.id,
-                    name: outcome.toolCall.name,
-                    payload: outcome.suspended
-                  }));
-              }
+              suspendRun(calls, outcomes);
               break;
             }
             // The batch was waited out and recorded; wind down before
@@ -639,27 +662,115 @@ module.exports = {
               break;
             }
           }
-        } catch (e) {
-          // Only an abort-shaped throw converts to a cancelled run, and
-          // only while this call's signal has fired — a genuine failure
-          // racing a cancel still throws
-          if (!isAbort(e) || !canonical.signal?.aborted) {
-            throw e;
-          }
-          cancelled = true;
         }
-        context.result = self.assembleResult(context, turn, {
-          steps,
-          usage,
-          pending,
-          suspended,
-          object: turn?.object,
-          hadTools: tools.size > 0,
-          ...(suspended && { finishReason: 'input' }),
-          ...(cancelled && { finishReason: 'cancel' })
-        });
-        await self.emit('afterGenerate', req, context);
-        return context.result;
+
+        // Executed outcomes alone: a suspended call's entry is not
+        // executed work, an unstarted call has none
+        function executedOutcomes(outcomes) {
+          return outcomes.filter(
+            (outcome) => outcome && outcome.suspended === undefined
+          );
+        }
+
+        // Executed outcomes as a tool message's toolResult parts
+        function toolResultParts(executed) {
+          return executed.map((outcome) => ({
+            type: 'toolResult',
+            toolCallId: outcome.toolCall.id,
+            ...(outcome.error !== undefined
+              ? { error: outcome.error }
+              : { output: outcome.result })
+          }));
+        }
+
+        // A handler suspended and the batch stopped at that call. The
+        // executed outcomes are already in the (partial) tool message,
+        // so the transcript is the run's complete state; the suspended
+        // calls and the unstarted actions come back unexecuted. A
+        // cancellation observed here wins: the run ends 'cancel' and
+        // no ask is surfaced
+        function suspendRun(calls, outcomes) {
+          pending = calls.filter((call, index) => !outcomes[index] ||
+            outcomes[index].suspended !== undefined);
+          if (canonical.signal?.aborted) {
+            cancelled = true;
+            return;
+          }
+          suspended = outcomes
+            .filter((outcome) => outcome &&
+              outcome.suspended !== undefined)
+            .map((outcome) => ({
+              callId: outcome.toolCall.id,
+              name: outcome.toolCall.name,
+              payload: outcome.suspended
+            }));
+        }
+
+        // The opt-in continuation of a transcript ending in unanswered
+        // tool calls (pending: 'execute'): the trailing calls run
+        // before any model turn — a suspended call reading its answer
+        // from toolInput on _context.input — and their results
+        // complete the trailing tool message, so the provider never
+        // sees the partial state. A call that suspends again winds the
+        // run down exactly like a mid-loop suspension, reported at
+        // step 0.
+        async function continuePending() {
+          const calls = canonical.pendingCalls;
+          if (!calls) {
+            return;
+          }
+          const onToolCall = canonical.onToolCall &&
+            ((event) => canonical.onToolCall({
+              ...event,
+              step: 0
+            }));
+          const outcomes = await self.executeToolCalls(
+            req,
+            tools,
+            calls,
+            {
+              ...handlerContext,
+              ...(canonical.toolInput && { inputs: canonical.toolInput })
+            },
+            onToolCall
+          );
+          const executed = executedOutcomes(outcomes);
+          steps.push(...executed);
+          mergeTrailing(executed);
+          if (executed.length < calls.length) {
+            suspendRun(calls, outcomes);
+            return;
+          }
+          if (canonical.signal?.aborted) {
+            cancelled = true;
+          }
+
+          // The new results into the trailing tool message, rebuilt in
+          // the assistant turn's call order; appended as a new message
+          // when nothing was answered before
+          function mergeTrailing(executed) {
+            if (!executed.length) {
+              return;
+            }
+            const messages = context.request.messages;
+            const last = messages.at(-1);
+            if (last?.role !== 'tool') {
+              messages.push({
+                role: 'tool',
+                content: toolResultParts(executed)
+              });
+              return;
+            }
+            const byId = new Map(
+              [ ...last.content, ...toolResultParts(executed) ]
+                .map((part) => [ part.toolCallId, part ])
+            );
+            last.content = messages.at(-2).content
+              .filter((part) => part.type === 'toolCall')
+              .map((call) => byId.get(call.id))
+              .filter(Boolean);
+          }
+        }
       },
 
       /**

--- a/packages/apostrophe/modules/@apostrophecms/ai/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/index.js
@@ -368,11 +368,18 @@ module.exports = {
        *   adapter translates for its provider; 'short' by default.
        * @property {AbortSignal} [signal] Cancels the call, as below; also
        *   injected into every handler's `args._context`.
-       * @property {(message: AiMessage) => Promise<void>}
+       * @property {(message: AiMessage, meta: { step: number }) => Promise<void>}
        *   [onMessage] Called with each intermediate assistant message — a turn
        *   whose tool requests the loop goes on to execute — and awaited before
-       *   those tools run. The final answer is not reported here, it is the
-       *   return value; a throw stops the call.
+       *   those tools run, with the model turn it came from. The final answer
+       *   is not reported here, it is the return value; a throw stops the call.
+       * @property {(event: AiToolCallEvent) => Promise<void>} [onToolCall]
+       *   Called twice around every tool handler the loop runs — `phase`
+       *   'start' before it, 'end' after it — and awaited, so the tool round
+       *   reports itself while it happens rather than when it is over. A call
+       *   naming no registered tool never starts and is not reported. A throw
+       *   stops the call, except from the end report of a handler whose own
+       *   failure is already stopping it.
        */
 
       /**
@@ -511,10 +518,17 @@ module.exports = {
               await canonical.onMessage({
                 role: 'assistant',
                 content: turn.content
-              });
+              }, { step: turns });
             }
+            // The loop owns step numbering, so the executor never has to
+            // know which turn it is running for
+            const onToolCall = canonical.onToolCall &&
+              ((event) => canonical.onToolCall({
+                ...event,
+                step: turns
+              }));
             const outcomes = await self.executeToolCalls(
-              req, tools, calls, handlerContext
+              req, tools, calls, handlerContext, onToolCall
             );
             steps.push(...outcomes);
             context.request.messages.push({
@@ -681,8 +695,8 @@ module.exports = {
 
       /**
        * What generateJob accepts on top of everything generate accepts, which
-       * is passed through untouched — `onMessage` is called as
-       * `(message, { jobId })` here.
+       * is passed through untouched — `onMessage` and `onToolCall` are called
+       * with `{ jobId }` merged into their meta here.
        *
        * @typedef {object} AiJobOptions
        * @property {(error: Error|null, result: AiResult|undefined) => Promise<void>}
@@ -694,7 +708,9 @@ module.exports = {
        * @property {boolean} [notify] Publish the run's progress to the caller's
        *   browser (see publishJobEvent); true by default. 'started' once the
        *   record exists, 'message' per intermediate assistant turn with the
-       *   turn as `message`, and 'ended' with the record's terminal `status`
+       *   turn as `message`, 'tool' as each tool call starts and ends —
+       *   summarized, never the result itself, which the transcript carries —
+       *   and 'ended' with the record's terminal `status`
        *   plus the result's `finishReason` or the failure's `error`
        *   ({ name, message }). Correlate by `jobId` and read the stored result
        *   from the job's status route — the record may flip to its terminal
@@ -773,12 +789,30 @@ module.exports = {
           ...generateOptions,
           signal,
           ...((notify || generateOptions.onMessage) && {
-            onMessage: async (message) => {
+            onMessage: async (message, meta) => {
               if (notify) {
-                await self.publishJobEvent(req, jobId, 'message', { message });
+                await self.publishJobEvent(req, jobId, 'message', {
+                  message,
+                  step: meta.step
+                });
               }
               if (generateOptions.onMessage) {
-                await generateOptions.onMessage(message, { jobId });
+                await generateOptions.onMessage(message, {
+                  ...meta,
+                  jobId
+                });
+              }
+            }
+          }),
+          ...((notify || generateOptions.onToolCall) && {
+            onToolCall: async (event) => {
+              if (notify) {
+                await self.publishJobEvent(
+                  req, jobId, 'tool', toolEventSummary(event)
+                );
+              }
+              if (generateOptions.onToolCall) {
+                await generateOptions.onToolCall(event, { jobId });
               }
             }
           })
@@ -879,6 +913,25 @@ module.exports = {
             }
           }
         }
+
+        // What a tool call puts on the wire: a progress line, not the
+        // work itself. A result runs to the tool's own size budget and
+        // the transcript carries it when the run ends, so only its size
+        // travels here
+        function toolEventSummary({
+          phase, call, step, result, error
+        }) {
+          return {
+            phase,
+            id: call.id,
+            name: call.name,
+            step,
+            ...(result !== undefined && {
+              chars: JSON.stringify(result).length
+            }),
+            ...(error !== undefined && { error })
+          };
+        }
       },
 
       /**
@@ -895,7 +948,7 @@ module.exports = {
        *
        * @param {object} req
        * @param {string} jobId
-       * @param {'started'|'message'|'ended'} stage
+       * @param {'started'|'message'|'tool'|'ended'} stage
        * @param {object} [data] The stage's payload.
        * @returns {Promise<void>}
        */

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/constants.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/constants.js
@@ -31,8 +31,8 @@ const FINISH_REASONS = Object.freeze([
   'stop', 'toolCalls', 'length', 'refusal'
 ]);
 
-// A tool's scheduling class
-const TOOL_ACCESS = Object.freeze([ 'read', 'write', 'agent' ]);
+// A tool's consequence class; scheduling and nesting rules derive from it
+const TOOL_KINDS = Object.freeze([ 'query', 'action', 'agent' ]);
 
 // The options generate accepts
 const GENERATE_OPTIONS = Object.freeze([
@@ -53,7 +53,7 @@ module.exports = {
   MESSAGE_ROLES,
   PART_ROLES,
   FINISH_REASONS,
-  TOOL_ACCESS,
+  TOOL_KINDS,
   GENERATE_OPTIONS,
   IMAGE_OPTIONS
 };

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/constants.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/constants.js
@@ -38,7 +38,7 @@ const TOOL_ACCESS = Object.freeze([ 'read', 'write', 'agent' ]);
 const GENERATE_OPTIONS = Object.freeze([
   'system', 'messages', 'tools', 'maxSteps', 'schema', 'effort',
   'provider', 'model', 'reasoning', 'maxTokens', 'cache', 'signal',
-  'onMessage'
+  'onMessage', 'onToolCall'
 ]);
 
 // The options generateImage accepts

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/constants.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/constants.js
@@ -34,11 +34,14 @@ const FINISH_REASONS = Object.freeze([
 // A tool's consequence class; scheduling and nesting rules derive from it
 const TOOL_KINDS = Object.freeze([ 'query', 'action', 'agent' ]);
 
+// What generate does with a transcript ending in unanswered tool calls
+const PENDING_POLICIES = Object.freeze([ 'refuse', 'execute' ]);
+
 // The options generate accepts
 const GENERATE_OPTIONS = Object.freeze([
-  'system', 'messages', 'tools', 'maxSteps', 'schema', 'effort',
-  'provider', 'model', 'reasoning', 'maxTokens', 'cache', 'signal',
-  'onMessage', 'onToolCall'
+  'system', 'messages', 'tools', 'maxSteps', 'pending', 'toolInput',
+  'schema', 'effort', 'provider', 'model', 'reasoning', 'maxTokens',
+  'cache', 'signal', 'onMessage', 'onToolCall'
 ]);
 
 // The options generateImage accepts
@@ -54,6 +57,7 @@ module.exports = {
   PART_ROLES,
   FINISH_REASONS,
   TOOL_KINDS,
+  PENDING_POLICIES,
   GENERATE_OPTIONS,
   IMAGE_OPTIONS
 };

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/normalize.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/normalize.js
@@ -169,6 +169,15 @@ module.exports = (self) => {
     // round-trips and a hand-built one fails clearly; messages are
     // rebuilt from the recognized properties, so one carrying app
     // metadata round-trips too.
+    //
+    // A provider's own artifacts are the exception, and they are the
+    // reason a returned transcript can be handed straight back: a
+    // reasoning block is a part type only its own dialect knows, and a
+    // reasoning signature is an extra property on an ordinary part.
+    // Neither is ours to understand, both are assistant-side, and an
+    // adapter that does not own them skips them — so unrecognized
+    // assistant parts and unrecognized part properties travel verbatim
+    // instead of being refused or quietly dropped.
     normalizeMessages(messages = []) {
       if (!Array.isArray(messages)) {
         invalid('"messages" must be an array');
@@ -206,6 +215,11 @@ module.exports = (self) => {
           }
           const roles = PART_ROLES[part.type];
           if (!roles) {
+            // Another dialect's part, replayed as it was received
+            if (role === 'assistant' && typeof part.type === 'string' &&
+              part.type.length) {
+              return { ...part };
+            }
             invalid(`${partName}.type "${part.type}" is unknown`);
           }
           if (!roles.includes(role)) {
@@ -216,30 +230,30 @@ module.exports = (self) => {
               typeof part.name !== 'string' || !isObject(part.input)) {
               invalid(`${partName} must be an object like { type, id, name, input }`);
             }
-            return {
+            return withDialect(part, {
               type: 'toolCall',
               id: part.id,
               name: part.name,
               input: part.input
-            };
+            });
           }
           if (part.type === 'toolResult') {
             if (typeof part.toolCallId !== 'string' || !part.toolCallId) {
               invalid(`${partName}.toolCallId must be a string`);
             }
             if (typeof part.error === 'string' && part.output === undefined) {
-              return {
+              return withDialect(part, {
                 type: 'toolResult',
                 toolCallId: part.toolCallId,
                 error: part.error
-              };
+              });
             }
             if (isObject(part.output) && part.error === undefined) {
-              return {
+              return withDialect(part, {
                 type: 'toolResult',
                 toolCallId: part.toolCallId,
                 output: part.output
-              };
+              });
             }
             invalid(`${partName} must carry an object "output" or a string "error", not both`);
           }
@@ -247,31 +261,49 @@ module.exports = (self) => {
             if (typeof part.text !== 'string') {
               invalid(`${partName}.text must be a string`);
             }
-            return {
+            return withDialect(part, {
               type: 'text',
               text: part.text
-            };
+            });
           }
           // image, the only remaining type
           const image = part.image;
           if (isObject(image) && typeof image.url === 'string') {
-            return {
+            return withDialect(part, {
               type: 'image',
               image: { url: image.url }
-            };
+            });
           }
           if (isObject(image) && typeof image.data === 'string' &&
             typeof image.mediaType === 'string') {
-            return {
+            return withDialect(part, {
               type: 'image',
               image: {
                 data: image.data,
                 mediaType: image.mediaType
               }
-            };
+            });
           }
           return invalid(`${partName}.image must be an object like { url } or { data, mediaType }`);
         });
+      }
+
+      // A validated part plus whatever else the caller put on it. A
+      // dialect may hang its own artifact on an ordinary part — a
+      // reasoning signature on a text part or a tool call — and rebuilding
+      // the part without it costs that provider its reasoning continuity
+      // on the next turn, silently. Message properties are still dropped:
+      // app metadata belongs to the app, not to the provider.
+      function withDialect(part, canonical) {
+        const extra = Object.fromEntries(
+          Object.entries(part).filter(([ key ]) => !(key in canonical))
+        );
+        return Object.keys(extra).length
+          ? {
+            ...canonical,
+            ...extra
+          }
+          : canonical;
       }
     },
     // Parse and validate generateImage's `(prompt, options)` arguments

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/normalize.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/normalize.js
@@ -18,7 +18,7 @@ module.exports = (self) => {
     // arguments into the canonical options object every later stage
     // reads: `{ system, messages, tools, maxSteps, schema,
     // validateObject, effort, provider, model, reasoning, maxTokens,
-    // cache, signal, onMessage }`, with a positional prompt string
+    // cache, signal, onMessage, onToolCall }`, with a positional prompt string
     // appended to `messages` as the final user turn, `tools` names
     // resolved to their activated definitions and unset options left
     // undefined.
@@ -48,7 +48,7 @@ module.exports = (self) => {
       }
       const {
         system, effort, provider, model, reasoning,
-        maxTokens, cache = 'short', signal, onMessage
+        maxTokens, cache = 'short', signal, onMessage, onToolCall
       } = options;
       for (const [ name, value ] of Object.entries({
         system,
@@ -71,8 +71,13 @@ module.exports = (self) => {
       if (signal !== undefined && !(signal instanceof AbortSignal)) {
         invalid('"signal" must be an AbortSignal');
       }
-      if (onMessage !== undefined && typeof onMessage !== 'function') {
-        invalid('"onMessage" must be a function');
+      for (const [ name, hook ] of Object.entries({
+        onMessage,
+        onToolCall
+      })) {
+        if (hook !== undefined && typeof hook !== 'function') {
+          invalid(`"${name}" must be a function`);
+        }
       }
       const maxSteps = options.maxSteps === undefined
         ? self.options.maxSteps
@@ -109,7 +114,8 @@ module.exports = (self) => {
         maxTokens,
         cache,
         signal,
-        onMessage
+        onMessage,
+        onToolCall
       };
 
       // The tools option → the activated definitions it names

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/normalize.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/normalize.js
@@ -4,9 +4,9 @@
 
 const {
   QUALITIES, CACHE_POLICIES, MESSAGE_ROLES, PART_ROLES,
-  GENERATE_OPTIONS, IMAGE_OPTIONS
+  PENDING_POLICIES, GENERATE_OPTIONS, IMAGE_OPTIONS
 } = require('./constants');
-const { isObject } = require('./util');
+const { isObject, oneOf } = require('./util');
 
 module.exports = (self) => {
   function invalid(message) {
@@ -16,12 +16,16 @@ module.exports = (self) => {
   return {
     // Parse and validate generate's `(stringOrOptions, options)`
     // arguments into the canonical options object every later stage
-    // reads: `{ system, messages, tools, maxSteps, schema,
-    // validateObject, effort, provider, model, reasoning, maxTokens,
-    // cache, signal, onMessage, onToolCall }`, with a positional prompt string
-    // appended to `messages` as the final user turn, `tools` names
-    // resolved to their activated definitions and unset options left
-    // undefined.
+    // reads: `{ system, messages, tools, maxSteps, pending,
+    // pendingCalls, toolInput, schema, validateObject, effort,
+    // provider, model, reasoning, maxTokens, cache, signal, onMessage,
+    // onToolCall }`, with a positional prompt string appended to
+    // `messages` as the final user turn, `tools` names resolved to
+    // their activated definitions and unset options left undefined.
+    // `pendingCalls` is computed, not an option: the transcript's
+    // trailing unanswered tool calls in model order, present only
+    // under pending: 'execute' — the default refuses the shape with a
+    // clear message, since no provider accepts it.
     normalizeGenerateOptions(stringOrOptions, options) {
       let prompt = null;
       if (typeof stringOrOptions === 'string') {
@@ -48,7 +52,8 @@ module.exports = (self) => {
       }
       const {
         system, effort, provider, model, reasoning,
-        maxTokens, cache = 'short', signal, onMessage, onToolCall
+        maxTokens, cache = 'short', signal, onMessage, onToolCall,
+        pending = 'refuse', toolInput
       } = options;
       for (const [ name, value ] of Object.entries({
         system,
@@ -79,6 +84,18 @@ module.exports = (self) => {
           invalid(`"${name}" must be a function`);
         }
       }
+      if (!PENDING_POLICIES.includes(pending)) {
+        invalid(`"pending" must be ${oneOf(PENDING_POLICIES)}`);
+      }
+      if (toolInput !== undefined) {
+        if (pending !== 'execute') {
+          invalid('"toolInput" requires pending: "execute"');
+        }
+        if (!isObject(toolInput) ||
+          Object.values(toolInput).some((value) => !isObject(value))) {
+          invalid('"toolInput" must map tool call ids to input objects');
+        }
+      }
       const maxSteps = options.maxSteps === undefined
         ? self.options.maxSteps
         : options.maxSteps;
@@ -88,6 +105,21 @@ module.exports = (self) => {
       const tools = toolDefinitions(options.tools);
       const { schema, validateObject } = structuredSchema(options.schema);
       const messages = self.normalizeMessages(options.messages);
+      const pendingCalls = trailingCalls(messages);
+      if (pendingCalls) {
+        if (pending === 'refuse') {
+          invalid('the transcript ends in unanswered tool calls; ' +
+            'pass pending: "execute" to run them first, or strip the unanswered turns');
+        }
+        if (prompt !== null) {
+          invalid('a prompt cannot be appended to a transcript ending in unanswered tool calls');
+        }
+      }
+      for (const id of Object.keys(toolInput || {})) {
+        if (!pendingCalls?.some((call) => call.id === id)) {
+          invalid(`"toolInput" answers "${id}", which is not an unanswered trailing tool call`);
+        }
+      }
       if (prompt !== null) {
         messages.push({
           role: 'user',
@@ -105,6 +137,9 @@ module.exports = (self) => {
         messages,
         tools,
         maxSteps,
+        pending,
+        pendingCalls,
+        toolInput,
         schema,
         validateObject,
         effort,
@@ -166,6 +201,47 @@ module.exports = (self) => {
           schema,
           validateObject
         };
+      }
+
+      // The transcript's trailing unanswered tool calls, in model
+      // order, or null when it ends complete: the final assistant
+      // turn's toolCall parts minus what a trailing tool message
+      // already answers. A trailing tool message must answer its own
+      // assistant turn — a result for a call that turn did not make is
+      // a malformed transcript, refused whatever the pending policy.
+      function trailingCalls(messages) {
+        let turn = messages.at(-1);
+        const answered = new Set();
+        if (turn?.role === 'tool') {
+          const previous = messages.at(-2);
+          if (previous?.role !== 'assistant') {
+            return null;
+          }
+          const ids = new Set(
+            toolCallParts(previous).map((call) => call.id)
+          );
+          for (const part of turn.content) {
+            if (part.type !== 'toolResult') {
+              continue;
+            }
+            if (!ids.has(part.toolCallId)) {
+              invalid(`the trailing tool message answers "${part.toolCallId}", ` +
+                'which the preceding assistant turn did not request');
+            }
+            answered.add(part.toolCallId);
+          }
+          turn = previous;
+        }
+        if (turn?.role !== 'assistant') {
+          return null;
+        }
+        const unanswered = toolCallParts(turn)
+          .filter((call) => !answered.has(call.id));
+        return unanswered.length ? unanswered : null;
+      }
+
+      function toolCallParts(message) {
+        return message.content.filter((part) => part.type === 'toolCall');
       }
     },
     // Validate and normalize generate's `messages` option into a new

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/request.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/request.js
@@ -127,7 +127,7 @@ module.exports = (self) => {
     // populated is what tells the caller what happened; the transcript
     // is resumable as the next call's `messages`.
     assembleResult(context, turn, {
-      steps, usage, pending, object, hadTools, finishReason
+      steps, usage, pending, suspended, object, hadTools, finishReason
     }) {
       // `turn` is null when a cancellation aborted the first provider
       // call of a step: there is no final assistant turn, only the
@@ -142,6 +142,7 @@ module.exports = (self) => {
         messages: [ ...context.request.messages ],
         ...(hadTools && { steps }),
         ...(pending && { toolCalls: pending }),
+        ...(suspended && { suspended }),
         // The step budget cutting the loop is its own finish reason,
         // like the token budget's 'length'; an explicit override wins
         // (a cancelled run)

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/startup.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/startup.js
@@ -4,7 +4,7 @@
 
 const startCase = require('lodash/startCase');
 const {
-  NAMED_ASPECTS, QUALITIES, TOOL_ACCESS
+  NAMED_ASPECTS, QUALITIES, TOOL_KINDS
 } = require('./constants');
 const {
   isObject, parseAspect, startupFail: fail
@@ -170,9 +170,9 @@ module.exports = (self) => {
             fail(`${name}: "schema" is not a valid JSON Schema: ${e.message}`);
           }
         }
-        const access = tool.access === undefined ? 'write' : tool.access;
-        if (!TOOL_ACCESS.includes(access)) {
-          fail(`${name}: "access" must be "read", "write" or "agent"`);
+        const kind = tool.kind === undefined ? 'action' : tool.kind;
+        if (!TOOL_KINDS.includes(kind)) {
+          fail(`${name}: "kind" must be "query", "action" or "agent"`);
         }
         if (tool.maxResultChars !== undefined &&
           (!Number.isInteger(tool.maxResultChars) || tool.maxResultChars < 1)) {
@@ -188,7 +188,7 @@ module.exports = (self) => {
           schema: tool.schema,
           validateResult,
           maxResultChars: tool.maxResultChars,
-          access,
+          kind,
           handler: resolveHandler(tool.handler, name)
         };
       }

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/startup.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/startup.js
@@ -155,24 +155,20 @@ module.exports = (self) => {
         }
         let validateArgs;
         try {
-          validateArgs = self.ajv.compile(tool.input);
+          validateArgs = self.ajvArgs.compile(tool.input);
         } catch (e) {
           fail(`${name}: "input" is not a valid JSON Schema: ${e.message}`);
         }
-        if (!isObject(tool.schema)) {
-          fail(`${name}: "schema" must be an object of schema fields describing the result`);
-        }
-        let schema;
-        try {
-          schema = self.apos.schema.compose({
-            addFields: self.apos.schema.fieldsToArray(`AI tool ${tool.name}`, tool.schema)
-          });
-          self.apos.schema.validate(schema, {
-            type: 'AI tool',
-            subtype: tool.name
-          });
-        } catch (e) {
-          fail(`${name}: "schema" is not a valid schema: ${e.message}`);
+        let validateResult;
+        if (tool.schema !== undefined) {
+          if (!isObject(tool.schema) || tool.schema.type !== 'object') {
+            fail(`${name}: "schema" must be a JSON Schema with an object root`);
+          }
+          try {
+            validateResult = self.ajv.compile(tool.schema);
+          } catch (e) {
+            fail(`${name}: "schema" is not a valid JSON Schema: ${e.message}`);
+          }
         }
         const access = tool.access === undefined ? 'write' : tool.access;
         if (!TOOL_ACCESS.includes(access)) {
@@ -185,7 +181,8 @@ module.exports = (self) => {
           tags: tool.tags || [],
           input: tool.input,
           validateArgs,
-          schema,
+          schema: tool.schema,
+          validateResult,
           access,
           handler: resolveHandler(tool.handler, name)
         };

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/startup.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/startup.js
@@ -174,6 +174,10 @@ module.exports = (self) => {
         if (!TOOL_ACCESS.includes(access)) {
           fail(`${name}: "access" must be "read", "write" or "agent"`);
         }
+        if (tool.maxResultChars !== undefined &&
+          (!Number.isInteger(tool.maxResultChars) || tool.maxResultChars < 1)) {
+          fail(`${name}: "maxResultChars" must be a positive integer`);
+        }
         return {
           name: tool.name,
           label: tool.label || startCase(tool.name),
@@ -183,6 +187,7 @@ module.exports = (self) => {
           validateArgs,
           schema: tool.schema,
           validateResult,
+          maxResultChars: tool.maxResultChars,
           access,
           handler: resolveHandler(tool.handler, name)
         };

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/startup.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/startup.js
@@ -172,7 +172,7 @@ module.exports = (self) => {
         }
         const kind = tool.kind === undefined ? 'action' : tool.kind;
         if (!TOOL_KINDS.includes(kind)) {
-          fail(`${name}: "kind" must be "query", "action" or "agent"`);
+          fail(`${name}: "kind" must be ${oneOf(TOOL_KINDS)}`);
         }
         if (tool.maxResultChars !== undefined &&
           (!Number.isInteger(tool.maxResultChars) || tool.maxResultChars < 1)) {
@@ -217,6 +217,12 @@ module.exports = (self) => {
           fail(`${name}: handler names unknown method "${methodName}" of "${moduleName}"`);
         }
         return (req, args) => module[methodName](req, args);
+      }
+
+      // An enum constant as its message states it: quoted, "or" last
+      function oneOf(values) {
+        const quoted = values.map((value) => `"${value}"`);
+        return `${quoted.slice(0, -1).join(', ')} or ${quoted.at(-1)}`;
       }
     },
     // Fail startup when a model's declared image `aspects` are

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/startup.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/startup.js
@@ -7,7 +7,7 @@ const {
   NAMED_ASPECTS, QUALITIES, TOOL_KINDS
 } = require('./constants');
 const {
-  isObject, parseAspect, startupFail: fail
+  isObject, parseAspect, oneOf, startupFail: fail
 } = require('./util');
 
 module.exports = (self) => {
@@ -217,12 +217,6 @@ module.exports = (self) => {
           fail(`${name}: handler names unknown method "${methodName}" of "${moduleName}"`);
         }
         return (req, args) => module[methodName](req, args);
-      }
-
-      // An enum constant as its message states it: quoted, "or" last
-      function oneOf(values) {
-        const quoted = values.map((value) => `"${value}"`);
-        return `${quoted.slice(0, -1).join(', ')} or ${quoted.at(-1)}`;
       }
     },
     // Fail startup when a model's declared image `aspects` are

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/tools.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/tools.js
@@ -18,7 +18,9 @@ module.exports = (self) => {
     // "default" values are written into what the handler receives,
     // while the transcript's own toolCall part is never mutated.
     // `context` is written to `args._context` after validation, so a
-    // model-provided property can never pose as core injection. A
+    // model-provided property can never pose as core injection, and it
+    // carries the executing call's own `id` and `name` — a handler that
+    // records what it did can say which request it was answering. A
     // handler throw passes through untouched — recovery is decided
     // elsewhere, by the error code alone. The result must be an
     // object; a tool that declares a result schema gets it validated,
@@ -36,7 +38,13 @@ module.exports = (self) => {
       if (!tool.validateArgs(args)) {
         throw self.apos.error('aiToolError', `invalid arguments for tool "${tool.name}": ${self.ajv.errorsText(tool.validateArgs.errors, { dataVar: 'arguments' })}`);
       }
-      args._context = context;
+      args._context = {
+        ...context,
+        call: {
+          id: call.id,
+          name: call.name
+        }
+      };
       const result = await tool.handler(req, args);
       if (!isObject(result)) {
         throw self.apos.error('invalid', `tool "${tool.name}" must return an object`);
@@ -91,7 +99,14 @@ module.exports = (self) => {
     // so a handler that spawns without declaring `access: 'agent'` is
     // contained all the same; `_context.depth` is the informational
     // copy a handler may act on.
-    async executeToolCalls(req, tools, calls, context = {}) {
+    //
+    // `onToolCall`, the caller's per-call progress hook, is awaited
+    // around each handler that runs — a call naming no registered tool
+    // never starts, so it is not reported. Its throw stops the call,
+    // like every other hook; the one exception is the end report of a
+    // handler that is already ending the call, where a failing hook
+    // must not replace the failure on its way out.
+    async executeToolCalls(req, tools, calls, context = {}, onToolCall = null) {
       const outcomes = new Array(calls.length);
       const depth = (req.aposAiDepth || 0) + 1;
       const handlerReq = req.clone({ aposAiDepth: depth });
@@ -137,6 +152,7 @@ module.exports = (self) => {
           tool
         };
         await self.emit('beforeToolCall', req, payload);
+        await report({ phase: 'start' });
         try {
           payload.result = await self.executeToolCall(
             handlerReq, tool, call, handlerContext
@@ -147,6 +163,19 @@ module.exports = (self) => {
           };
         } catch (e) {
           if (e?.name !== 'aiToolError') {
+            // A call that started is always reported finished, so a
+            // consumer never waits on a step that ended the run
+            try {
+              await report({
+                phase: 'end',
+                error: e.message
+              });
+            } catch (hookError) {
+              self.logError(req, 'hook', hookError.message, {
+                tool: call.name,
+                stack: hookError.stack
+              });
+            }
             throw e;
           }
           payload.error = e.message;
@@ -156,6 +185,24 @@ module.exports = (self) => {
           };
         }
         await self.emit('afterToolCall', req, payload);
+        await report({
+          phase: 'end',
+          ...(payload.error !== undefined
+            ? { error: payload.error }
+            : { result: payload.result })
+        });
+
+        // The call is what the model asked for, verbatim; the step the
+        // hook also carries is the loop's, bound before it got here
+        async function report(event) {
+          if (!onToolCall) {
+            return;
+          }
+          await onToolCall({
+            ...event,
+            call
+          });
+        }
       }
     }
   };

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/tools.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/tools.js
@@ -8,48 +8,40 @@ module.exports = (self) => {
   return {
     // Execute one model-requested tool call — a toolCall content part —
     // against `tool`, its activated registry definition (getTool),
-    // returning the handler's result converted through the tool's
-    // schema, ready to be serialized for the model.
+    // returning the handler's result ready to be serialized for the
+    // model.
     //
     // Invalid arguments never reach the handler: they throw
     // 'aiToolError', the recoverable code, so the loop can feed the
-    // validation message back to the model. `context` is written to
-    // `args._context` after validation, so a model-provided property
-    // can never pose as core injection. A handler throw passes through
-    // untouched — recovery is decided elsewhere, by the error code
-    // alone. A result the schema rejects is a handler bug, not model
-    // misbehaviour: it throws 'invalid', a standard code that breaks
-    // the AI chain with no retries, and no detail of it is ever fed
-    // back to the model.
+    // validation message back to the model. Validation runs on a deep
+    // clone of the requested arguments — the input schema's declared
+    // "default" values are written into what the handler receives,
+    // while the transcript's own toolCall part is never mutated.
+    // `context` is written to `args._context` after validation, so a
+    // model-provided property can never pose as core injection. A
+    // handler throw passes through untouched — recovery is decided
+    // elsewhere, by the error code alone. The result must be an
+    // object; a tool that declares a result schema gets it validated,
+    // never mutated — the handler's object is what the model reads
+    // either way. A result the schema rejects is a handler bug, not
+    // model misbehaviour: it throws 'invalid', a standard code that
+    // breaks the AI chain with no retries, and no detail of it is
+    // ever fed back to the model.
     async executeToolCall(req, tool, call, context = {}) {
-      if (!tool.validateArgs(call.input)) {
+      const args = structuredClone(call.input);
+      if (!tool.validateArgs(args)) {
         throw self.apos.error('aiToolError', `invalid arguments for tool "${tool.name}": ${self.ajv.errorsText(tool.validateArgs.errors, { dataVar: 'arguments' })}`);
       }
-      const args = {
-        ...call.input,
-        _context: context
-      };
+      args._context = context;
       const result = await tool.handler(req, args);
       if (!isObject(result)) {
-        throw self.apos.error('invalid', `tool "${tool.name}" must return an object matching its schema`);
+        throw self.apos.error('invalid', `tool "${tool.name}" must return an object`);
       }
-      const converted = {};
-      try {
-        await self.apos.schema.convert(req, tool.schema, result, converted);
-      } catch (errors) {
-        throw self.apos.error('invalid', `tool "${tool.name}" returned a result that does not match its schema: ${detail(errors)}`);
+      if (tool.validateResult && !tool.validateResult(result)) {
+        const errors = self.ajv.errorsText(tool.validateResult.errors, { dataVar: 'result' });
+        throw self.apos.error('invalid', `tool "${tool.name}" returned a result that does not match its schema: ${errors}`);
       }
-      return converted;
-
-      // The convert rejection → one readable line naming each field
-      function detail(errors) {
-        if (!Array.isArray(errors)) {
-          return errors.message || String(errors);
-        }
-        return errors
-          .map((error) => `${error.path}: ${error.message || error.name}`)
-          .join('; ');
-      }
+      return result;
     },
     // Execute one batch of model-requested tool calls — the toolCall
     // parts of a single assistant turn — against `tools`, the call's

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/tools.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/tools.js
@@ -26,7 +26,11 @@ module.exports = (self) => {
     // either way. A result the schema rejects is a handler bug, not
     // model misbehaviour: it throws 'invalid', a standard code that
     // breaks the AI chain with no retries, and no detail of it is
-    // ever fed back to the model.
+    // ever fed back to the model. A result over the tool's declared
+    // maxResultChars budget is the opposite — data-dependent, so the
+    // model can correct it: the oversized result is withheld and an
+    // 'aiToolError' report (actual size, budget, largest properties)
+    // is fed back instead.
     async executeToolCall(req, tool, call, context = {}) {
       const args = structuredClone(call.input);
       if (!tool.validateArgs(args)) {
@@ -41,7 +45,27 @@ module.exports = (self) => {
         const errors = self.ajv.errorsText(tool.validateResult.errors, { dataVar: 'result' });
         throw self.apos.error('invalid', `tool "${tool.name}" returned a result that does not match its schema: ${errors}`);
       }
+      if (tool.maxResultChars) {
+        const size = JSON.stringify(result).length;
+        if (size > tool.maxResultChars) {
+          throw self.apos.error('aiToolError', `the result is too large: ${size} characters ` +
+            `against the tool's budget of ${tool.maxResultChars}; ` +
+            `largest properties: ${largestProperties(result)}; ` +
+            'request less data, like fewer items or specific properties');
+        }
+      }
       return result;
+
+      // The size report: top-level properties by serialized size,
+      // largest first, so the model sees what to narrow
+      function largestProperties(result) {
+        return Object.entries(result)
+          .map(([ key, value ]) => [ key, JSON.stringify(value)?.length || 0 ])
+          .sort(([ , a ], [ , b ]) => b - a)
+          .slice(0, 5)
+          .map(([ key, length ]) => `${key} (${length})`)
+          .join(', ');
+      }
     },
     // Execute one batch of model-requested tool calls — the toolCall
     // parts of a single assistant turn — against `tools`, the call's

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/tools.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/tools.js
@@ -89,6 +89,17 @@ module.exports = (self) => {
     // aborting the remaining actions when thrown by one — and no trace
     // of it is ever model-bound.
     //
+    // A handler that cannot answer without outside input throws
+    // 'aiInput', the ask riding the throw's `data`; the call stays
+    // unexecuted and its outcome is { toolCall, suspended } — the
+    // payload as apos.error attached it. Suspension stops the
+    // batch at the suspended call: queries all complete together, so
+    // several may suspend at once, and no action past the earliest
+    // suspended call in model order ever starts — it may depend on
+    // that call's outcome. Unstarted calls have no outcome entry. In
+    // a nested run the throw converts to 'aiToolError' instead — a
+    // delegated run has no one to ask.
+    //
     // Handlers run on a clone of the caller's req stamped with the
     // batch's depth (`aposAiDepth`) — an immutable property of the
     // request each handler received, never shared mutable state — so a
@@ -131,8 +142,22 @@ module.exports = (self) => {
           throw query.reason;
         }
       }
+      // The earliest suspended query bounds the action lane in model
+      // order: an action before it cannot depend on it and still runs
+      let bound = calls.length;
+      for (const [ , index ] of queries) {
+        if (outcomes[index]?.suspended !== undefined && index < bound) {
+          bound = index;
+        }
+      }
       for (const [ call, index ] of actions) {
+        if (index > bound) {
+          break;
+        }
         await run(call, index);
+        if (outcomes[index]?.suspended !== undefined) {
+          break;
+        }
       }
       return outcomes;
 
@@ -162,7 +187,22 @@ module.exports = (self) => {
             result: payload.result
           };
         } catch (e) {
-          if (e?.name !== 'aiToolError') {
+          if (e?.name === 'aiInput' && depth === 1) {
+            payload.suspended = e.data ?? null;
+            outcomes[index] = {
+              toolCall: call,
+              suspended: payload.suspended
+            };
+          } else if (e?.name === 'aiInput') {
+            // A delegated run has no one to ask: the suspend signal
+            // converts to the recoverable code so the child model can
+            // adapt or answer without the input
+            payload.error = 'a delegated run cannot wait for input';
+            outcomes[index] = {
+              toolCall: call,
+              error: payload.error
+            };
+          } else if (e?.name !== 'aiToolError') {
             // A call that started is always reported finished, so a
             // consumer never waits on a step that ended the run
             try {
@@ -177,20 +217,24 @@ module.exports = (self) => {
               });
             }
             throw e;
+          } else {
+            payload.error = e.message;
+            outcomes[index] = {
+              toolCall: call,
+              error: e.message
+            };
           }
-          payload.error = e.message;
-          outcomes[index] = {
-            toolCall: call,
-            error: e.message
-          };
         }
         await self.emit('afterToolCall', req, payload);
-        await report({
-          phase: 'end',
-          ...(payload.error !== undefined
-            ? { error: payload.error }
-            : { result: payload.result })
-        });
+        const end = { phase: 'end' };
+        if (payload.error !== undefined) {
+          end.error = payload.error;
+        } else if (payload.suspended !== undefined) {
+          end.suspended = payload.suspended;
+        } else {
+          end.result = payload.result;
+        }
+        await report(end);
 
         // The call is what the model asked for, verbatim; the step the
         // hook also carries is the loop's, bound before it got here

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/tools.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/tools.js
@@ -21,8 +21,11 @@ module.exports = (self) => {
     // model-provided property can never pose as core injection, and it
     // carries the executing call's own `id` and `name` — a handler that
     // records what it did can say which request it was answering. A
-    // handler throw passes through untouched — recovery is decided
-    // elsewhere, by the error code alone. The result must be an
+    // context `inputs` map — the per-call answers a continuation
+    // carries — is never leaked wholesale: only the executing call's
+    // own entry surfaces, as `_context.input`. A handler throw passes
+    // through untouched — recovery is decided elsewhere, by the error
+    // code alone. The result must be an
     // object; a tool that declares a result schema gets it validated,
     // never mutated — the handler's object is what the model reads
     // either way. A result the schema rejects is a handler bug, not
@@ -38,8 +41,10 @@ module.exports = (self) => {
       if (!tool.validateArgs(args)) {
         throw self.apos.error('aiToolError', `invalid arguments for tool "${tool.name}": ${self.ajv.errorsText(tool.validateArgs.errors, { dataVar: 'arguments' })}`);
       }
+      const { inputs, ...injected } = context;
       args._context = {
-        ...context,
+        ...injected,
+        ...(inputs?.[call.id] !== undefined && { input: inputs[call.id] }),
         call: {
           id: call.id,
           name: call.name

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/tools.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/tools.js
@@ -77,16 +77,16 @@ module.exports = (self) => {
     },
     // Execute one batch of model-requested tool calls — the toolCall
     // parts of a single assistant turn — against `tools`, the call's
-    // selected definitions as a Map by name. Reads run first, in
-    // parallel; writes follow serially, in the order the model
+    // selected definitions as a Map by name. Queries run first, in
+    // parallel; actions follow serially, in the order the model
     // requested them. Returns outcomes in model order regardless of
     // scheduling: { toolCall, result } per success, { toolCall, error }
     // per recoverable failure — a call naming a tool outside the
     // selected set, invalid arguments, or a handler's aiToolError. The
     // error message is what the model reads back, and siblings are
     // unaffected. Any other throw is a hard stop: it propagates
-    // immediately, before any write runs when thrown by a read,
-    // aborting the remaining writes when thrown by one — and no trace
+    // immediately, before any action runs when thrown by a query,
+    // aborting the remaining actions when thrown by one — and no trace
     // of it is ever model-bound.
     //
     // Handlers run on a clone of the caller's req stamped with the
@@ -96,7 +96,7 @@ module.exports = (self) => {
     // nested, even delayed or from a stashed reference, while the
     // caller's original req is untouched and concurrent calls sharing
     // it are unaffected. Every batch is stamped, not only agent tools,
-    // so a handler that spawns without declaring `access: 'agent'` is
+    // so a handler that spawns without declaring `kind: 'agent'` is
     // contained all the same; `_context.depth` is the informational
     // copy a handler may act on.
     //
@@ -114,24 +114,24 @@ module.exports = (self) => {
         ...context,
         depth
       };
-      const reads = [];
-      const writes = [];
+      const queries = [];
+      const actions = [];
       calls.forEach((call, index) => {
-        if (tools.get(call.name)?.access === 'read') {
-          reads.push([ call, index ]);
+        if (tools.get(call.name)?.kind === 'query') {
+          queries.push([ call, index ]);
         } else {
-          writes.push([ call, index ]);
+          actions.push([ call, index ]);
         }
       });
       const settled = await Promise.allSettled(
-        reads.map(([ call, index ]) => run(call, index))
+        queries.map(([ call, index ]) => run(call, index))
       );
-      for (const read of settled) {
-        if (read.status === 'rejected') {
-          throw read.reason;
+      for (const query of settled) {
+        if (query.status === 'rejected') {
+          throw query.reason;
         }
       }
-      for (const [ call, index ] of writes) {
+      for (const [ call, index ] of actions) {
         await run(call, index);
       }
       return outcomes;

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/types.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/types.js
@@ -98,7 +98,7 @@
  *   `schema` validator; absent when the tool declares no result schema.
  * @property {number} [maxResultChars] The result-size budget in serialized
  *   characters; absent means unlimited.
- * @property {'read'|'write'|'agent'} access
+ * @property {'query'|'action'|'agent'} kind
  * @property {(req: object, args: object) => Promise<object>} handler
  */
 

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/types.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/types.js
@@ -92,8 +92,10 @@
  * @property {object} input The JSON Schema the model's arguments must satisfy.
  * @property {(args: object) => boolean} validateArgs The compiled `input`
  *   validator.
- * @property {object[]} schema The result's Apostrophe schema, composed to the
- *   array form apos.schema.convert consumes.
+ * @property {object} [schema] The result's JSON Schema, as registered.
+ *   Internal — never sent to the model.
+ * @property {(result: object) => boolean} [validateResult] The compiled
+ *   `schema` validator; absent when the tool declares no result schema.
  * @property {'read'|'write'|'agent'} access
  * @property {(req: object, args: object) => Promise<object>} handler
  */

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/types.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/types.js
@@ -96,6 +96,8 @@
  *   Internal — never sent to the model.
  * @property {(result: object) => boolean} [validateResult] The compiled
  *   `schema` validator; absent when the tool declares no result schema.
+ * @property {number} [maxResultChars] The result-size budget in serialized
+ *   characters; absent means unlimited.
  * @property {'read'|'write'|'agent'} access
  * @property {(req: object, args: object) => Promise<object>} handler
  */

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/types.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/types.js
@@ -205,6 +205,21 @@
  */
 
 /**
+ * One tool call reporting itself to the caller's `onToolCall` hook, as it
+ * starts and again as it ends. `result` and `error` are the outcome of an
+ * 'end' report and are absent from a 'start' one; a recoverable error is the
+ * message the model was told, a hard-stopping one the message that is about
+ * to be thrown.
+ *
+ * @typedef {object} AiToolCallEvent
+ * @property {'start'|'end'} phase
+ * @property {AiToolCallPart} call The request, exactly as the model made it.
+ * @property {number} step The model turn that asked for it, counting from 1.
+ * @property {object} [result]
+ * @property {string} [error]
+ */
+
+/**
  * What generate resolves with. Which fields are populated is what tells the
  * caller what happened.
  *

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/types.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/types.js
@@ -206,10 +206,11 @@
 
 /**
  * One tool call reporting itself to the caller's `onToolCall` hook, as it
- * starts and again as it ends. `result` and `error` are the outcome of an
- * 'end' report and are absent from a 'start' one; a recoverable error is the
- * message the model was told, a hard-stopping one the message that is about
- * to be thrown.
+ * starts and again as it ends. `result`, `error` and `suspended` are the
+ * outcome of an 'end' report and are absent from a 'start' one; a
+ * recoverable error is the message the model was told, a hard-stopping one
+ * the message that is about to be thrown, and `suspended` is the ask of a
+ * handler that ended the run waiting for input.
  *
  * @typedef {object} AiToolCallEvent
  * @property {'start'|'end'} phase
@@ -217,6 +218,19 @@
  * @property {number} step The model turn that asked for it, counting from 1.
  * @property {object} [result]
  * @property {string} [error]
+ * @property {object|null} [suspended]
+ */
+
+/**
+ * One suspended tool call's ask: the handler threw "aiInput" because it
+ * cannot answer without outside input, and the run ended with finishReason
+ * 'input'. The call itself stays unexecuted on `toolCalls`.
+ *
+ * @typedef {object} AiSuspendedCall
+ * @property {string} callId
+ * @property {string} name The registered tool name.
+ * @property {object} payload The throw's `data`, authored by the handler —
+ *   what it needs to continue; {} when the throw carried none.
  */
 
 /**
@@ -233,9 +247,14 @@
  *   when the call carried tools.
  * @property {AiToolCallPart[]} [toolCalls] Unexecuted requests the caller must
  *   run itself.
- * @property {'stop'|'length'|'cancel'|'maxSteps'} finishReason 'maxSteps'
- *   whenever the step budget cut the loop, the step budget's counterpart of
- *   'length'.
+ * @property {AiSuspendedCall[]} [suspended] The asks of the calls that
+ *   suspended the run, in model order; present only with finishReason
+ *   'input'. The transcript already carries the executed outcomes as a
+ *   partial tool message.
+ * @property {'stop'|'length'|'cancel'|'maxSteps'|'input'} finishReason
+ *   'maxSteps' whenever the step budget cut the loop, the step budget's
+ *   counterpart of 'length'; 'input' when a tool handler suspended the run
+ *   for outside input.
  * @property {AiUsage} usage
  * @property {string} model What actually answered.
  * @property {string} provider

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/types.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/types.js
@@ -246,8 +246,14 @@
  * provider entry's, merged, the entry winning.
  *
  * @typedef {object} AiModelMeta
+ * @property {string} [label] The model's human name, for pickers and
+ * receipts ("Opus 5"); the id stays the wire truth.
  * @property {number} [contextWindow]
  * @property {number} [maxOutputTokens]
+ * @property {string[]} [reasoning] The values a call may pass as its
+ * `reasoning` for this model, in the provider's own vocabulary.
+ * Informational: read back by modelCatalog, never enforced by the engine —
+ * the adapter keeps its own rejections.
  * @property {string[]} [aspects] The image ratios the model supports, as 'W:H'.
  */
 
@@ -266,6 +272,20 @@
  */
 
 /**
+ * What modelCatalog reports: the whole routing configuration, shaped for
+ * building pickers. Every object is a copy, safe to serialize or amend.
+ *
+ * @typedef {object} AiModelCatalog
+ * @property {{ default: string, levels: Object<string, { provider: string,
+ * model: string, reasoning?: string }> }} effort The resolved routing
+ * table and the level an effortless call lands on.
+ * @property {Object<string, { label: string,
+ * capabilities: Object<string, boolean>,
+ * models: Object<string, AiModelMeta> }>} providers Configured providers
+ * by name, each with its adapter's label and merged model metadata.
+ */
+
+/**
  * A provider adapter: the translation between the normalized protocol above and
  * one service's dialect. Registered with addAdapter and instantiated per
  * provider entry at startup, with `provider`, `apiKey` and `baseUrl` filled in
@@ -274,6 +294,7 @@
  * @typedef {object} AiAdapter
  * @property {string} name The registry name. A provider entry names it with
  *   `adapter`, or shares its own key with it.
+ * @property {string} label The service's human name ("Anthropic (Claude)").
  * @property {string} [envKey] The environment variable the key is read from
  *   unless the entry names its own.
  * @property {string} [baseUrl]

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/util.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/util.js
@@ -31,6 +31,12 @@ function parseAspect(value) {
   return w > 0 && h > 0 ? [ w, h ] : null;
 }
 
+// An enum constant as its message states it: quoted, "or" last
+function oneOf(values) {
+  const quoted = values.map((value) => `"${value}"`);
+  return `${quoted.slice(0, -1).join(', ')} or ${quoted.at(-1)}`;
+}
+
 // Startup-only: a bad configuration must kill the boot with a plain prefixed
 // Error. Runtime code throws self.apos.error(...) instead, so the name says
 // where this belongs.
@@ -42,5 +48,6 @@ module.exports = {
   isObject,
   isAbort,
   parseAspect,
+  oneOf,
   startupFail
 };

--- a/packages/apostrophe/test/ai-adapter-anthropic.js
+++ b/packages/apostrophe/test/ai-adapter-anthropic.js
@@ -28,7 +28,6 @@ describe('AI adapter: anthropic', function() {
                 properties: { value: { type: 'string' } },
                 required: [ 'value' ]
               },
-              schema: { value: { type: 'string' } },
               handler: (req, args) => ({ value: args.value })
             });
           }

--- a/packages/apostrophe/test/ai-adapter-anthropic.js
+++ b/packages/apostrophe/test/ai-adapter-anthropic.js
@@ -107,11 +107,15 @@ describe('AI adapter: anthropic', function() {
     assert.equal(apos.ai.active, true);
     const info = apos.ai.modelInfo();
     assert.equal(info.provider, 'anthropic');
-    assert.equal(info.model, 'claude-sonnet-4-6');
-    assert.equal(info.contextWindow, 200000);
+    assert.equal(info.model, 'claude-sonnet-5');
+    assert.equal(info.contextWindow, 1000000);
     assert.equal(info.maxOutputTokens, 64000);
+    assert.equal(info.reasoning, 'medium');
+    const low = apos.ai.modelInfo({ effort: 'low' });
+    assert.equal(low.model, 'claude-haiku-4-5');
+    assert.equal(low.reasoning, undefined);
     const high = apos.ai.modelInfo({ effort: 'high' });
-    assert.equal(high.model, 'claude-opus-4-8');
+    assert.equal(high.model, 'claude-opus-5');
     assert.equal(high.reasoning, 'high');
   });
 
@@ -226,6 +230,38 @@ describe('AI adapter: anthropic', function() {
       }
     });
 
+    it('maps reasoning levels to effort on an adaptive model', function() {
+      for (const level of [ 'low', 'medium', 'high', 'xhigh', 'max' ]) {
+        const body = adapter.buildBody(request({
+          model: 'claude-opus-5',
+          reasoning: level
+        }));
+        assert.deepEqual(body.thinking, { type: 'adaptive' });
+        assert.deepEqual(body.output_config, { effort: level });
+      }
+    });
+
+    it('never sends a token budget to an adaptive model', function() {
+      const body = adapter.buildBody(request({
+        model: 'claude-sonnet-5',
+        reasoning: 'high'
+      }));
+      assert.equal(body.thinking.budget_tokens, undefined);
+    });
+
+    it('reads which models are adaptive from the adaptiveModels option', function() {
+      const saved = adapter.options.adaptiveModels;
+      try {
+        adapter.options.adaptiveModels = [ ...saved, 'claude-sonnet-4-6' ];
+        assert.deepEqual(
+          adapter.buildBody(request({ reasoning: 'high' })).thinking,
+          { type: 'adaptive' }
+        );
+      } finally {
+        adapter.options.adaptiveModels = saved;
+      }
+    });
+
     it('reads the budgets from the thinkingBudgets option', function() {
       const saved = adapter.options.thinkingBudgets;
       try {
@@ -253,6 +289,13 @@ describe('AI adapter: anthropic', function() {
       throwsInvalid(
         () => adapter.buildBody(request({ reasoning: 'extreme' })),
         /no thinking budget is configured for reasoning "extreme"/
+      );
+      throwsInvalid(
+        () => adapter.buildBody(request({
+          model: 'claude-opus-5',
+          reasoning: 'extreme'
+        })),
+        /reasoning "extreme" is not an effort level/
       );
       throwsInvalid(
         () => adapter.buildBody(request({
@@ -691,7 +734,7 @@ describe('AI adapter: anthropic', function() {
       assert.equal(call.options.headers['x-api-key'], 'sk-test');
       assert.equal(call.options.headers['anthropic-version'], '2023-06-01');
       assert.equal(call.options.timeout, 600000);
-      assert.equal(call.options.body.model, 'claude-sonnet-4-6');
+      assert.equal(call.options.body.model, 'claude-sonnet-5');
       assert.equal(call.options.body.max_tokens, 64000);
       // The default short cache policy became the rolling marker
       assert.deepEqual(call.options.body.messages, [ {
@@ -708,7 +751,7 @@ describe('AI adapter: anthropic', function() {
       httpScript = [ () => fixture() ];
       await apos.ai.generate(apos.task.getReq(), 'p', {
         provider: 'gateway',
-        model: 'claude-sonnet-4-6'
+        model: 'claude-sonnet-5'
       });
       const [ call ] = httpCalls;
       assert.equal(call.url, 'https://llm-gateway.example.com/anthropic/v1/messages');
@@ -796,12 +839,11 @@ describe('AI adapter: anthropic', function() {
       assert.equal(result.text, 'done');
       assert.equal(result.finishReason, 'stop');
       assert.equal(httpCalls.length, 2);
-      // Thinking was on for both turns of the loop
+      // Thinking was on for both turns of the loop, at the level the
+      // call asked for
       for (const call of httpCalls) {
-        assert.deepEqual(call.options.body.thinking, {
-          type: 'enabled',
-          budget_tokens: 16384
-        });
+        assert.deepEqual(call.options.body.thinking, { type: 'adaptive' });
+        assert.deepEqual(call.options.body.output_config, { effort: 'high' });
       }
       // The second call replays the assistant turn with its signed
       // thinking block restored, unmodified, ahead of the tool use

--- a/packages/apostrophe/test/ai-adapter-anthropic.js
+++ b/packages/apostrophe/test/ai-adapter-anthropic.js
@@ -22,7 +22,7 @@ describe('AI adapter: anthropic', function() {
             self.apos.ai.addTool({
               name: 'echo',
               description: 'Echo the value back',
-              access: 'read',
+              kind: 'query',
               input: {
                 type: 'object',
                 properties: { value: { type: 'string' } },

--- a/packages/apostrophe/test/ai-adapter-anthropic.js
+++ b/packages/apostrophe/test/ai-adapter-anthropic.js
@@ -1041,6 +1041,49 @@ describe('AI adapter: anthropic', function() {
     });
   });
 
+  describe('model metadata', function() {
+    it('labels every model', function() {
+      const { models } = adapter.adapter();
+      const labels = Object.fromEntries(
+        Object.entries(models).map(([ id, meta ]) => [ id, meta.label ])
+      );
+      assert.deepEqual(labels, {
+        'claude-haiku-4-5': 'Haiku 4.5',
+        'claude-sonnet-5': 'Sonnet 5',
+        'claude-opus-5': 'Opus 5'
+      });
+    });
+
+    it('declares effort levels as the reasoning of an adaptive model', function() {
+      const { models } = adapter.adapter();
+      const levels = [ 'low', 'medium', 'high', 'xhigh', 'max' ];
+      assert.deepEqual(models['claude-sonnet-5'].reasoning, levels);
+      assert.deepEqual(models['claude-opus-5'].reasoning, levels);
+    });
+
+    it('declares the configured budget names as the reasoning of a budgeted model', function() {
+      assert.deepEqual(
+        adapter.adapter().models['claude-haiku-4-5'].reasoning,
+        [ 'low', 'medium', 'high' ]
+      );
+      // The definition is built from the options, so an extended budget
+      // table reaches a declaration built afterwards
+      const saved = adapter.options.thinkingBudgets;
+      try {
+        adapter.options.thinkingBudgets = {
+          ...saved,
+          xhigh: 32768
+        };
+        assert.deepEqual(
+          adapter.adapter().models['claude-haiku-4-5'].reasoning,
+          [ 'low', 'medium', 'high', 'xhigh' ]
+        );
+      } finally {
+        adapter.options.thinkingBudgets = saved;
+      }
+    });
+  });
+
   describe('environment key', function() {
     before(async function() {
       process.env.APOS_ANTHROPIC_KEY = 'sk-env';

--- a/packages/apostrophe/test/ai-adapter-google.js
+++ b/packages/apostrophe/test/ai-adapter-google.js
@@ -28,7 +28,6 @@ describe('AI adapter: google', function() {
                 properties: { value: { type: 'string' } },
                 required: [ 'value' ]
               },
-              schema: { value: { type: 'string' } },
               handler: (req, args) => ({ value: args.value })
             });
           }

--- a/packages/apostrophe/test/ai-adapter-google.js
+++ b/packages/apostrophe/test/ai-adapter-google.js
@@ -22,7 +22,7 @@ describe('AI adapter: google', function() {
             self.apos.ai.addTool({
               name: 'echo',
               description: 'Echo the value back',
-              access: 'read',
+              kind: 'query',
               input: {
                 type: 'object',
                 properties: { value: { type: 'string' } },

--- a/packages/apostrophe/test/ai-adapter-openai-compatible.js
+++ b/packages/apostrophe/test/ai-adapter-openai-compatible.js
@@ -28,7 +28,6 @@ describe('AI adapter: openai-compatible', function() {
                 properties: { value: { type: 'string' } },
                 required: [ 'value' ]
               },
-              schema: { value: { type: 'string' } },
               handler: (req, args) => ({ value: args.value })
             });
           }

--- a/packages/apostrophe/test/ai-adapter-openai-compatible.js
+++ b/packages/apostrophe/test/ai-adapter-openai-compatible.js
@@ -22,7 +22,7 @@ describe('AI adapter: openai-compatible', function() {
             self.apos.ai.addTool({
               name: 'echo',
               description: 'Echo the value back',
-              access: 'read',
+              kind: 'query',
               input: {
                 type: 'object',
                 properties: { value: { type: 'string' } },

--- a/packages/apostrophe/test/ai-adapter-openai.js
+++ b/packages/apostrophe/test/ai-adapter-openai.js
@@ -22,7 +22,7 @@ describe('AI adapter: openai', function() {
             self.apos.ai.addTool({
               name: 'echo',
               description: 'Echo the value back',
-              access: 'read',
+              kind: 'query',
               input: {
                 type: 'object',
                 properties: { value: { type: 'string' } },

--- a/packages/apostrophe/test/ai-adapter-openai.js
+++ b/packages/apostrophe/test/ai-adapter-openai.js
@@ -28,7 +28,6 @@ describe('AI adapter: openai', function() {
                 properties: { value: { type: 'string' } },
                 required: [ 'value' ]
               },
-              schema: { value: { type: 'string' } },
               handler: (req, args) => ({ value: args.value })
             });
           }

--- a/packages/apostrophe/test/ai-generate.js
+++ b/packages/apostrophe/test/ai-generate.js
@@ -71,7 +71,6 @@ describe('AI generate', function() {
                 type: 'object',
                 properties: { text: { type: 'string' } }
               },
-              schema: { text: { type: 'string' } },
               handler: (req, args) => ({ text: args.text })
             });
           }

--- a/packages/apostrophe/test/ai-generate.js
+++ b/packages/apostrophe/test/ai-generate.js
@@ -274,6 +274,10 @@ describe('AI generate', function() {
         () => apos.ai.normalizeGenerateOptions('p', { onMessage: 'notify me' }),
         /"onMessage" must be a function/
       );
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions('p', { onToolCall: 'tell me' }),
+        /"onToolCall" must be a function/
+      );
     });
 
     it('defaults cache to short and honors an explicit false', function() {

--- a/packages/apostrophe/test/ai-generate.js
+++ b/packages/apostrophe/test/ai-generate.js
@@ -291,6 +291,149 @@ describe('AI generate', function() {
         'long'
       );
     });
+
+    it('validates pending and the trailing-calls rules', function() {
+      const call = (id) => ({
+        type: 'toolCall',
+        id,
+        name: 'echo',
+        input: {}
+      });
+      const pendingMessages = [
+        {
+          role: 'user',
+          content: 'go'
+        },
+        {
+          role: 'assistant',
+          content: [ call('c1') ]
+        }
+      ];
+      // A partial trailing tool message is the same pending state
+      const partial = [
+        {
+          role: 'user',
+          content: 'go'
+        },
+        {
+          role: 'assistant',
+          content: [ call('c1'), call('c2') ]
+        },
+        {
+          role: 'tool',
+          content: [ {
+            type: 'toolResult',
+            toolCallId: 'c1',
+            output: { ok: true }
+          } ]
+        }
+      ];
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions('p', { pending: 'maybe' }),
+        /"pending" must be "refuse" or "execute"/
+      );
+      // The default refuses both pending shapes with the clear message
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions({ messages: pendingMessages }),
+        /ends in unanswered tool calls/
+      );
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions({ messages: partial }),
+        /ends in unanswered tool calls/
+      );
+      // 'execute' computes the unanswered calls, in model order
+      const canonical = apos.ai.normalizeGenerateOptions({
+        messages: partial,
+        pending: 'execute'
+      });
+      assert.deepEqual(
+        canonical.pendingCalls.map((pendingCall) => pendingCall.id),
+        [ 'c2' ]
+      );
+      // A complete transcript has nothing pending: 'execute' is a no-op
+      assert.equal(
+        apos.ai.normalizeGenerateOptions('p', { pending: 'execute' }).pendingCalls,
+        null
+      );
+      // A prompt cannot bury unanswered calls
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions('p', {
+          messages: pendingMessages,
+          pending: 'execute'
+        }),
+        /a prompt cannot be appended to a transcript ending in unanswered tool calls/
+      );
+      // A trailing tool message must answer its own assistant turn
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions({
+          messages: [
+            partial[0],
+            partial[1],
+            {
+              role: 'tool',
+              content: [ {
+                type: 'toolResult',
+                toolCallId: 'zz',
+                output: {}
+              } ]
+            }
+          ]
+        }),
+        /answers "zz", which the preceding assistant turn did not request/
+      );
+    });
+
+    it('validates toolInput against the trailing calls', function() {
+      const messages = [
+        {
+          role: 'user',
+          content: 'go'
+        },
+        {
+          role: 'assistant',
+          content: [ {
+            type: 'toolCall',
+            id: 'c1',
+            name: 'echo',
+            input: {}
+          } ]
+        }
+      ];
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions('p', { toolInput: {} }),
+        /"toolInput" requires pending: "execute"/
+      );
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions('p', {
+          pending: 'execute',
+          toolInput: 'yes'
+        }),
+        /"toolInput" must map tool call ids to input objects/
+      );
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions({
+          messages,
+          pending: 'execute',
+          toolInput: { c1: 'yes' }
+        }),
+        /"toolInput" must map tool call ids to input objects/
+      );
+      // Every key must name an unanswered trailing call
+      throwsInvalid(
+        () => apos.ai.normalizeGenerateOptions({
+          messages,
+          pending: 'execute',
+          toolInput: { c9: { answered: true } }
+        }),
+        /"toolInput" answers "c9", which is not an unanswered trailing tool call/
+      );
+      const canonical = apos.ai.normalizeGenerateOptions({
+        messages,
+        pending: 'execute',
+        toolInput: { c1: { answered: true } }
+      });
+      assert.deepEqual(canonical.toolInput, { c1: { answered: true } });
+    });
   });
 
   describe('message normalization', function() {

--- a/packages/apostrophe/test/ai-generate.js
+++ b/packages/apostrophe/test/ai-generate.js
@@ -306,13 +306,15 @@ describe('AI generate', function() {
     it('rebuilds text and image parts in canonical form', function() {
       const normalized = apos.ai.normalizeMessages([ {
         role: 'user',
-        // Extra properties, as on a stored transcript, do not travel
+        // App metadata on a message, as on a stored transcript, does not
+        // travel; a property on a part does, because that is where a
+        // dialect puts its own artifacts
         _id: 'stored',
         content: [
           {
             type: 'text',
             text: 'describe this',
-            stray: true
+            dialectArtifact: true
           },
           {
             type: 'image',
@@ -333,7 +335,8 @@ describe('AI generate', function() {
         content: [
           {
             type: 'text',
-            text: 'describe this'
+            text: 'describe this',
+            dialectArtifact: true
           },
           {
             type: 'image',
@@ -359,7 +362,9 @@ describe('AI generate', function() {
             id: 'call_1',
             name: 'find_pages',
             input: { query: 'pricing' },
-            extra: 'dropped'
+            // A dialect's own artifact on an ordinary part: kept, because
+            // the provider that made it needs it back
+            thoughtSignature: 'sig'
           } ]
         },
         {
@@ -385,7 +390,8 @@ describe('AI generate', function() {
             type: 'toolCall',
             id: 'call_1',
             name: 'find_pages',
-            input: { query: 'pricing' }
+            input: { query: 'pricing' },
+            thoughtSignature: 'sig'
           } ]
         },
         {
@@ -491,6 +497,66 @@ describe('AI generate', function() {
           } ]
         } ]),
         /messages\[0\]\.content\[0\]\.image must be an object/
+      );
+    });
+
+    it('replays a provider\'s own artifacts, so a returned transcript resumes', function() {
+      const transcript = [
+        {
+          role: 'user',
+          content: 'why?'
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'thinking',
+              block: {
+                signature: 'opaque',
+                thinking: 'because'
+              }
+            },
+            {
+              type: 'text',
+              text: 'because.',
+              thoughtSignature: 'sig'
+            },
+            {
+              type: 'toolCall',
+              id: 'call-1',
+              name: 'find_pages',
+              input: {},
+              thoughtSignature: 'sig2'
+            }
+          ]
+        }
+      ];
+      const normalized = apos.ai.normalizeMessages(transcript);
+      // The dialect's own part type, untouched
+      assert.deepEqual(normalized[1].content[0], transcript[1].content[0]);
+      // And its signature on parts we do understand
+      assert.equal(normalized[1].content[1].thoughtSignature, 'sig');
+      assert.equal(normalized[1].content[1].text, 'because.');
+      assert.equal(normalized[1].content[2].thoughtSignature, 'sig2');
+      assert.equal(normalized[1].content[2].name, 'find_pages');
+      // A copy, never the caller's own objects
+      assert.notEqual(normalized[1].content[0], transcript[1].content[0]);
+    });
+
+    it('refuses an unknown part type outside an assistant turn', function() {
+      throwsInvalid(
+        () => apos.ai.normalizeMessages([ {
+          role: 'user',
+          content: [ { type: 'thinking' } ]
+        } ]),
+        /messages\[0\]\.content\[0\]\.type "thinking" is unknown/
+      );
+      throwsInvalid(
+        () => apos.ai.normalizeMessages([ {
+          role: 'assistant',
+          content: [ { type: '' } ]
+        } ]),
+        /messages\[0\]\.content\[0\]\.type "" is unknown/
       );
     });
   });

--- a/packages/apostrophe/test/ai-generate.js
+++ b/packages/apostrophe/test/ai-generate.js
@@ -66,7 +66,7 @@ describe('AI generate', function() {
             self.apos.ai.addTool({
               name: 'echo',
               description: 'Echo the text back',
-              access: 'read',
+              kind: 'query',
               input: {
                 type: 'object',
                 properties: { text: { type: 'string' } }

--- a/packages/apostrophe/test/ai-job.js
+++ b/packages/apostrophe/test/ai-job.js
@@ -106,7 +106,10 @@ describe('AI generateJob', function() {
               name: 'ask',
               description: 'The ask tool.',
               input: okInput,
-              handler: async () => {
+              handler: async (req, args) => {
+                if (args._context.input !== undefined) {
+                  return { ...args._context.input };
+                }
                 throw self.apos.error('aiInput', 'needs the editor', {
                   questions: [ 'Which one?' ]
                 });
@@ -245,6 +248,39 @@ describe('AI generateJob', function() {
     // The stored transcript ends in the partial tool message
     assert.equal(job.results.messages.at(-1).role, 'tool');
     assert.deepEqual(job.results.toolCalls.map(call => call.id), [ 'c2' ]);
+  });
+
+  it('a suspended job continues in a new job with the answer', async function() {
+    const req = apos.task.getReq({ user: { _id: 'owner1' } });
+    chatScript = [
+      toolTurn(toolCall('c1', 'echo'), toolCall('c2', 'ask'))
+    ];
+    const { jobId } = await apos.ai.generateJob(req, 'go', {
+      tools: [ 'echo', 'ask' ]
+    });
+    const job = await waitForJob(jobId);
+    assert.equal(job.results.finishReason, 'input');
+
+    chatScript = [ textTurn('resumed') ];
+    const { jobId: secondId } = await apos.ai.generateJob(req, {
+      messages: job.results.messages,
+      tools: [ 'echo', 'ask' ],
+      pending: 'execute',
+      toolInput: { c2: { answered: true } }
+    });
+    const second = await waitForJob(secondId);
+
+    assert.equal(second.status, 'completed');
+    assert.equal(second.results.finishReason, 'stop');
+    assert.equal(second.results.text, 'resumed');
+    assert.deepEqual(second.results.steps, [ {
+      toolCall: toolCall('c2', 'ask'),
+      result: { answered: true }
+    } ]);
+    // The stored transcript's tool message is complete, in call order
+    const tool = second.results.messages.at(-2);
+    assert.deepEqual(tool.content.map(part => part.toolCallId),
+      [ 'c1', 'c2' ]);
   });
 
   it('fires onMessage with the jobId and onEnd with the result', async function() {

--- a/packages/apostrophe/test/ai-job.js
+++ b/packages/apostrophe/test/ai-job.js
@@ -102,6 +102,16 @@ describe('AI generateJob', function() {
               input: okInput,
               handler: async () => ({ ok: true })
             });
+            self.apos.ai.addTool({
+              name: 'ask',
+              description: 'The ask tool.',
+              input: okInput,
+              handler: async () => {
+                throw self.apos.error('aiInput', 'needs the editor', {
+                  questions: [ 'Which one?' ]
+                });
+              }
+            });
             // Ignores the abort signal: runs until the test releases it
             self.apos.ai.addTool({
               name: 'gate',
@@ -212,6 +222,29 @@ describe('AI generateJob', function() {
     assert.deepEqual(job.results, blocking);
     assert.equal(job.userId, 'owner1');
     assert.equal(job.expireAt instanceof Date, true);
+  });
+
+  it('a suspended run ends the job complete with the input finish reason', async function() {
+    const req = apos.task.getReq({ user: { _id: 'owner1' } });
+    chatScript = [
+      toolTurn(toolCall('c1', 'echo'), toolCall('c2', 'ask'))
+    ];
+
+    const { jobId } = await apos.ai.generateJob(req, 'go', {
+      tools: [ 'echo', 'ask' ]
+    });
+    const job = await waitForJob(jobId);
+
+    assert.equal(job.status, 'completed');
+    assert.equal(job.results.finishReason, 'input');
+    assert.deepEqual(job.results.suspended, [ {
+      callId: 'c2',
+      name: 'ask',
+      payload: { questions: [ 'Which one?' ] }
+    } ]);
+    // The stored transcript ends in the partial tool message
+    assert.equal(job.results.messages.at(-1).role, 'tool');
+    assert.deepEqual(job.results.toolCalls.map(call => call.id), [ 'c2' ]);
   });
 
   it('fires onMessage with the jobId and onEnd with the result', async function() {

--- a/packages/apostrophe/test/ai-job.js
+++ b/packages/apostrophe/test/ai-job.js
@@ -245,7 +245,10 @@ describe('AI generateJob', function() {
         role: 'assistant',
         content: [ toolCall('c1', 'echo') ]
       },
-      meta: { jobId }
+      meta: {
+        step: 1,
+        jobId
+      }
     } ]);
     assert.equal(ended.err, null);
     assert.equal(ended.result.finishReason, 'stop');
@@ -445,7 +448,7 @@ describe('AI generateJob', function() {
     ]);
   });
 
-  it('publishes started, per-turn and ended events over bus notifications', async function() {
+  it('publishes started, per-turn, per-tool-call and ended events over bus notifications', async function() {
     const req = apos.task.getReq({ user: { _id: 'owner1' } });
     const seen = [];
     chatScript = [
@@ -467,6 +470,8 @@ describe('AI generateJob', function() {
       [
         [ 'ai-generate-job', 'started', jobId ],
         [ 'ai-generate-job', 'message', jobId ],
+        [ 'ai-generate-job', 'tool', jobId ],
+        [ 'ai-generate-job', 'tool', jobId ],
         [ 'ai-generate-job', 'ended', jobId ]
       ]
     );
@@ -474,7 +479,7 @@ describe('AI generateJob', function() {
       role: 'assistant',
       content: [ toolCall('c1', 'echo') ]
     });
-    assert.deepEqual(events[2].data, {
+    assert.deepEqual(events[4].data, {
       jobId,
       stage: 'ended',
       status: 'completed',
@@ -494,8 +499,68 @@ describe('AI generateJob', function() {
         userId: 'owner1',
         bus: true
       }),
-      3
+      5
     );
+  });
+
+  it('a tool stage reports the call, not its result', async function() {
+    const req = apos.task.getReq({ user: { _id: 'owner1' } });
+    chatScript = [
+      toolTurn(toolCall('c1', 'echo'), toolCall('c2', 'nosuchtool')),
+      textTurn('all done')
+    ];
+
+    const { jobId } = await apos.ai.generateJob(req, 'go', { tools: [ 'echo' ] });
+    await waitForJob(jobId);
+
+    const tools = triggered
+      .map(({ options }) => options.event.data)
+      .filter((data) => data.stage === 'tool');
+    // The call naming no registered tool never starts, so it is not
+    // reported; the size of the result stands in for the result
+    assert.deepEqual(tools, [
+      {
+        jobId,
+        stage: 'tool',
+        phase: 'start',
+        id: 'c1',
+        name: 'echo',
+        step: 1
+      },
+      {
+        jobId,
+        stage: 'tool',
+        phase: 'end',
+        id: 'c1',
+        name: 'echo',
+        step: 1,
+        chars: JSON.stringify({ ok: true }).length
+      }
+    ]);
+  });
+
+  it('a caller hook sees the whole event, the wire sees the summary', async function() {
+    const req = apos.task.getReq({ user: { _id: 'owner1' } });
+    const seen = [];
+    chatScript = [
+      toolTurn(toolCall('c1', 'echo')),
+      textTurn('all done')
+    ];
+
+    const { jobId } = await apos.ai.generateJob(req, 'go', {
+      tools: [ 'echo' ],
+      onToolCall(event, meta) {
+        seen.push({
+          event,
+          meta
+        });
+      }
+    });
+    await waitForJob(jobId);
+
+    assert.deepEqual(seen.map(({ event }) => event.phase), [ 'start', 'end' ]);
+    assert.deepEqual(seen[1].event.result, { ok: true });
+    assert.deepEqual(seen[0].meta, { jobId });
   });
 
   it('a failed run publishes an ended event carrying the error', async function() {

--- a/packages/apostrophe/test/ai-job.js
+++ b/packages/apostrophe/test/ai-job.js
@@ -96,12 +96,10 @@ describe('AI generateJob', function() {
               type: 'object',
               properties: {}
             };
-            const okSchema = { ok: { type: 'boolean' } };
             self.apos.ai.addTool({
               name: 'echo',
               description: 'The echo tool.',
               input: okInput,
-              schema: okSchema,
               handler: async () => ({ ok: true })
             });
             // Ignores the abort signal: runs until the test releases it
@@ -109,7 +107,6 @@ describe('AI generateJob', function() {
               name: 'gate',
               description: 'The gate tool.',
               input: okInput,
-              schema: okSchema,
               handler: async () => {
                 if (gateNotify) {
                   gateNotify();
@@ -125,7 +122,6 @@ describe('AI generateJob', function() {
               name: 'until_abort',
               description: 'The until_abort tool.',
               input: okInput,
-              schema: { sawAbort: { type: 'boolean' } },
               handler: async (req, args) => {
                 if (abortNotify) {
                   abortNotify();

--- a/packages/apostrophe/test/ai-providers.js
+++ b/packages/apostrophe/test/ai-providers.js
@@ -82,8 +82,10 @@ describe('AI: named providers and baseUrl', function() {
                 apiKey: 'gsk-test',
                 models: {
                   'llama-3.1-8b-instant': {
+                    label: 'Llama 3.1 8B Instant',
                     contextWindow: 131072,
-                    maxOutputTokens: 8192
+                    maxOutputTokens: 8192,
+                    reasoning: [ 'none', 'low' ]
                   },
                   'llama-3.3-70b-versatile': {
                     contextWindow: 131072,
@@ -165,6 +167,78 @@ describe('AI: named providers and baseUrl', function() {
     apos.ai.checkCapability('anthropic', 'text');
   });
 
+  describe('modelCatalog', function() {
+    it('reports the effort table with its default level', function() {
+      const catalog = apos.ai.modelCatalog();
+      assert.equal(catalog.effort.default, 'medium');
+      assert.deepEqual(catalog.effort.levels.low, {
+        provider: 'groq',
+        model: 'llama-3.1-8b-instant'
+      });
+      assert.deepEqual(catalog.effort.levels.medium, {
+        provider: 'groq',
+        model: 'llama-3.3-70b-versatile'
+      });
+    });
+
+    it('reports each provider with its adapter label and merged models', function() {
+      const catalog = apos.ai.modelCatalog();
+      assert.deepEqual(
+        Object.keys(catalog.providers).sort(),
+        [ 'anthropic', 'groq' ]
+      );
+      assert.equal(catalog.providers.groq.label, 'OpenAI Completions');
+      assert.equal(catalog.providers.groq.capabilities.image, false);
+      // The entry's own declarations, label and reasoning included
+      assert.deepEqual(catalog.providers.groq.models['llama-3.1-8b-instant'], {
+        label: 'Llama 3.1 8B Instant',
+        contextWindow: 131072,
+        maxOutputTokens: 8192,
+        reasoning: [ 'none', 'low' ]
+      });
+      // A model declaring no reasoning simply carries none
+      assert.equal(
+        catalog.providers.groq.models['llama-3.3-70b-versatile'].reasoning,
+        undefined
+      );
+    });
+
+    it('reports the anthropic adapter\'s own declarations', function() {
+      const { models } = apos.ai.modelCatalog().providers.anthropic;
+      assert.equal(models['claude-sonnet-5'].label, 'Sonnet 5');
+      assert.deepEqual(
+        models['claude-sonnet-5'].reasoning,
+        [ 'low', 'medium', 'high', 'xhigh', 'max' ]
+      );
+      assert.deepEqual(
+        models['claude-haiku-4-5'].reasoning,
+        [ 'low', 'medium', 'high' ]
+      );
+    });
+
+    it('returns copies, never the registry', function() {
+      const catalog = apos.ai.modelCatalog();
+      catalog.effort.levels.low.model = 'clobbered';
+      delete catalog.effort.levels.medium;
+      catalog.providers.groq.label = 'clobbered';
+      catalog.providers.groq.models['llama-3.1-8b-instant'].reasoning
+        .push('clobbered');
+      catalog.providers.groq.capabilities.text = false;
+      const fresh = apos.ai.modelCatalog();
+      assert.equal(fresh.effort.levels.low.model, 'llama-3.1-8b-instant');
+      assert.deepEqual(fresh.effort.levels.medium, {
+        provider: 'groq',
+        model: 'llama-3.3-70b-versatile'
+      });
+      assert.equal(fresh.providers.groq.label, 'OpenAI Completions');
+      assert.deepEqual(
+        fresh.providers.groq.models['llama-3.1-8b-instant'].reasoning,
+        [ 'none', 'low' ]
+      );
+      assert.equal(fresh.providers.groq.capabilities.text, true);
+    });
+  });
+
   describe('the wire, for real', function() {
     it('generates through the stub host with zero adapter code', async function() {
       const result = await apos.ai.generate(
@@ -206,6 +280,17 @@ describe('AI: named providers and baseUrl', function() {
       const [ hit ] = hits;
       assert.equal(hit.body.model, 'llama-3.3-70b-versatile');
       assert.equal(hit.body.max_completion_tokens, 32768);
+    });
+
+    it('passes a reasoning value outside the declaration through untouched', async function() {
+      // The declared list is catalog information, not a gate: the
+      // adapter and the service keep their own rejections
+      await apos.ai.generate(apos.task.getReq(), 'p', {
+        effort: 'low',
+        reasoning: 'undeclared'
+      });
+      const [ hit ] = hits;
+      assert.equal(hit.body.reasoning_effort, 'undeclared');
     });
   });
 

--- a/packages/apostrophe/test/ai-smoke.js
+++ b/packages/apostrophe/test/ai-smoke.js
@@ -61,7 +61,7 @@ function echoTool() {
   return {
     name: 'echo',
     description: 'Echo the value back',
-    access: 'read',
+    kind: 'query',
     input: {
       type: 'object',
       properties: { value: { type: 'string' } },

--- a/packages/apostrophe/test/ai-smoke.js
+++ b/packages/apostrophe/test/ai-smoke.js
@@ -67,7 +67,6 @@ function echoTool() {
       properties: { value: { type: 'string' } },
       required: [ 'value' ]
     },
-    schema: { value: { type: 'string' } },
     handler: (req, args) => ({ value: args.value })
   };
 }

--- a/packages/apostrophe/test/ai-tools.js
+++ b/packages/apostrophe/test/ai-tools.js
@@ -18,7 +18,7 @@ describe('AI tools', function() {
               name: 'find_pages',
               description: 'Search pages. Use when the user asks about existing content.',
               tags: [ 'content', 'pages' ],
-              access: 'read',
+              kind: 'query',
               input: {
                 type: 'object',
                 properties: {
@@ -184,13 +184,13 @@ describe('AI tools', function() {
     it('activates canonical definitions', function() {
       const tool = apos.ai.getTool('find_pages');
       assert.deepEqual(Object.keys(tool).sort(), [
-        'access', 'description', 'handler', 'input', 'label',
+        'description', 'handler', 'input', 'kind', 'label',
         'maxResultChars', 'name', 'schema', 'tags', 'validateArgs',
         'validateResult'
       ]);
       assert.equal(tool.label, 'Find Pages');
       assert.deepEqual(tool.tags, [ 'content', 'pages' ]);
-      assert.equal(tool.access, 'read');
+      assert.equal(tool.kind, 'query');
       assert.equal(typeof tool.handler, 'function');
       assert.equal(typeof tool.validateArgs, 'function');
       // The result schema is JSON Schema, kept as registered, with its
@@ -199,10 +199,10 @@ describe('AI tools', function() {
       assert.equal(typeof tool.validateResult, 'function');
     });
 
-    it('keeps an explicit label, defaults access to write, tags and schema to none', function() {
+    it('keeps an explicit label, defaults kind to action, tags and schema to none', function() {
       const tool = apos.ai.getTool('create_page');
       assert.equal(tool.label, 'Add a page');
-      assert.equal(tool.access, 'write');
+      assert.equal(tool.kind, 'action');
       const plain = apos.ai.getTool('no_object');
       assert.deepEqual(plain.tags, []);
       // The result schema is optional
@@ -350,8 +350,8 @@ describe('AI tools', function() {
       }), /"schema" is not a valid JSON Schema.*propreties/);
     });
 
-    it('panics on a bad access value', async function() {
-      await failsToBoot(minimal({ access: 'delete' }), /"access" must be "read", "write" or "agent"/);
+    it('panics on a bad kind value', async function() {
+      await failsToBoot(minimal({ kind: 'delete' }), /"kind" must be "query", "action" or "agent"/);
     });
 
     it('panics on a bad result budget', async function() {
@@ -666,12 +666,12 @@ describe('AI tools', function() {
               });
               add({
                 name: 'read_a',
-                access: 'read',
+                kind: 'query',
                 handler: track('read_a')
               });
               add({
                 name: 'read_b',
-                access: 'read',
+                kind: 'query',
                 handler: track('read_b')
               });
               add({
@@ -684,7 +684,7 @@ describe('AI tools', function() {
               });
               add({
                 name: 'agent_a',
-                access: 'agent',
+                kind: 'agent',
                 handler: track('agent_a')
               });
               add({
@@ -711,7 +711,7 @@ describe('AI tools', function() {
               });
               add({
                 name: 'sub_agent',
-                access: 'agent',
+                kind: 'agent',
                 handler: async (req, args) => {
                   depths.push([ 'sub_agent', args._context.depth ]);
                   const inner = await self.apos.ai.generate(req, 'inner question', {
@@ -722,7 +722,7 @@ describe('AI tools', function() {
               });
               add({
                 name: 'sub_sub',
-                access: 'agent',
+                kind: 'agent',
                 handler: async (req) => {
                   const inner = await self.apos.ai.generate(req, 'nested', {
                     tools: [ 'sub_agent', 'echo' ]
@@ -739,7 +739,7 @@ describe('AI tools', function() {
               });
               add({
                 name: 'sub_deep',
-                access: 'agent',
+                kind: 'agent',
                 handler: async (req) => {
                   await self.apos.ai.generate(req, 'inner', {
                     tools: [ 'spawner' ]
@@ -1102,7 +1102,7 @@ describe('AI tools', function() {
       assert.equal(chatCalls[0].schema.type, 'object');
     });
 
-    it('runs reads in parallel first, then writes serially in model order', async function() {
+    it('runs queries in parallel first, then actions serially in model order', async function() {
       const req = apos.task.getReq();
       let release;
       const opened = new Promise((resolve) => {
@@ -1357,7 +1357,7 @@ describe('AI tools', function() {
       const req = apos.task.getReq();
       chatScript = [
         toolTurn(toolCall('c1', 'sub_deep')),
-        // The subagent's conversation requests a plain write tool,
+        // The subagent's conversation requests a plain action tool,
         // whose handler tries to generate again
         toolTurn(toolCall('c2', 'spawner'))
       ];

--- a/packages/apostrophe/test/ai-tools.js
+++ b/packages/apostrophe/test/ai-tools.js
@@ -23,7 +23,10 @@ describe('AI tools', function() {
                 type: 'object',
                 properties: {
                   query: { type: 'string' },
-                  limit: { type: 'integer' }
+                  limit: {
+                    type: 'integer',
+                    default: 10
+                  }
                 },
                 required: [ 'query' ]
               },
@@ -73,9 +76,24 @@ describe('AI tools', function() {
                 type: 'object',
                 properties: {}
               },
+              // Under budget: the result passes through untouched
+              maxResultChars: 10000,
               handler: async () => ({
                 count: '5',
                 anything: 'goes'
+              })
+            });
+            self.apos.ai.addTool({
+              name: 'bulky',
+              description: 'Returns more than its result budget.',
+              input: {
+                type: 'object',
+                properties: {}
+              },
+              maxResultChars: 80,
+              handler: async () => ({
+                ok: true,
+                blob: 'x'.repeat(200)
               })
             });
             self.apos.ai.addTool({
@@ -166,8 +184,9 @@ describe('AI tools', function() {
     it('activates canonical definitions', function() {
       const tool = apos.ai.getTool('find_pages');
       assert.deepEqual(Object.keys(tool).sort(), [
-        'access', 'description', 'handler', 'input', 'label', 'name',
-        'schema', 'tags', 'validateArgs', 'validateResult'
+        'access', 'description', 'handler', 'input', 'label',
+        'maxResultChars', 'name', 'schema', 'tags', 'validateArgs',
+        'validateResult'
       ]);
       assert.equal(tool.label, 'Find Pages');
       assert.deepEqual(tool.tags, [ 'content', 'pages' ]);
@@ -217,8 +236,9 @@ describe('AI tools', function() {
       assert.deepEqual(
         apos.ai.getTools().map(tool => tool.name).sort(),
         [
-          'create_page', 'find_pages', 'forbidden_tool', 'no_object',
-          'schemaless', 'send_email', 'tool_trouble', 'wrong_shape'
+          'bulky', 'create_page', 'find_pages', 'forbidden_tool',
+          'no_object', 'schemaless', 'send_email', 'tool_trouble',
+          'wrong_shape'
         ]
       );
       assert.deepEqual(
@@ -334,6 +354,11 @@ describe('AI tools', function() {
       await failsToBoot(minimal({ access: 'delete' }), /"access" must be "read", "write" or "agent"/);
     });
 
+    it('panics on a bad result budget', async function() {
+      await failsToBoot(minimal({ maxResultChars: 0 }), /"maxResultChars" must be a positive integer/);
+      await failsToBoot(minimal({ maxResultChars: 'big' }), /"maxResultChars" must be a positive integer/);
+    });
+
     it('panics on an unresolvable handler', async function() {
       await failsToBoot(minimal({ handler: 42 }), /"handler" must be a function or a "moduleName:methodName" string/);
       await failsToBoot(minimal({ handler: 'findPages' }), /must name a module and a method/);
@@ -381,6 +406,20 @@ describe('AI tools', function() {
         count: '5',
         anything: 'goes'
       });
+    });
+
+    it('applies input-schema defaults to the args, never to the transcript', async function() {
+      const req = apos.task.getReq();
+      const call = {
+        id: 'call_1',
+        name: 'find_pages',
+        input: { query: 'pricing' }
+      };
+      await apos.ai.executeToolCall(req, apos.ai.getTool('find_pages'), call);
+      // The handler received the declared default
+      assert.equal(seen.args.limit, 10);
+      // The recorded call still reads exactly as the model made it
+      assert.deepEqual(call.input, { query: 'pricing' });
     });
 
     it('injects _context after validation, replacing any model-provided value', async function() {
@@ -447,6 +486,24 @@ describe('AI tools', function() {
         (e) => {
           assert.equal(e.name, 'forbidden');
           assert.equal(e.message, 'not for you');
+          return true;
+        }
+      );
+    });
+
+    it('withholds an oversized result and reports the sizes to the model', async function() {
+      const req = apos.task.getReq();
+      await assert.rejects(
+        apos.ai.executeToolCall(req, apos.ai.getTool('bulky'), {
+          id: 'call_1',
+          name: 'bulky',
+          input: {}
+        }),
+        (e) => {
+          assert.equal(e.name, 'aiToolError');
+          assert.match(e.message, /too large: 221 characters against the tool's budget of 80/);
+          // Largest first, so the model sees what to narrow
+          assert.match(e.message, /largest properties: blob \(202\), ok \(4\)/);
           return true;
         }
       );

--- a/packages/apostrophe/test/ai-tools.js
+++ b/packages/apostrophe/test/ai-tools.js
@@ -757,6 +757,21 @@ describe('AI tools', function() {
                 }
               });
               add({
+                name: 'ask_answer',
+                handler: async (req, args) => {
+                  log.push('start:ask_answer');
+                  if (args._context.input === undefined) {
+                    throw self.apos.error('aiInput', 'needs the editor', {
+                      questions: [ 'Which color?' ]
+                    });
+                  }
+                  return {
+                    answered: true,
+                    ...args._context.input
+                  };
+                }
+              });
+              add({
                 name: 'ask_query',
                 kind: 'query',
                 handler: async () => {
@@ -1501,6 +1516,133 @@ describe('AI tools', function() {
         finish: 'stop',
         report: 'a delegated run cannot wait for input'
       });
+    });
+
+    it('continues a suspended transcript, the answer on _context.input', async function() {
+      const req = apos.task.getReq();
+      const tools = [ 'read_a', 'ask_answer', 'write_b' ];
+      chatScript = [
+        toolTurn(
+          toolCall('c1', 'read_a'),
+          toolCall('c2', 'ask_answer'),
+          toolCall('c3', 'write_b')
+        )
+      ];
+      const first = await apos.ai.generate(req, 'go', { tools });
+      assert.equal(first.finishReason, 'input');
+
+      chatCalls = [];
+      chatScript = [ textTurn('continued') ];
+      const events = [];
+      const second = await apos.ai.generate(req, {
+        messages: first.messages,
+        tools,
+        pending: 'execute',
+        toolInput: { c2: { color: 'blue' } },
+        onToolCall: async (event) => events.push(event)
+      });
+
+      assert.equal(second.text, 'continued');
+      assert.equal(second.finishReason, 'stop');
+      // Only the unanswered calls ran, in model order — the answered
+      // read travels as recorded outcome, never re-run
+      assert.deepEqual(second.steps, [
+        {
+          toolCall: toolCall('c2', 'ask_answer'),
+          result: {
+            answered: true,
+            color: 'blue'
+          }
+        },
+        {
+          toolCall: toolCall('c3', 'write_b'),
+          result: { ok: true }
+        }
+      ]);
+      // The trailing tool message was completed in the assistant
+      // turn's call order before the model saw anything
+      const sent = chatCalls[0].messages;
+      assert.deepEqual(sent.map(message => message.role),
+        [ 'user', 'assistant', 'tool' ]);
+      assert.deepEqual(sent.at(-1).content.map(part => part.toolCallId),
+        [ 'c1', 'c2', 'c3' ]);
+      assert.deepEqual(sent.at(-1).content[1].output, {
+        answered: true,
+        color: 'blue'
+      });
+      // Continuation work reports at step 0, serial in model order
+      assert.deepEqual(
+        events.map(event => [ event.phase, event.call.id, event.step ]),
+        [
+          [ 'start', 'c2', 0 ],
+          [ 'end', 'c2', 0 ],
+          [ 'start', 'c3', 0 ],
+          [ 'end', 'c3', 0 ]
+        ]
+      );
+    });
+
+    it('a continuation without its answer suspends again', async function() {
+      const req = apos.task.getReq();
+      const tools = [ 'read_a', 'ask_answer', 'write_b' ];
+      chatScript = [
+        toolTurn(
+          toolCall('c1', 'read_a'),
+          toolCall('c2', 'ask_answer'),
+          toolCall('c3', 'write_b')
+        )
+      ];
+      const first = await apos.ai.generate(req, 'go', { tools });
+
+      chatCalls = [];
+      chatScript = [];
+      const again = await apos.ai.generate(req, {
+        messages: first.messages,
+        tools,
+        pending: 'execute'
+      });
+
+      assert.equal(again.finishReason, 'input');
+      assert.deepEqual(again.suspended, [ {
+        callId: 'c2',
+        name: 'ask_answer',
+        payload: { questions: [ 'Which color?' ] }
+      } ]);
+      assert.deepEqual(again.toolCalls.map(call => call.id), [ 'c2', 'c3' ]);
+      assert.deepEqual(again.steps, []);
+      // No model call was spent; the trailing message still answers
+      // only the executed read
+      assert.equal(chatCalls.length, 0);
+      assert.deepEqual(again.messages.at(-1).content.map(part => part.toolCallId),
+        [ 'c1' ]);
+    });
+
+    it('a continuation missing the tool feeds the unknown-tool error back', async function() {
+      const req = apos.task.getReq();
+      chatScript = [
+        toolTurn(
+          toolCall('c1', 'read_a'),
+          toolCall('c2', 'ask_answer')
+        )
+      ];
+      const first = await apos.ai.generate(req, 'go', {
+        tools: [ 'read_a', 'ask_answer' ]
+      });
+
+      chatCalls = [];
+      chatScript = [ textTurn('moving on') ];
+      const second = await apos.ai.generate(req, {
+        messages: first.messages,
+        tools: [ 'read_a' ],
+        pending: 'execute',
+        toolInput: { c2: { color: 'blue' } }
+      });
+
+      assert.equal(second.text, 'moving on');
+      const sent = chatCalls[0].messages;
+      assert.deepEqual(sent.at(-1).content.map(part => part.toolCallId),
+        [ 'c1', 'c2' ]);
+      assert.match(sent.at(-1).content[1].error, /unknown tool "ask_answer"/);
     });
 
     it('an agent tool runs a subagent, one level deep', async function() {

--- a/packages/apostrophe/test/ai-tools.js
+++ b/packages/apostrophe/test/ai-tools.js
@@ -28,8 +28,12 @@ describe('AI tools', function() {
                 required: [ 'query' ]
               },
               schema: {
-                found: { type: 'boolean' },
-                summary: { type: 'string' }
+                type: 'object',
+                properties: {
+                  found: { type: 'boolean' },
+                  summary: { type: 'string' }
+                },
+                required: [ 'found', 'summary' ]
               },
               handler: 'tool-handlers:findPages'
             });
@@ -45,7 +49,10 @@ describe('AI tools', function() {
                 }
               },
               schema: {
-                ok: { type: 'boolean' }
+                type: 'object',
+                properties: {
+                  ok: { type: 'boolean' }
+                }
               },
               handler: async () => ({ ok: true })
             });
@@ -57,24 +64,18 @@ describe('AI tools', function() {
                 type: 'object',
                 properties: {}
               },
-              schema: {
-                ok: { type: 'boolean' }
-              },
               handler: async () => ({ ok: 'original' })
             });
             self.apos.ai.addTool({
-              name: 'normalizer',
-              description: 'Returns a result needing coercion.',
+              name: 'schemaless',
+              description: 'Declares no result schema.',
               input: {
                 type: 'object',
                 properties: {}
               },
-              schema: {
-                count: { type: 'integer' }
-              },
               handler: async () => ({
                 count: '5',
-                leaked: 'never'
+                anything: 'goes'
               })
             });
             self.apos.ai.addTool({
@@ -83,9 +84,6 @@ describe('AI tools', function() {
               input: {
                 type: 'object',
                 properties: {}
-              },
-              schema: {
-                ok: { type: 'boolean' }
               },
               handler: async () => {
                 throw self.apos.error('aiToolError', 'the search index is rebuilding');
@@ -98,9 +96,6 @@ describe('AI tools', function() {
                 type: 'object',
                 properties: {}
               },
-              schema: {
-                ok: { type: 'boolean' }
-              },
               handler: async () => {
                 throw self.apos.error('forbidden', 'not for you');
               }
@@ -112,9 +107,6 @@ describe('AI tools', function() {
                 type: 'object',
                 properties: {}
               },
-              schema: {
-                ok: { type: 'boolean' }
-              },
               handler: async () => 'not an object'
             });
             self.apos.ai.addTool({
@@ -125,10 +117,11 @@ describe('AI tools', function() {
                 properties: {}
               },
               schema: {
-                count: {
-                  type: 'integer',
-                  required: true
-                }
+                type: 'object',
+                properties: {
+                  count: { type: 'integer' }
+                },
+                required: [ 'count' ]
               },
               handler: async () => ({ wrong: true })
             });
@@ -139,8 +132,9 @@ describe('AI tools', function() {
                 seen.req = req;
                 seen.args = args;
                 return {
-                  found: 'yes',
-                  summary: 'one match'
+                  found: true,
+                  summary: 'one match',
+                  extra: 'kept'
                 };
               }
             };
@@ -155,9 +149,6 @@ describe('AI tools', function() {
               input: {
                 type: 'object',
                 properties: {}
-              },
-              schema: {
-                ok: { type: 'string' }
               },
               handler: async () => ({ ok: 'replaced' })
             });
@@ -175,26 +166,29 @@ describe('AI tools', function() {
     it('activates canonical definitions', function() {
       const tool = apos.ai.getTool('find_pages');
       assert.deepEqual(Object.keys(tool).sort(), [
-        'access', 'description', 'handler', 'input', 'label',
-        'name', 'schema', 'tags', 'validateArgs'
+        'access', 'description', 'handler', 'input', 'label', 'name',
+        'schema', 'tags', 'validateArgs', 'validateResult'
       ]);
       assert.equal(tool.label, 'Find Pages');
       assert.deepEqual(tool.tags, [ 'content', 'pages' ]);
       assert.equal(tool.access, 'read');
       assert.equal(typeof tool.handler, 'function');
       assert.equal(typeof tool.validateArgs, 'function');
-      assert.deepEqual(
-        tool.schema.map(field => [ field.name, field.type ]),
-        [ [ 'found', 'boolean' ], [ 'summary', 'string' ] ]
-      );
+      // The result schema is JSON Schema, kept as registered, with its
+      // compiled validator alongside
+      assert.deepEqual(Object.keys(tool.schema.properties), [ 'found', 'summary' ]);
+      assert.equal(typeof tool.validateResult, 'function');
     });
 
-    it('keeps an explicit label, defaults access to write and tags to none', function() {
+    it('keeps an explicit label, defaults access to write, tags and schema to none', function() {
       const tool = apos.ai.getTool('create_page');
       assert.equal(tool.label, 'Add a page');
       assert.equal(tool.access, 'write');
       const plain = apos.ai.getTool('no_object');
       assert.deepEqual(plain.tags, []);
+      // The result schema is optional
+      assert.equal(plain.schema, undefined);
+      assert.equal(plain.validateResult, undefined);
     });
 
     it('the last registration of a name wins', async function() {
@@ -224,7 +218,7 @@ describe('AI tools', function() {
         apos.ai.getTools().map(tool => tool.name).sort(),
         [
           'create_page', 'find_pages', 'forbidden_tool', 'no_object',
-          'normalizer', 'send_email', 'tool_trouble', 'wrong_shape'
+          'schemaless', 'send_email', 'tool_trouble', 'wrong_shape'
         ]
       );
       assert.deepEqual(
@@ -288,7 +282,10 @@ describe('AI tools', function() {
         properties: {}
       },
       schema: {
-        ok: { type: 'boolean' }
+        type: 'object',
+        properties: {
+          ok: { type: 'boolean' }
+        }
       },
       handler: async () => ({ ok: true }),
       ...extras
@@ -317,24 +314,20 @@ describe('AI tools', function() {
     });
 
     it('panics on a bad result schema', async function() {
-      await failsToBoot(minimal({ schema: undefined }), /"schema" must be an object of schema fields/);
+      // Missing an object root — including the apos-schema shape the
+      // earlier contract accepted here
+      await failsToBoot(minimal({ schema: { type: 'array' } }), /"schema" must be a JSON Schema with an object root/);
       await failsToBoot(minimal({
         schema: {
-          found: { type: 'nonsense' }
+          found: { type: 'boolean' }
         }
-      }), /Unknown schema field type/);
+      }), /"schema" must be a JSON Schema with an object root/);
       await failsToBoot(minimal({
         schema: {
-          docs: {
-            type: 'array',
-            fields: {
-              add: {
-                title: { type: 'nonsense' }
-              }
-            }
-          }
+          type: 'object',
+          propreties: {}
         }
-      }), /Unknown schema field type/);
+      }), /"schema" is not a valid JSON Schema.*propreties/);
     });
 
     it('panics on a bad access value', async function() {
@@ -353,7 +346,7 @@ describe('AI tools', function() {
   });
 
   describe('executing a tool call', function() {
-    it('runs the handler with req and validated args, returns the converted result', async function() {
+    it('runs the handler with req and validated args, returns the result verbatim', async function() {
       const req = apos.task.getReq();
       const result = await apos.ai.executeToolCall(req, apos.ai.getTool('find_pages'), {
         id: 'call_1',
@@ -369,21 +362,25 @@ describe('AI tools', function() {
         limit: 3,
         _context: {}
       });
-      // Converted: laundered to the schema's types, every field present
+      // Validated, never mutated: undeclared fields survive
       assert.deepEqual(result, {
         found: true,
-        summary: 'one match'
+        summary: 'one match',
+        extra: 'kept'
       });
     });
 
-    it('normalizes the result and drops what the schema does not declare', async function() {
+    it('a tool without a result schema passes any object through', async function() {
       const req = apos.task.getReq();
-      const result = await apos.ai.executeToolCall(req, apos.ai.getTool('normalizer'), {
+      const result = await apos.ai.executeToolCall(req, apos.ai.getTool('schemaless'), {
         id: 'call_1',
-        name: 'normalizer',
+        name: 'schemaless',
         input: {}
       });
-      assert.deepEqual(result, { count: 5 });
+      assert.deepEqual(result, {
+        count: '5',
+        anything: 'goes'
+      });
     });
 
     it('injects _context after validation, replacing any model-provided value', async function() {
@@ -531,7 +528,6 @@ describe('AI tools', function() {
       },
       model: 'fake-medium'
     });
-    const okSchema = { ok: { type: 'boolean' } };
     const okInput = {
       type: 'object',
       properties: {}
@@ -598,7 +594,6 @@ describe('AI tools', function() {
               const add = (tool) => self.apos.ai.addTool({
                 description: `The ${tool.name} tool.`,
                 input: okInput,
-                schema: okSchema,
                 ...tool
               });
               add({
@@ -634,7 +629,11 @@ describe('AI tools', function() {
                   required: [ 'value' ]
                 },
                 schema: {
-                  value: { type: 'string' }
+                  type: 'object',
+                  properties: {
+                    value: { type: 'string' }
+                  },
+                  required: [ 'value' ]
                 },
                 handler: async (req, args) => {
                   log.push('start:echo');
@@ -645,9 +644,6 @@ describe('AI tools', function() {
               add({
                 name: 'sub_agent',
                 access: 'agent',
-                schema: {
-                  value: { type: 'string' }
-                },
                 handler: async (req, args) => {
                   depths.push([ 'sub_agent', args._context.depth ]);
                   const inner = await self.apos.ai.generate(req, 'inner question', {
@@ -659,9 +655,6 @@ describe('AI tools', function() {
               add({
                 name: 'sub_sub',
                 access: 'agent',
-                schema: {
-                  value: { type: 'string' }
-                },
                 handler: async (req) => {
                   const inner = await self.apos.ai.generate(req, 'nested', {
                     tools: [ 'sub_agent', 'echo' ]
@@ -701,10 +694,11 @@ describe('AI tools', function() {
               add({
                 name: 'bad_shape',
                 schema: {
-                  count: {
-                    type: 'integer',
-                    required: true
-                  }
+                  type: 'object',
+                  properties: {
+                    count: { type: 'integer' }
+                  },
+                  required: [ 'count' ]
                 },
                 handler: async () => ({ wrong: true })
               });
@@ -1177,9 +1171,6 @@ describe('AI tools', function() {
                     value: { type: 'string' }
                   },
                   required: [ 'value' ]
-                },
-                schema: {
-                  value: { type: 'string' }
                 },
                 handler: async (req, args) => {
                   log.push(args.value);

--- a/packages/apostrophe/test/ai-tools.js
+++ b/packages/apostrophe/test/ai-tools.js
@@ -385,7 +385,12 @@ describe('AI tools', function() {
       assert.deepEqual(seen.args, {
         query: 'pricing',
         limit: 3,
-        _context: {}
+        _context: {
+          call: {
+            id: 'call_1',
+            name: 'find_pages'
+          }
+        }
       });
       // Validated, never mutated: undeclared fields survive
       assert.deepEqual(result, {
@@ -434,7 +439,13 @@ describe('AI tools', function() {
       };
       const context = { signal: 'the abort signal' };
       await apos.ai.executeToolCall(req, apos.ai.getTool('find_pages'), call, context);
-      assert.deepEqual(seen.args._context, context);
+      assert.deepEqual(seen.args._context, {
+        ...context,
+        call: {
+          id: 'call_1',
+          name: 'find_pages'
+        }
+      });
       // The transcript's own part is never mutated
       assert.equal(call.input._context, 'evil');
     });
@@ -862,6 +873,192 @@ describe('AI tools', function() {
         role: 'assistant',
         content: [ toolCall('c2', 'echo', { value: 'two' }) ]
       } ]);
+    });
+
+    it('onMessage carries the model turn it came from', async function() {
+      const req = apos.task.getReq();
+      const steps = [];
+      chatScript = [
+        toolTurn(toolCall('c1', 'echo', { value: 'one' })),
+        toolTurn(toolCall('c2', 'echo', { value: 'two' })),
+        textTurn('all done')
+      ];
+      await apos.ai.generate(req, 'find it', {
+        tools: [ 'echo' ],
+        onMessage(message, meta) {
+          steps.push(meta.step);
+        }
+      });
+
+      assert.deepEqual(steps, [ 1, 2 ]);
+    });
+
+    it('onToolCall reports every handler that runs, around its run', async function() {
+      const req = apos.task.getReq();
+      const events = [];
+      chatScript = [
+        toolTurn(toolCall('c1', 'echo', { value: 'one' })),
+        toolTurn(toolCall('c2', 'echo', { value: 'two' })),
+        textTurn('all done')
+      ];
+      await apos.ai.generate(req, 'go', {
+        tools: [ 'echo' ],
+        onToolCall(event) {
+          events.push(event);
+          log.push(`${event.phase}:hook`);
+        }
+      });
+
+      assert.deepEqual(events, [
+        {
+          phase: 'start',
+          call: toolCall('c1', 'echo', { value: 'one' }),
+          step: 1
+        },
+        {
+          phase: 'end',
+          call: toolCall('c1', 'echo', { value: 'one' }),
+          result: { value: 'one' },
+          step: 1
+        },
+        {
+          phase: 'start',
+          call: toolCall('c2', 'echo', { value: 'two' }),
+          step: 2
+        },
+        {
+          phase: 'end',
+          call: toolCall('c2', 'echo', { value: 'two' }),
+          result: { value: 'two' },
+          step: 2
+        }
+      ]);
+      // Around the handler, not around the turn
+      assert.deepEqual(log, [
+        'start:hook', 'start:echo', 'end:hook',
+        'start:hook', 'start:echo', 'end:hook'
+      ]);
+    });
+
+    it('onToolCall follows the schedule, and a call with no tool never starts', async function() {
+      const req = apos.task.getReq();
+      const events = [];
+      let release;
+      const opened = new Promise((resolve) => {
+        release = resolve;
+      });
+      readGate = {
+        expected: 2,
+        started: 0,
+        release,
+        opened
+      };
+      chatScript = [
+        toolTurn(
+          toolCall('c1', 'read_a'),
+          toolCall('c2', 'ghost'),
+          toolCall('c3', 'write_a'),
+          toolCall('c4', 'read_b')
+        ),
+        textTurn()
+      ];
+      await apos.ai.generate(req, 'go', {
+        tools: [ 'read_a', 'read_b', 'write_a' ],
+        onToolCall(event) {
+          events.push([ event.phase, event.call.name ]);
+        }
+      });
+
+      // Both reads are reported started before either is reported
+      // finished; the write follows on its own
+      assert.deepEqual(events.slice(0, 2).sort(), [
+        [ 'start', 'read_a' ], [ 'start', 'read_b' ]
+      ]);
+      assert.deepEqual(events.slice(2, 4).sort(), [
+        [ 'end', 'read_a' ], [ 'end', 'read_b' ]
+      ]);
+      assert.deepEqual(events.slice(4), [
+        [ 'start', 'write_a' ], [ 'end', 'write_a' ]
+      ]);
+    });
+
+    it('onToolCall ends a call the model can recover from, and one that stops the run', async function() {
+      const req = apos.task.getReq();
+      const recoverable = [];
+      chatScript = [
+        toolTurn(toolCall('c1', 'boom_recover')),
+        textTurn()
+      ];
+      await apos.ai.generate(req, 'go', {
+        tools: [ 'boom_recover' ],
+        onToolCall(event) {
+          recoverable.push(event);
+        }
+      });
+      assert.equal(recoverable.at(-1).error, 'the search index is rebuilding');
+      assert.equal(recoverable.at(-1).result, undefined);
+
+      const stopping = [];
+      chatScript = [
+        toolTurn(toolCall('c1', 'boom_forbidden'))
+      ];
+      await assert.rejects(
+        apos.ai.generate(req, 'go', {
+          tools: [ 'boom_forbidden' ],
+          onToolCall(event) {
+            stopping.push(event);
+          }
+        }),
+        (e) => {
+          assert.equal(e.name, 'forbidden');
+          return true;
+        }
+      );
+      // A call that started is always reported finished
+      assert.deepEqual(stopping.map((event) => event.phase), [ 'start', 'end' ]);
+      assert.equal(stopping.at(-1).error, 'not for you');
+    });
+
+    it('a throwing onToolCall stops the call, except on the way out', async function() {
+      const req = apos.task.getReq();
+      chatScript = [
+        toolTurn(toolCall('c1', 'echo', { value: 'one' }))
+      ];
+      await assert.rejects(
+        apos.ai.generate(req, 'go', {
+          tools: [ 'echo' ],
+          onToolCall() {
+            throw new Error('hook bug');
+          }
+        }),
+        (e) => {
+          assert.equal(e.message, 'hook bug');
+          return true;
+        }
+      );
+      // It threw on 'start', so the handler never ran
+      assert.deepEqual(log, []);
+
+      // The end report of a handler that is already stopping the run:
+      // the hook's own failure must not replace it
+      chatScript = [
+        toolTurn(toolCall('c1', 'boom_forbidden'))
+      ];
+      await assert.rejects(
+        apos.ai.generate(req, 'go', {
+          tools: [ 'boom_forbidden' ],
+          onToolCall(event) {
+            if (event.phase === 'end') {
+              throw new Error('hook bug');
+            }
+          }
+        }),
+        (e) => {
+          assert.equal(e.name, 'forbidden');
+          assert.equal(e.message, 'not for you');
+          return true;
+        }
+      );
     });
 
     it('combines tools and schema: the loop runs free, the final answer validates', async function() {

--- a/packages/apostrophe/test/ai-tools.js
+++ b/packages/apostrophe/test/ai-tools.js
@@ -748,6 +748,42 @@ describe('AI tools', function() {
                 }
               });
               add({
+                name: 'ask_input',
+                handler: async () => {
+                  log.push('start:ask_input');
+                  throw self.apos.error('aiInput', 'needs the editor', {
+                    questions: [ 'Which color?' ]
+                  });
+                }
+              });
+              add({
+                name: 'ask_query',
+                kind: 'query',
+                handler: async () => {
+                  throw self.apos.error('aiInput', 'needs the editor', { ask: 'q' });
+                }
+              });
+              add({
+                name: 'ask_bare',
+                kind: 'query',
+                handler: async () => {
+                  throw self.apos.error('aiInput', 'needs the editor');
+                }
+              });
+              add({
+                name: 'sub_ask',
+                kind: 'agent',
+                handler: async (req) => {
+                  const inner = await self.apos.ai.generate(req, 'inner', {
+                    tools: [ 'ask_input' ]
+                  });
+                  return {
+                    finish: inner.finishReason,
+                    report: inner.steps[0].error
+                  };
+                }
+              });
+              add({
                 name: 'boom_recover',
                 handler: async () => {
                   throw self.apos.error('aiToolError', 'the search index is rebuilding');
@@ -1304,6 +1340,167 @@ describe('AI tools', function() {
         chatCalls.at(-1).messages.map(message => message.role),
         [ 'user', 'assistant', 'tool' ]
       );
+    });
+
+    it('a suspending action stops the batch and the run ends with the ask', async function() {
+      const req = apos.task.getReq();
+      chatScript = [
+        toolTurn(
+          toolCall('c1', 'read_a'),
+          toolCall('c2', 'ask_input'),
+          toolCall('c3', 'write_b')
+        )
+      ];
+      const events = [];
+      const result = await apos.ai.generate(req, 'go', {
+        tools: [ 'read_a', 'ask_input', 'write_b' ],
+        onToolCall: async (event) => events.push(event)
+      });
+
+      assert.equal(result.finishReason, 'input');
+      assert.equal(result.text, '');
+      assert.deepEqual(result.suspended, [ {
+        callId: 'c2',
+        name: 'ask_input',
+        payload: { questions: [ 'Which color?' ] }
+      } ]);
+      // The suspended call and the unstarted action, in model order
+      assert.deepEqual(result.toolCalls, [
+        toolCall('c2', 'ask_input'),
+        toolCall('c3', 'write_b')
+      ]);
+      assert.deepEqual(result.steps, [ {
+        toolCall: toolCall('c1', 'read_a'),
+        result: { ok: true }
+      } ]);
+      // The transcript ends in the partial tool message answering
+      // only the executed call
+      assert.deepEqual(result.messages.map(message => message.role),
+        [ 'user', 'assistant', 'tool' ]);
+      assert.deepEqual(result.messages.at(-1).content, [ {
+        type: 'toolResult',
+        toolCallId: 'c1',
+        output: { ok: true }
+      } ]);
+      // The action past the suspended call never started; the model
+      // was never asked again
+      assert.ok(!log.includes('start:write_b'));
+      assert.equal(chatCalls.length, 1);
+      // The end report carries the ask; afterToolCall fired for it
+      const end = events.find(
+        (event) => event.call.id === 'c2' && event.phase === 'end'
+      );
+      assert.deepEqual(end.suspended, { questions: [ 'Which color?' ] });
+      assert.ok(toolEvents.some(
+        ([ kind, name ]) => kind === 'after' && name === 'ask_input'
+      ));
+    });
+
+    it('parallel queries suspend together and later actions never start', async function() {
+      const req = apos.task.getReq();
+      chatScript = [
+        toolTurn(
+          toolCall('c1', 'ask_query'),
+          toolCall('c2', 'write_a'),
+          toolCall('c3', 'ask_bare')
+        )
+      ];
+      const result = await apos.ai.generate(req, 'go', {
+        tools: [ 'ask_query', 'write_a', 'ask_bare' ]
+      });
+
+      assert.equal(result.finishReason, 'input');
+      // Both asks, in model order; a throw without data carries {}
+      assert.deepEqual(result.suspended, [
+        {
+          callId: 'c1',
+          name: 'ask_query',
+          payload: { ask: 'q' }
+        },
+        {
+          callId: 'c3',
+          name: 'ask_bare',
+          payload: {}
+        }
+      ]);
+      assert.deepEqual(result.toolCalls.map(call => call.id),
+        [ 'c1', 'c2', 'c3' ]);
+      assert.deepEqual(result.steps, []);
+      // Nothing executed: no partial tool message is appended
+      assert.deepEqual(result.messages.map(message => message.role),
+        [ 'user', 'assistant' ]);
+      assert.ok(!log.includes('start:write_a'));
+    });
+
+    it('an action before the earliest suspended call still runs', async function() {
+      const req = apos.task.getReq();
+      chatScript = [
+        toolTurn(
+          toolCall('c1', 'write_a'),
+          toolCall('c2', 'ask_query')
+        )
+      ];
+      const result = await apos.ai.generate(req, 'go', {
+        tools: [ 'write_a', 'ask_query' ]
+      });
+
+      assert.equal(result.finishReason, 'input');
+      assert.deepEqual(result.steps.map(step => step.toolCall.id), [ 'c1' ]);
+      assert.deepEqual(result.messages.at(-1).content.map(part => part.toolCallId),
+        [ 'c1' ]);
+      assert.deepEqual(result.toolCalls.map(call => call.id), [ 'c2' ]);
+      assert.ok(log.includes('end:write_a'));
+    });
+
+    it('a cancellation observed at the suspension wins', async function() {
+      const req = apos.task.getReq();
+      const controller = new AbortController();
+      chatScript = [
+        toolTurn(
+          toolCall('c1', 'read_a'),
+          toolCall('c2', 'ask_input')
+        )
+      ];
+      const result = await apos.ai.generate(req, 'go', {
+        tools: [ 'read_a', 'ask_input' ],
+        signal: controller.signal,
+        onToolCall: async (event) => {
+          if (event.call.id === 'c2' && event.phase === 'start') {
+            controller.abort();
+          }
+        }
+      });
+
+      assert.equal(result.finishReason, 'cancel');
+      // No ask is surfaced; the recorded work and the pending calls
+      // come back as on any cancel
+      assert.equal(result.suspended, undefined);
+      assert.deepEqual(result.steps.map(step => step.toolCall.id), [ 'c1' ]);
+      assert.deepEqual(result.messages.at(-1).content.map(part => part.toolCallId),
+        [ 'c1' ]);
+      assert.deepEqual(result.toolCalls.map(call => call.id), [ 'c2' ]);
+    });
+
+    it('a subagent tool suspending converts to the recoverable code', async function() {
+      const req = apos.task.getReq();
+      chatScript = [
+        // Outer turn: request the agent tool
+        toolTurn(toolCall('c1', 'sub_ask')),
+        // Inner conversation: the suspend throw converts, the child
+        // model reads the report and adapts
+        toolTurn(toolCall('i1', 'ask_input')),
+        textTurn('adapted'),
+        // Outer conversation resumes
+        textTurn('outer done')
+      ];
+      const result = await apos.ai.generate(req, 'go', { tools: [ 'sub_ask' ] });
+
+      assert.equal(result.finishReason, 'stop');
+      assert.equal(result.text, 'outer done');
+      assert.deepEqual(result.steps[0].result, {
+        finish: 'stop',
+        report: 'a delegated run cannot wait for input'
+      });
     });
 
     it('an agent tool runs a subagent, one level deep', async function() {

--- a/packages/apostrophe/test/ai.js
+++ b/packages/apostrophe/test/ai.js
@@ -532,6 +532,32 @@ describe('AI engine', function() {
       }
     });
 
+    it('answers modelCatalog with the empty shape under mock alone', async function() {
+      // Mock adds nothing to the catalog: it reports configuration,
+      // and `active` answers whether AI is usable
+      process.env.APOS_AI_MOCK = '1';
+      let mockApos;
+      try {
+        mockApos = await t.create({
+          root: module,
+          modules: {
+            '@apostrophecms/ai': {}
+          }
+        });
+        assert.equal(mockApos.ai.active, true);
+        assert.deepEqual(mockApos.ai.modelCatalog(), {
+          effort: {
+            default: 'medium',
+            levels: {}
+          },
+          providers: {}
+        });
+      } finally {
+        delete process.env.APOS_AI_MOCK;
+        await t.destroy(mockApos);
+      }
+    });
+
     describe('activation failures', function() {
       // Activation throws on ready, after every init has run, so the
       // partially booted instance can be captured and destroyed


### PR DESCRIPTION
Exactly what the title says. 

UPDATE: Last moment contract changes and features
- `access: 'read' | 'write' | 'agent'` replaced with `kind: 'query' | 'action' | 'agent'` (clear intent)
- The core engine now supports turn suspension. This was a real blocker. Some tools require user input or some kind of acknowledgment - it became quickly clear that not offering that core feature leads to awful hacks (tools internal blocking via timeout and long Promises). Tools can now throw `aiInput` that suspends the turn. Resume is possible - the caller is responsible for passing the transcript and resume as usual. The implementation was tested with a prototype.
- The change above is deliberate contradiction to the original rule "core doesn't know about flows/transcripts/etc, keep it dead simple". A minimal knowledge is required so that callers have freedom to implement any feature they'd need.