### PR TITLE
Fix duplicate _id on import of force-published docs

### DIFF
--- a/.changeset/doc-no-retry-id-collision.md
+++ b/.changeset/doc-no-retry-id-collision.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": patch
+---
+
+`retryUntilUnique` no longer retries an `_id` collision that `fixUniqueError` handlers cannot resolve.

--- a/.changeset/import-export-force-published-import.md
+++ b/.changeset/import-export-force-published-import.md
@@ -1,0 +1,5 @@
+---
+"@apostrophecms/import-export": patch
+---
+
+Importing a document that a handler published during the draft insert (for example a template on a type that is not autopublished) no longer fails with a duplicate `_id` error.

--- a/packages/apostrophe/modules/@apostrophecms/doc/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/doc/index.js
@@ -893,7 +893,7 @@ module.exports = {
             }
             // fixUniqueError handlers adjust slug-like properties. Nothing
             // can make an _id unique, so retrying repeats the same failure.
-            if (err.keyPattern?._id) {
+            if (self.isIdUniqueError(err)) {
               throw err;
             }
             if (!firstError) {
@@ -1294,6 +1294,15 @@ module.exports = {
         return err.code === 13596 ||
           err.code === 11000 ||
           err.code === 11001;
+      },
+      // True if `err` is a unique index error naming `_id`. Adapters report the
+      // offending key in `keyValue`; MongoDB also supplies `keyPattern`.
+      isIdUniqueError(err) {
+        if (!self.isUniqueError(err)) {
+          return false;
+        }
+        const key = err.keyValue || err.keyPattern;
+        return !!key && Object.hasOwn(key, '_id');
       },
       // Set the manager object corresponding
       // to a given doc type. Typically `manager`

--- a/packages/apostrophe/modules/@apostrophecms/doc/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/doc/index.js
@@ -891,6 +891,11 @@ module.exports = {
             if (!self.isUniqueError(err)) {
               throw err;
             }
+            // fixUniqueError handlers adjust slug-like properties. Nothing
+            // can make an _id unique, so retrying repeats the same failure.
+            if (err.keyPattern?._id) {
+              throw err;
+            }
             if (!firstError) {
               firstError = err;
             }
@@ -1287,7 +1292,6 @@ module.exports = {
           return false;
         }
         return err.code === 13596 ||
-          err.code === 13596 ||
           err.code === 11000 ||
           err.code === 11001;
       },

--- a/packages/apostrophe/test/docs.js
+++ b/packages/apostrophe/test/docs.js
@@ -319,7 +319,7 @@ describe('Docs', function() {
       }),
       (err) => {
         assert.equal(err.code, 11000);
-        assert.deepEqual(err.keyPattern, { _id: 1 });
+        assert.equal(err.keyValue._id, 'same-id:en:published');
         assert.equal(err.aposAddendum, undefined);
         return true;
       }

--- a/packages/apostrophe/test/docs.js
+++ b/packages/apostrophe/test/docs.js
@@ -70,6 +70,17 @@ describe('Docs', function() {
         },
         'test-page': {
           extend: '@apostrophecms/page-type'
+        },
+        'unique-error-counter': {
+          handlers(self) {
+            return {
+              '@apostrophecms/doc:fixUniqueError': {
+                count() {
+                  self.count = (self.count || 0) + 1;
+                }
+              }
+            };
+          }
         }
       }
     });
@@ -254,6 +265,66 @@ describe('Docs', function() {
       assert(e);
       assert(e.code === 11000);
     }
+  });
+
+  it('should retry a slug collision through fixUniqueError handlers', async function() {
+    const counter = apos.modules['unique-error-counter'];
+    counter.count = 0;
+
+    await insertOne(apos);
+    const doc = await apos.doc.insert(apos.task.getReq(), {
+      slug: 'one',
+      visibility: 'public',
+      type: 'test-people',
+      firstName: 'Harry',
+      lastName: 'Gerber',
+      age: 29,
+      alive: true
+    });
+
+    assert(doc.slug !== 'one');
+    assert(counter.count >= 1);
+  });
+
+  it('should not retry an _id collision', async function() {
+    const counter = apos.modules['unique-error-counter'];
+    counter.count = 0;
+
+    const first = await apos.doc.insert(apos.task.getReq(), {
+      _id: 'same-id:en:published',
+      aposDocId: 'same-id',
+      aposLocale: 'en:published',
+      slug: 'same-id-first',
+      visibility: 'public',
+      type: 'test-people',
+      firstName: 'First',
+      lastName: 'Person',
+      age: 30,
+      alive: true
+    });
+    assert.equal(first._id, 'same-id:en:published');
+
+    await assert.rejects(
+      apos.doc.insert(apos.task.getReq(), {
+        _id: 'same-id:en:published',
+        aposDocId: 'same-id',
+        aposLocale: 'en:published',
+        slug: 'same-id-second',
+        visibility: 'public',
+        type: 'test-people',
+        firstName: 'Second',
+        lastName: 'Person',
+        age: 31,
+        alive: true
+      }),
+      (err) => {
+        assert.equal(err.code, 11000);
+        assert.deepEqual(err.keyPattern, { _id: 1 });
+        assert.equal(err.aposAddendum, undefined);
+        return true;
+      }
+    );
+    assert.equal(counter.count, 0);
   });
 
   /// ///

--- a/packages/import-export/lib/methods/import.js
+++ b/packages/import-export/lib/methods/import.js
@@ -907,7 +907,10 @@ module.exports = self => {
           throw new Error('Inserting document failed');
         }
 
-        if (manager.options.autopublish === true) {
+        if (await self.isAlreadyPublished(doc, {
+          manager,
+          method
+        })) {
           return true;
         }
       }
@@ -1451,6 +1454,25 @@ module.exports = self => {
         ids: [],
         types: new Set()
       });
+    },
+
+    // Whether the draft insert has already published this doc, so the
+    // published doc from the file must be skipped: the type autopublishes,
+    // or a handler published this particular doc during the draft insert.
+    // Only on insert. On update the published doc always exists and the
+    // file's version must still be applied.
+    async isAlreadyPublished(doc, { manager, method }) {
+      if (manager.options.autopublish === true) {
+        return true;
+      }
+      if (method !== 'insert') {
+        return false;
+      }
+      const existing = await self.apos.doc.db.findOne(
+        { _id: doc._id },
+        { projection: { _id: 1 } }
+      );
+      return Boolean(existing);
     },
 
     // Stamp the specific document that was imported.

--- a/packages/import-export/test/force-published.js
+++ b/packages/import-export/test/force-published.js
@@ -1,0 +1,369 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const t = require('apostrophe/test-lib/util.js');
+const { output: gzip } = require('../lib/formats/gzip.js');
+const {
+  getAppConfig, insertAdminUser, cleanData
+} = require('./util/index.js');
+
+// A handler publishing selected drafts of a type that is not autopublished,
+// the way a project may publish some documents on their own.
+function forcePublishHandlers(self) {
+  return {
+    afterSave: {
+      autopublish(_super, req, doc, options) {
+        if (
+          self.options.localized &&
+          !self.options.autopublish &&
+          doc.aposLocale.includes(':draft') &&
+          doc.forcePublish === true
+        ) {
+          return self.publish(req, doc, {
+            ...options,
+            autopublishing: true
+          });
+        }
+        return _super(req, doc, options);
+      }
+    }
+  };
+}
+
+const forcePublishField = {
+  forcePublish: {
+    type: 'boolean',
+    def: false
+  }
+};
+
+describe('#import - documents published by the draft insert', function() {
+  this.timeout(t.timeout);
+
+  let apos;
+  let importExportManager;
+  let jobManager;
+  let tempPath;
+  let exportsPath;
+
+  before(async function() {
+    apos = await t.create({
+      root: module,
+      testModule: true,
+      modules: getAppConfig({
+        '@apostrophecms/page': {
+          options: {
+            park: [],
+            types: [
+              {
+                name: '@apostrophecms/home-page',
+                label: 'Home'
+              },
+              {
+                name: 'force-published-page',
+                label: 'Force Published Page'
+              }
+            ]
+          }
+        },
+        'force-published-piece': {
+          extend: '@apostrophecms/piece-type',
+          options: {
+            alias: 'forcePublishedPiece',
+            autopublish: false
+          },
+          fields: {
+            add: forcePublishField
+          },
+          extendHandlers: forcePublishHandlers
+        },
+        'force-published-page': {
+          extend: '@apostrophecms/page-type',
+          options: {
+            autopublish: false
+          },
+          fields: {
+            add: forcePublishField
+          },
+          extendHandlers: forcePublishHandlers
+        }
+      })
+    });
+
+    tempPath = path.join(apos.rootDir, 'data/temp/uploadfs');
+    exportsPath = path.join(apos.rootDir, 'public/uploads/exports');
+    importExportManager = apos.modules['@apostrophecms/import-export'];
+    jobManager = apos.modules['@apostrophecms/job'];
+
+    await insertAdminUser(apos);
+  });
+
+  after(async function() {
+    await cleanData([ tempPath, exportsPath ]);
+    await t.destroy(apos);
+  });
+
+  afterEach(async function() {
+    await apos.doc.db.deleteMany({
+      type: { $in: [ 'force-published-piece', 'force-published-page', 'article' ] }
+    });
+  });
+
+  // Export the given ids (both modes) to a file the import can consume.
+  async function exportToTemp(manager, ids) {
+    const req = apos.task.getReq({
+      mode: 'draft',
+      body: {
+        _ids: ids,
+        type: 'test'
+      }
+    });
+    const { url } = await importExportManager.export(req, manager);
+    const fileName = path.basename(url);
+    const importFilePath = path.join(tempPath, fileName);
+    await fs.mkdir(tempPath, { recursive: true });
+    await fs.copyFile(path.join(exportsPath, fileName), importFilePath);
+    return importFilePath;
+  }
+
+  // Run an import while recording every logged error and every low-level
+  // write and lookup on the docs collection.
+  async function importWithSpies(importFilePath, body = {}) {
+    const errors = [];
+    const insertOneIds = [];
+    const findOneIds = [];
+    const origError = apos.util.error;
+    const origInsertOne = apos.doc.db.insertOne;
+    const origFindOne = apos.doc.db.findOne;
+    apos.util.error = (error) => errors.push(error);
+    apos.doc.db.insertOne = function(doc, ...rest) {
+      insertOneIds.push(doc._id);
+      return origInsertOne.call(this, doc, ...rest);
+    };
+    apos.doc.db.findOne = function(criteria, ...rest) {
+      findOneIds.push(criteria?._id);
+      return origFindOne.call(this, criteria, ...rest);
+    };
+
+    const req = apos.task.getReq({
+      locale: 'en',
+      body,
+      files: {
+        file: {
+          path: importFilePath,
+          type: importExportManager.formats.gzip.allowedTypes[0]
+        }
+      }
+    });
+
+    try {
+      const result = await importExportManager.import(req);
+      return {
+        req,
+        result,
+        errors,
+        insertOneIds,
+        findOneIds
+      };
+    } finally {
+      apos.util.error = origError;
+      apos.doc.db.insertOne = origInsertOne;
+      apos.doc.db.findOne = origFindOne;
+    }
+  }
+
+  async function assertRoundTrip({
+    type, ids, errors, insertOneIds, jobId, title
+  }) {
+    const job = await jobManager.db.findOne({ _id: jobId });
+    const docs = await apos.doc.db
+      .find({ type })
+      .sort({ _id: 1 })
+      .toArray();
+
+    assert.deepEqual(errors, [], 'no error should be logged');
+    assert.equal(job.bad, 0);
+    assert.equal(job.good, 2);
+    assert.deepEqual(
+      insertOneIds.filter(id => id === ids.published),
+      [ ids.published ],
+      'the published doc should be inserted exactly once'
+    );
+    assert.deepEqual(
+      docs.map(doc => doc._id),
+      [ ids.draft, ids.published ]
+    );
+    for (const doc of docs) {
+      assert.equal(doc.title, title);
+      assert.ok(doc.importedAt instanceof Date, `${doc._id} should be stamped`);
+    }
+  }
+
+  it('should import a piece the draft insert published', async function() {
+    const req = apos.task.getReq({ mode: 'draft' });
+    const draft = await apos.forcePublishedPiece.insert(req, {
+      ...apos.forcePublishedPiece.newInstance(),
+      title: 'force published piece',
+      forcePublish: true
+    });
+    const ids = {
+      draft: draft._id,
+      published: `${draft.aposDocId}:en:published`
+    };
+
+    const importFilePath = await exportToTemp(apos.forcePublishedPiece, [ draft._id ]);
+    await apos.doc.db.deleteMany({ type: 'force-published-piece' });
+
+    const {
+      result, errors, insertOneIds
+    } = await importWithSpies(importFilePath);
+
+    await assertRoundTrip({
+      type: 'force-published-piece',
+      ids,
+      errors,
+      insertOneIds,
+      jobId: result.jobId,
+      title: 'force published piece'
+    });
+  });
+
+  it('should import a page the draft insert published', async function() {
+    const req = apos.task.getReq({ mode: 'draft' });
+    const draft = await apos.page.insert(req, '_home', 'lastChild', {
+      title: 'force published page',
+      type: 'force-published-page',
+      slug: '/force-published-page',
+      forcePublish: true
+    });
+    const ids = {
+      draft: draft._id,
+      published: `${draft.aposDocId}:en:published`
+    };
+
+    const importFilePath = await exportToTemp(apos.page, [ draft._id ]);
+    await apos.doc.db.deleteMany({ type: 'force-published-page' });
+
+    const {
+      result, errors, insertOneIds
+    } = await importWithSpies(importFilePath);
+
+    await assertRoundTrip({
+      type: 'force-published-page',
+      ids,
+      errors,
+      insertOneIds,
+      jobId: result.jobId,
+      title: 'force published page'
+    });
+  });
+
+  it('should still apply the published doc from the file when overriding duplicates', async function() {
+    const req = apos.task.getReq({ mode: 'draft' });
+    const draft = await apos.forcePublishedPiece.insert(req, {
+      ...apos.forcePublishedPiece.newInstance(),
+      title: 'force published piece',
+      forcePublish: true
+    });
+    const publishedId = `${draft.aposDocId}:en:published`;
+
+    // Same docs as on the site, with a change made only to the published one.
+    const docs = await apos.doc.db
+      .find({ type: 'force-published-piece' })
+      .sort({ _id: 1 })
+      .toArray();
+    const published = docs.find(doc => doc._id === publishedId);
+    published.title = 'force published piece EDITED';
+    const importFilePath = path.join(tempPath, 'force-published-override.tar.gz');
+    await fs.mkdir(tempPath, { recursive: true });
+    await gzip(importFilePath, { docs }, async () => {});
+
+    const {
+      req: importReq, result, errors
+    } = await importWithSpies(importFilePath, { formatLabel: 'gzip' });
+    assert.deepEqual(errors, []);
+    assert.equal(result.duplicatedDocs.length, 1);
+
+    const origError = apos.util.error;
+    const overrideErrors = [];
+    apos.util.error = (error) => overrideErrors.push(error);
+    try {
+      await importExportManager.overrideDuplicates(importReq.clone({
+        body: {
+          ...importReq.body,
+          docIds: result.duplicatedDocs.map(({ aposDocId }) => aposDocId),
+          duplicatedDocs: result.duplicatedDocs,
+          importedAttachments: result.importedAttachments,
+          exportId: result.exportId,
+          jobId: result.jobId,
+          notificationId: result.notificationId,
+          formatLabel: result.formatLabel
+        }
+      }));
+    } finally {
+      apos.util.error = origError;
+    }
+
+    const job = await jobManager.db.findOne({ _id: result.jobId });
+    // Re-publishing the existing doc also writes a `:previous` copy.
+    const after = await apos.doc.db
+      .find({
+        type: 'force-published-piece',
+        aposMode: { $in: [ 'draft', 'published' ] }
+      })
+      .sort({ _id: 1 })
+      .toArray();
+
+    assert.deepEqual(overrideErrors, []);
+    assert.equal(job.bad, 0);
+    assert.deepEqual(
+      after.map(({ _id, title }) => ({
+        _id,
+        title
+      })),
+      [
+        {
+          _id: draft._id,
+          title: 'force published piece'
+        },
+        {
+          _id: publishedId,
+          title: 'force published piece EDITED'
+        }
+      ]
+    );
+  });
+
+  it('should not look up the published doc of an autopublished type', async function() {
+    const req = apos.task.getReq({ mode: 'draft' });
+    const draft = await apos.article.insert(req, {
+      ...apos.article.newInstance(),
+      title: 'autopublished article'
+    });
+    const ids = {
+      draft: draft._id,
+      published: `${draft.aposDocId}:en:published`
+    };
+
+    const importFilePath = await exportToTemp(apos.article, [ draft._id ]);
+    await apos.doc.db.deleteMany({ type: 'article' });
+
+    const {
+      result, errors, insertOneIds, findOneIds
+    } = await importWithSpies(importFilePath);
+
+    await assertRoundTrip({
+      type: 'article',
+      ids,
+      errors,
+      insertOneIds,
+      jobId: result.jobId,
+      title: 'autopublished article'
+    });
+    assert.deepEqual(
+      findOneIds.filter(id => id === ids.published),
+      [],
+      'the published doc should not be looked up for an autopublished type'
+    );
+  });
+});


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:

*Check one*
- [ ] main
- [x] latest
- [x] stable
- [ ] Check if this PR will be resubmitted against another branch

## Summary

Importing a document that a handler published during the draft insert (for example a template on a type that is not autopublished) no longer fails with a duplicate `_id` error.

`retryUntilUnique` no longer retries an `_id` collision that `fixUniqueError` handlers cannot resolve.

## What are the specific steps to test this change?

Import doc templates on doc types that are not autopublished now doesn't raise duplicate errors.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
