### PR TITLE
fix(sanitize-html): apply allowedSchemesByTag to srcset URLs

### DIFF
--- a/.changeset/sanitize-html-srcset-allowed-schemes-by-tag.md
+++ b/.changeset/sanitize-html-srcset-allowed-schemes-by-tag.md
@@ -1,0 +1,5 @@
+---
+"sanitize-html": patch
+---
+
+`allowedSchemesByTag` is now applied to `srcset` and `imagesrcset` URLs. Previously the per-tag lookup used the attribute name instead of the tag name, so these attributes always fell back to the global `allowedSchemes` and ignored a tag-specific scheme allowlist.

--- a/packages/sanitize-html/index.js
+++ b/packages/sanitize-html/index.js
@@ -478,7 +478,7 @@ function sanitizeHtml(html, options, _recursing) {
               try {
                 let parsed = parseSrcset(value);
                 parsed.forEach(function(value) {
-                  if (naughtyHref(a, value.url)) {
+                  if (naughtyHref(name, value.url)) {
                     value.evil = true;
                   }
                 });

--- a/packages/sanitize-html/test/test.js
+++ b/packages/sanitize-html/test/test.js
@@ -1025,6 +1025,17 @@ describe('sanitizeHtml', function() {
       '<img src="fallback.jpg" srcset="/upload/f_auto,q_auto:eco,c_fit,w_1460,h_2191/abc.jpg 1460w, /upload/f_auto,q_auto:eco,c_fit,w_1360,h_2041/abc.jpg" />'
     );
   });
+  it('should apply allowedSchemesByTag restrictions to srcset URLs', function() {
+    assert.equal(
+      sanitizeHtml('<img src="https://example.com/fallback.jpg" srcset="https://example.com/foo.jpg 100w" />', {
+        allowedTags: sanitizeHtml.defaults.allowedTags.concat([ 'img' ]),
+        allowedAttributes: { img: [ 'src', 'srcset' ] },
+        allowedSchemes: [ 'http', 'https' ],
+        allowedSchemesByTag: { img: [] }
+      }),
+      '<img />'
+    );
+  });
   it('should drop javascript: in form action', function() {
     assert.equal(
       sanitizeHtml('<form action="javascript:alert(1)"><button>x</button></form>', {


### PR DESCRIPTION
`allowedSchemesByTag` lets an app restrict URL schemes per tag, tighter than the global `allowedSchemes`. It is correctly applied to `src`, but not to `srcset`/`imagesrcset`: the per-tag check passes the attribute name (`'srcset'`) to `naughtyHref()` where the tag name is expected, so `allowedSchemesByTag['srcset']` is never found and the check silently falls back to the global `allowedSchemes`.

For example, an `<img>` locked down to no schemes still lets a `srcset` URL through:

```js
sanitizeHtml('<img src="https://x/a.jpg" srcset="https://x/b.jpg 1x">', {
  allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
  allowedAttributes: { img: ['src', 'srcset'] },
  allowedSchemes: ['http', 'https'],
  allowedSchemesByTag: { img: [] }
})
// before: <img srcset="https://x/b.jpg 1x" />
// after:  <img />
```

Passing the tag name makes `srcset`/`imagesrcset` honour `allowedSchemesByTag` the same way `src` already does, in both directions (narrowing below and widening above the global list). Added a regression test.
