### PR TITLE
RT bubble menu position regression

### DIFF
--- a/packages/apostrophe/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
+++ b/packages/apostrophe/modules/@apostrophecms/rich-text-widget/ui/apos/components/AposRichTextWidgetEditor.vue
@@ -241,7 +241,6 @@ export default {
             {
               name: 'preventOverflow',
               options: {
-                altAxis: true,
                 padding: 8,
                 boundary: this.$el
               }


### PR DESCRIPTION
## Summary

Fix a regression introduced with a recent RT change that let's the bubble menu positioned over the selected text due to configuration conflict.

