### PR TITLE
fix(sanitize-html): do not escape HTML fallback inside discarded iframes

### DIFF
--- a/packages/sanitize-html/index.js
+++ b/packages/sanitize-html/index.js
@@ -652,6 +652,16 @@ function sanitizeHtml(html, options, _recursing) {
         // htmlparser2, so their contents are decoded and must be escaped below
         // like any other text (important to prevent XSS via entity-encoded
         // payloads such as <option>&lt;script&gt;...&lt;/script&gt;</option>).
+      } else if (
+        // htmlparser2 treats <iframe> as a raw-text element, so markup inside
+        // (including after an unclosed <iframe>) arrives as a single text node.
+        // When the iframe is discarded, re-sanitize that fallback markup as HTML
+        // instead of escaping it as plain text (issue #5550).
+        tag === 'iframe' &&
+        !tagAllowed(tag) &&
+        options.disallowedTagsMode === 'discard'
+      ) {
+        result += sanitizeHtml(text, options);
       } else if (!addedText) {
         const escaped = escapeHtml(text, false);
         if (options.textFilter) {

--- a/packages/sanitize-html/test/test.js
+++ b/packages/sanitize-html/test/test.js
@@ -2079,6 +2079,27 @@ describe('sanitizeHtml', function() {
       ), '!<xmp>&lt;/xmp&gt;&lt;svg/onload=prompt`xs`&gt;</xmp>!'
     );
   });
+  it('should sanitize away disallowed iframe without escaping fallback html', function() {
+    // Regression for #5550: htmlparser2 treats iframe as raw-text, so an
+    // unclosed iframe's following markup arrives as text and must be
+    // re-sanitized rather than escaped when the iframe is discarded.
+    assert.equal(
+      sanitizeHtml('<iframe src="http://nono.ohno"><i>test</i>'),
+      '<i>test</i>'
+    );
+  });
+  it('should re-sanitize closed disallowed iframe fallback html', function() {
+    assert.equal(
+      sanitizeHtml('<iframe src="http://nono.ohno"><i>test</i></iframe>'),
+      '<i>test</i>'
+    );
+  });
+  it('should not allow XSS via disallowed iframe fallback markup', function() {
+    assert.equal(
+      sanitizeHtml('<iframe src="http://evil"><img src=x onerror=alert(1)><b>ok</b>'),
+      '<b>ok</b>'
+    );
+  });
 
   describe('CVE-2026-44990 regression and raw-text edge cases', function() {
     it('should escape raw-text inner content when xmp tag is disallowed and discarded under custom nonTextTags', function() {


### PR DESCRIPTION
## Summary

Fixes #5550.

When `sanitize-html` discards a disallowed `<iframe>`, markup that `htmlparser2` treats as iframe raw-text (including after an unclosed iframe) was being HTML-escaped instead of kept as sanitized HTML.

**Before**

```html
sanitizeHtml('<iframe src="http://nono.ohno"><i>test</i>')
// → &lt;i&gt;test&lt;/i&gt;
```

**After**

```html
sanitizeHtml('<iframe src="http://nono.ohno"><i>test</i>')
// → <i>test</i>
```

## Approach

I dug into why this started after 2.17.6. `htmlparser2` treats `<iframe>` as a raw-text element, so something like `<iframe src="..."><i>test</i>` never shows up as nested tags - the whole `<i>test</i>` arrives as one text node inside the iframe.

With the default discard mode, we correctly drop the iframe, but that text was going through `escapeHtml`, so you got `&lt;i&gt;test&lt;/i&gt;` instead of real markup.

I didn’t want to just stop escaping it (that would open an XSS path), and I didn’t want to dump iframe into `nonTextTags` either (that would wipe the content entirely and miss what #5550 asks for).

So when an iframe is disallowed and we’re in `discard` mode, I re-run that text through `sanitizeHtml()`. Allowed fallback tags like `<i>` / `<b>` survive, dangerous stuff still gets stripped, and the textarea / xmp / script security paths stay untouched.

## Test plan

* [x] Added the unclosed-iframe case from #5550
* [x] Added the same case with a proper closing `</iframe>`
* [x] Added a guard so markup like `<img onerror=...>` inside discarded iframe fallback can’t slip through
* [x] Ran the sanitize-html mocha suite locally - all 258 tests passing

## Notes for reviewers

This is scoped to `packages/sanitize-html` only. Apostrophe’s rich-text widget doesn’t allow iframes by default, so the main impact is on direct `sanitize-html` consumers.

I kept the fix iframe-specific on purpose so we don’t disturb the recent raw-text / XSS hardening around textarea and xmp.

Happy to adjust if you’d rather drop discarded-iframe content entirely instead of re-sanitizing the fallback - just figured matching the issue’s expected output was the cleaner fit.
