### PR TITLE
Fix broken README and package.json links reported on the extensions site

### DIFF
--- a/.changeset/readme-broken-links.md
+++ b/.changeset/readme-broken-links.md
@@ -1,0 +1,12 @@
+---
+"@apostrophecms/favicon": patch
+"@apostrophecms/anchors": patch
+"@apostrophecms/form": patch
+"@apostrophecms/import-export": patch
+"@apostrophecms/redirect": patch
+"@apostrophecms/form-submission-google": patch
+---
+
+Broken links in the README and `package.json` of these packages, as surfaced by their pages on the ApostropheCMS extensions site, are corrected. The license badges pointed at the retired standalone repositories, and in the case of `@apostrophecms/redirect` and `@apostrophecms/form-submission-google` at the Blog module's license rather than their own; "Give us a star on GitHub!" pointed at the archived `apostrophecms/form` and `apostrophecms/anchors` repositories; and `@apostrophecms/import-export` linked `@apostrophecms/import-export-xlsx` to its archived repository. All now resolve within the monorepo. The `@apostrophecms/form` README also linked `@apostrophecms-pro/advanced-permission` to a private repository, which 404s for anyone without access; it now links to the public extension page.
+
+In `package.json`, `@apostrophecms/favicon` had its `repository.directory` misspelled as `packages/favison` and `@apostrophecms/import-export` had `packages/` missing from its `homepage`. `@apostrophecms/favicon`, `@apostrophecms/anchors` and `@apostrophecms/form-submission-google` were each missing a `bugs` field, so tools that need one derived it from `homepage` and produced an unusable URL. No code changes.

--- a/packages/anchors/README.md
+++ b/packages/anchors/README.md
@@ -10,7 +10,7 @@
     <a aria-label="Join the community on Discord" href="http://chat.apostrophecms.org">
       <img alt="" src="https://img.shields.io/discord/517772094482677790?color=5865f2&label=Join%20the%20Discord&logo=discord&logoColor=fff&labelColor=000&style=for-the-badge&logoWidth=20" />
     </a>
-    <a aria-label="License" href="https://github.com/apostrophecms/anchors/blob/main/LICENSE.md">
+    <a aria-label="License" href="https://github.com/apostrophecms/apostrophe/blob/main/packages/anchors/LICENSE.md">
       <img alt="" src="https://img.shields.io/static/v1?style=for-the-badge&labelColor=000000&label=License&message=MIT&color=3DA639" />
     </a>
   </p>
@@ -136,6 +136,6 @@ New to using ApostropheCMS with Astro? Check out our starter kits:
 ---
 
 <div>
-  <p>Made with ❤️ by the <a href="https://apostrophecms.com">ApostropheCMS</a> team. <strong>Found this useful? <a href="https://github.com/apostrophecms/anchors">Give us a star on GitHub!</a> ⭐</strong>
+  <p>Made with ❤️ by the <a href="https://apostrophecms.com">ApostropheCMS</a> team. <strong>Found this useful? <a href="https://github.com/apostrophecms/apostrophe">Give us a star on GitHub!</a> ⭐</strong>
   </p>
 </div>

--- a/packages/anchors/package.json
+++ b/packages/anchors/package.json
@@ -19,6 +19,9 @@
     "apostrophe"
   ],
   "homepage": "https://github.com/apostrophecms/apostrophe/tree/main/packages/anchors#readme",
+  "bugs": {
+    "url": "https://github.com/apostrophecms/apostrophe/issues"
+  },
   "author": "Apostrophe Technologies",
   "license": "MIT",
   "devDependencies": {

--- a/packages/favicon/package.json
+++ b/packages/favicon/package.json
@@ -11,9 +11,12 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/apostrophecms/apostrophe.git",
-    "directory": "packages/favison"
+    "directory": "packages/favicon"
   },
   "homepage": "https://github.com/apostrophecms/apostrophe/tree/main/packages/favicon#readme",
+  "bugs": {
+    "url": "https://github.com/apostrophecms/apostrophe/issues"
+  },
   "author": "Apostrophe Technologies",
   "license": "MIT",
   "devDependencies": {

--- a/packages/form-submission-google/README.md
+++ b/packages/form-submission-google/README.md
@@ -9,7 +9,7 @@
     <a aria-label="Join the community on Discord" href="http://chat.apostrophecms.org">
       <img alt="" src="https://img.shields.io/discord/517772094482677790?color=5865f2&label=Join%20the%20Discord&logo=discord&logoColor=fff&labelColor=000&style=for-the-badge&logoWidth=20">
     </a>
-    <a aria-label="License" href="https://github.com/apostrophecms/blog/blob/main/LICENSE.md">
+    <a aria-label="License" href="https://github.com/apostrophecms/apostrophe/blob/main/packages/form-submission-google/LICENSE.md">
       <img alt="" src="https://img.shields.io/static/v1?style=for-the-badge&labelColor=000000&label=License&message=MIT&color=3DA639">
     </a>
   </p>

--- a/packages/form-submission-google/package.json
+++ b/packages/form-submission-google/package.json
@@ -14,6 +14,9 @@
     "directory": "packages/form-submission-google"
   },
   "homepage": "https://github.com/apostrophecms/apostrophe/tree/main/packages/form-submission-google#readme",
+  "bugs": {
+    "url": "https://github.com/apostrophecms/apostrophe/issues"
+  },
   "author": "Apostrophe Technologies",
   "license": "MIT",
   "devDependencies": {

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -9,7 +9,7 @@
     <a aria-label="Join the community on Discord" href="http://chat.apostrophecms.org">
       <img alt="" src="https://img.shields.io/discord/517772094482677790?color=5865f2&label=Join%20the%20Discord&logo=discord&logoColor=fff&labelColor=000&style=for-the-badge&logoWidth=20">
     </a>
-    <a aria-label="License" href="https://github.com/apostrophecms/form/blob/main/LICENSE.md">
+    <a aria-label="License" href="https://github.com/apostrophecms/apostrophe/blob/main/packages/form/LICENSE.md">
       <img alt="" src="https://img.shields.io/static/v1?style=for-the-badge&labelColor=000000&label=License&message=MIT&color=3DA639">
     </a>
   </p>
@@ -194,7 +194,7 @@ export default {
 
 The rich text widget allows editors to add instructions within forms. Any widget type can be included in this configuration.
 
-> **Need different field types for different forms?** The `formWidgets` option is global and cannot be set per-area or per-page. If you need separate sets of allowed fields (for example, a simple contact form vs. a detailed application form), extend the `@apostrophecms/form` module to create a second form piece-type with its own `formWidgets` configuration. **However**, without additional controls, all editors can use both form types. Use [`@apostrophecms-pro/advanced-permission`](https://github.com/apostrophecms/advanced-permission) to restrict which user groups can create and manage each form type—ensuring junior editors only access basic forms while senior staff can use advanced forms. [Learn more about Pro features](#-ready-for-more).
+> **Need different field types for different forms?** The `formWidgets` option is global and cannot be set per-area or per-page. If you need separate sets of allowed fields (for example, a simple contact form vs. a detailed application form), extend the `@apostrophecms/form` module to create a second form piece-type with its own `formWidgets` configuration. **However**, without additional controls, all editors can use both form types. Use [`@apostrophecms-pro/advanced-permission`](https://apostrophecms.com/extensions/advanced-permission) to restrict which user groups can create and manage each form type—ensuring junior editors only access basic forms while senior staff can use advanced forms. [Learn more about Pro features](#-ready-for-more).
 
 ## Handling Submissions
 
@@ -556,5 +556,5 @@ Create an account on Apostrophe Workspaces and upgrade to [**ApostropheCMS Pro**
 ---
 
 <div>
-  <p>Made with ❤️ by the <a href="https://apostrophecms.com">ApostropheCMS</a> team. <strong>Found this useful? <a href="https://github.com/apostrophecms/form">Give us a star on GitHub!</a> ⭐</strong></p>
+  <p>Made with ❤️ by the <a href="https://apostrophecms.com">ApostropheCMS</a> team. <strong>Found this useful? <a href="https://github.com/apostrophecms/apostrophe">Give us a star on GitHub!</a> ⭐</strong></p>
 </div>

--- a/packages/import-export/README.md
+++ b/packages/import-export/README.md
@@ -9,7 +9,7 @@
     <a aria-label="Join the community on Discord" href="http://chat.apostrophecms.org">
       <img alt="" src="https://img.shields.io/discord/517772094482677790?color=5865f2&label=Join%20the%20Discord&logo=discord&logoColor=fff&labelColor=000&style=for-the-badge&logoWidth=20">
     </a>
-    <a aria-label="License" href="https://github.com/apostrophecms/import-export/blob/main/LICENSE.md">
+    <a aria-label="License" href="https://github.com/apostrophecms/apostrophe/blob/main/packages/import-export/LICENSE.md">
       <img alt="" src="https://img.shields.io/static/v1?style=for-the-badge&labelColor=000000&label=License&message=MIT&color=3DA639">
     </a>
   </p>
@@ -318,7 +318,7 @@ module.exports = {
 
 You might want to scope one or multiple formats in another module for several reasons:
 
-- The formats rely on a dependency that is not hosted on NPM (which is the case with [@apostrophecms/import-export-xlsx](https://github.com/apostrophecms/import-export-xlsx))
+- The formats rely on a dependency that is not hosted on NPM (which is the case with [@apostrophecms/import-export-xlsx](https://github.com/apostrophecms/apostrophe/tree/main/packages/import-export-xlsx))
 - You want to fully scope the format in a separate module and repository for an easier maintenance
 - ...
 

--- a/packages/import-export/package.json
+++ b/packages/import-export/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/apostrophecms/apostrophe.git",
     "directory": "packages/import-export"
   },
-  "homepage": "https://github.com/apostrophecms/apostrophe/tree/main/import-export#readme",
+  "homepage": "https://github.com/apostrophecms/apostrophe/tree/main/packages/import-export#readme",
   "author": "Apostrophe Technologies",
   "license": "MIT",
   "devDependencies": {

--- a/packages/redirect/README.md
+++ b/packages/redirect/README.md
@@ -9,7 +9,7 @@
     <a aria-label="Join the community on Discord" href="http://chat.apostrophecms.org">
       <img alt="" src="https://img.shields.io/discord/517772094482677790?color=5865f2&label=Join%20the%20Discord&logo=discord&logoColor=fff&labelColor=000&style=for-the-badge&logoWidth=20">
     </a>
-    <a aria-label="License" href="https://github.com/apostrophecms/blog/blob/main/LICENSE.md">
+    <a aria-label="License" href="https://github.com/apostrophecms/apostrophe/blob/main/packages/redirect/LICENSE.md">
       <img alt="" src="https://img.shields.io/static/v1?style=for-the-badge&labelColor=000000&label=License&message=MIT&color=3DA639">
     </a>
   </p>


### PR DESCRIPTION
Fixes the broken links reported on the ApostropheCMS extensions site for the six monorepo packages named below. README and `package.json` only — no code changes.

### README links

| Package | Was | Now |
| --- | --- | --- |
| `redirect` | License badge → `apostrophecms/blog/blob/main/LICENSE.md` (the **Blog** module's license, and an archived repo) | its own `packages/redirect/LICENSE.md` |
| `form-submission-google` | License badge → the same Blog license | its own `packages/form-submission-google/LICENSE.md` |
| `form` | License badge → archived `apostrophecms/form` | `packages/form/LICENSE.md` |
| `form` | "Give us a star on GitHub!" → archived `apostrophecms/form` | `apostrophecms/apostrophe` |
| `form` | `@apostrophecms-pro/advanced-permission` → `apostrophecms/advanced-permission`, a **private** repo that 404s for the public | the public extension page |
| `anchors` | License badge → archived `apostrophecms/anchors` | `packages/anchors/LICENSE.md` |
| `anchors` | "Give us a star on GitHub!" → archived `apostrophecms/anchors` | `apostrophecms/apostrophe` |
| `import-export` | License badge → archived `apostrophecms/import-export` | `packages/import-export/LICENSE.md` |
| `import-export` | `@apostrophecms/import-export-xlsx` → archived `apostrophecms/import-export-xlsx` | `packages/import-export-xlsx` in this monorepo |

Every replacement URL was checked and returns 200.

### package.json metadata

- **`favicon`** — `repository.directory` was `packages/favison`, a typo. Corrected to `packages/favicon`.
- **`import-export`** — `homepage` was missing `packages/` (`…/tree/main/import-export#readme`).
- **`favicon`, `anchors`, `form-submission-google`** — no `bugs` field at all. Consumers that need a bug-report URL fall back to deriving one from `homepage`, which ends in `#readme`; appending a path to that yields e.g. `…/form-submission-google#readme/issues/new?…`, which the browser reads entirely as a fragment. This is the cause of the broken "Report a bug" link reported for `form-submission-google`. All three now carry an explicit `bugs.url`.

A patch release of each package is needed for these to reach npm and the extensions site, hence the changeset.

### Not addressed here

Two reported items are **not** fixable in these packages:

- **`/extensions/favicon` and `/extensions/anchors` "README" links** (`…/tree/main/packages/favicon/blob/HEAD/README.md`). These are generated by `extensionReadmeSourceUrl()` in `frontend/src/lib/extensions/show.js` on the website, which appends `/blob/HEAD/README.md` to the `repoUrl` field of the extension piece. When `repoUrl` is a monorepo `/tree/main/packages/…` path, the result is a nested and invalid URL. This needs a website-side fix.
- **Archived-repo links in other monorepo packages.** The same stale-license-badge defect exists in `blog`, `open-graph`, `sitemap` and `seo`, and a wider sweep found ~21 archived `apostrophecms/*` repos still linked from various package READMEs. Left out to keep this PR to the reported list; worth a follow-up sweep.
