### PR TITLE
fix(rich-text-widget): match most specific style when tags overlap

### DIFF
--- a/.changeset/rich-text-style-selection-bug.md
+++ b/.changeset/rich-text-style-selection-bug.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": patch
+---
+
+Fixed the rich text style picker marking the wrong style as active when multiple styles share the same tag. Styles are now matched in descending order of specificity (number of classes), so a `<p class="small">` correctly shows "Small" as the active style instead of the plain "Paragraph".

--- a/.changeset/rich-text-style-selection-bug.md
+++ b/.changeset/rich-text-style-selection-bug.md
@@ -2,4 +2,4 @@
 "apostrophe": patch
 ---
 
-Fixed the rich text style picker marking the wrong style as active when multiple styles share the same tag. Styles are now matched in descending order of specificity (number of classes), so a `<p class="small">` correctly shows "Small" as the active style instead of the plain "Paragraph".
+Fixed the rich text style picker marking the wrong style as active when multiple styles share the same tag. Styles are now matched in descending order of specificity (number of classes), so a `<p class="small">` correctly shows "Small" as the active style instead of the plain "Paragraph". The matching logic moved to `findActiveStyleIndex`, covered by unit tests.

--- a/packages/apostrophe/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapStyles.vue
+++ b/packages/apostrophe/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapStyles.vue
@@ -118,11 +118,24 @@ export default {
           if (activeEls[0].name === 'defaultNode') {
             return 1;
           } else {
-            const match = nodes.findIndex(node =>
+            // Match the most specific style first. When several styles
+            // share the same tag (e.g. a plain `<p>` and a `<p class="small">`)
+            // a `<p class="small">` would otherwise match the generic `<p>`
+            // style, marking the wrong option as active. We sort a copy of
+            // the nodes by descending class count and pick the first match,
+            // then resolve it back to its original index so the dropdown
+            // (which keeps the original order) highlights the correct option.
+            const sortedNodes = [ ...nodes ].sort((a, b) => {
+              const aCount = a.class ? a.class.trim().split(/\s+/).length : 0;
+              const bCount = b.class ? b.class.trim().split(/\s+/).length : 0;
+              return bCount - aCount;
+            });
+            const matchedNode = sortedNodes.find(node =>
               node.class === activeEls[0].class &&
               node.type === activeEls[0].name &&
               node.level === activeEls[0].level
             );
+            const match = nodes.indexOf(matchedNode);
             return match + 1;
           }
         }

--- a/packages/apostrophe/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapStyles.vue
+++ b/packages/apostrophe/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposTiptapStyles.vue
@@ -37,6 +37,8 @@
 
 <script>
 
+import findActiveStyleIndex from 'Modules/@apostrophecms/rich-text-widget/lib/findActiveStyleIndex.js';
+
 export default {
   name: 'AposTiptapStyles',
   props: {
@@ -118,24 +120,7 @@ export default {
           if (activeEls[0].name === 'defaultNode') {
             return 1;
           } else {
-            // Match the most specific style first. When several styles
-            // share the same tag (e.g. a plain `<p>` and a `<p class="small">`)
-            // a `<p class="small">` would otherwise match the generic `<p>`
-            // style, marking the wrong option as active. We sort a copy of
-            // the nodes by descending class count and pick the first match,
-            // then resolve it back to its original index so the dropdown
-            // (which keeps the original order) highlights the correct option.
-            const sortedNodes = [ ...nodes ].sort((a, b) => {
-              const aCount = a.class ? a.class.trim().split(/\s+/).length : 0;
-              const bCount = b.class ? b.class.trim().split(/\s+/).length : 0;
-              return bCount - aCount;
-            });
-            const matchedNode = sortedNodes.find(node =>
-              node.class === activeEls[0].class &&
-              node.type === activeEls[0].name &&
-              node.level === activeEls[0].level
-            );
-            const match = nodes.indexOf(matchedNode);
+            const match = findActiveStyleIndex(nodes, activeEls[0]);
             return match + 1;
           }
         }

--- a/packages/apostrophe/modules/@apostrophecms/rich-text-widget/ui/apos/lib/findActiveStyleIndex.js
+++ b/packages/apostrophe/modules/@apostrophecms/rich-text-widget/ui/apos/lib/findActiveStyleIndex.js
@@ -1,0 +1,19 @@
+// When several configured styles share the same tag (e.g. a plain `<p>` and a
+// `<p class="small">`), the most specific one (the one with more classes) is the
+// one that applies. Nodes are matched in order of descending class count and the
+// result is resolved back to the original index, so the dropdown highlights the
+// correct option while keeping the configured order.
+
+export default function findActiveStyleIndex(nodes, activeEl) {
+  const sortedNodes = [ ...nodes ].sort((a, b) => {
+    const aCount = a.class ? a.class.trim().split(/\s+/).length : 0;
+    const bCount = b.class ? b.class.trim().split(/\s+/).length : 0;
+    return bCount - aCount;
+  });
+  const matchedNode = sortedNodes.find(node =>
+    node.class === activeEl.class &&
+    node.type === activeEl.name &&
+    node.level === activeEl.level
+  );
+  return nodes.indexOf(matchedNode);
+}

--- a/packages/apostrophe/test/rich-text-style-selection.js
+++ b/packages/apostrophe/test/rich-text-style-selection.js
@@ -1,0 +1,51 @@
+const assert = require('node:assert/strict');
+const findActiveStyleIndex = require(
+  '../modules/@apostrophecms/rich-text-widget/ui/apos/lib/findActiveStyleIndex.js'
+).default;
+
+describe('findActiveStyleIndex', () => {
+  it('prefers the most specific style when several styles share the same tag', () => {
+    const nodes = [
+      { type: 'paragraph', class: null, level: null },
+      { type: 'paragraph', class: 'small', level: null }
+    ];
+    const activeEl = { name: 'paragraph', class: 'small', level: null };
+    assert.strictEqual(findActiveStyleIndex(nodes, activeEl), 1);
+  });
+
+  it('does not depend on the order of the configured styles', () => {
+    const nodes = [
+      { type: 'paragraph', class: 'small', level: null },
+      { type: 'paragraph', class: null, level: null }
+    ];
+    const activeEl = { name: 'paragraph', class: 'small', level: null };
+    assert.strictEqual(findActiveStyleIndex(nodes, activeEl), 0);
+  });
+
+  it('matches the plain style when no specific style applies', () => {
+    const nodes = [
+      { type: 'paragraph', class: 'small', level: null },
+      { type: 'paragraph', class: null, level: null }
+    ];
+    const activeEl = { name: 'paragraph', class: null, level: null };
+    assert.strictEqual(findActiveStyleIndex(nodes, activeEl), 1);
+  });
+
+  it('counts multiple classes toward specificity', () => {
+    const nodes = [
+      { type: 'paragraph', class: null, level: null },
+      { type: 'paragraph', class: 'highlight', level: null },
+      { type: 'paragraph', class: 'highlight small', level: null }
+    ];
+    const activeEl = { name: 'paragraph', class: 'highlight small', level: null };
+    assert.strictEqual(findActiveStyleIndex(nodes, activeEl), 2);
+  });
+
+  it('returns -1 when no style matches', () => {
+    const nodes = [
+      { type: 'paragraph', class: null, level: null }
+    ];
+    const activeEl = { name: 'heading', class: null, level: 2 };
+    assert.strictEqual(findActiveStyleIndex(nodes, activeEl), -1);
+  });
+});


### PR DESCRIPTION
Fixes #3622

Supersedes #5507. The matching logic now lives in a small helper (`findActiveStyleIndex`) with unit tests covering the overlapping-tags scenario discussed there: when several configured styles share the same tag, the most specific one (most classes) wins, so a `<p class="small">` shows "Small" instead of the plain "Paragraph".

Unit tests: packages/apostrophe/test/rich-text-style-selection.js
Changeset included.