### PR TITLE
Mergeback: create-apostrophe 1.2.0 / db-connect 1.0.2 release details

### DIFF
--- a/.changeset/create-apostrophe-windows-fix.md
+++ b/.changeset/create-apostrophe-windows-fix.md
@@ -1,6 +1,0 @@
----
-"create-apostrophe": minor
----
-
-- Fix a bug that prevented successful installation of dependencies on Windows when not using WSL.
-- Include the Node.js version and OS name in telemetry.

--- a/.changeset/sqlite-windows-path.md
+++ b/.changeset/sqlite-windows-path.md
@@ -1,5 +1,0 @@
----
-'@apostrophecms/db-connect': patch
----
-
-Fixed the sqlite adapter rejecting a Windows database path. The adapter parsed `sqlite://` URIs with `new URL`, but the thing after the scheme is a filesystem path, not a URL. On Windows, `sqlite://C:\site\data\site.sqlite` was read as host `C` with port `\site\data\site.sqlite` and thrown out as `ERR_INVALID_URL`, so a site using the default sqlite adapter could not start at all; POSIX escaped this only because its absolute paths begin with `/`. The path after the scheme is now taken verbatim, which also fixes three quieter bugs on every platform: a path containing a space was percent-encoded, so a project under `My Project` silently created and used a directory named `My%20Project`; the relative form `sqlite://Data/site.db` was lowercased to `data/`; and `sqlite://:memory:` failed with a URL parse error instead of the adapter's own explanation. The `file://` spelling of a drive path, `sqlite:///C:/site/data/site.sqlite`, is now accepted on Windows as well.

--- a/.changeset/surface-child-process-errors.md
+++ b/.changeset/surface-child-process-errors.md
@@ -1,5 +1,0 @@
----
-'create-apostrophe': patch
----
-
-Fixed the installer reporting a failed step with no explanation. On failure it printed "See the messages above for the underlying error", but the failing child process's output was captured and discarded, so there were no messages above — nothing was left to go on but a stage name and an error code. Failures of `npm install` and of the `@apostrophecms/user:add` / `@apostrophecms/user:change-password` tasks now print the tail of the child's own output (the last 30 lines, since that is where the actual error is). This matters most at the admin-account step: it is the first thing that boots the newly generated project's Apostrophe, so a startup problem of any kind — a bad database connection string, a missing dependency — surfaces there and was previously invisible. The output is written to the terminal only; telemetry continues to receive nothing but the symbolic error code.

--- a/packages/apostrophe/CHANGELOG.md
+++ b/packages/apostrophe/CHANGELOG.md
@@ -4,11 +4,7 @@
 
 ### Fixes
 
-- Redirects reported to an external front end are now sent with an HTTP status of 200, fixing a 500 error in Astro when a soft redirect was followed.
-
-  Apostrophe cannot issue a redirect itself when an external front end holds the browser's connection, so `@apostrophecms/express` replaces `res.redirect` with one that describes the redirect as JSON (`{ redirect: true, url, status }`) for the front end to act on. That response carries no `Location` header, because the external front end is not the party being redirected. It was, however, inheriting whatever status the request had already set, and `@apostrophecms/soft-redirect` sets `req.statusCode` to 302 before the redirect is emitted. The result was a 302 with a body and no `Location` — which `@apostrophecms/apostrophe-astro` reasonably treated as bodiless, discarding the very payload it needed and failing with `Unexpected end of JSON input`.
-
-  Visiting a page at a slug it used to live at therefore produced a 500 rather than a redirect. Redirects created with `@apostrophecms/redirect` were unaffected, as those are emitted from middleware that never sets a status first.
+- Fixed a bug that caused "soft redirects" issued for changed page or piece URLs to generate a 500 error in Astro projects.
 
 ## 4.32.1 (2026-08-13)
 

--- a/packages/create-apostrophe/CHANGELOG.md
+++ b/packages/create-apostrophe/CHANGELOG.md
@@ -1,5 +1,17 @@
 # create-apostrophe
 
+## 1.2.0 (2026-09-03)
+
+### Fixes
+
+- Fixed a bug that prevented successful installation of dependencies on Windows when not using WSL.
+- Reports the actual error message when installation fails, per claims already made in the CLI.
+
+### Adds
+
+- Include the Node.js version and OS name in telemetry (note that telemetry is anonymous, opt-in and only in play when creating projects, to
+help us debug issues with the CLI).
+
 ## 1.1.0 (2026-07-10)
 
 ### Fixes

--- a/packages/create-apostrophe/package.json
+++ b/packages/create-apostrophe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-apostrophe",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Guided installer for ApostropheCMS — npm create apostrophe@latest",
   "type": "module",
   "engines": {

--- a/packages/db-connect/CHANGELOG.md
+++ b/packages/db-connect/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @apostrophecms/db-connect
+
+## 1.0.2 (2026-09-03)
+
+### Fixes
+
+- Fixed the sqlite adapter rejecting a Windows database path in `DB_URI`. The sqlite adapter now expects everything after `sqlite:` to be a filesystem path and accepts both Windows and POSIX-style paths. This corrects an issue that prevented new projects from spinning up in the CLI when using `sqlite`.
+
+## 1.0.0, 1.0.1
+
+- Initial releases (no significant differences).
+

--- a/packages/db-connect/package.json
+++ b/packages/db-connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apostrophecms/db-connect",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Database connection library and dump/restore tools for ApostropheCMS",
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
Brings the release bookkeeping from the `create-apostrophe@1.2.0` / `@apostrophecms/db-connect@1.0.2` release (cut on `hotfixes/create-apostrophe-1.2.0`) back to `main`.

Bookkeeping only — no code changes. The fixes these entries describe already landed on `main` in #5575; what was missing was the version bumps, the changelog entries, and the removal of the changesets those entries consumed.

### Contents

- `packages/create-apostrophe/package.json` — 1.1.0 → 1.2.0
- `packages/create-apostrophe/CHANGELOG.md` — 1.2.0 entry
- `packages/db-connect/package.json` — 1.0.1 → 1.0.2
- `packages/db-connect/CHANGELOG.md` — new file, 1.0.2 entry
- Removed the three now-published changesets: `create-apostrophe-windows-fix.md`, `sqlite-windows-path.md`, `surface-child-process-errors.md`
- `packages/apostrophe/CHANGELOG.md` — condensed the published 4.32.2 entry to its released one-line wording, so `main`, `latest` and the release branch read alike. The version bump itself was already here.

Only the `version` field of each `package.json` was touched; `main`'s newer dependency ranges are left as they are.

Companion PR for `latest`: #5579 — that one carries the code too, since `latest` did not have these fixes yet.
