### PR TITLE
Fix protocol output for locales with unique prefixes

### DIFF
--- a/.changeset/some-grapes-write.md
+++ b/.changeset/some-grapes-write.md
@@ -1,0 +1,5 @@
+---
+"@apostrophecms/sitemap": patch
+---
+
+Per-locale sitemap generation (`perLocale: true`) now uses the scheme (`http`/`https`) of the site's configured `baseUrl` for locales with their own hostname (`separateHost: true` / a `hostname` locale option), instead of always defaulting to `http`. Previously, `<loc>` and `xhtml:link hreflang` URLs for such locales could be emitted as `http://` even when the site and that host are served exclusively over HTTPS.

--- a/packages/sitemap/index.js
+++ b/packages/sitemap/index.js
@@ -319,10 +319,29 @@ module.exports = {
       // incorrect cache behavior (e.g. poisoning the sitemap cache with
       // static-build URLs).
       getReq(locale, { staticBuild = false, externalFront = false } = {}) {
+        // `getAnonReq` builds a synthetic request that is not tied to any
+        // actual HTTP connection, so `req.protocol` always defaults to
+        // `http`. That's fine for locales without a separate host, whose
+        // sitemap URLs are built from the site-wide `baseUrl` (which does
+        // carry the correct scheme), but locales configured with their own
+        // hostname (`separateHost: true`) get their base URL from
+        // `${req.protocol}://${hostname}` in
+        // `@apostrophecms/url:getBaseUrl`, so an incorrect `req.protocol`
+        // there results in `http://` URLs even on an all-HTTPS site — both
+        // in the `<loc>` for that locale and, because `doc._url` is built
+        // from `req.prefix` at request-construction time
+        // (`@apostrophecms/i18n:setPrefixUrls`, called synchronously inside
+        // `getAnonReq`), in every URL fetched via this req. So `protocol`
+        // must be passed in up front rather than set on the req
+        // afterward — setting it later is too late to affect
+        // `req.prefix`. Derive the scheme from the configured site
+        // `baseUrl` so it is consistent across every locale.
+        const protocol = self.baseUrl.split('://')[0] || 'http';
         const req = self.apos.task.getAnonReq({
           locale,
           mode: 'published',
-          staticBuild
+          staticBuild,
+          protocol
         });
         if (externalFront) {
           req.aposExternalFront = true;

--- a/packages/sitemap/test/test.js
+++ b/packages/sitemap/test/test.js
@@ -1142,6 +1142,55 @@ describe('Sitemap – static build URL generation', function () {
   });
 });
 
+describe('Sitemap – locale hostname scheme consistency', function () {
+  let apos;
+
+  before(async function () {
+    apos = await t.create({
+      root: module,
+      baseUrl: 'https://kidney.ca',
+      testModule: true,
+      modules: getAppConfig({
+        multilanguage: true,
+        perLocale: true
+      })
+    });
+  });
+
+  after(async function () {
+    await t.destroy(apos);
+  });
+
+  it('per-locale sitemap for a locale hostname should use the baseUrl scheme', async function () {
+    const frXml = await apos.http.get('/sitemaps/fr.xml');
+
+    assert(frXml.indexOf('<loc>https://fr.example.com/</loc>') !== -1,
+      'French locale hostname sitemap should use https, matching the site baseUrl scheme');
+    assert(frXml.indexOf('http://fr.example.com') === -1,
+      'French locale hostname sitemap should not fall back to http');
+  });
+
+  it('hreflang alternates for a locale hostname should also use the baseUrl scheme', async function () {
+    const enXml = await apos.http.get('/sitemaps/en.xml');
+
+    assert(
+      enXml.indexOf('hreflang="fr" href="https://fr.example.com/"') !== -1,
+      'French hreflang alternate embedded in the English sitemap should use https'
+    );
+    assert(
+      enXml.indexOf('href="http://fr.example.com/"') === -1,
+      'French hreflang alternate should not fall back to http'
+    );
+  });
+
+  it('sitemap index should use the baseUrl scheme for every locale entry', async function () {
+    const indexXml = await apos.http.get('/sitemaps/index.xml');
+
+    assert(indexXml.indexOf('<loc>https://kidney.ca/sitemaps/en.xml</loc>') !== -1);
+    assert(indexXml.indexOf('<loc>https://kidney.ca/sitemaps/fr.xml</loc>') !== -1);
+  });
+});
+
 function getProductAppConfig({
   perPage = 3, staticUrls = false, multilanguage = false
 } = {}) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:

*Check one*
- [ ] main
- [ ] latest
- [ ] stable
- [ ] Check if this PR will be resubmitted against another branch

## Summary
*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
This PR fixes an issue the Raisin experienced.
```
I discovered the following behaviour with the sitemap extension on multisite.

On a multisite project with two locales — en-CA (no separate host) and fr-CA configured with separateHost: true — the per-locale sitemaps are generated with inconsistent schemes. 

/sitemaps/en-CA.xml contains https:// in every <loc>, but /sitemaps/fr-CA.xml contains http:// in every <loc>, even though the site's configured base URL is https:// and the French host is served over HTTPS only. 

The http:// URLs also appear in the xhtml:link hreflang alternates for the French locale, including the alternates embedded in the English sitemap. 

This is not affected by which host the sitemap is requested from — the French sitemap returns http:// whether fetched via the English domain (kidney.ca) or the French one (rein.ca). Versions: apostrophe 4.32.1, @apostrophecms/sitemap 1.5.0 (with perLocale: true), @apostrophecms-pro/multisite 4.5.3.
```
The root cause is that the protocol is set from `getAnonReq()`, which hardcodes `http` as a default.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
