### PR TITLE
fix(sanitize-html): preserve incomplete tag prefix dropped by htmlparser2

### DIFF
--- a/packages/sanitize-html/index.js
+++ b/packages/sanitize-html/index.js
@@ -598,6 +598,11 @@ function sanitizeHtml(html, options, _recursing) {
       frame.openingTagLength = result.length - frame.tagPosition;
     },
     ontext: function(text) {
+      if (html[parser.startIndex] === '<' && text[0] !== '<') {
+        const original = html.substring(parser.startIndex, parser.endIndex + 1);
+        const prefixEnd = original.length - text.length;
+        text = original.substring(0, prefixEnd) + text;
+      }
       if (skipText) {
         return;
       }

--- a/packages/sanitize-html/test/test.js
+++ b/packages/sanitize-html/test/test.js
@@ -164,14 +164,14 @@ describe('sanitizeHtml', function() {
   it('should preserve entities as such', function() {
     assert.equal(sanitizeHtml('<a name="&lt;silly&gt;">&lt;Kapow!&gt;</a>'), '<a name="&lt;silly&gt;">&lt;Kapow!&gt;</a>');
   });
-  it('should dump closing tags which do not have any opening tags.', function() {
+  it('should escape incomplete tags', function() {
     assert.equal(sanitizeHtml('<b><div/', {
       allowedTags: [ 'b' ]
-    }), '<b>/</b>');
+    }), '<b>&lt;div/</b>');
 
     assert.equal(sanitizeHtml('<b><b<<div/', {
       allowedTags: [ 'b' ]
-    }), '<b>/</b>');
+    }), '<b>&lt;b&lt;&lt;div/</b>');
   });
   it('should tolerate not closed p tags', function() {
     assert.equal(sanitizeHtml('<div><p>inner text 1<p>inner text 2<p>inner text 3</div>'), '<div><p>inner text 1</p><p>inner text 2</p><p>inner text 3</p></div>');


### PR DESCRIPTION
Fixes an issue where sanitize-html incorrectly strips the `<` and following characters of an incomplete tag ending in a space (e.g. `a <i `) when htmlparser2 drops them. Also properly escapes incomplete tags in escape/discard mode.