### PR TITLE
Send external front redirect payloads with a 200 status

### DIFF
--- a/.changeset/external-front-redirect-envelope.md
+++ b/.changeset/external-front-redirect-envelope.md
@@ -1,0 +1,9 @@
+---
+"apostrophe": patch
+---
+
+Redirects reported to an external front end are now sent with an HTTP status of 200, fixing a 500 error in Astro when a soft redirect was followed.
+
+Apostrophe cannot issue a redirect itself when an external front end holds the browser's connection, so `@apostrophecms/express` replaces `res.redirect` with one that describes the redirect as JSON (`{ redirect: true, url, status }`) for the front end to act on. That response carries no `Location` header, because the external front end is not the party being redirected. It was, however, inheriting whatever status the request had already set, and `@apostrophecms/soft-redirect` sets `req.statusCode` to 302 before the redirect is emitted. The result was a 302 with a body and no `Location` — which `@apostrophecms/apostrophe-astro` reasonably treated as bodiless, discarding the very payload it needed and failing with `Unexpected end of JSON input`.
+
+Visiting a page at a slug it used to live at therefore produced a 500 rather than a redirect. Redirects created with `@apostrophecms/redirect` were unaffected, as those are emitted from middleware that never sets a status first.

--- a/packages/apostrophe/modules/@apostrophecms/express/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/express/index.js
@@ -288,7 +288,15 @@ module.exports = {
           // so that frontends like Astro (which don't do it for us) don't bomb
           // attempting to issue the redirect
           url = encodeUrl(url);
-          return res.send({
+          // This response *describes* a redirect, it is not itself one, and
+          // it carries no `Location` header because the external front is not
+          // the party being redirected. Emit it as a 200 so the front end
+          // receives the body and can issue the real redirect to the browser.
+          // Otherwise a 3xx status set earlier in the request (as
+          // @apostrophecms/soft-redirect does) would leak onto this response,
+          // and a front end that reasonably treats 3xx as bodiless would
+          // discard the payload it needs.
+          return res.status(200).send({
             redirect: true,
             url,
             status

--- a/packages/apostrophe/test/soft-redirects.js
+++ b/packages/apostrophe/test/soft-redirects.js
@@ -137,3 +137,87 @@ describe('Soft Redirects - with `statusCode` option', function() {
     assert.strictEqual(response.headers.location, `${apos.http.getBase()}/child-moved`);
   });
 });
+
+describe('Soft Redirects - with an external front', function() {
+  let apos;
+  let priorKey;
+  const externalFrontKey = 'this is a test external front key';
+
+  this.timeout(t.timeout);
+
+  before(function() {
+    // Set here, rather than at module scope, so that a key in your bashrc
+    // etc. cannot interfere and so that our cleanup cannot surprise another
+    // test file that manages this variable for itself.
+    priorKey = process.env.APOS_EXTERNAL_FRONT_KEY;
+    process.env.APOS_EXTERNAL_FRONT_KEY = externalFrontKey;
+  });
+
+  after(async function() {
+    if (priorKey === undefined) {
+      delete process.env.APOS_EXTERNAL_FRONT_KEY;
+    } else {
+      process.env.APOS_EXTERNAL_FRONT_KEY = priorKey;
+    }
+    return t.destroy(apos);
+  });
+
+  it('should exist', async function() {
+    apos = await t.create({
+      root: module,
+      modules: {
+        '@apostrophecms/page': {
+          options: {
+            park: [
+              {
+                parkedId: 'child',
+                title: 'Child',
+                slug: '/child',
+                type: 'default-page'
+              }
+            ]
+          }
+        },
+        'default-page': {}
+      }
+    });
+    assert(apos.modules['@apostrophecms/soft-redirect']);
+  });
+
+  it('should be able to serve the /child page (which also populates historicUrls)', async function() {
+    const body = await apos.http.get('/child');
+    // Did we get our page back?
+    assert(body.match(/Default Page Template/));
+  });
+
+  it('should be able to change the URL via db', async function() {
+    return apos.doc.db.updateOne({
+      slug: '/child',
+      aposLocale: 'en:published'
+    }, { $set: { slug: '/child-moved' } });
+  });
+
+  it('should describe the redirect to the external front in a 200 response', async function() {
+    const response = await apos.http.get('/child', {
+      fullResponse: true,
+      redirect: 'manual',
+      headers: {
+        'x-requested-with': 'AposExternalFront',
+        'apos-external-front-key': externalFrontKey
+      }
+    });
+    // The external front is the one holding the browser's connection, so it
+    // issues the real redirect. This response only describes that redirect,
+    // and carries no `Location` header, so it must arrive as a 200 with its
+    // body intact. Sending it as a 3xx would invite any reasonable client to
+    // treat it as bodiless and discard the payload.
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.headers.location, undefined);
+    // The status the browser should ultimately see travels in the body.
+    assert.deepStrictEqual(response.body, {
+      redirect: true,
+      url: '/child-moved',
+      status: 302
+    });
+  });
+});


### PR DESCRIPTION
## The bug

Visiting a page at a slug it used to live at returns a **500** instead of redirecting, when the site is served through an external front end (Astro). Reproduced on apostrophecms.com: `/extensions/template-library` (moved to `/extensions/document-template-library`) 500s, while `/extensions/document-template-library` is fine.

## Why

Apostrophe can't issue a redirect itself when an external front end holds the browser's connection, so `@apostrophecms/express` replaces `res.redirect` with one that *describes* the redirect as JSON for the front end to act on:

```js
res.redirect = function(...args) {
  // ...
  return res.send({ redirect: true, url, status });
};
```

That response deliberately carries no `Location` header — the external front is not the party being redirected. But it was inheriting whatever status the request had already set. `@apostrophecms/soft-redirect` sets `req.statusCode = 302`, and `@apostrophecms/page`'s `serveDeliver` copies that onto the response *before* calling `res.redirect`:

```js
if (req.statusCode) {
  req.res.statusCode = req.statusCode;   // page/index.js
}
if (req.redirect) {
  return req.res.redirect(status, req.redirect);
}
```

So the front end received a **302 with a body and no `Location`** — and `@apostrophecms/apostrophe-astro` reasonably treats 3xx as bodiless, dumping the body before parsing it. `aposPageFetch` then throws `Unexpected end of JSON input`, which surfaces as the 500.

Redirects created with `@apostrophecms/redirect` were unaffected: those are emitted from middleware that runs before page serving and never sets a status first, so they were already going out as 200 and worked correctly. That asymmetry is what made the failure look intermittent — identical payloads got different envelopes purely by internal code path.

## The fix

Set the status explicitly:

```js
return res.status(200).send({ redirect: true, url, status });
```

A 3xx is an instruction aimed at the browser, and the browser is not on the Astro→Apostrophe hop; its `Location` contract can't be honored there. The status the browser should ultimately see already travels in the body, where the front end reads it — that redundant `status` field, and the original `res.send` (rather than `res.status(302).send`), are both evidence the 3xx envelope was never intended.

This also fixes the live site with no adapter upgrade: the currently released `apostrophe-astro` already handles the 200-plus-JSON shape correctly, as `@apostrophecms/redirect` redirects demonstrate today.

## Test

`test/soft-redirects.js` gains a third describe block covering the external front. It fails on `main` (`302 !== 200`) and passes here. The assertion also pins the body, so the intended 302 must still reach the front end.

## Verification

- `test/soft-redirects.js`, `external-front.js`, `express.js`, `i18n.js`, `pages.js`, `static-build.js`, `urls.js` — 300 passing, 0 failing.
- `eslint` clean on both changed files.
- No consumer depends on the 3xx envelope: `apostrophe-astro` dispatches on the body's `redirect` flag, and its own `aposPageFetch` tests already model these responses as status 200.
