### PR TITLE
Introduce AI adapter settings

### DIFF
--- a/.changeset/ai-adapters.md
+++ b/.changeset/ai-adapters.md
@@ -5,7 +5,7 @@
 Added `apos.ai`, a provider-agnostic AI API for text generation with tool calling, image generation and background jobs. Feature code is written once, against one normalized surface: switching between Anthropic, OpenAI, Google or any OpenAI-compatible service is a configuration change, not a rewrite. It is opt-in - no provider and no key are configured out of the box.
 
 - `@apostrophecms/ai`: the engine - normalized request and result shapes, a tool registry, an agent loop, effort levels, retries, a permission seam and a mock mode for tests.
-- `@apostrophecms/ai-adapter-anthropic`: Anthropic (Claude) support, via the Messages API.
+- `@apostrophecms/ai-adapter-anthropic`: Anthropic (Claude) support, via the Messages API. An entry may set `workspaceId` (or export `APOS_ANTHROPIC_WORKSPACE_ID`) to send the `anthropic-workspace-id` header, required with an identity-linked API key that is not scoped to a single workspace.
 - `@apostrophecms/ai-adapter-openai`: OpenAI support, via the Responses and Images APIs.
 - `@apostrophecms/ai-adapter-openai-compatible`: support for any Chat Completions service (Groq, Mistral, OpenRouter, Ollama, vLLM and friends) with no adapter code of your own.
 - `@apostrophecms/ai-adapter-google`: Google (Gemini) support, text and images through one API.

--- a/packages/apostrophe/modules/@apostrophecms/ai-adapter-anthropic/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai-adapter-anthropic/index.js
@@ -58,6 +58,13 @@ module.exports = {
           label: 'Anthropic (Claude)',
           baseUrl: 'https://api.anthropic.com',
           envKey: 'APOS_ANTHROPIC_KEY',
+          settings: {
+            // The workspace requests act in, riding the
+            // anthropic-workspace-id header. Anthropic requires it when
+            // the key is identity-linked and not scoped to a single
+            // workspace; a scoped key ignores it
+            workspaceId: { envKey: 'APOS_ANTHROPIC_WORKSPACE_ID' }
+          },
           capabilities: {
             text: true,
             tools: true,
@@ -116,7 +123,9 @@ module.exports = {
             const response = await self.apos.http.post(`${this.baseUrl}/v1/messages`, {
               headers: {
                 'x-api-key': this.apiKey,
-                'anthropic-version': self.options.version
+                'anthropic-version': self.options.version,
+                ...(this.workspaceId &&
+                  { 'anthropic-workspace-id': this.workspaceId })
               },
               body: self.buildBody(request),
               timeout: self.options.timeout,

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/constants.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/constants.js
@@ -49,6 +49,22 @@ const IMAGE_OPTIONS = Object.freeze([
   'count', 'aspect', 'quality', 'images', 'provider', 'model', 'signal'
 ]);
 
+// The provider entry keys the engine itself reads. Any other key must
+// be a setting the entry's adapter declares (its `settings` map)
+const ENTRY_KEYS = Object.freeze([
+  'adapter', 'apiKey', 'envKey', 'baseUrl', 'models', 'effort', 'capabilities'
+]);
+
+// Names a declared setting may not use: the entry keys above plus the
+// adapter definition's own fields and the engine-assigned ones — a
+// resolved setting lands on the adapter instance, so a collision would
+// clobber what it collides with
+const RESERVED_SETTING_NAMES = Object.freeze([
+  ...ENTRY_KEYS,
+  'name', 'label', 'settings', 'provider',
+  'validate', 'chat', 'image', 'normalizeError'
+]);
+
 // Doc types no AI action may touch, whatever the user's own permissions:
 // accounts and permission grants, where a model's mistake is a privilege
 // escalation. Not configurable, and deliberately every action, read
@@ -72,5 +88,7 @@ module.exports = {
   PENDING_POLICIES,
   GENERATE_OPTIONS,
   IMAGE_OPTIONS,
+  ENTRY_KEYS,
+  RESERVED_SETTING_NAMES,
   DENIED_TYPES
 };

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/startup.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/startup.js
@@ -4,7 +4,7 @@
 
 const startCase = require('lodash/startCase');
 const {
-  NAMED_ASPECTS, QUALITIES, TOOL_KINDS
+  NAMED_ASPECTS, QUALITIES, TOOL_KINDS, ENTRY_KEYS, RESERVED_SETTING_NAMES
 } = require('./constants');
 const {
   isObject, parseAspect, oneOf, startupFail: fail
@@ -41,7 +41,8 @@ module.exports = (self) => {
           ...adapter,
           provider: name,
           apiKey: envApiKey || entry.apiKey,
-          baseUrl: entry.baseUrl || adapter.baseUrl
+          baseUrl: entry.baseUrl || adapter.baseUrl,
+          ...self.resolveSettings(name, adapter, entry)
         };
         if (!self.mockMode) {
           await instance.validate();
@@ -93,6 +94,47 @@ module.exports = (self) => {
 
       self.active = Object.keys(self.providers).length > 0 ||
         self.mockMode;
+    },
+    // Resolve the entry keys the entry's adapter declares beyond the
+    // standard set — its `settings` map, { key: { envKey } } — against
+    // the entry and the environment, the variable's value winning over
+    // the entry's like the api key does. The declaration is also the
+    // whitelist: an entry key that is neither standard nor declared
+    // fails the boot, so a typo dies here instead of riding silently
+    // past the provider call. Returns the resolved values; they land on
+    // the adapter instance beside apiKey and baseUrl, which is what the
+    // reserved-name check protects.
+    resolveSettings(providerName, adapter, entry) {
+      const settings = adapter.settings || {};
+      for (const [ key, declared ] of Object.entries(settings)) {
+        if (RESERVED_SETTING_NAMES.includes(key)) {
+          fail(`adapter "${adapter.name}" declares reserved setting "${key}"`);
+        }
+        if (!isObject(declared)) {
+          fail(`adapter "${adapter.name}" setting "${key}" must be an object like { envKey }`);
+        }
+        if (declared.envKey !== undefined && typeof declared.envKey !== 'string') {
+          fail(`adapter "${adapter.name}" setting "${key}": "envKey" must be a string`);
+        }
+      }
+      for (const key of Object.keys(entry)) {
+        if (!ENTRY_KEYS.includes(key) && !Object.hasOwn(settings, key)) {
+          fail(`"providers.${providerName}.${key}" is neither a standard entry key nor a setting of adapter "${adapter.name}"`);
+        }
+      }
+      const resolved = {};
+      for (const [ key, declared ] of Object.entries(settings)) {
+        const value = (declared.envKey && process.env[declared.envKey]) ||
+          entry[key];
+        if (value === undefined) {
+          continue;
+        }
+        if (typeof value !== 'string') {
+          fail(`"providers.${providerName}.${key}" must be a string`);
+        }
+        resolved[key] = value;
+      }
+      return resolved;
     },
     // The routing table: the default provider's rows are the base,
     // the project's "effort.levels" replace it level by level

--- a/packages/apostrophe/modules/@apostrophecms/ai/lib/types.js
+++ b/packages/apostrophe/modules/@apostrophecms/ai/lib/types.js
@@ -317,6 +317,12 @@
  * @property {string} [envKey] The environment variable the key is read from
  *   unless the entry names its own.
  * @property {string} [baseUrl]
+ * @property {Object<string, { envKey?: string }>} [settings] The entry keys
+ *   this adapter reads beyond the standard set, each resolved from the
+ *   variable its `envKey` names or from the entry — the variable wins — and
+ *   assigned onto the instance beside `apiKey`. The declaration doubles as
+ *   the whitelist: a non-standard entry key no setting declares fails
+ *   startup.
  * @property {Object<string, boolean>} capabilities What the service offers:
  *   'text', 'tools', 'structured', 'image'. A call needing one the routed
  *   provider lacks is a clear error, never a silent re-route.

--- a/packages/apostrophe/test/ai-adapter-anthropic.js
+++ b/packages/apostrophe/test/ai-adapter-anthropic.js
@@ -8,12 +8,15 @@ describe('AI adapter: anthropic', function() {
   // The adapter module instance, for unit access to the dialect methods
   let adapter;
   let savedLiveKey;
+  let savedWorkspaceId;
 
   before(async function() {
-    // A real key in the environment would override the fixture keys
-    // below (envKey); keep the suite hermetic and restore at the end
+    // A real key or workspace in the environment would override the
+    // fixture values below; keep the suite hermetic and restore at the end
     savedLiveKey = process.env.APOS_ANTHROPIC_KEY;
+    savedWorkspaceId = process.env.APOS_ANTHROPIC_WORKSPACE_ID;
     delete process.env.APOS_ANTHROPIC_KEY;
+    delete process.env.APOS_ANTHROPIC_WORKSPACE_ID;
     apos = await t.create({
       root: module,
       modules: {
@@ -40,7 +43,10 @@ describe('AI adapter: anthropic', function() {
               gateway: {
                 adapter: 'anthropic',
                 apiKey: 'sk-gw',
-                baseUrl: 'https://llm-gateway.example.com/anthropic'
+                baseUrl: 'https://llm-gateway.example.com/anthropic',
+                // The declared workspaceId setting, from config: an
+                // identity-linked multi-workspace key needs one
+                workspaceId: 'wrkspc-gw'
               }
             },
             // Keep retried tests fast; the delay engine has its own suite
@@ -55,6 +61,9 @@ describe('AI adapter: anthropic', function() {
   after(async function() {
     if (savedLiveKey !== undefined) {
       process.env.APOS_ANTHROPIC_KEY = savedLiveKey;
+    }
+    if (savedWorkspaceId !== undefined) {
+      process.env.APOS_ANTHROPIC_WORKSPACE_ID = savedWorkspaceId;
     }
     if (apos) {
       return t.destroy(apos);
@@ -733,6 +742,8 @@ describe('AI adapter: anthropic', function() {
       assert.equal(call.url, 'https://api.anthropic.com/v1/messages');
       assert.equal(call.options.headers['x-api-key'], 'sk-test');
       assert.equal(call.options.headers['anthropic-version'], '2023-06-01');
+      // No workspaceId on this entry, no header
+      assert.equal('anthropic-workspace-id' in call.options.headers, false);
       assert.equal(call.options.timeout, 600000);
       assert.equal(call.options.body.model, 'claude-sonnet-5');
       assert.equal(call.options.body.max_tokens, 64000);
@@ -756,6 +767,7 @@ describe('AI adapter: anthropic', function() {
       const [ call ] = httpCalls;
       assert.equal(call.url, 'https://llm-gateway.example.com/anthropic/v1/messages');
       assert.equal(call.options.headers['x-api-key'], 'sk-gw');
+      assert.equal(call.options.headers['anthropic-workspace-id'], 'wrkspc-gw');
       assert.equal(call.options.body.max_tokens, 64000);
     });
 
@@ -1088,6 +1100,7 @@ describe('AI adapter: anthropic', function() {
     before(async function() {
       process.env.APOS_ANTHROPIC_KEY = 'sk-env';
       process.env.APOS_SECOND_KEY = 'sk-second';
+      process.env.APOS_ANTHROPIC_WORKSPACE_ID = 'wrkspc-env';
       await t.destroy(apos);
       apos = await t.create({
         root: module,
@@ -1105,10 +1118,12 @@ describe('AI adapter: anthropic', function() {
                   envKey: 'APOS_SECOND_KEY'
                 },
                 // An alias without envKey shares the native secret;
-                // the environment overrides even its configured key
+                // the environment overrides even its configured key —
+                // and its configured workspaceId setting
                 shared: {
                   adapter: 'anthropic',
-                  apiKey: 'sk-config'
+                  apiKey: 'sk-config',
+                  workspaceId: 'wrkspc-config'
                 },
                 // A named variable that is unset falls back to config
                 fallback: {
@@ -1126,6 +1141,7 @@ describe('AI adapter: anthropic', function() {
     after(function() {
       delete process.env.APOS_ANTHROPIC_KEY;
       delete process.env.APOS_SECOND_KEY;
+      delete process.env.APOS_ANTHROPIC_WORKSPACE_ID;
     });
 
     it('resolves each entry to the key its envKey names', function() {
@@ -1139,6 +1155,13 @@ describe('AI adapter: anthropic', function() {
         shared: 'sk-env',
         fallback: 'sk-fallback'
       });
+    });
+
+    it('resolves the declared workspaceId setting, the environment winning', function() {
+      // The variable applies to an entry that configured nothing...
+      assert.equal(apos.ai.providers.anthropic.adapter.workspaceId, 'wrkspc-env');
+      // ...and beats one that did
+      assert.equal(apos.ai.providers.shared.adapter.workspaceId, 'wrkspc-env');
     });
   });
 });

--- a/packages/apostrophe/test/ai.js
+++ b/packages/apostrophe/test/ai.js
@@ -615,6 +615,49 @@ describe('AI engine', function() {
         (apos) => apos.ai.addAdapter({ name: 'noval' }));
       });
 
+      it('fails on an entry key the adapter does not declare', async function() {
+        await failsToActivate({
+          providers: {
+            fake: {
+              apiKey: 'k',
+              workspaceId: 'wrkspc-1'
+            }
+          }
+        }, /@apostrophecms\/ai: "providers\.fake\.workspaceId" is neither a standard entry key nor a setting of adapter "fake"/);
+      });
+
+      it('fails on a setting declaration using a reserved name', async function() {
+        await failsToActivate({
+          providers: { fake: { apiKey: 'k' } }
+        }, /@apostrophecms\/ai: adapter "fake" declares reserved setting "chat"/,
+        (apos) => apos.ai.addAdapter(fakeAdapter('fake', {
+          settings: { chat: {} }
+        })));
+      });
+
+      it('fails on a malformed setting declaration', async function() {
+        await failsToActivate({
+          providers: { fake: { apiKey: 'k' } }
+        }, /@apostrophecms\/ai: adapter "fake" setting "workspaceId" must be an object like \{ envKey \}/,
+        (apos) => apos.ai.addAdapter(fakeAdapter('fake', {
+          settings: { workspaceId: 'APOS_FAKE_WORKSPACE_ID' }
+        })));
+      });
+
+      it('fails on a non-string setting value', async function() {
+        await failsToActivate({
+          providers: {
+            fake: {
+              apiKey: 'k',
+              workspaceId: 42
+            }
+          }
+        }, /@apostrophecms\/ai: "providers\.fake\.workspaceId" must be a string/,
+        (apos) => apos.ai.addAdapter(fakeAdapter('fake', {
+          settings: { workspaceId: {} }
+        })));
+      });
+
       it('fails on a routing entry referencing an unconfigured provider', async function() {
         await failsToActivate({
           providers: { fake: { apiKey: 'k' } },
@@ -691,6 +734,76 @@ describe('AI engine', function() {
           }
         }, /@apostrophecms\/ai: the default effort level "medium" resolves to no routing entry/);
       });
+    });
+  });
+
+  describe('extending a shipped adapter at project level', function() {
+    let extendedApos;
+    let savedKey;
+    let savedWorkspaceId;
+
+    before(async function() {
+      savedKey = process.env.APOS_ANTHROPIC_KEY;
+      savedWorkspaceId = process.env.APOS_ANTHROPIC_WORKSPACE_ID;
+      delete process.env.APOS_ANTHROPIC_KEY;
+      // A decoy in the declared default variable: if the extension were
+      // applied after the adapter registered its definition, this value
+      // would win and the assertion below would catch it
+      process.env.APOS_ANTHROPIC_WORKSPACE_ID = 'wrkspc-decoy';
+      process.env.MY_CLAUDE_WORKSPACE = 'wrkspc-renamed';
+      extendedApos = await t.create({
+        root: module,
+        modules: {
+          // The documented recipe for renaming a declared setting's
+          // variable: extendMethods composes before init runs, so the
+          // definition init registers already carries the new envKey
+          '@apostrophecms/ai-adapter-anthropic': {
+            extendMethods(self) {
+              return {
+                adapter(_super) {
+                  const definition = _super();
+                  definition.settings.workspaceId.envKey =
+                    'MY_CLAUDE_WORKSPACE';
+                  return definition;
+                }
+              };
+            }
+          },
+          '@apostrophecms/ai': {
+            options: {
+              provider: 'anthropic',
+              providers: {
+                anthropic: {
+                  apiKey: 'sk-test',
+                  workspaceId: 'wrkspc-config'
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+
+    after(async function() {
+      if (savedKey !== undefined) {
+        process.env.APOS_ANTHROPIC_KEY = savedKey;
+      }
+      if (savedWorkspaceId !== undefined) {
+        process.env.APOS_ANTHROPIC_WORKSPACE_ID = savedWorkspaceId;
+      } else {
+        delete process.env.APOS_ANTHROPIC_WORKSPACE_ID;
+      }
+      delete process.env.MY_CLAUDE_WORKSPACE;
+      if (extendedApos) {
+        return t.destroy(extendedApos);
+      }
+    });
+
+    it('resolves the setting from the renamed variable, never the default one', function() {
+      const { adapter } = extendedApos.ai.providers.anthropic;
+      // The renamed variable wins over the configured value; the
+      // decoy in the default variable is never read
+      assert.equal(adapter.workspaceId, 'wrkspc-renamed');
     });
   });
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:

*Check one*
- [x] main
- [x] latest
- [ ] stable
- [ ] Check if this PR will be resubmitted against another branch

## Summary

Introduce specific to adapter settings that can be declared per adapter. Conflicting setting names are being linted. The settings can be used directly in the `ai.options.providers` config. Anthropic adapter has now optional `workspaceId` setting (required with an identity-linked API key).

**Example 1**

```sh
export APOS_ANTHROPIC_KEY=sk-ant-api03-...
export APOS_ANTHROPIC_WORKSPACE_ID=wrkspc_xxx
```

```js
// app.js
'@apostrophecms/ai': {
  options: {
    providers: {
      anthropic: {}
    }
  }
}
```

**Example 2**

```sh
export APOS_ANTHROPIC_KEY=sk-ant-api03-...
export MY_CLAUDE_WORKSPACE=wrkspc_xxx
```

```js
// app.js
'@apostrophecms/ai': {
  options: {
    providers: {
      anthropic: {
        workspaceId: process.env.MY_CLAUDE_WORKSPACE
      }
    }
  }
}
```

Closes PRO-9950

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
