### PR TITLE
PRO-9904 Fix apos.boxField.toCss invalid CSS for non-uniform values and harden…

### DIFF
--- a/.changeset/big-regions-buy.md
+++ b/.changeset/big-regions-buy.md
@@ -1,0 +1,5 @@
+---
+"apostrophe": patch
+---
+
+Fix apos.boxField.toCss invalid CSS for non-uniform values and harden missing value/property (PRO-9904)

--- a/packages/apostrophe/modules/@apostrophecms/box-field/index.js
+++ b/packages/apostrophe/modules/@apostrophecms/box-field/index.js
@@ -124,17 +124,25 @@ module.exports = {
       }
     };
   },
-  helpers() {
+  helpers(self) {
     return {
       toCss(value, property, unit = 'px') {
+        if (typeof property !== 'string' || !property) {
+          self.apos.util.warnDevOnce(
+            'box-field-toCss-property',
+            'apos.boxField.toCss requires a CSS property (e.g. "margin" or "padding-%key%").'
+          );
+          return '';
+        }
+
         const {
           top, right, bottom, left
-        } = value;
+        } = value || {};
         const vals = [ top, right, bottom, left ];
 
         if (vals.every(v => v == null)) {
           return '';
-        };
+        }
 
         if (vals.every(v => v === top && v != null)) {
           const normalizedProperty = property
@@ -161,12 +169,12 @@ module.exports = {
             ? property
               .replaceAll('-%key%', `-${side}`)
               .replaceAll('%key%-', `${side}-`)
-            : `property-${side}`;
+            : `${property}-${side}`;
 
           parts.push(`${normalizedProperty}: ${val}${unit}`);
         }
 
-        return parts.join(' ');
+        return parts.join(';') + ';';
       }
     };
   }

--- a/packages/apostrophe/test/box-field.js
+++ b/packages/apostrophe/test/box-field.js
@@ -1,0 +1,80 @@
+const t = require('../test-lib/test.js');
+const assert = require('node:assert/strict');
+
+describe('Box field', function () {
+  this.timeout(t.timeout);
+
+  let apos;
+  let toCss;
+
+  before(async function () {
+    apos = await t.create({
+      root: module
+    });
+    toCss = apos.modules['@apostrophecms/box-field'].__helpers.toCss;
+  });
+
+  after(async function () {
+    return t.destroy(apos);
+  });
+
+  describe('toCss helper', function () {
+    const uniform = {
+      top: 24,
+      right: 24,
+      bottom: 24,
+      left: 24
+    };
+    const nonUniform = {
+      top: 32,
+      right: 24,
+      bottom: 32,
+      left: 24
+    };
+
+    it('emits a shorthand declaration for a uniform box with %key%', function () {
+      assert.equal(toCss(uniform, 'padding-%key%'), 'padding: 24px;');
+    });
+
+    it('emits a shorthand declaration for a uniform box without %key%', function () {
+      assert.equal(toCss(uniform, 'padding'), 'padding: 24px;');
+    });
+
+    it('emits per-side declarations for a non-uniform box with %key%', function () {
+      assert.equal(
+        toCss(nonUniform, 'padding-%key%'),
+        'padding-top: 32px;padding-right: 24px;padding-bottom: 32px;padding-left: 24px;'
+      );
+    });
+
+    it('emits per-side declarations for a non-uniform box without %key%', function () {
+      assert.equal(
+        toCss(nonUniform, 'padding'),
+        'padding-top: 32px;padding-right: 24px;padding-bottom: 32px;padding-left: 24px;'
+      );
+    });
+
+    it('returns an empty string when value is undefined', function () {
+      assert.equal(toCss(undefined, 'padding'), '');
+    });
+
+    it('returns an empty string when property is missing', function () {
+      const original = apos.util.warnDevOnce;
+      const warnings = [];
+      apos.util.warnDevOnce = (...args) => {
+        warnings.push(args);
+      };
+      try {
+        assert.equal(toCss(uniform), '');
+        assert.equal(toCss(nonUniform), '');
+        assert.equal(toCss(uniform, ''), '');
+        assert.equal(toCss(uniform, null), '');
+        assert.equal(apos.template.templateApos.boxField.toCss(nonUniform), '');
+        assert.ok(warnings.length >= 1);
+        assert.equal(warnings[0][0], 'box-field-toCss-property');
+      } finally {
+        apos.util.warnDevOnce = original;
+      }
+    });
+  });
+});


### PR DESCRIPTION
… missing value/property (PRO-9904)

*Check one*
- [X] main
- [ ] latest
- [ ] stable
- [ ] Check if this PR will be resubmitted against another branch

## Summary
- Non-uniform box values no longer emit a single space-joined declaration that browsers drop. Per-side rules are joined with ;, and a plain property name like 'padding' becomes padding-top instead of property-top.
- Missing value or property no longer throws: undefined values return '', and a missing property warns once in development then returns ''.
- Adds helper tests for uniform/non-uniform output and the missing-argument cases.

## What are the specific steps to test this change?

*For example:*
1. Render a widget with a uniform box ({ top: 24, right: 24, bottom: 24, left: 24 }) via apos.boxField.toCss(..., 'padding-%key%') and confirm padding: 24px;
2. Change one side (e.g. top/bottom 32, left/right 24) and confirm per-side declarations with semicolons are applied in the browser
3. Call toCss(value, 'padding') without %key% and confirm padding-top / padding-right / etc., not property-top
4. Call toCss with undefined value or no property and confirm the page renders; in development, missing property logs box-field-toCss-property once
5. `npx mocha -t 10000 test/box-field.js in packages/apostrophe`

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
