### PR TITLE
Force login direction (ltr/rtl)

### DIFF
--- a/.changeset/login-direction.md
+++ b/.changeset/login-direction.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": minor
+---
+
+Added the `direction` option to `@apostrophecms/login` (`ltr` or `rtl`) to force the text direction of the login page and the pages related to it (password reset, additional login requirements) regardless of the direction of the current locale; unset, the login page keeps following the locale. Projects that override `TheAposLogin.vue` keep the `<html dir>` fix but lose the root direction class; projects that override `login.html` without extending `data.outerLayout` must set the `dir` attribute themselves.

--- a/.changeset/login-hcaptcha-language.md
+++ b/.changeset/login-hcaptcha-language.md
@@ -1,0 +1,5 @@
+---
+"@apostrophecms/login-hcaptcha": minor
+---
+
+The hCaptcha widget is displayed in the language of the admin UI (`defaultAdminLocale`, otherwise the locale of the login page), and the new `hcaptcha.hl` option of `@apostrophecms/login` forces a specific language.

--- a/.changeset/passport-bridge-direction.md
+++ b/.changeset/passport-bridge-direction.md
@@ -1,0 +1,5 @@
+---
+"@apostrophecms/passport-bridge": patch
+---
+
+The login error page follows the `direction` option of `@apostrophecms/login`.

--- a/packages/apostrophe/modules/@apostrophecms/i18n/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/i18n/index.js
@@ -695,10 +695,16 @@ module.exports = {
           return `${id}:${locale}:${mode}`;
         }
       },
-      getBrowserData(req) {
-        const adminLocale = req.user?.adminLocale === ''
+      // The locale of the admin UI for this request: the user's choice when
+      // they made one, otherwise `defaultAdminLocale`, otherwise the request
+      // locale.
+      getAdminLocale(req) {
+        return req.user?.adminLocale === ''
           ? req.locale
           : req.user?.adminLocale || self.defaultAdminLocale || req.locale;
+      },
+      getBrowserData(req) {
+        const adminLocale = self.getAdminLocale(req);
         const i18n = {
           [adminLocale]: self.getBrowserBundles(adminLocale)
         };

--- a/packages/apostrophe/modules/@apostrophecms/login/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/login/index.js
@@ -23,6 +23,14 @@
 // acted upon in time, the user must request a password reset again.
 // The default is `48`.
 //
+// `direction`
+//
+// Forces the text direction of the login page and the pages related to it
+// (password reset, additional login requirements). May be `ltr` or `rtl`.
+// If not set, the login page follows the direction of the current locale.
+// Useful when the editors read a different direction than the site visitors,
+// for instance an English speaking team managing an Arabic site.
+//
 // `bearerTokens`
 //
 // If not explicitly set to `false`, apps may log in via the login route
@@ -77,6 +85,12 @@ module.exports = {
     whoamiFields: []
   },
   async init(self) {
+    if (self.options.direction && ![ 'ltr', 'rtl' ].includes(self.options.direction)) {
+      throw self.apos.error(
+        'invalid',
+        `The "direction" option of "${self.__meta.name}" module must be "ltr", "rtl" or "null".`
+      );
+    }
     self.passport = new Passport();
     self.enableSerializeUsers();
     self.enableDeserializeUsers();
@@ -101,6 +115,13 @@ module.exports = {
           await self.checkForUserAndAlert();
         }
       },
+      '@apostrophecms/page:beforeSend': {
+        setLoginPageDirection(req) {
+          if (req.aposLoginPage && req.data.i18n) {
+            req.data.i18n.direction = self.getDirection(req);
+          }
+        }
+      },
       'apostrophe:destroy': {
         clearIntervals() {
           if (self.cleanupInterval) {
@@ -123,6 +144,7 @@ module.exports = {
             return res.redirect('/');
           }
           req.scene = 'apos';
+          req.aposLoginPage = true;
           try {
             await self.sendPage(req, 'login', {});
           } catch (e) {
@@ -470,6 +492,16 @@ module.exports = {
         return self.options.loginUrl ? self.options.loginUrl : '/login';
       },
 
+      // The text direction of the login page for this request: the `direction`
+      // option when set, otherwise the direction of the request locale.
+      // Pages related to login (rendered with `sendPage` while
+      // `req.aposLoginPage` is true) follow the same rule.
+      getDirection(req) {
+        return self.options.direction ||
+          self.apos.i18n.locales[req.locale]?.direction ||
+          'ltr';
+      },
+
       // The URL a human logs in at, or `null` when there is none to point at:
       // local login can be turned off in favor of another mechanism, and a
       // module that replaces it should override this to say where it moved.
@@ -623,6 +655,7 @@ module.exports = {
           schema: self.getSchema(),
           action: self.action,
           passwordResetEnabled: self.isPasswordResetEnabled(),
+          direction: self.getDirection(req),
           ...(req.user
             ? {
               user: {
@@ -1028,7 +1061,8 @@ module.exports = {
             label: field.label,
             placeholder: self.options.placeholder[field.name],
             type: field.type,
-            required: true
+            required: true,
+            ...(self.options.direction ? { direction: self.options.direction } : {})
           })
           );
       },

--- a/packages/apostrophe/modules/@apostrophecms/login/ui/apos/components/TheAposLogin.vue
+++ b/packages/apostrophe/modules/@apostrophecms/login/ui/apos/components/TheAposLogin.vue
@@ -4,7 +4,7 @@
       v-show="loaded"
       class="apos-login apos-theme-dark"
       data-apos-test="loginPage"
-      :class="themeClass"
+      :class="[ themeClass, directionClass ]"
     >
       <transition name="fade-outer">
         <div

--- a/packages/apostrophe/modules/@apostrophecms/login/ui/apos/logic/AposForgotPasswordForm.js
+++ b/packages/apostrophe/modules/@apostrophecms/login/ui/apos/logic/AposForgotPasswordForm.js
@@ -18,7 +18,8 @@ export default {
           label: 'apostrophe:email',
           placeholder: 'apostrophe:loginEnterEmail',
           type: 'email',
-          required: true
+          required: true,
+          direction: apos.login.direction
         }
       ]
     };

--- a/packages/apostrophe/modules/@apostrophecms/login/ui/apos/logic/AposResetPasswordForm.js
+++ b/packages/apostrophe/modules/@apostrophecms/login/ui/apos/logic/AposResetPasswordForm.js
@@ -29,7 +29,8 @@ export default {
           name: 'password',
           label: 'apostrophe:newPassword',
           type: 'password',
-          required: true
+          required: true,
+          direction: apos.login.direction
         }
       ]
     };

--- a/packages/apostrophe/modules/@apostrophecms/login/ui/apos/logic/TheAposLogin.js
+++ b/packages/apostrophe/modules/@apostrophecms/login/ui/apos/logic/TheAposLogin.js
@@ -32,6 +32,9 @@ export default {
     },
     homeUrl() {
       return `${apos.prefix}/`;
+    },
+    directionClass() {
+      return apos.login.direction ? `apos-${apos.login.direction}` : null;
     }
   },
   // We need it here and not in the login form because the version used in the

--- a/packages/apostrophe/test/login-direction.js
+++ b/packages/apostrophe/test/login-direction.js
@@ -1,0 +1,219 @@
+const cheerio = require('cheerio');
+const assert = require('node:assert/strict');
+const t = require('../test-lib/test.js');
+
+const locales = {
+  en: {
+    label: 'English'
+  },
+  he: {
+    label: 'Hebrew',
+    prefix: '/he',
+    direction: 'rtl'
+  }
+};
+
+async function create(loginOptions = {}) {
+  return t.create({
+    root: module,
+    modules: {
+      '@apostrophecms/i18n': {
+        options: {
+          locales
+        }
+      },
+      '@apostrophecms/login': {
+        options: {
+          passwordReset: true,
+          ...loginOptions
+        }
+      },
+      // Renders a page that extends the outer layout, see test/modules
+      'i18n-test-page': {
+        options: {
+          ignoreNoExtendWarning: true
+        }
+      }
+    }
+  });
+}
+
+// Renders a regular page, as any module rendering with `sendPage` does
+async function getPageAttrs(apos, req) {
+  const $ = cheerio.load(await apos.modules['i18n-test-page'].renderPage(req, 'page'));
+  const $html = $('html');
+  return {
+    lang: $html.attr('lang'),
+    dir: $html.attr('dir')
+  };
+}
+
+async function getHtmlAttrs(apos, url) {
+  const $ = cheerio.load(await apos.http.get(url));
+  const $html = $('html');
+  return {
+    lang: $html.attr('lang'),
+    dir: $html.attr('dir')
+  };
+}
+
+describe('Login direction', function () {
+  this.timeout(t.timeout);
+
+  describe('default (follow the locale)', function () {
+    let apos;
+
+    before(async function () {
+      apos = await create();
+    });
+
+    after(async function () {
+      return t.destroy(apos);
+    });
+
+    it('should render the login page in the locale direction', async function () {
+      assert.deepEqual(await getHtmlAttrs(apos, '/login'), {
+        lang: 'en',
+        dir: 'ltr'
+      });
+      assert.deepEqual(await getHtmlAttrs(apos, '/he/login'), {
+        lang: 'he',
+        dir: 'rtl'
+      });
+    });
+
+    it('should expose the locale direction to the browser', async function () {
+      assert.equal(apos.login.getBrowserData(apos.task.getReq()).direction, 'ltr');
+      assert.equal(
+        apos.login.getBrowserData(apos.task.getReq({ locale: 'he' })).direction,
+        'rtl'
+      );
+    });
+
+    it('should not force a direction on the login fields', function () {
+      const schema = apos.login.getSchema();
+      assert.equal(schema.length, 2);
+      for (const field of schema) {
+        assert.equal(field.direction, undefined);
+      }
+    });
+  });
+
+  describe('direction: ltr on an RTL locale', function () {
+    let apos;
+
+    before(async function () {
+      apos = await create({ direction: 'ltr' });
+    });
+
+    after(async function () {
+      return t.destroy(apos);
+    });
+
+    it('should render the login page LTR and keep the locale lang', async function () {
+      assert.deepEqual(await getHtmlAttrs(apos, '/login'), {
+        lang: 'en',
+        dir: 'ltr'
+      });
+      assert.deepEqual(await getHtmlAttrs(apos, '/he/login'), {
+        lang: 'he',
+        dir: 'ltr'
+      });
+    });
+
+    it('should expose the forced direction to the browser', async function () {
+      assert.equal(apos.login.getBrowserData(apos.task.getReq()).direction, 'ltr');
+      assert.equal(
+        apos.login.getBrowserData(apos.task.getReq({ locale: 'he' })).direction,
+        'ltr'
+      );
+    });
+
+    it('should force the direction of the login fields', function () {
+      const schema = apos.login.getSchema();
+      assert.equal(schema.length, 2);
+      for (const field of schema) {
+        assert.equal(field.direction, 'ltr');
+      }
+    });
+
+    it('should not change the direction of regular pages', async function () {
+      assert.deepEqual(await getPageAttrs(apos, apos.task.getReq()), {
+        lang: 'en',
+        dir: 'ltr'
+      });
+      assert.deepEqual(await getPageAttrs(apos, apos.task.getReq({ locale: 'he' })), {
+        lang: 'he',
+        dir: 'rtl'
+      });
+    });
+
+    it('should apply to any page flagged as a login page', async function () {
+      const req = apos.task.getReq({ locale: 'he' });
+      req.aposLoginPage = true;
+      assert.deepEqual(await getPageAttrs(apos, req), {
+        lang: 'he',
+        dir: 'ltr'
+      });
+    });
+  });
+
+  describe('direction: rtl on an LTR locale', function () {
+    let apos;
+
+    before(async function () {
+      apos = await create({ direction: 'rtl' });
+    });
+
+    after(async function () {
+      return t.destroy(apos);
+    });
+
+    it('should render the login page RTL', async function () {
+      assert.deepEqual(await getHtmlAttrs(apos, '/login'), {
+        lang: 'en',
+        dir: 'rtl'
+      });
+      assert.deepEqual(await getPageAttrs(apos, apos.task.getReq()), {
+        lang: 'en',
+        dir: 'ltr'
+      });
+    });
+  });
+
+  describe('invalid direction', function () {
+    it('should refuse to start', async function () {
+      // The i18n module initializes before the login module, so the
+      // partially booted instance can be captured and destroyed
+      let captured;
+      try {
+        await assert.rejects(
+          t.create({
+            root: module,
+            exit: 'throw',
+            modules: {
+              '@apostrophecms/i18n': {
+                init(self) {
+                  captured = self.apos;
+                }
+              },
+              '@apostrophecms/login': {
+                options: {
+                  direction: 'up'
+                }
+              }
+            }
+          }),
+          (e) => {
+            assert(e.message.includes(
+              'The "direction" option of "@apostrophecms/login" module must be "ltr", "rtl" or "null".'
+            ));
+            return true;
+          }
+        );
+      } finally {
+        await t.destroy(captured);
+      }
+    });
+  });
+});

--- a/packages/login-hcaptcha/README.md
+++ b/packages/login-hcaptcha/README.md
@@ -58,6 +58,36 @@ module.exports = {
 
 Once configured, hCaptcha verification should work on all login attempts.
 
+### Language
+
+The hCaptcha is displayed in the language of the admin UI: the `defaultAdminLocale` of the `@apostrophecms/i18n` module when set, otherwise the locale of the login page. Set `hl` to force a specific language ([ISO 639-1 code](https://docs.hcaptcha.com/languages)). hCaptcha falls back to auto-detection when the code is not supported.
+
+```javascript
+// modules/@apostrophecms/login/index.js
+module.exports = {
+  options: {
+    hcaptcha: {
+      site: 'ADD YOUR SITE KEY',
+      secret: 'ADD YOUR SECRET KEY',
+      hl: 'en'
+    }
+  }
+};
+```
+
+### Right-to-left websites
+
+On a website whose current locale is right-to-left, the login page and the hCaptcha widget are laid out right-to-left as well. If your editors prefer a left-to-right login page, set the `direction` option of the `@apostrophecms/login` module (*not* this module):
+
+```javascript
+// modules/@apostrophecms/login/index.js
+module.exports = {
+  options: {
+    direction: 'ltr'
+  }
+};
+```
+
 ### Content security headers
 
 If your site has a content security policy, including if you use the [Apostrophe Security Headers](https://www.npmjs.com/package/@apostrophecms/security-headers) module, you will need to add additional configuration to use this module. This module adds a script tag to the site's `head` tag fetching hCaptcha code, so we need to allow resources from that domain.

--- a/packages/login-hcaptcha/index.js
+++ b/packages/login-hcaptcha/index.js
@@ -15,7 +15,10 @@ module.exports = {
           phase: 'beforeSubmit',
           async props(req) {
             return {
-              sitekey: self.options.hcaptcha.site
+              sitekey: self.options.hcaptcha.site,
+              hl: self.options.hcaptcha.hl ||
+                self.apos.i18n.getAdminLocale?.(req) ||
+                req.locale
             };
           },
           async verify(req, data) {

--- a/packages/login-hcaptcha/test/test.js
+++ b/packages/login-hcaptcha/test/test.js
@@ -114,6 +114,7 @@ describe('@apostrophecms/login-hcaptcha', function () {
       );
 
       assert.equal(context.requirementProps.AposHcaptcha.sitekey, siteConfig.site);
+      assert.equal(context.requirementProps.AposHcaptcha.hl, 'en');
 
       await apos.http.post(
         '/api/v1/@apostrophecms/login/login',
@@ -236,5 +237,60 @@ describe('@apostrophecms/login-hcaptcha', function () {
         'error-codes': [ 'invalid-input-response' ]
       }
     });
+  });
+});
+
+describe('@apostrophecms/login-hcaptcha widget language and login direction', function () {
+  let apos;
+
+  this.timeout(25000);
+
+  after(async function () {
+    await testUtil.destroy(apos);
+  });
+
+  it('should follow the default admin locale and honor hcaptcha.hl', async function () {
+    const config = getAppConfig();
+    config['@apostrophecms/i18n'] = {
+      options: {
+        defaultAdminLocale: 'en',
+        locales: {
+          en: { label: 'English' },
+          he: {
+            label: 'Hebrew',
+            prefix: '/he',
+            direction: 'rtl'
+          }
+        }
+      }
+    };
+    config['@apostrophecms/login'].options.direction = 'ltr';
+    apos = await testUtil.create({
+      shortname: 'loginTest',
+      testModule: true,
+      modules: config
+    });
+
+    // establish session
+    const jar = apos.http.jar();
+    await apos.http.get('/he/', { jar });
+
+    const context = await apos.http.post('/he/api/v1/@apostrophecms/login/context', {
+      body: {},
+      jar
+    });
+    assert.equal(context.requirementProps.AposHcaptcha.hl, 'en');
+
+    apos.login.options.hcaptcha.hl = 'fr';
+    const overridden = await apos.http.post('/he/api/v1/@apostrophecms/login/context', {
+      body: {},
+      jar
+    });
+    assert.equal(overridden.requirementProps.AposHcaptcha.hl, 'fr');
+  });
+
+  it('should render the login page LTR on an RTL locale', async function () {
+    const page = await apos.http.get('/he/login');
+    assert.match(page, /<html lang="he" dir="ltr"/);
   });
 });

--- a/packages/login-hcaptcha/ui/apos/components/AposHcaptcha.vue
+++ b/packages/login-hcaptcha/ui/apos/components/AposHcaptcha.vue
@@ -12,6 +12,12 @@ export default {
       type: String,
       default: null
     },
+    // Widget language, an ISO 639-1 code. hCaptcha auto-detects when unset
+    // or unsupported.
+    hl: {
+      type: String,
+      default: null
+    },
     url: {
       type: String,
       default: 'https://js.hcaptcha.com/1/api.js?render=explicit'
@@ -65,6 +71,7 @@ export default {
 
       const options = {
         sitekey: this.sitekey,
+        ...(this.hl ? { hl: this.hl } : {}),
         callback: this.verify,
         'expired-callback': this.reset,
         'error-callback': this.reset

--- a/packages/login-recaptcha/README.md
+++ b/packages/login-recaptcha/README.md
@@ -58,6 +58,19 @@ module.exports = {
 
 Once configured, reCAPTCHA verification should work on all login attempts.
 
+### Right-to-left websites
+
+On a website whose current locale is right-to-left, the login page is laid out right-to-left as well (the reCAPTCHA badge keeps its own fixed position). If your editors prefer a left-to-right login page, set the `direction` option of the `@apostrophecms/login` module (*not* this module):
+
+```javascript
+// modules/@apostrophecms/login/index.js
+module.exports = {
+  options: {
+    direction: 'ltr'
+  }
+};
+```
+
 ### Content security headers
 
 If your site has a content security policy, including if you use the [Apostrophe Security Headers](https://www.npmjs.com/package/@apostrophecms/security-headers) module, you will need to add additional configuration to use this module. This module adds a script tag to the site's `head` tag fetching reCAPTCHA code. That reCAPTCHA code also constructs an iframe. The external script and iframe use the `www.google.com` and `www.gstatic.com` domains, so we need to allow resources from that domain.

--- a/packages/login-recaptcha/test/test.js
+++ b/packages/login-recaptcha/test/test.js
@@ -249,3 +249,54 @@ describe('@apostrophecms/login-recaptcha', function () {
     }
   });
 });
+
+describe('@apostrophecms/login-recaptcha login direction', function () {
+  let apos;
+
+  this.timeout(25000);
+
+  after(async function () {
+    await testUtil.destroy(apos);
+  });
+
+  it('should render the login page LTR on an RTL locale', async function () {
+    apos = await testUtil.create({
+      shortname: 'loginTest',
+      testModule: true,
+      modules: {
+        '@apostrophecms/express': {
+          options: {
+            session: {
+              secret: 'test-this-module'
+            }
+          }
+        },
+        '@apostrophecms/i18n': {
+          options: {
+            locales: {
+              en: { label: 'English' },
+              he: {
+                label: 'Hebrew',
+                prefix: '/he',
+                direction: 'rtl'
+              }
+            }
+          }
+        },
+        '@apostrophecms/login-recaptcha': {},
+        '@apostrophecms/login': {
+          options: {
+            direction: 'ltr',
+            recaptcha: {
+              site: getSiteConfig().site,
+              secret: getSiteConfig().secret
+            }
+          }
+        }
+      }
+    });
+
+    const page = await apos.http.get('/he/login');
+    assert.match(page, /<html lang="he" dir="ltr"/);
+  });
+});

--- a/packages/login-totp/README.md
+++ b/packages/login-totp/README.md
@@ -58,6 +58,19 @@ module.exports = {
 
 > ⚠️ All configuration of TOTP related options is done on the `@apostrophecms/login` module. The `@apostrophecms/login-totp` module is just an "improvement" to that module, so it has no configuration options of its own.
 
+### Right-to-left websites
+
+On a website whose current locale is right-to-left, the login page, including the TOTP setup and verification screens, is laid out right-to-left as well. If your editors prefer a left-to-right login page, set the `direction` option of the `@apostrophecms/login` module (*not* this module):
+
+```javascript
+// modules/@apostrophecms/login/index.js
+module.exports = {
+  options: {
+    direction: 'ltr'
+  }
+};
+```
+
 ### Resetting TOTP when a user loses their device
 
 If a user loses their device, an admin can edit the appropriate user via the admin bar. Select "Yes" for the "Reset TOTP" field and save the user.

--- a/packages/login-totp/test/test.js
+++ b/packages/login-totp/test/test.js
@@ -127,3 +127,53 @@ describe('totp module', function () {
     });
   });
 });
+
+describe('@apostrophecms/login-totp login direction', function () {
+  let apos;
+
+  this.timeout(25000);
+
+  after(async function () {
+    await testUtil.destroy(apos);
+  });
+
+  it('should render the login page LTR on an RTL locale', async function () {
+    apos = await testUtil.create({
+      shortname: 'loginTest',
+      testModule: true,
+      modules: {
+        '@apostrophecms/express': {
+          options: {
+            session: {
+              secret: 'test-this-module'
+            }
+          }
+        },
+        '@apostrophecms/i18n': {
+          options: {
+            locales: {
+              en: { label: 'English' },
+              he: {
+                label: 'Hebrew',
+                prefix: '/he',
+                direction: 'rtl'
+              }
+            }
+          }
+        },
+        '@apostrophecms/login-totp': {},
+        '@apostrophecms/login': {
+          options: {
+            direction: 'ltr',
+            totp: {
+              secret: 'totpsecret'
+            }
+          }
+        }
+      }
+    });
+
+    const page = await apos.http.get('/he/login');
+    assert.match(page, /<html lang="he" dir="ltr"/);
+  });
+});

--- a/packages/passport-bridge/README.md
+++ b/packages/passport-bridge/README.md
@@ -369,6 +369,10 @@ After successful authentication, users will be redirected to your Astro frontend
 
 The `failureRedirect` configuration will send users to your specified error page (e.g., `/login?error=oauth_failed`) where you can display appropriate error messages based on URL parameters.
 
+### Right-to-left websites
+
+The error page shown when a login attempt is rejected follows the text direction of the current locale. Set the `direction` option of the `@apostrophecms/login` module to `ltr` or `rtl` to force a direction for it, as for the login page itself.
+
 ### Configuring your identity provider
 
 #### What is my oauth callback URL?

--- a/packages/passport-bridge/index.js
+++ b/packages/passport-bridge/index.js
@@ -246,6 +246,8 @@ module.exports = {
 
       addFailureRoute(spec) {
         self.apos.app.get(self.getFailureUrl(spec), function (req, res) {
+          // Follows the `direction` option of the login module
+          req.aposLoginPage = true;
           // Gets i18n'd in the template
           return self.sendPage(req, 'error', {
             spec,


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:

*Check one*
- [x] main
- [x] latest
- [ ] stable
- [ ] Check if this PR will be resubmitted against another branch

## Summary

Force login screens text direction (`dir`) as login module option. 

## What are the specific steps to test this change?

When login module option `direction: 'ltr'` is set, the login screens should be always LTR, no matter the language. Without setting it, no change of the current behavior (follows the current locale direction). 

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
